### PR TITLE
fix(dashboard): resolve market KPI loading state

### DIFF
--- a/components/dashboard/MarketIntelligence.tsx
+++ b/components/dashboard/MarketIntelligence.tsx
@@ -10,10 +10,10 @@ interface KpiCard {
   period: string;
 }
 
-const STATIC_KPIS: KpiCard[] = [
-  { label: 'Bunker Rotterdam', value: '—', unit: 'USD/t', period: 'Loading…' },
-  { label: 'EUA EU ETS', value: '—', unit: 'EUR/t', period: 'Loading…' },
-  { label: 'BHSI', value: '—', unit: 'index', period: 'Loading…' },
+// Cards with no backend support show "Unavailable" immediately (no fetch).
+const UNAVAILABLE_KPIS: KpiCard[] = [
+  { label: 'Bunker Rotterdam', value: '—', unit: 'USD/t', period: 'Unavailable' },
+  { label: 'EUA EU ETS', value: '—', unit: 'EUR/t', period: 'Unavailable' },
 ];
 
 interface MarketIntelligenceProps {
@@ -25,6 +25,13 @@ export function MarketIntelligence({ noActiveDeals }: MarketIntelligenceProps) {
     label: 'Toepfer TMI',
     value: '—',
     unit: 'USD/day',
+    period: 'Loading…',
+  });
+
+  const [bhsiCard, setBhsiCard] = useState<KpiCard>({
+    label: 'BHSI',
+    value: '—',
+    unit: 'index',
     period: 'Loading…',
   });
 
@@ -48,7 +55,27 @@ export function MarketIntelligence({ noActiveDeals }: MarketIntelligenceProps) {
       });
   }, []);
 
-  const allKpis: KpiCard[] = [tmiCard, ...STATIC_KPIS];
+  useEffect(() => {
+    fetch('/api/market/benchmark?indicator=BHSI')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: MarketBenchmark | null) => {
+        if (data) {
+          setBhsiCard({
+            label: 'BHSI',
+            value: data.value.toLocaleString('en-US'),
+            unit: data.unit,
+            period: data.period,
+          });
+        } else {
+          setBhsiCard((prev) => ({ ...prev, period: 'Unavailable' }));
+        }
+      })
+      .catch(() => {
+        setBhsiCard((prev) => ({ ...prev, period: 'Unavailable' }));
+      });
+  }, []);
+
+  const allKpis: KpiCard[] = [tmiCard, ...UNAVAILABLE_KPIS, bhsiCard];
 
   return (
     <div className="space-y-3">

--- a/components/dashboard/__tests__/MarketIntelligence.test.tsx
+++ b/components/dashboard/__tests__/MarketIntelligence.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { MarketIntelligence } from '../MarketIntelligence';
 
 beforeEach(() => {
@@ -44,5 +44,46 @@ describe('MarketIntelligence', () => {
   it('shows empty-state suggestion when no active deals', () => {
     render(<MarketIntelligence noActiveDeals />);
     expect(screen.getByText(/WhatsApp|Gmail/i)).toBeTruthy();
+  });
+
+  // F7 regression: no card should remain "Loading…" forever after fetch settles
+  it('shows no "Loading…" text after fetch resolves (fetch failure → Unavailable)', async () => {
+    await act(async () => {
+      render(<MarketIntelligence />);
+    });
+    // flush microtasks so all useEffect fetch promises resolve
+    await act(async () => {});
+    const loadingEls = screen.queryAllByText(/Loading…/);
+    expect(loadingEls).toHaveLength(0);
+  });
+
+  it('shows no "Loading…" text after fetch resolves (fetch success for BHSI)', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('BHSI')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            indicator: 'BHSI',
+            value: 1234,
+            unit: 'index',
+            period: 'Apr 2026',
+            sourceUrl: 'https://example.com',
+            fetchedAt: new Date().toISOString(),
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    await act(async () => {
+      render(<MarketIntelligence />);
+    });
+    await act(async () => {});
+
+    const loadingEls = screen.queryAllByText(/Loading…/);
+    expect(loadingEls).toHaveLength(0);
+
+    // BHSI card should now show the live value
+    expect(screen.getByText('1,234')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Closes E2E-MED from docs/E2E-ACCEPTANCE-WAVE-ALPHA.md.

**Approach: A+B hybrid**

- **BHSI** → Option A: wired to `/api/market/benchmark?indicator=BHSI`. The route already declares `BHSI` in `VALID_INDICATORS`, so a live fetch is wired with the same pattern as `TOEPFER_TMI`. Falls back to `'Unavailable'` on 404/503.
- **Bunker Rotterdam** → Option B: set to `'Unavailable'` immediately. No `BUNKER_ROTTERDAM` indicator exists in `route.ts` or `MarketIndicator` type.
- **EUA EU ETS** → Option B: set to `'Unavailable'` immediately. No `EUA_ETS` indicator exists in the API.

**Root cause**: `STATIC_KPIS` const initialised all three cards with `period: 'Loading…'` and no fetch was ever dispatched for them.

## Changes

- `components/dashboard/MarketIntelligence.tsx` — remove `STATIC_KPIS`, add `UNAVAILABLE_KPIS` for Bunker/EUA, add `bhsiCard` state + `useEffect` fetch for BHSI.
- `components/dashboard/__tests__/MarketIntelligence.test.tsx` — add 2 regression tests: one for fetch-failure path, one for BHSI live-value path.

## QI checklist

- [x] No card permanently in "Loading…"
- [x] On fetch failure / unsupported indicator → "Unavailable"
- [x] No unrelated changes

## Test results

```
Tests: 1351 passed, 1351 total (full suite)
```