### PR TITLE
fix(whatsapp): guard audio/document payloads + reconcile TANKER cargoType

### DIFF
--- a/lib/whatsapp/__tests__/forward-parser.test.ts
+++ b/lib/whatsapp/__tests__/forward-parser.test.ts
@@ -152,4 +152,57 @@ describe('parseForwardedMessage', () => {
     expect(result.rawText).toBe('');
     expect(result.confidence).toBe('uncertain');
   });
+
+  // F33-F1: audio payload null-guard
+  it('F33-F1: type=audio but audio field missing → returns uncertain stub, no crash', async () => {
+    const msg = makeMessage({ type: 'audio' }); // audio field absent
+
+    const result = await parseForwardedMessage(msg, client as never);
+
+    expect(result.confidence).toBe('uncertain');
+    expect(result.missingFields).toContain('audio payload missing');
+    expect(result.rawText).toBe('');
+    // Must NOT call transcribeAudio or callAiJson
+    expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    expect(mockCallAiJson).not.toHaveBeenCalled();
+  });
+
+  // F33-F1: document payload null-guard
+  it('F33-F1: type=document but document field missing → returns uncertain stub, no crash', async () => {
+    const msg = makeMessage({ type: 'document' }); // document field absent
+
+    const result = await parseForwardedMessage(msg, client as never);
+
+    expect(result.confidence).toBe('uncertain');
+    expect(result.missingFields).toContain('document payload missing');
+    expect(result.rawText).toBe('');
+    // Must NOT call extractTextFromPdf or callAiJson
+    expect(mockExtractTextFromPdf).not.toHaveBeenCalled();
+    expect(mockCallAiJson).not.toHaveBeenCalled();
+  });
+
+  // F33-F2: TANKER keyword → should fall back to BULK (no TANKER in CargoType enum)
+  it('F33-F2: "Crude oil tanker, 100kt" text → cargoType falls back to BULK, no TANKER in output', async () => {
+    mockCallAiJson.mockResolvedValue({
+      cargo_description: { value: 'Crude oil', confidence: 'confirmed' },
+      origin_port: { value: 'Ras Tanura', confidence: 'confirmed' },
+      destination_port: { value: 'Rotterdam', confidence: 'confirmed' },
+      weight_mt: { value: 100000, confidence: 'confirmed' },
+      missing_info: [],
+    });
+
+    const msg = makeMessage({
+      type: 'text',
+      text: { body: 'Crude oil tanker, 100kt from Ras Tanura to Rotterdam' },
+    });
+
+    const result = await parseForwardedMessage(msg, client as never);
+
+    expect(result.parsedCargo).toBeDefined();
+    // TANKER is a vessel type, not a cargo type — must fall back to BULK
+    expect(result.parsedCargo?.cargoType).toBe('BULK');
+    // Ensure no TANKER string appears in the serialized output
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('"TANKER"');
+  });
 });

--- a/lib/whatsapp/forward-parser.ts
+++ b/lib/whatsapp/forward-parser.ts
@@ -42,7 +42,6 @@ const CARGO_TYPE_KEYWORDS: Array<[string, string]> = [
   ['RORO', 'RORO|ROLL.?ON.?ROLL.?OFF'],
   ['FCL', '\\bFCL\\b|FULL.?CONTAINER'],
   ['LCL', '\\bLCL\\b|LESS.?THAN.?CONTAINER'],
-  ['TANKER', 'TANKER'],
   ['PROJECT', 'PROJECT.?CARGO'],
   ['AIR', '\\bAIR.?FREIGHT\\b'],
   ['BULK', '\\bBULK\\b'],
@@ -108,14 +107,30 @@ export async function parseForwardedMessage(
     }
 
     case 'audio': {
-      const media = await client.downloadMedia(msg.audio!.id);
+      // F33-F1: guard against malformed payload where audio field is absent
+      if (!msg.audio) {
+        return {
+          confidence: 'uncertain',
+          missingFields: ['audio payload missing'],
+          rawText: '',
+        };
+      }
+      const media = await client.downloadMedia(msg.audio.id);
       const transcription = await transcribeAudio(media.url, media.mimeType);
       rawText = transcription.text;
       break;
     }
 
     case 'document': {
-      const media = await client.downloadMedia(msg.document!.id);
+      // F33-F1: guard against malformed payload where document field is absent
+      if (!msg.document) {
+        return {
+          confidence: 'uncertain',
+          missingFields: ['document payload missing'],
+          rawText: '',
+        };
+      }
+      const media = await client.downloadMedia(msg.document.id);
       rawText = await extractTextFromPdf(media.url);
       break;
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #33 review. Closes two review findings:

- **F33-F1 [MEDIUM]**: Extends the `image` null-guard pattern from PR #33 to the `audio` and `document` switch cases. Both previously used `msg.audio!.id` / `msg.document!.id` non-null assertions that crash on malformed WhatsApp payloads. Each now returns an `{ confidence: 'uncertain', missingFields: ['audio payload missing'] }` stub — consistent with how the image case was fixed.

- **F33-F2 [LOW]**: Removed `TANKER` from `CARGO_TYPE_KEYWORDS`. Decision: **remove, not add to enum**. Rationale: TANKER is a vessel type, not a cargo type. Liquid bulk cargo (crude oil, fuel oil) correctly maps to `BULK`. Adding `TANKER` to `CargoType` would require updating the `COMPATIBILITY` matrix (`match-filters.ts`) and `CARGO_NEEDS_EXPLANATION` map — semantically wrong and out of scope. Input "Crude oil tanker, 100kt" → `cargoType: 'BULK'` (correct).

Also carries forward BUG-C1/C2/C3 fixes that were introduced in PR #33 (AI-driven cargoType, image null-guard, callAiJson null/throw handling), since this branch is based on `main` (pre-merge).

## Test plan

- [x] `type=audio` with missing `msg.audio` field → no crash, returns `{ confidence: 'uncertain', missingFields: ['audio payload missing'] }`
- [x] `type=document` with missing `msg.document` field → no crash, returns `{ confidence: 'uncertain', missingFields: ['document payload missing'] }`
- [x] "Crude oil tanker, 100kt" text → `cargoType: 'BULK'`, no `"TANKER"` string in output
- [x] `npm test --no-coverage` → 1352/1352 green (baseline was 1349; +3 new tests)
- [x] Regression suite (`tests/regression/**`) → 84/84 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)