### PR TITLE
fix(hydration): pin formatDate to UTC + use it on all detail pages

### DIFF
--- a/app/cargo/[id]/page.tsx
+++ b/app/cargo/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { sanitizeEmailBody } from '@/lib/utils';
+import { sanitizeEmailBody, formatDate } from '@/lib/utils';
 import { cookies } from 'next/headers';
 import { redirect, notFound } from 'next/navigation';
 import Link from 'next/link';
@@ -60,14 +60,14 @@ export default async function CargoDetailPage({ params }: Props) {
             </div>
             <h1 className="text-lg sm:text-xl font-bold mt-2">{safeRender(email.subject)}</h1>
             <p className="text-sm text-muted-foreground">
-              From: {safeRender(email.from)} · {new Date(email.date).toLocaleDateString()}
+              From: {safeRender(email.from)} · {formatDate(email.date)}
             </p>
             {processed && (
               <p className="text-xs text-muted-foreground mt-1">
                 {processed.freshness === 'stale'
                   ? '⚠️ STALE — laycan/dates expired'
                   : processed.expiryDate
-                    ? `Active until ${new Date(processed.expiryDate).toLocaleDateString()}`
+                    ? `Active until ${formatDate(processed.expiryDate)}`
                     : 'Active'}
               </p>
             )}

--- a/app/email/[id]/page.tsx
+++ b/app/email/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getSession } from '@/lib/session';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { EmailBodyViewer, type Highlight } from '@/components/email-body-viewer';
 import type { ConfidenceField } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
 
 const FIELD_COLORS: Record<string, string> = {
   originPort:         'bg-blue-200',
@@ -93,7 +94,7 @@ export default async function EmailDetailPage({ params }: Props) {
         <div>
           <h1 className="text-lg font-bold">{email.subject}</h1>
           <p className="text-sm text-muted-foreground">
-            From: {email.from} · {new Date(email.date).toLocaleDateString()}
+            From: {email.from} · {formatDate(email.date)}
           </p>
         </div>
         {legendItems.length > 0 && (

--- a/app/fixture/[id]/page.tsx
+++ b/app/fixture/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Renderable } from '@/lib/types';
 import { CopyButton } from '@/components/copy-button';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { safeRender, getConf, ConfIcon } from '@/lib/ui-render';
+import { formatDate } from '@/lib/utils';
 
 function CField({ label, field }: { label: string; field: Renderable }) {
   const val = safeRender(field);
@@ -67,7 +68,7 @@ export default async function FixtureDetailPage({ params }: Props) {
         <div>
           <Badge variant="secondary" className="bg-purple-100 text-purple-800">FIXTURE RECAP</Badge>
           <h1 className="text-lg sm:text-xl font-bold mt-2">{email.subject}</h1>
-          <p className="text-sm text-muted-foreground">From: {email.from} · {new Date(email.date).toLocaleDateString()}</p>
+          <p className="text-sm text-muted-foreground">From: {email.from} · {formatDate(email.date)}</p>
         </div>
 
         <Card>

--- a/app/vessel/[id]/page.tsx
+++ b/app/vessel/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Renderable } from '@/lib/types';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { ClickableField } from '@/components/clickable-field';
 import { safeRender, getConf, ConfIcon } from '@/lib/ui-render';
+import { formatDate } from '@/lib/utils';
 
 function Spec({ label, value, unit, confidence }: { label: string; value: Renderable; unit?: string; confidence?: string }) {
   const rendered = safeRender(value);
@@ -68,7 +69,7 @@ export default async function VesselDetailPage({ params }: Props) {
             )}
           </div>
           <h1 className="text-lg sm:text-xl font-bold mt-2">{email.subject}</h1>
-          <p className="text-sm text-muted-foreground">From: {email.from} · {new Date(email.date).toLocaleDateString()}</p>
+          <p className="text-sm text-muted-foreground">From: {email.from} · {formatDate(email.date)}</p>
           {processed?.expiryDate && <p className="text-xs text-muted-foreground">Active until {processed.expiryDate}</p>}
         </div>
 

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test for the React #418 hydration mismatch on /cargo/[id], /vessel/[id],
+ * /fixture/[id], /email/[id] (2026-04-29).
+ *
+ * Without an explicit timeZone, `toLocaleDateString` formats relative to the
+ * runtime's local zone — server (UTC on the VPS) and client (user-local)
+ * disagree for any user east/west of UTC, causing React to flag a hydration
+ * warning every time a date is rendered in a server component.
+ *
+ * Pin formatDate to UTC so SSR and CSR always emit the same string.
+ */
+import { formatDate } from '@/lib/utils';
+
+describe('formatDate — timezone determinism', () => {
+  it('formats an ISO date identically regardless of process timezone', () => {
+    // 2026-10-10T00:00:00 UTC. In en-US/UTC this is "Oct 10, 2026".
+    // In Asia/Tokyo (UTC+9) the same instant is Oct 10 09:00 — same date.
+    // In America/Los_Angeles (UTC-8) the same instant is Oct 9 16:00 — different
+    // date if we don't pin timeZone.
+    const iso = '2026-10-10T00:00:00.000Z';
+
+    const original = process.env.TZ;
+    try {
+      process.env.TZ = 'UTC';
+      const utc = formatDate(iso);
+
+      process.env.TZ = 'Asia/Tokyo';
+      const tokyo = formatDate(iso);
+
+      process.env.TZ = 'America/Los_Angeles';
+      const la = formatDate(iso);
+
+      // All three must match — that's the hydration contract.
+      expect(utc).toBe(tokyo);
+      expect(utc).toBe(la);
+
+      // Sanity: it produces a recognizable Oct 10 2026 string.
+      expect(utc).toMatch(/Oct\s+10,?\s+2026/);
+    } finally {
+      process.env.TZ = original;
+    }
+  });
+
+  it('returns the input string when given an unparseable date', () => {
+    expect(formatDate('not-a-date')).toMatch(/Invalid|not-a-date/);
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,10 +12,15 @@ export function truncateText(text: string, maxChars: number): string {
 
 export function formatDate(dateStr: string): string {
   try {
+    // Pin timeZone to UTC so server (UTC) and client (user-local) render the
+    // same string. Without this, dates rendered in server components and
+    // hydrated on the client differ by one day for users east/west of UTC,
+    // triggering React #418 hydration warnings.
     return new Date(dateStr).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
+      timeZone: 'UTC',
     });
   } catch {
     return dateStr;


### PR DESCRIPTION
## Summary
- Server components on `/cargo/[id]`, `/vessel/[id]`, `/fixture/[id]`, `/email/[id]` rendered dates with `new Date(x).toLocaleDateString()` (no timeZone) — server (UTC) ≠ browser (user-local) → React #418 hydration warnings every ~45s on production.
- Fix: pin `lib/utils.ts:formatDate()` to `timeZone: 'UTC'` and route all four detail pages through it.
- Companion to PR #39 (which fixed MorningHeader on `/dashboard` via suppressHydrationWarning).

## Test plan
- [x] Unit: `lib/__tests__/utils.test.ts` — formatDate produces identical output under TZ=UTC, Asia/Tokyo, America/Los_Angeles.
- [x] tsc --noEmit clean; 450 tests in `lib/__tests__/` green.
- [ ] After deploy: open `/`, `/cargo/<id>`, `/vessel/<id>` in browser → DevTools Console shows 0 React #418.

Generated with Claude Code