### PR TITLE
fix(config): add better-sqlite3 to serverExternalPackages — fix 500 crash-loop

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverExternalPackages: ['better-sqlite3'],
   async rewrites() {
     return [{ source: '/api/v1/:path*', destination: '/api/:path*' }];
   },


### PR DESCRIPTION
## Root Cause

Next.js 16 + Turbopack copies native modules into \`.next/node_modules/\` with a content-hash suffix (\`better-sqlite3-90e2652d1716b047\`). The turbopack SSR runtime resolves external modules from the **project root** (\`/root/quantika-demo/\`), not from \`.next/server/chunks/ssr/\` where the module IS findable.

Result: \`require('better-sqlite3-<hash>')\` → \`Cannot find module\` → crash when \`_global-error/page.js\` renders → pm2 crash-loop (124 restarts observed).

**Evidence:**
- \`pm2 show quantika-demo\` → 124 restarts, uptime ~37s
- From project root: \`node -e "require('better-sqlite3-<hash>')"\` → NOT FOUND
- From \`.next/server/chunks/ssr/\`: same require → OK

## Fix

One line in \`next.config.mjs\`:
\`\`\`js
serverExternalPackages: ['better-sqlite3']
\`\`\`
Tells Turbopack to skip bundling and emit \`require('better-sqlite3')\` — resolves correctly from \`node_modules/better-sqlite3\`.

## Verification after deploy

\`\`\`bash
curl -sI https://demo.quantika.org/           # expect 200
curl -sI https://demo.quantika.org/onboarding  # expect 200
curl -s https://demo.quantika.org/api/health | jq '.uptime'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)