### PR TITLE
ci: parallel jobs + coverage artifact + concurrency cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - run: npm ci
-      - run: npm test -- --coverage --forceExit
+      - run: npm test -- --coverage --coverageProvider=v8 --forceExit
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,40 +6,118 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  ci:
+  typecheck:
+    name: TypeCheck
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '22'
-
-      - name: Cache npm
-        uses: actions/cache@v4
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
 
-      - name: Install dependencies
-        run: npm ci
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm test -- --coverage --forceExit
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 14
 
-      - name: Lint
-        run: npm run lint
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
 
-      - name: Test
-        run: npm test
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run build
 
-      - name: Audit
-        run: npm audit --audit-level=high
-
-      - name: Build
-        run: npm run build
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- Split single sequential CI job into 5 parallel jobs: \`typecheck\`, \`test\`, \`build\`, \`e2e\`, \`audit\`
- \`typecheck\` runs \`npm run lint\` + \`npx tsc --noEmit\` — catches TypeScript errors on PRs
- \`test\` uploads \`coverage/\` artifact (14-day retention)
- \`e2e\` installs Chromium, runs Playwright against prod \`demo.quantika.org\`, \`continue-on-error\`
- \`audit\` is warning-only (\`continue-on-error\`)
- Added \`concurrency\` cancel-in-progress to kill stale runs

## Test plan
- [ ] Check all 5 jobs appear in GitHub Actions UI after push
- [ ] Verify \`typecheck\` job shows lint + tsc output
- [ ] Verify \`test\` job shows coverage summary + artifact uploaded
- [ ] Confirm \`audit\` job does NOT block merge even if red
- [ ] Confirm \`e2e\` job does NOT block merge even if red

🤖 Generated with [Claude Code](https://claude.com/claude-code)