### PR TITLE
ci: cost control and concurrency optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".claude/**"
+      - ".specs/**"
+      - "README*"
+      - "*.svg"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".claude/**"
+      - ".specs/**"
+      - "README*"
+      - "*.svg"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,19 +28,15 @@ jobs:
   typecheck:
     name: TypeCheck
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: "22"
+          cache: "npm"
       - run: npm ci
       - run: npm run lint
       - run: npx tsc --noEmit
@@ -34,19 +44,15 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: "22"
+          cache: "npm"
       - run: npm ci
       - run: npm test -- --coverage --coverageProvider=v8 --forceExit
       - uses: actions/upload-artifact@v4
@@ -54,11 +60,13 @@ jobs:
         with:
           name: coverage
           path: coverage/
-          retention-days: 14
+          retention-days: 7
 
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'push'
     permissions:
       contents: read
     continue-on-error: true
@@ -66,13 +74,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: "22"
+          cache: "npm"
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
@@ -86,25 +89,30 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: "22"
+          cache: "npm"
       - uses: actions/cache@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+            ${{ runner.os }}-nextjs-
       - run: npm ci
       - run: npm run build
 
   audit:
     name: Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'push'
     permissions:
       contents: read
     continue-on-error: true
@@ -112,12 +120,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: "22"
+          cache: "npm"
       - run: npm ci
       - run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

- **paths-ignore** on both `push`/`pull_request` triggers — skip full CI for `**.md`, `docs/**`, `.claude/**`, `.specs/**`, `README*`, `*.svg` changes
- **npm cache fix** — replace manual `actions/cache path: ~/.npm` with `setup-node cache: 'npm'` in all 5 jobs (more reliable, one less step)
- **`.next/cache`** in `build` job — avoid full Next.js rebuild when source unchanged
- **timeout-minutes** on all jobs (10/15/20/10/5) — prevent runaway jobs from draining budget
- **E2E off PRs** (`if: github.event_name == 'push'`) — skip `playwright install --with-deps chromium` (~200MB) on every PR
- **Audit off PRs** (`if: github.event_name == 'push'`) — npm audit result doesn't depend on PR code
- **coverage retention**: 14d → 7d

## Cost impact

| Change | Saving/mo |
|--------|-----------|
| E2E off PRs (~254s × 20 PRs) | ~$0.68 |
| Audit off PRs (~37s × 20 PRs) | ~$0.10 |
| .next/cache (30-60s/build) | ~$0.08 |
| paths-ignore (doc-only runs) | ~$0.10–0.20 |
| **Total** | **~$0.96–1.06** |

Baseline: $4.01/mo → target: ~$2.95–3.05/mo (~25% reduction)

## What stays the same

- `concurrency: cancel-in-progress: true` — already present, not touched
- Branch protection rules — `enforce_admins: false` already gives admin bypass, no ruleset migration needed
- No matrix changes, no self-hosted runners
- E2E still runs on every merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)