### PR TITLE
fix: E2E repoRoot path + Caddy domain-sync runbook

### DIFF
--- a/__tests__/e2e/skeptical-forwarder.spec.ts
+++ b/__tests__/e2e/skeptical-forwarder.spec.ts
@@ -78,14 +78,13 @@ function parseDate(s: string): Date | null {
   return isNaN(d.getTime()) ? null : d;
 }
 
-/** Load JSON file from the main repo root (~/work/quantika-demo/).
- *  __dirname = e2e-playwright/__tests__/e2e
- *  worktreeRoot = e2e-playwright/
- *  repoRoot = worktreeRoot/../../../ = ~/work/quantika-demo
+/** Load JSON file from the repo root.
+ *  __dirname = <repo>/__tests__/e2e
+ *  repoRoot  = <repo>
+ *  Works in both local dev and GitHub Actions (no env-dependent cwd assumptions).
  */
 function loadJson<T>(relPath: string): T {
-  const worktreeRoot = path.resolve(__dirname, '../..');
-  const repoRoot = path.resolve(worktreeRoot, '../../..');
+  const repoRoot = path.resolve(__dirname, '../..');
   const fullPath = path.join(repoRoot, relPath);
   if (!fs.existsSync(fullPath)) {
     throw new Error(`Fixture file not found: ${fullPath} (repoRoot: ${repoRoot})`);

--- a/docs/RUNBOOK-CADDY-DOMAINS.md
+++ b/docs/RUNBOOK-CADDY-DOMAINS.md
@@ -1,0 +1,44 @@
+# Runbook — Adding a Domain to Caddy on VPS
+
+Active Caddyfile: `/etc/caddy/Caddyfile` on `root@185.249.225.169`.
+Per-domain blocks live in repo at `ops/Caddyfile.<domain>` and must be **manually
+appended** to `/etc/caddy/Caddyfile` on the VPS — Caddy does NOT auto-import
+these.
+
+## Steps to add a new domain
+
+```bash
+ssh root@185.249.225.169
+cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.bak.$(date +%Y%m%d-%H%M%S)
+cat /root/quantika-demo/ops/Caddyfile.<domain> >> /etc/caddy/Caddyfile
+systemctl reload caddy
+systemctl is-active caddy   # must be 'active'
+```
+
+Wait ~30s for Let's Encrypt provisioning, then verify:
+
+```bash
+curl -sI https://<domain>/api/health   # expect HTTP/2 200
+```
+
+## Cloudflare prerequisites
+
+- Cloudflare SSL mode must be **Full** (not Flexible, not Full-strict).
+  Caddy auto-provisions a Let's Encrypt cert; CF "Full-strict" rejects only
+  self-signed, so LE works either way — but **Full** is the documented setting.
+- DNS A record points `<domain>` → VPS public IP `185.249.225.169`.
+
+## Rollback
+
+```bash
+cp /etc/caddy/Caddyfile.bak.<timestamp> /etc/caddy/Caddyfile
+systemctl reload caddy
+```
+
+## Why blocks aren't auto-imported
+
+The active `/etc/caddy/Caddyfile` is hand-curated (e.g., `allegro.quantika.org`
+includes `basic_auth` with env-var credentials that depend on
+`/etc/systemd/system/caddy.service.d/auth.conf`). Auto-importing every
+`ops/Caddyfile.*` would require unifying all secrets in systemd drop-ins.
+Until that is done, this runbook is the source of truth.


### PR DESCRIPTION
## Summary

Closes 2 pre-existing post-Wave-α issues observed during PR #25 deploy.

| # | Bug | Root cause | Fix |
|---|-----|-----------|-----|
| 1 | E2E suite fails in CI with \`repoRoot=/home/runner\` (fixtures not found) | \`skeptical-forwarder.spec.ts:88\` did \`path.resolve(worktreeRoot, '../../..')\` — walked 3 levels above repo, landing in user home | Use \`__dirname/../..\` directly (already the repo root) |
| 2 | \`https://demo.quantika.org\` returned Cloudflare 525 (TLS edge↔origin handshake fail) | \`ops/Caddyfile.demo.quantika.org\` existed in repo but was never appended to \`/etc/caddy/Caddyfile\` on VPS — Caddy had no TLS policy for that hostname | Sysops fix applied to VPS (see PR description); new runbook \`docs/RUNBOOK-CADDY-DOMAINS.md\` documents the manual sync so it doesn't recur |

## Verification

**E2E (will be confirmed by CI on this PR):**
\`\`\`bash
npm run test:e2e   # was: "Fixture file not found: /home/runner/__tests__/..."
\`\`\`

**Cloudflare 525 (already fixed live):**
\`\`\`bash
curl -sI https://demo.quantika.org/api/health
# HTTP/2 200
# {"status":"ok","sessions":1,"uptime":287.92,"version":"0.1.0"}
\`\`\`

VPS sysops change applied:
\`\`\`bash
ssh root@185.249.225.169
cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.bak.<ts>
cat /root/quantika-demo/ops/Caddyfile.demo.quantika.org >> /etc/caddy/Caddyfile
systemctl reload caddy
\`\`\`

## Out of scope

- Auto-import of \`ops/Caddyfile.*\` blocks — requires unifying secret-management for all domains (basic_auth env vars on allegro etc.). Tracked in runbook.
- Caddyfile formatting (\`caddy fmt --overwrite\` warning) — cosmetic.
- E2E suite still has unrelated failures behind the now-fixed fixture loader; those will surface on next CI run and should be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)