### PR TITLE
fix(economics): NaN guards + bunker EU-locale + war-risk hyphen port

### DIFF
--- a/lib/confidence.ts
+++ b/lib/confidence.ts
@@ -36,7 +36,7 @@ export function mapConfidenceToLevel(
   score: number | null | undefined,
   hasSourceQuote: boolean = false,
 ): ConfidenceLevel {
-  if (score === null || score === undefined || Number.isNaN(score) || score === Infinity) return 'missing';
+  if (score === null || score === undefined || !Number.isFinite(score)) return 'missing';
   if (score >= 0.85 && hasSourceQuote) return 'verified';
   if (score >= 0.85) return 'inferred'; // high score without sourceQuote → inferred
   if (score >= 0.5) return 'inferred';

--- a/lib/economics/bunker.ts
+++ b/lib/economics/bunker.ts
@@ -23,16 +23,19 @@ export function parseBunkerHtml(html: string): Map<string, BunkerPrice> {
     const rowHtml = rowMatch[1];
 
     const portMatch = /<td[^>]*class="[^"]*port-name[^"]*"[^>]*>\s*([^<]+)\s*<\/td>/i.exec(rowHtml);
-    const vlsfoMatch = /<td[^>]*class="[^"]*vlsfo[^"]*"[^>]*>\s*([\d]+\.[\d]+)\s*<\/td>/i.exec(rowHtml);
+    const vlsfoMatch = /<td[^>]*class="[^"]*vlsfo[^"]*"[^>]*>([\s\S]*?)<\/td>/i.exec(rowHtml);
 
     if (!portMatch || !vlsfoMatch) continue;
 
     const port = portMatch[1].trim();
-    const vlsfo = parseFloat(vlsfoMatch[1]);
+    // Strip nested HTML tags, normalize EU locale comma-decimal, then parse
+    const vlsfoRaw = vlsfoMatch[1].replace(/<[^>]+>/g, '').trim().replace(/,(\d{2})$/, '.$1').replace(/[.,](?=\d{3})/g, '');
+    const vlsfo = parseFloat(vlsfoRaw);
     if (!port || isNaN(vlsfo)) continue;
 
-    const mgoMatch = /<td[^>]*class="[^"]*mgo[^"]*"[^>]*>\s*([\d]+\.[\d]+)\s*<\/td>/i.exec(rowHtml);
-    const mgo = mgoMatch ? parseFloat(mgoMatch[1]) : undefined;
+    const mgoMatch = /<td[^>]*class="[^"]*mgo[^"]*"[^>]*>([\s\S]*?)<\/td>/i.exec(rowHtml);
+    const mgoRaw = mgoMatch ? mgoMatch[1].replace(/<[^>]+>/g, '').trim().replace(/,(\d{2})$/, '.$1').replace(/[.,](?=\d{3})/g, '') : null;
+    const mgo = mgoRaw ? parseFloat(mgoRaw) : undefined;
 
     result.set(port, { port, vlsfo, mgo, fetched_at: now });
   }

--- a/lib/economics/ets.ts
+++ b/lib/economics/ets.ts
@@ -16,7 +16,12 @@ export interface EuEtsResult {
 export function calculateEuEts(input: EuEtsInput): EuEtsResult {
   const { distanceNm, euLegPercent, vlsfoBurnMt, euaPrice } = input;
 
-  if (distanceNm <= 0 || euLegPercent <= 0 || euLegPercent > 1 || vlsfoBurnMt <= 0 || euaPrice <= 0) {
+  if (
+    !Number.isFinite(distanceNm) || distanceNm <= 0 ||
+    !Number.isFinite(euLegPercent) || euLegPercent <= 0 || euLegPercent > 1 ||
+    !Number.isFinite(vlsfoBurnMt) || vlsfoBurnMt <= 0 ||
+    !Number.isFinite(euaPrice) || euaPrice <= 0
+  ) {
     return { amountEur: 0, applicable: false };
   }
 

--- a/lib/economics/war-risk.ts
+++ b/lib/economics/war-risk.ts
@@ -48,16 +48,16 @@ export interface WarRiskResult {
 export function calculateWarRiskPremium(input: WarRiskInput): WarRiskResult {
   const { route, vesselValueUsd, daysInHra } = input;
 
-  if (daysInHra <= 0) {
+  if (!Number.isFinite(daysInHra) || daysInHra <= 0) {
     return { premiumUsd: 0, zones: [] };
   }
 
-  if (vesselValueUsd < 0) {
+  if (!Number.isFinite(vesselValueUsd) || vesselValueUsd < 0) {
     return { premiumUsd: 0, zones: [] };
   }
 
-  const fromLower = route.fromPort.toLowerCase();
-  const toLower = route.toPort.toLowerCase();
+  const fromLower = route.fromPort.toLowerCase().replace(/-/g, ' ');
+  const toLower = route.toPort.toLowerCase().replace(/-/g, ' ');
   const viaLower = (route.viaCanal ?? '').toLowerCase();
 
   const matchedZones: HraZone[] = [];

--- a/tests/regression/test_confidence_gate_property.test.ts
+++ b/tests/regression/test_confidence_gate_property.test.ts
@@ -271,13 +271,13 @@ describe('H8 — Infinity score', () => {
     expect(result).not.toBe('inferred'); // desired: reject
   });
 
-  it('-Infinity maps to uncertain (lower-bound covered by uncertain fallthrough)', () => {
-    // -Infinity < 0.5, so falls to uncertain — no special guard needed here
-    expect(mapConfidenceToLevel(-Infinity, false)).toBe('uncertain');
+  it('-Infinity maps to missing (non-finite guard — BUG-B10 fixed)', () => {
+    // -Infinity is non-finite → !Number.isFinite(-Infinity) → 'missing'
+    expect(mapConfidenceToLevel(-Infinity, false)).toBe('missing');
   });
 
-  it('-Infinity with sourceQuote still maps to uncertain', () => {
-    expect(mapConfidenceToLevel(-Infinity, true)).toBe('uncertain');
+  it('-Infinity with sourceQuote maps to missing (non-finite guard)', () => {
+    expect(mapConfidenceToLevel(-Infinity, true)).toBe('missing');
   });
 });
 

--- a/tests/regression/test_economics_confidence_adv.test.ts
+++ b/tests/regression/test_economics_confidence_adv.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Agent B — Adversarial QA Phase 3
+ * ATTACK-5: ETS calculator — hostile HTML input, NaN inputs
+ * ATTACK-6: War-risk — NaN inputs, Constanta false-positive, Bab al-Mandeb, hyphen ports
+ * ATTACK-9: Confidence engine — -Infinity, empty sourceText, unknown criticalFields
+ *
+ * DO NOT edit feature code. Document bugs via failing assertions.
+ */
+
+import { calculateEuEts } from '@/lib/economics/ets';
+import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
+import { mapConfidenceToLevel, computeMatchConfidence } from '@/lib/confidence';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+function makeCargo(overrides: Partial<ParsedCargo> = {}): ParsedCargo {
+  return {
+    emailId: 'test-b',
+    itemIndex: 0,
+    originPort: null,
+    originCountry: null,
+    destinationPort: null,
+    destinationCountry: null,
+    cargoDescription: null,
+    weightMt: null,
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BREAK_BULK',
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    ...overrides,
+  };
+}
+
+function makeVessel(overrides: Partial<ParsedVessel> = {}): ParsedVessel {
+  return {
+    emailId: 'test-b',
+    itemIndex: 0,
+    vesselName: null,
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: null,
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: null,
+    speedBallast: null,
+    consumption: null,
+    deckCapacity: null,
+    specialFeatures: [],
+    verificationWarning: null,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// ATTACK-5: ETS Calculator — hostile HTML input, NaN inputs
+// ============================================================================
+
+describe('ATTACK-5 — ETS: NaN and boundary inputs', () => {
+
+  // A5-1: fetchEuaPrice is async/network — we test the downstream concern:
+  // if fetchEuaPrice returns NaN (parse fails on unexpected HTML format),
+  // does calculateEuEts(legs, NaN) return NaN, Infinity, or throw?
+  it('A5-1: calculateEuEts with euaPrice=NaN — guard must not pass NaN through', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: NaN,
+    });
+    // NaN <= 0 is false in JS → guard does NOT catch NaN
+    // amount = 100 * 3.114 * 0.5 * NaN = NaN
+    // Bug: amountEur=NaN, applicable=false (NaN > 0 is false)
+    expect(Number.isNaN(result.amountEur)).toBe(false);
+    expect(result.amountEur).toBe(0);
+  });
+
+  it('A5-2: calculateEuEts with euaPrice=NaN — applicable must not be NaN or corrupt', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: NaN,
+    });
+    // applicable = (NaN > 0) = false — this is accidentally "correct" but amountEur=NaN leaks
+    expect(typeof result.applicable).toBe('boolean');
+  });
+
+  it('A5-3: euaPrice=0 → amountEur=0, applicable=false (guard covers this)', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: 0,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('A5-4: euaPrice=-50 → guard (euaPrice <= 0) catches it → amountEur=0', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: -50,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('A5-5: distanceNm=NaN — guard (distanceNm <= 0) does NOT catch NaN, may propagate', () => {
+    const result = calculateEuEts({
+      distanceNm: NaN,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: 87.5,
+    });
+    // NaN <= 0 is false → guard does not fire → amount = 100 * 3.114 * 0.5 * 87.5 = valid (distanceNm unused in formula)
+    // Actually distanceNm is not used in the multiplication formula! Only guard-checked.
+    // So result may be a valid number despite NaN distanceNm — document the semantics.
+    expect(Number.isNaN(result.amountEur)).toBe(false);
+  });
+
+  it('A5-6: vlsfoBurnMt=NaN — guard (vlsfoBurnMt <= 0) does NOT catch NaN', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: NaN,
+      euaPrice: 87.5,
+    });
+    // NaN <= 0 is false → guard passes → amount = NaN * 3.114 * 0.5 * 87.5 = NaN
+    // Bug: returns amountEur=NaN silently
+    expect(Number.isNaN(result.amountEur)).toBe(false);
+    expect(result.amountEur).toBe(0);
+  });
+
+  it('A5-7: euLegPercent=NaN — guard (euLegPercent <= 0) does NOT catch NaN', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: NaN,
+      vlsfoBurnMt: 100,
+      euaPrice: 87.5,
+    });
+    // NaN <= 0 is false, NaN > 1 is false → guard bypassed → amount = 100 * 3.114 * NaN * 87.5 = NaN
+    expect(Number.isNaN(result.amountEur)).toBe(false);
+    expect(result.amountEur).toBe(0);
+  });
+
+  it('A5-8: euaPrice=Infinity → not guarded (Infinity > 0 is true) → amountEur=Infinity', () => {
+    const result = calculateEuEts({
+      distanceNm: 1000,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: Infinity,
+    });
+    // amount = 100 * 3.114 * 0.5 * Infinity = Infinity
+    // Math.round(Infinity * 100) / 100 = Infinity
+    expect(Number.isFinite(result.amountEur)).toBe(true);
+  });
+
+  it('A5-9: all params valid, distanceNm=0 → guard fires → {0, false}', () => {
+    const result = calculateEuEts({
+      distanceNm: 0,
+      euLegPercent: 0.5,
+      vlsfoBurnMt: 100,
+      euaPrice: 87.5,
+    });
+    expect(result).toEqual({ amountEur: 0, applicable: false });
+  });
+
+  // A5-10: fetchEuaPrice HTML injection — if hostile price element contains script tags,
+  // parseFloat('<script>alert(1)</script>') = NaN, which falls through to fallback.
+  // We test the fallback path: when HTML parse yields NaN, the function returns FALLBACK_EUA_PRICE.
+  // This is indirectly tested by checking that the module exports a fallback for failed parse.
+  it('A5-10: parseFloat of hostile HTML string returns NaN (not a code execution risk)', () => {
+    // This confirms parseFloat behavior used by fetchEuaPrice
+    const hostile = '<script>alert(1)</script>';
+    expect(Number.isNaN(parseFloat(hostile))).toBe(true);
+    // The fetchEuaPrice regex would not match this, so it falls back to FALLBACK_EUA_PRICE (87.5)
+    // No XSS risk in a server-side fetch; parseFloat is safe.
+  });
+});
+
+// ============================================================================
+// ATTACK-6: War-risk — NaN inputs, Constanta, Bab al-Mandeb gap, hyphen ports
+// ============================================================================
+
+describe('ATTACK-6 — War-risk: NaN, Constanta, Bab al-Mandeb, hyphen ports', () => {
+
+  // A6-1: daysInHra=NaN — guard (daysInHra <= 0) does NOT catch NaN
+  it('A6-1: daysInHra=NaN — should return {0, []} not NaN premium', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: NaN,
+    });
+    // NaN <= 0 is false → guard bypassed → premiumUsd = 10M * rate * NaN = NaN
+    // Bug: premiumUsd=NaN silently
+    expect(Number.isNaN(result.premiumUsd)).toBe(false);
+    expect(result.premiumUsd).toBeGreaterThanOrEqual(0);
+  });
+
+  // A6-2: vesselValueUsd=NaN — no guard (only checks < 0, NaN < 0 is false)
+  it('A6-2: vesselValueUsd=NaN — should return {0, []} not NaN premium', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
+      vesselValueUsd: NaN,
+      daysInHra: 5,
+    });
+    // NaN < 0 is false → passes guard → premium = NaN * rate * 5 = NaN
+    expect(Number.isNaN(result.premiumUsd)).toBe(false);
+    expect(result.premiumUsd).toBeGreaterThanOrEqual(0);
+  });
+
+  // A6-3: both NaN
+  it('A6-3: daysInHra=NaN, vesselValueUsd=NaN → premium should be 0 or throw, NOT NaN', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
+      vesselValueUsd: NaN,
+      daysInHra: NaN,
+    });
+    expect(Number.isNaN(result.premiumUsd)).toBe(false);
+  });
+
+  // A6-4: vesselValueUsd=0 — legitimate zero-value vessel
+  it('A6-4: vesselValueUsd=0 → premiumUsd=0, zone still matched', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
+      vesselValueUsd: 0,
+      daysInHra: 5,
+    });
+    expect(result.premiumUsd).toBe(0);
+    expect(result.zones).toContain('Gulf of Guinea HRA');
+  });
+
+  // A6-5: vesselValueUsd=-1_000_000 — existing guard: vesselValueUsd < 0 → {0, []}
+  it('A6-5: vesselValueUsd=-1M → guard fires → {0, []}', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
+      vesselValueUsd: -1_000_000,
+      daysInHra: 5,
+    });
+    expect(result.premiumUsd).toBe(0);
+    expect(result.zones).toHaveLength(0);
+  });
+
+  // A6-6: Constanta — this is INTENTIONALLY in the Black Sea HRA zone list
+  // The war-risk module explicitly lists 'constanta' under "Black Sea Russia/Ukraine HRA"
+  // because during 2022-2025 Black Sea conflict, Constanta was a major transshipment point
+  // for Ukrainian grain under NATO escort. The test documents that this IS a deliberate design choice.
+  it('A6-6: Port "Constanta" IS listed in Black Sea HRA — design intent verification', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Constanta', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    // Constanta is explicitly in ports list for Black Sea HRA
+    // This is intentional — document the design choice
+    expect(result.zones).toContain('Black Sea Russia/Ukraine HRA');
+    expect(result.premiumUsd).toBeGreaterThan(0);
+  });
+
+  // A6-7: "constanta" lowercase — same match (function lowercases input)
+  it('A6-7: Port "constanta" (lowercase) matches Black Sea HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'constanta', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    expect(result.zones).toContain('Black Sea Russia/Ukraine HRA');
+  });
+
+  // A6-8: "Constantza" — alternate spelling NOT in ports list
+  it('A6-8: Port "Constantza" (alternate spelling) should NOT match Black Sea HRA (not in list)', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Constantza', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    // 'constantza' does NOT include 'constanta' (different string), \b regex won't match
+    // This is a gap: an operator might type "Constantza" and get no HRA detection
+    expect(result.zones).toHaveLength(0);
+  });
+
+  // A6-9: Bab al-Mandeb — Aden as origin (in Red Sea/Bab al-Mandeb HRA port list)
+  it('A6-9: fromPort="Aden" correctly triggers Red Sea/Bab al-Mandeb HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Aden', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 5,
+    });
+    expect(result.zones).toContain('Red Sea / Bab al-Mandeb HRA');
+    expect(result.premiumUsd).toBeGreaterThan(0);
+  });
+
+  // A6-10: Djibouti as destination — in Red Sea HRA list
+  it('A6-10: toPort="Djibouti" correctly triggers Red Sea/Bab al-Mandeb HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Rotterdam', toPort: 'Djibouti' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 5,
+    });
+    expect(result.zones).toContain('Red Sea / Bab al-Mandeb HRA');
+  });
+
+  // A6-11: Aden→Djibouti route (both in Red Sea HRA) — zone matched once only
+  it('A6-11: from=Aden to=Djibouti (both Red Sea HRA ports) charges once, not doubled', () => {
+    const bothPorts = calculateWarRiskPremium({
+      route: { fromPort: 'Aden', toPort: 'Djibouti' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 5,
+    });
+    const singlePort = calculateWarRiskPremium({
+      route: { fromPort: 'Aden', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 5,
+    });
+    expect(bothPorts.premiumUsd).toBe(singlePort.premiumUsd);
+    expect(bothPorts.zones.filter(z => z === 'Red Sea / Bab al-Mandeb HRA')).toHaveLength(1);
+  });
+
+  // A6-12: Port with hyphen "Um-Qasr" — regex uses \b word boundary
+  // "um-qasr".toLowerCase() = "um-qasr"
+  // Ports list does not include "um-qasr" or "umqasr" — but let's check if hyphenated
+  // ports that ARE in the list (e.g. "dar es salaam") work
+  it('A6-12: Port "Dar Es Salaam" (with spaces) matches Indian Ocean HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Dar Es Salaam', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 5,
+    });
+    // 'dar es salaam' with \b regex should match
+    expect(result.zones).toContain('Indian Ocean / Somali Corridor HRA');
+  });
+
+  // A6-13: "Um-Qasr" (Iraq port) — NOT in any HRA zone list → no premium
+  // But the attack tests whether hyphens break matching when the port IS listed
+  // We test a fabricated hyphen variant of a listed port: "tin-can" vs "tin can"
+  it('A6-13: Port "Tin-Can" (hyphen variant of "Tin Can" in Gulf of Guinea list) — may miss detection', () => {
+    const withHyphen = calculateWarRiskPremium({
+      route: { fromPort: 'Tin-Can', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    const withSpace = calculateWarRiskPremium({
+      route: { fromPort: 'Tin Can', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    // "tin can" with regex \btin can\b — 'tin-can' lowercased = 'tin-can'
+    // 'tin-can'.test(/\btin can\b/) = false because hyphen ≠ space
+    // Potential gap: hyphenated port misses detection
+    if (withHyphen.premiumUsd === 0 && withSpace.premiumUsd > 0) {
+      console.warn('[A6-13 GAP] "Tin-Can" (hyphen) misses Gulf of Guinea HRA detection; "Tin Can" (space) matches');
+    }
+    // Document: we expect hyphenated form to match if port is real
+    // This test asserts the gap IS a bug if it exists
+    expect(withHyphen.zones).toEqual(withSpace.zones);
+  });
+
+  // A6-14: empty port strings — should not throw
+  it('A6-14: empty fromPort and toPort do not crash', () => {
+    expect(() => calculateWarRiskPremium({
+      route: { fromPort: '', toPort: '' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 5,
+    })).not.toThrow();
+  });
+
+  // A6-15: daysInHra=Infinity — not guarded (Infinity <= 0 is false)
+  it('A6-15: daysInHra=Infinity → premiumUsd should be finite, not Infinity', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: Infinity,
+    });
+    // premium = 10M * rate * Infinity = Infinity
+    expect(Number.isFinite(result.premiumUsd)).toBe(true);
+  });
+});
+
+// ============================================================================
+// ATTACK-9: Confidence engine — -Infinity, empty sourceText, unknown criticalFields
+// ============================================================================
+
+describe('ATTACK-9 — Confidence: -Infinity, empty sourceText, unknown fields, boundaries', () => {
+
+  // A9-1: -Infinity score — already guarded in confidence.ts line 39?
+  // Code: if score === null || undefined || isNaN || === Infinity → 'missing'
+  // Note: only +Infinity is checked, NOT -Infinity
+  it('A9-1: mapConfidenceToLevel(-Infinity) — not in explicit guard, falls to uncertain', () => {
+    const result = mapConfidenceToLevel(-Infinity, false);
+    // -Infinity < 0.5 → falls to 'uncertain' (not 'missing')
+    // The guard only checks === Infinity (positive), not -Infinity
+    // -Infinity should map to 'missing' (invalid input), not 'uncertain' (which blocks sends)
+    if (result === 'uncertain') {
+      console.warn('[A9-1 BUG] -Infinity maps to "uncertain", should be "missing". Blocks send silently.');
+    }
+    expect(result).toBe('missing');
+  });
+
+  // A9-2: +Infinity — code explicitly guards: score === Infinity → 'missing'
+  it('A9-2: mapConfidenceToLevel(Infinity) → "missing" (explicit guard in code)', () => {
+    expect(mapConfidenceToLevel(Infinity, false)).toBe('missing');
+  });
+
+  // A9-3: +Infinity with sourceQuote — still guarded → 'missing'
+  it('A9-3: mapConfidenceToLevel(Infinity, true) → "missing" (guard before sourceQuote check)', () => {
+    expect(mapConfidenceToLevel(Infinity, true)).toBe('missing');
+  });
+
+  // A9-4: NaN score — code explicitly guards: Number.isNaN → 'missing'
+  it('A9-4: mapConfidenceToLevel(NaN) → "missing" (explicit guard)', () => {
+    expect(mapConfidenceToLevel(NaN, false)).toBe('missing');
+  });
+
+  // A9-5: computeMatchConfidence with all-undefined fields in cargo
+  // (different from null — undefined means property not set at all)
+  it('A9-5: all critical cargo fields undefined → level=missing, blockSend=false', () => {
+    // Create cargo where fields that resolveField accesses are explicitly undefined
+    const cargo = makeCargo({
+      weightMt: undefined as unknown as null,
+      originPort: undefined as unknown as null,
+      destinationPort: undefined as unknown as null,
+      laycan: undefined as unknown as null,
+    });
+    const vessel = makeVessel({ imo: undefined as unknown as null });
+    const result = computeMatchConfidence(cargo, vessel);
+    // resolveField checks !cf → undefined is falsy → returns {level:'missing'}
+    expect(result.level).toBe('missing');
+    expect(result.blockSend).toBe(false);
+  });
+
+  // A9-6: sourceText="" (empty string) — treated as missing or present?
+  // In resolveField: !!cf.sourceText → !!"" → false → hasSourceQuote=false
+  // So empty sourceText → inferred (not verified), not missing
+  it('A9-6: sourceText="" (empty string) treated as absent (no sourceQuote)', () => {
+    const cargo = makeCargo({
+      weightMt: { value: 5000, confidence: 'confirmed', sourceText: '' },
+    });
+    const vessel = makeVessel();
+    const result = computeMatchConfidence(cargo, vessel);
+    const weightField = result.fieldConfidences.find(f => f.field === 'cargo.weightMt');
+    // score = parseConfToScore('confirmed') = 0.9
+    // hasSourceQuote = !!"" = false → mapConfidenceToLevel(0.9, false) = 'inferred'
+    expect(weightField?.level).toBe('inferred'); // not 'verified'
+    expect(weightField?.sourceQuote).toBe('');
+  });
+
+  // A9-7: criticalFields containing an unknown field name
+  it('A9-7: unknown criticalField name → resolveField returns {level:"missing"} (default case)', () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    const result = computeMatchConfidence(cargo, vessel, ['cargo.unknownField', 'vessel.nonExistent']);
+    // resolveField switch default → {field, level:'missing'}
+    expect(result.fieldConfidences).toHaveLength(2);
+    expect(result.fieldConfidences[0].level).toBe('missing');
+    expect(result.fieldConfidences[1].level).toBe('missing');
+    // missing does NOT block send
+    expect(result.blockSend).toBe(false);
+  });
+
+  // A9-8: mixed unknown + uncertain field
+  it('A9-8: unknown field + uncertain real field → blockSend=true (uncertain dominates)', () => {
+    const cargo = makeCargo({
+      weightMt: { value: 5000, confidence: 'uncertain', sourceText: undefined },
+    });
+    const vessel = makeVessel();
+    const result = computeMatchConfidence(cargo, vessel, ['cargo.weightMt', 'cargo.unknownField']);
+    expect(result.blockSend).toBe(true);
+    expect(result.blockedFields).toContain('cargo.weightMt');
+    expect(result.level).toBe('uncertain');
+  });
+
+  // A9-9: score exactly at 0.5 boundary (inclusive → inferred)
+  it('A9-9: score=0.5 exactly → inferred (boundary inclusive)', () => {
+    expect(mapConfidenceToLevel(0.5, false)).toBe('inferred');
+  });
+
+  // A9-10: score just below 0.5 → uncertain
+  it('A9-10: score=0.4999 → uncertain', () => {
+    expect(mapConfidenceToLevel(0.4999, false)).toBe('uncertain');
+  });
+
+  // A9-11: score exactly at 0.75 (mid-band) → inferred
+  it('A9-11: score=0.75 → inferred (in 0.5–0.85 band)', () => {
+    expect(mapConfidenceToLevel(0.75, false)).toBe('inferred');
+  });
+
+  // A9-12: score exactly at 0.85 without sourceQuote → inferred
+  it('A9-12: score=0.85 without sourceQuote → inferred (not verified)', () => {
+    expect(mapConfidenceToLevel(0.85, false)).toBe('inferred');
+  });
+
+  // A9-13: score exactly at 0.85 with sourceQuote → verified
+  it('A9-13: score=0.85 with sourceQuote → verified', () => {
+    expect(mapConfidenceToLevel(0.85, true)).toBe('verified');
+  });
+
+  // A9-14: -Infinity propagation into computeMatchConfidence
+  // If a field's score somehow becomes -Infinity, it routes to 'uncertain' → blocks send
+  it('A9-14: -Infinity score in computeMatchConfidence pipeline maps to "uncertain" (blast radius)', () => {
+    // We test mapConfidenceToLevel directly as the entry point
+    const level = mapConfidenceToLevel(-Infinity, false);
+    // If level === 'uncertain', any critical field with -Infinity blocks send
+    // This is the blast radius of the -Infinity gap
+    if (level === 'uncertain') {
+      console.warn('[A9-14 BLAST RADIUS] -Infinity critical field → blockSend=true, silently blocking all quotes');
+    }
+    // Expected safe behavior: -Infinity → 'missing' (not 'uncertain')
+    expect(level).toBe('missing');
+  });
+
+  // A9-15: empty criticalFields array (this is handled: returns level=missing per source)
+  it('A9-15: empty criticalFields [] → returns level=missing, blockSend=false', () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    const result = computeMatchConfidence(cargo, vessel, []);
+    expect(result.level).toBe('missing');
+    expect(result.blockSend).toBe(false);
+    expect(result.fieldConfidences).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **BUG-B1/B2/B3** (`lib/economics/ets.ts`): Replace `<= 0` guards with `!Number.isFinite(x) || x <= 0` for all numeric inputs (`distanceNm`, `euLegPercent`, `vlsfoBurnMt`, `euaPrice`) — NaN and Infinity previously bypassed the guard and propagated silently
- **BUG-B5/B6/B7** (`lib/economics/war-risk.ts`): Same `Number.isFinite` guard for `daysInHra` and `vesselValueUsd` — NaN inputs resulted in `premiumUsd: NaN`
- **BUG-B8** (`lib/economics/war-risk.ts`): Normalize hyphen→space in port names before regex match so "Tin-Can" correctly triggers Gulf of Guinea HRA (`\btin can\b` wouldn't match "tin-can")
- **BUG-B10** (`lib/confidence.ts`): Replace `score === Infinity` guard with `!Number.isFinite(score)` — `-Infinity` was falling through to `'uncertain'` (blocking Send Quote silently instead of treating as missing data)
- **BUG-C5** (`lib/economics/bunker.ts`): Strip nested HTML tags from price cells and normalize EU-locale comma-decimal ("450,50" → "450.50", "1.234,56" → "1234.56") before `parseFloat`

Adds regression test `test_economics_confidence_adv.test.ts` (ATTACK-5/6/9). Updates `test_confidence_gate_property.test.ts` to reflect correct post-fix behavior for `-Infinity`.

Closes BUG-B1/B2/B3, B5/B6/B7, B8, B10, C5 from Wave α QA iter 2 `.test-review/findings.md`.

## Test plan

- [x] `npx jest --config=jest.regression.config.mjs` — 124 passed, 0 failed
- [x] `npx jest --config=jest.config.mjs` — 1349 passed, 0 failed
- [x] ETS: NaN/Infinity in any field → `{amountEur: 0, applicable: false}`
- [x] War-risk: NaN/Infinity in daysInHra or vesselValueUsd → `{premiumUsd: 0, zones: []}`
- [x] War-risk: "Tin-Can" (hyphen port) matches Gulf of Guinea HRA same as "Tin Can"
- [x] Confidence: `-Infinity` → `'missing'` (not `'uncertain'`), blockSend stays false
- [x] Bunker: "450,50" parses to 450.50; nested `<span>` stripped before parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)