### PR TITLE
fix(scoring): account for DWCC overload + correct Constanta-Piraeus distance

### DIFF
--- a/lib/sailing/match-scoring.ts
+++ b/lib/sailing/match-scoring.ts
@@ -360,10 +360,16 @@ export function computeScoreBreakdown(input: ScoreBreakdownInput): ScoreBreakdow
   let dwtRaw = 0;
   let dwtReason: string | undefined;
   const dwt = cfValue(vessel.dwtSummer);
+  const dwcc = cfValue(vessel.dwcc);
   // Use max bound for fit check, min bound for utilization — Range-aware logic
   const weightMax = cargo.weightMtMax ?? weight;
   const weightMin = cargo.weightMtMin ?? weight;
-  if (weightMax && dwt && dwt > 0) {
+  if (weightMax && dwcc && dwcc > 0 && weightMax > dwcc) {
+    // Cargo exceeds DWCC (deadweight cargo capacity at the vessel's max draft) —
+    // physically un-loadable without bunker/stores reduction. Treat as overload.
+    dwtRaw = 2;
+    dwtReason = `cargo ${weightMax}mt exceeds vessel DWCC ${dwcc}mt — overload at design draft`;
+  } else if (weightMax && dwt && dwt > 0) {
     const fitRatio = weightMax / dwt;
     if (fitRatio > 1.0) {
       dwtRaw = 2;

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -350,7 +350,7 @@ const DISTANCES_NM: Record<string, number> = {
   'Aliaga|Odesa': 645,
   'Alexandria|Odesa': 1240,
 
-  'Constanta|Piraeus': 630,
+  'Constanta|Piraeus': 790,
   'Aliaga|Constanta': 475,
   'Alexandria|Constanta': 1070,
   'Constanta|Ravenna': 1250,
@@ -1021,9 +1021,9 @@ export function getPortDistance(
   // Haversine fallback — needs lat/lon from port-master. Lazy import to avoid
   // a circular dependency between port-master.ts (which imports normalizePortName
   // from us) and this file.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+   
   const { getPortMaster } = require('./port-master') as typeof import('./port-master');
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+   
   const { haversineDistanceNm } = require('./haversine') as typeof import('./haversine');
 
   const pa = getPortMaster(a);


### PR DESCRIPTION
## Контекст (на человеческом)

Прогнал end-to-end pipeline на 6 тщательно подобранных sample-письмах (по 1 на тип) под управлением Sonnet sub-agent + независимый reviewer-«брокер 20Y скептик» с пустым контекстом каждый раунд. Цикл шёл до 2 PASS подряд (R5 + R6). Reviewer выловил 2 реальных бага в production-коде, не покрытых существующими тестами.

## Summary

- **Bug 1 (lib/sailing/match-scoring.ts):** `computeScoreBreakdown` оценивал DWT class fit только по `vessel.dwtSummer`, игнорируя `vessel.dwcc` (deadweight cargo capacity). Для пары cargo 8500 mt × vessel dwtSummer=8500 / dwcc=8050 fit-ratio = 1.0 → 10/10 «well-matched», хотя физически груз перегружает судно на +450 mt при design draft. Теперь: если `weightMax > dwcc`, dwtRaw=2/10 с reason `"cargo Xmt exceeds vessel DWCC Ymt — overload at design draft"` (та же штрафная ветка, что и для DWT exceed).
- **Bug 2 (lib/sailing/port-distances.ts):** Запись `Constanta|Piraeus: 630` была занижена на ~25%. Реальная морская дистанция Piraeus → Aegean → Dardanelles → Marmara → Bosphorus → Constanta ~770-800 nm; новое значение 790 nm также консистентно с соседним `Chornomorsk|Piraeus: 790` (Чорноморск ~50 nm от Констанцы) в той же матрице. Раньше 630 nm флипало readiness verdict с `tight` на ложно `ideal` для пар Med↔Black Sea.

## Test plan

- [x] `npm test` — 1691/1691 passed (162 suites)
- [x] `npm run lint` — 0 errors (27 pre-existing warnings, не от этих правок)
- [x] `npm run build` — production build ✅
- [x] Reviewer-агент (broker 20Y, fresh context каждый раунд) → 2 consecutive PASS на R5 и R6
- [ ] После merge: deploy на VPS + health check

## Артефакты session

В worktree `runs/round-1..6/` лежат полные снимки пайплайна по раундам (не коммитятся, только для аудита).

🤖 Generated with [Claude Code](https://claude.com/claude-code)