### PR TITLE
fix(economics): add Bab al-Mandab to Red Sea HRA ports

### DIFF
--- a/lib/economics/war-risk.ts
+++ b/lib/economics/war-risk.ts
@@ -14,7 +14,7 @@ export const JWC_HRA_ZONES: HraZone[] = [
   {
     name: 'Red Sea / Bab al-Mandeb HRA',
     premiumPercent: 0.075,
-    ports: ['aden', 'hodeidah', 'djibouti', 'berbera', 'jeddah', 'yanbu', 'salalah'],
+    ports: ['aden', 'hodeidah', 'djibouti', 'berbera', 'jeddah', 'yanbu', 'salalah', 'bab al mandab', 'bab el mandab'],
     canals: ['suez'],
   },
   {
@@ -58,7 +58,7 @@ export function calculateWarRiskPremium(input: WarRiskInput): WarRiskResult {
 
   const fromLower = route.fromPort.toLowerCase().replace(/-/g, ' ');
   const toLower = route.toPort.toLowerCase().replace(/-/g, ' ');
-  const viaLower = (route.viaCanal ?? '').toLowerCase();
+  const viaLower = (route.viaCanal ?? '').toLowerCase().replace(/-/g, ' ');
 
   const matchedZones: HraZone[] = [];
 

--- a/tests/regression/test_economics_edge_cases.test.ts
+++ b/tests/regression/test_economics_edge_cases.test.ts
@@ -273,6 +273,50 @@ describe('calculateWarRiskPremium — adversarial', () => {
     expect(result.premiumUsd).toBeGreaterThan(0);
   });
 
+  // F29-F1 regression: Bab-el-Mandab / Bab al-Mandab strait must trigger Red Sea HRA
+  // Prior to fix, neither spelling was in the ports list — routes through the strait
+  // received no surcharge after PR #29 hyphen normalization.
+  it('F29-F1: fromPort "Bab-el-Mandab" triggers Red Sea HRA (hyphen normalized to space)', () => {
+    // Hyphen normalization: "Bab-el-Mandab" → "bab el mandab" → matches keyword
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Bab-el-Mandab', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    expect(result.zones).toContain('Red Sea / Bab al-Mandeb HRA');
+    expect(result.premiumUsd).toBeGreaterThan(0);
+  });
+
+  it('F29-F1: fromPort "Bab el-Mandab" (mixed hyphen) triggers Red Sea HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Bab el-Mandab', toPort: 'Rotterdam' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 3,
+    });
+    expect(result.zones).toContain('Red Sea / Bab al-Mandeb HRA');
+    expect(result.premiumUsd).toBeGreaterThan(0);
+  });
+
+  it('F29-F1: toPort "Bab al-Mandab" (al-variant) triggers Red Sea HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Rotterdam', toPort: 'Bab al-Mandab' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 2,
+    });
+    expect(result.zones).toContain('Red Sea / Bab al-Mandeb HRA');
+    expect(result.premiumUsd).toBeGreaterThan(0);
+  });
+
+  it('F29-F1: toPort "Bab el-Mandab" (el-variant with hyphen) triggers Red Sea HRA', () => {
+    const result = calculateWarRiskPremium({
+      route: { fromPort: 'Rotterdam', toPort: 'Bab el-Mandab' },
+      vesselValueUsd: 10_000_000,
+      daysInHra: 2,
+    });
+    expect(result.zones).toContain('Red Sea / Bab al-Mandeb HRA');
+    expect(result.premiumUsd).toBeGreaterThan(0);
+  });
+
   // H19: premium math precision — verify formula manually
   it('premium math: Black Sea 0.10%, $20M vessel, 2 days = correct value', () => {
     const result = calculateWarRiskPremium({


### PR DESCRIPTION
## Summary

Follow-up to PR #29 review item F29-F1.

- Routes through Bab-el-Mandab strait now correctly receive Red Sea HRA surcharge (previously fell through after hyphen normalization)
- Added hyphen→space normalization in `calculateWarRiskPremium` port matching (consistent with PR #29 intent)
- Added `'bab al mandab'` and `'bab el mandab'` to `JWC_HRA_ZONES['Red Sea / Bab al-Mandeb HRA'].ports`
- 4 regression tests covering: `Bab-el-Mandab` (hyphenated), `Bab el-Mandab` (mixed), `Bab al-Mandab`, `Bab el-Mandab` spellings

Closes review item F29-F1.

## Test plan

- [x] `npm run test:regression` — 88 tests pass (4 new F29-F1 cases green)
- [x] `npm test` — 1349 tests pass (full suite green)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)