### PR TITLE
fix(api): sanitize brokerName in extension draft route (XSS/CRLF/length)

### DIFF
--- a/app/api/extension/draft/route.ts
+++ b/app/api/extension/draft/route.ts
@@ -8,6 +8,30 @@ interface DraftRequestBody {
   brokerName: string;
 }
 
+/** Maximum allowed length for brokerName (BUG-D4: length cap). */
+const BROKER_NAME_MAX_LEN = 256;
+
+/**
+ * Sanitize brokerName before inserting into draft template.
+ * - Truncates to BROKER_NAME_MAX_LEN chars (BUG-D4)
+ * - Strips CR (\r) and LF (\n) control characters (BUG-D3)
+ * - HTML-escapes <, >, &, ", ' to prevent XSS in downstream renderers (BUG-D2)
+ */
+function sanitizeBrokerName(name: string): string {
+  // D4: truncate first
+  let s = name.slice(0, BROKER_NAME_MAX_LEN);
+  // D3: strip CR and LF
+  s = s.replace(/[\r\n]/g, ' ');
+  // D2: HTML-escape special chars
+  s = s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+  return s;
+}
+
 export const maxDuration = 30;
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -30,7 +54,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const { parsedCargo, brokerName } = body;
 
-  const draftText = buildDraft(parsedCargo, brokerName);
+  const safeBrokerName = sanitizeBrokerName(brokerName);
+  const draftText = buildDraft(parsedCargo, safeBrokerName);
 
   return NextResponse.json({ draftText });
 }

--- a/tests/regression/test_api_contracts_adv.test.ts
+++ b/tests/regression/test_api_contracts_adv.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Adversarial QA — Agent D: API Contract Tests
+ *
+ * ATTACK-2  [CRITICAL]: Extension context route — auth enforcement
+ * ATTACK-8  [HIGH]:     Extension draft route — template injection
+ * ATTACK-13 [LOW]:      Webhook fire-and-forget — first-throw aborts loop
+ */
+
+import { createHmac } from 'node:crypto';
+import { NextRequest } from 'next/server';
+
+// ---------------------------------------------------------------------------
+// Shared mocks
+// ---------------------------------------------------------------------------
+
+// Mock session-store so we can inject sessions without a real SQLite DB
+jest.mock('@/lib/session-store', () => {
+  const sessions = new Map<string, object>();
+  return {
+    getStore: () => ({
+      getSession: (id: string) => sessions.get(id) ?? null,
+      createSession: (token: string) => {
+        const id = `sess-${token}`;
+        sessions.set(id, {
+          id,
+          accessToken: token,
+          createdAt: new Date(),
+          emails: [],
+          classifications: [],
+          processedEmails: [],
+          parsedCargos: [],
+          parsedVessels: [],
+          parsedFixtureRecaps: [],
+          matches: [],
+          recaps: [],
+          commissionSummary: null,
+          counterparties: [],
+        });
+        return id;
+      },
+      expireOldSessions: () => {},
+      getSessionCount: () => sessions.size,
+    }),
+    __sessions: sessions,
+  };
+});
+
+// Prevent real migrations from running
+jest.mock('@/lib/migrations/runner', () => ({ runMigrations: jest.fn() }));
+jest.mock('@/lib/migrations/index', () => ({ allMigrations: [] }));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a NextRequest so that request.cookies.get() works correctly.
+ * NextRequest extends Request and parses the Cookie header into a cookies map.
+ */
+function makeRequest(
+  url: string,
+  options: {
+    method?: string;
+    cookies?: Record<string, string>;
+    body?: string;
+    headers?: Record<string, string>;
+  } = {},
+): NextRequest {
+  const headers: Record<string, string> = { ...(options.headers ?? {}) };
+
+  if (options.cookies && Object.keys(options.cookies).length > 0) {
+    headers['cookie'] = Object.entries(options.cookies)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ');
+  }
+
+  return new NextRequest(url, {
+    method: options.method ?? 'GET',
+    headers,
+    body: options.body,
+  });
+}
+
+function makeSignature(body: string, secret: string): string {
+  const hex = createHmac('sha256', secret).update(body).digest('hex');
+  return `sha256=${hex}`;
+}
+
+// ---------------------------------------------------------------------------
+// ATTACK-2: Extension context route — auth enforcement
+// ---------------------------------------------------------------------------
+describe('ATTACK-2 — /api/extension/context auth enforcement', () => {
+   
+  const { GET } = require('@/app/api/extension/context/route') as {
+    GET: (req: Request) => Promise<Response>;
+  };
+
+  test('A2-1 [CRITICAL]: no session cookie → must return 401', async () => {
+    const req = makeRequest('http://localhost/api/extension/context');
+    const res = await GET(req);
+    // If this fails with 200 → BUG-D1 (no auth enforcement)
+    expect(res.status).toBe(401);
+  });
+
+  test('A2-2 [CRITICAL]: unknown session id → must return 401', async () => {
+    const req = makeRequest('http://localhost/api/extension/context', {
+      cookies: { session_id: 'nonexistent-session-id-xyz' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  test('A2-3 [PASS CASE]: valid session id → should return 200', async () => {
+    // Create a real session via the store mock
+     
+    const { getStore } = require('@/lib/session-store') as {
+      getStore: () => { createSession: (t: string) => string };
+    };
+    const sessionId = getStore().createSession('token-abc');
+
+    const req = makeRequest('http://localhost/api/extension/context', {
+      cookies: { session_id: sessionId },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { parsedCargo: unknown; topMatches: unknown[] };
+    expect(body).toHaveProperty('parsedCargo');
+    expect(body).toHaveProperty('topMatches');
+  });
+
+  test('A2-4: session cookie present but empty string → must return 401', async () => {
+    const req = makeRequest('http://localhost/api/extension/context', {
+      cookies: { session_id: '' },
+    });
+    const res = await GET(req);
+    // Empty string cookie value — requireSession should reject
+    expect([401, 403]).toContain(res.status);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATTACK-8: Extension draft route — template injection
+// ---------------------------------------------------------------------------
+describe('ATTACK-8 — /api/extension/draft template injection', () => {
+   
+  const { POST } = require('@/app/api/extension/draft/route') as {
+    POST: (req: Request) => Promise<Response>;
+  };
+
+   
+  const { getStore } = require('@/lib/session-store') as {
+    getStore: () => { createSession: (t: string) => string };
+  };
+  let sessionId: string;
+
+  beforeAll(() => {
+    sessionId = getStore().createSession('token-draft');
+  });
+
+  const baseCargo = {
+    emailId: 'e1',
+    originPort: 'Dubai',
+    destinationPort: 'Shanghai',
+    cargoDescription: 'Steel coils',
+    weightMt: 5000,
+    laycan: '2026-05-01/2026-05-07',
+  };
+
+  async function postDraft(
+    brokerName: unknown,
+    cargo: unknown = baseCargo,
+    vesselId = 'vessel-1',
+  ): Promise<{ res: Response; body: unknown }> {
+    const payload = JSON.stringify({ parsedCargo: cargo, vesselId, brokerName });
+    const req = makeRequest('http://localhost/api/extension/draft', {
+      method: 'POST',
+      cookies: { session_id: sessionId },
+      body: payload,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await POST(req);
+    let body: unknown;
+    try { body = await res.json(); } catch { body = null; }
+    return { res, body };
+  }
+
+  test('A8-1 [HIGH]: brokerName with XSS payload — must not appear unescaped (BUG-D2)', async () => {
+    const xss = '<script>alert(1)</script>';
+    const { res, body } = await postDraft(xss);
+    // Route must either reject (400) or escape the HTML before inserting into draftText
+    if (res.status === 200) {
+      const draftText = (body as { draftText: string }).draftText;
+      expect(typeof draftText).toBe('string');
+      // STRICT: raw <script> tag MUST NOT appear verbatim — BUG-D2
+      expect(draftText).not.toContain('<script>');
+      expect(draftText).not.toContain('</script>');
+      // Escaped form must be present instead
+      expect(draftText).toContain('&lt;script&gt;');
+    } else {
+      // 400 rejection is also acceptable
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test('A8-2 [HIGH]: CRLF injection via brokerName — must be stripped (BUG-D3)', async () => {
+    const crlf = 'Broker\r\nX-Custom-Header: injected';
+    const { res, body } = await postDraft(crlf);
+    if (res.status === 200) {
+      const draftText = (body as { draftText: string }).draftText;
+      // STRICT: CR/LF characters MUST NOT appear verbatim in the draft — BUG-D3
+      expect(draftText).not.toMatch(/\r/);
+      expect(draftText).not.toMatch(/\n.*X-Custom-Header/);
+      expect(typeof draftText).toBe('string');
+    } else {
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test('A8-3 [HIGH]: SQL-injection-style cargo description — must not crash', async () => {
+    const sqlCargo = {
+      ...baseCargo,
+      cargoDescription: "'; DROP TABLE matches;--",
+    };
+    const { res } = await postDraft('ValidBroker', sqlCargo);
+    // Route builds a text template; no DB involved. Should return 200 safely.
+    expect([200, 400]).toContain(res.status);
+    expect(res.status).not.toBe(500);
+  });
+
+  test('A8-4 [MED]: extremely long brokerName (10,000 chars) — must be truncated or rejected (BUG-D4)', async () => {
+    const longName = 'A'.repeat(10_000);
+    const { res, body } = await postDraft(longName);
+    // STRICT: route MUST either reject (400) or truncate brokerName to ≤256 chars — BUG-D4
+    if (res.status === 200) {
+      const draftText = (body as { draftText: string }).draftText;
+      // The broker name portion in "Dear <name>," must not exceed 256 chars
+      const match = draftText.match(/^Dear (.+),/);
+      expect(match).not.toBeNull();
+      if (match) {
+        expect(match[1].length).toBeLessThanOrEqual(256);
+      }
+    } else {
+      // 400 reject is also acceptable
+      expect(res.status).toBe(400);
+    }
+    expect(res.status).not.toBe(500);
+  });
+
+  test('A8-5 [HIGH]: brokerName = undefined → must not output "undefined" as text', async () => {
+    // isValidDraftBody checks typeof brokerName === 'string' && length > 0
+    // So undefined should return 400 — but verify the actual behaviour
+    const payload = JSON.stringify({ parsedCargo: baseCargo, vesselId: 'vessel-1', brokerName: undefined });
+    const req = makeRequest('http://localhost/api/extension/draft', {
+      method: 'POST',
+      cookies: { session_id: sessionId },
+      body: payload,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await POST(req);
+    if (res.status === 200) {
+      const body = await res.json() as { draftText: string };
+      // If the draft says "Dear undefined," → BUG-D5
+      expect(body.draftText).not.toContain('Dear undefined');
+    } else {
+      // 400 is the correct response
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test('A8-6: brokerName = empty string → must return 400', async () => {
+    const { res } = await postDraft('');
+    // isValidDraftBody: brokerName.length > 0 required
+    expect(res.status).toBe(400);
+  });
+
+  test('A8-7: missing parsedCargo → must return 400', async () => {
+    const payload = JSON.stringify({ vesselId: 'v1', brokerName: 'Broker' });
+    const req = makeRequest('http://localhost/api/extension/draft', {
+      method: 'POST',
+      cookies: { session_id: sessionId },
+      body: payload,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  test('A8-8: no session cookie → must return 401 before processing body', async () => {
+    const payload = JSON.stringify({ parsedCargo: baseCargo, vesselId: 'v1', brokerName: 'Broker' });
+    const req = makeRequest('http://localhost/api/extension/draft', {
+      method: 'POST',
+      body: payload,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATTACK-13: WhatsApp webhook — fire-and-forget loop error isolation
+// ---------------------------------------------------------------------------
+describe('ATTACK-13 — /api/whatsapp/webhook fire-and-forget loop', () => {
+  const WEBHOOK_SECRET = 'test-secret-13';
+
+  // Mock environment
+  beforeAll(() => {
+    process.env['WHATSAPP_APP_SECRET'] = WEBHOOK_SECRET;
+    process.env['WHATSAPP_VERIFY_TOKEN'] = 'verify-token-13';
+  });
+
+  afterAll(() => {
+    delete process.env['WHATSAPP_APP_SECRET'];
+    delete process.env['WHATSAPP_VERIFY_TOKEN'];
+  });
+
+  // Mock the WhatsApp client factory so we don't need real credentials
+  jest.mock('@/lib/whatsapp/client', () => ({
+    getWhatsAppClient: jest.fn(() => ({
+      markAsRead: jest.fn().mockResolvedValue(undefined),
+      sendText: jest.fn().mockResolvedValue(undefined),
+      sendInteractive: jest.fn().mockResolvedValue(undefined),
+    })),
+  }));
+
+  // Mock routeIncomingMessage so we can control throws
+  jest.mock('@/lib/whatsapp/router', () => ({
+    routeIncomingMessage: jest.fn(),
+  }));
+
+  function buildPayload(messages: Array<{ id: string; type: string; from: string; text?: { body: string } }>) {
+    return {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: 'entry-1',
+          changes: [
+            {
+              value: { messages },
+              field: 'messages',
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  function buildRequest(payloadObj: unknown): Request {
+    const body = JSON.stringify(payloadObj);
+    const sig = makeSignature(body, WEBHOOK_SECRET);
+    return makeRequest('http://localhost/api/whatsapp/webhook', {
+      method: 'POST',
+      body,
+      headers: {
+        'content-type': 'application/json',
+        'x-hub-signature-256': sig,
+      },
+    });
+  }
+
+  test('A13-1: always returns HTTP 200 immediately (fire-and-forget contract)', async () => {
+     
+    const { POST } = require('@/app/api/whatsapp/webhook/route') as {
+      POST: (req: Request) => Promise<Response>;
+    };
+     
+    const { routeIncomingMessage } = require('@/lib/whatsapp/router') as {
+      routeIncomingMessage: jest.Mock;
+    };
+
+    routeIncomingMessage.mockResolvedValue(undefined);
+
+    const payload = buildPayload([
+      { id: 'msg-1', type: 'text', from: '1234567890', text: { body: 'hello' } },
+    ]);
+    const req = buildRequest(payload);
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+  });
+
+  test('A13-2 [LOW]: first message throws — subsequent messages MUST still be processed', async () => {
+     
+    const { POST } = require('@/app/api/whatsapp/webhook/route') as {
+      POST: (req: Request) => Promise<Response>;
+    };
+     
+    const { routeIncomingMessage } = require('@/lib/whatsapp/router') as {
+      routeIncomingMessage: jest.Mock;
+    };
+
+    let callCount = 0;
+    routeIncomingMessage.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('First message exploded');
+      // Second call succeeds
+    });
+
+    const payload = buildPayload([
+      { id: 'msg-1', type: 'text', from: '111', text: { body: 'first' } },
+      { id: 'msg-2', type: 'text', from: '222', text: { body: 'second' } },
+    ]);
+    const req = buildRequest(payload);
+    const res = await POST(req);
+
+    // Response must be 200 regardless
+    expect(res.status).toBe(200);
+
+    // Give the fire-and-forget async IIFE time to run
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // FINDING: If callCount === 1 → the loop aborts on first throw → BUG-D6
+    // The outer try/catch in the IIFE wraps the ENTIRE loop, so first throw
+    // causes the catch to fire and the second message is NEVER processed.
+    if (callCount < 2) {
+      console.warn(
+        '[ATTACK-13] BUG-D6: first message throw aborts the loop — ' +
+        `routeIncomingMessage called ${callCount} time(s) instead of 2. ` +
+        'Second message was dropped.'
+      );
+    }
+    // Document the actual count — test is informational (low severity)
+    // We do NOT assert callCount === 2 here because the current implementation
+    // has a single try/catch wrapping the full loop (known architectural tradeoff).
+    // The test VERIFIES the HTTP response contract (200) and DOCUMENTS the drop.
+    expect(callCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test('A13-3 [LOW]: router throws on unknown type — HTTP 200 still returned', async () => {
+     
+    const { POST } = require('@/app/api/whatsapp/webhook/route') as {
+      POST: (req: Request) => Promise<Response>;
+    };
+     
+    const { routeIncomingMessage } = require('@/lib/whatsapp/router') as {
+      routeIncomingMessage: jest.Mock;
+    };
+
+    routeIncomingMessage.mockRejectedValue(new Error('Unknown message type: sticker'));
+
+    const payload = buildPayload([
+      { id: 'msg-sticker', type: 'sticker', from: '999' },
+    ]);
+    const req = buildRequest(payload);
+    const res = await POST(req);
+
+    // Meta requires 200 even when internal processing fails
+    expect(res.status).toBe(200);
+  });
+
+  test('A13-4: invalid JSON body → returns 200 (webhook always ACKs to Meta)', async () => {
+     
+    const { POST } = require('@/app/api/whatsapp/webhook/route') as {
+      POST: (req: Request) => Promise<Response>;
+    };
+
+    const badBody = 'not-json-at-all';
+    const sig = makeSignature(badBody, WEBHOOK_SECRET);
+    const req = makeRequest('http://localhost/api/whatsapp/webhook', {
+      method: 'POST',
+      body: badBody,
+      headers: {
+        'content-type': 'application/json',
+        'x-hub-signature-256': sig,
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  test('A13-5: invalid signature → returns 401', async () => {
+     
+    const { POST } = require('@/app/api/whatsapp/webhook/route') as {
+      POST: (req: Request) => Promise<Response>;
+    };
+
+    const body = JSON.stringify(buildPayload([]));
+    const req = makeRequest('http://localhost/api/whatsapp/webhook', {
+      method: 'POST',
+      body,
+      headers: {
+        'content-type': 'application/json',
+        'x-hub-signature-256': 'sha256=deabeef000000000000000000000000000000000000000000000000000000000',
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Closes BUG-D2, BUG-D3, BUG-D4 from `.test-review/findings.md`.

- **BUG-D2 [HIGH]**: `<script>` and other HTML in `brokerName` appeared unescaped in draftText. Fixed by HTML-escaping `<`, `>`, `&`, `"`, `'`.
- **BUG-D3 [HIGH]**: CR/LF chars in `brokerName` allowed header/body injection. Fixed by replacing `\r` and `\n` with space.
- **BUG-D4 [MED]**: No length cap on `brokerName`. Fixed by **truncating** to 256 chars (silent truncation, no 400 reject — keeps API backward-compatible for callers that already send long names).

All three fixes are applied in a single `sanitizeBrokerName()` helper in `app/api/extension/draft/route.ts`. Applied to `brokerName` before template interpolation in `buildDraft()`.

## Approach for D4

**Truncate** (not reject). Rationale: a 256-char limit is generous for broker names, truncation is silent and UX-friendly, and the route is a draft generator — a slight name truncation is preferable to a hard error. If a strict reject is preferred in future, change `slice(0, BROKER_NAME_MAX_LEN)` to a 400 response in `POST`.

## Test plan

- `tests/regression/test_api_contracts_adv.test.ts` — `test_api_contracts_adv.test.ts` added with strict assertions for A8-1/A8-2/A8-4 (previously warn-only)
- RED→GREEN confirmed: 3 tests failed before fix, 17/17 pass after
- Full regression suite: **101 passed, 0 failed** across 6 test suites

## Files changed

- `app/api/extension/draft/route.ts` — added `sanitizeBrokerName()` helper + apply before interpolation
- `tests/regression/test_api_contracts_adv.test.ts` — strict assertions for BUG-D2/D3/D4

🤖 Generated with [Claude Code](https://claude.com/claude-code)