### PR TITLE
fix(deploy): harden VPS deploy script for idempotent first-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,17 @@ docker compose up
 bash scripts/deploy-vps.sh
 ```
 
-Скрипт делает: git pull → npm ci → build → install Caddy config → seed port-DA → pm2 reload → health check. Idempotent — повторный запуск безопасен.
+Скрипт делает: self-update deploy assets → git pull → npm ci → build (4GB heap) → install Caddy config → seed port-DA → pm2 reload → health check. Idempotent — повторный запуск безопасен.
+
+### First-time bootstrap
+
+Если на VPS ещё нет актуального `scripts/deploy-vps.sh`, забери его из origin одной командой и запусти:
+
+```bash
+ssh root@VPS 'cd /root/quantika-demo && git fetch origin main && git checkout origin/main -- scripts/deploy-vps.sh ops/caddy/install-caddy-config.sh ops/caddy/Caddyfile.demo && bash scripts/deploy-vps.sh'
+```
+
+Дальше скрипт сам подтягивает свежую версию себя и Caddy-конфигов из `origin/main` перед каждым деплоем.
 
 ## Deployment
 

--- a/ops/caddy/install-caddy-config.sh
+++ b/ops/caddy/install-caddy-config.sh
@@ -2,22 +2,43 @@
 set -euo pipefail
 
 REPO_ROOT="${1:-/root/quantika-demo}"
+SRC="${REPO_ROOT}/ops/caddy/Caddyfile.demo"
+DST="/etc/caddy/Caddyfile.demo"
+MAIN="/etc/caddy/Caddyfile"
 
-echo "==> Installing Caddy config from ${REPO_ROOT}/ops/caddy/Caddyfile.demo ..."
+echo "==> Installing Caddy config from ${SRC} ..."
 
-install -m 0644 -D "${REPO_ROOT}/ops/caddy/Caddyfile.demo" /etc/caddy/Caddyfile.demo
+# Validate our segment in isolation (the main Caddyfile uses env vars from a
+# systemd drop-in for unrelated sites — running `caddy validate` against it
+# without those env vars would fail spuriously).
+caddy validate --adapter caddyfile --config "${SRC}"
 
-if ! grep -q '^import /etc/caddy/Caddyfile.demo$' /etc/caddy/Caddyfile; then
-    echo "import /etc/caddy/Caddyfile.demo" >> /etc/caddy/Caddyfile
-    echo "==> Added import line to /etc/caddy/Caddyfile"
-else
-    echo "==> Import line already present in /etc/caddy/Caddyfile"
+# Backup current target so we can roll back if reload misbehaves.
+if [ -f "${DST}" ]; then
+    cp -p "${DST}" "${DST}.bak"
 fi
 
-caddy validate --config /etc/caddy/Caddyfile
+install -m 0644 -D "${SRC}" "${DST}"
 
-systemctl reload caddy
+if ! grep -q "^import ${DST}\$" "${MAIN}"; then
+    echo "import ${DST}" >> "${MAIN}"
+    echo "==> Added import line to ${MAIN}"
+else
+    echo "==> Import line already present in ${MAIN}"
+fi
+
+# Reload via systemctl (preserves the unit's Environment= drop-in for env vars
+# referenced elsewhere in the main Caddyfile). On failure, restore backup.
+if ! systemctl reload caddy; then
+    echo "✗ caddy reload failed — restoring previous ${DST}" >&2
+    if [ -f "${DST}.bak" ]; then
+        mv "${DST}.bak" "${DST}"
+        systemctl reload caddy || true
+    fi
+    exit 1
+fi
+
+# Reload succeeded — drop the backup.
+rm -f "${DST}.bak"
 
 echo "✓ Caddy config installed and reloaded"
-
-exit 0

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -1,20 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "${1:-/root/quantika-demo}"
-echo "==> Pulling latest main..."
+
+echo "==> Self-updating deploy assets from origin/main..."
 git fetch origin main
+git checkout origin/main -- \
+    scripts/deploy-vps.sh \
+    ops/caddy/install-caddy-config.sh \
+    ops/caddy/Caddyfile.demo
+
+echo "==> Pulling latest main..."
 git reset --hard origin/main
+
 echo "==> Installing dependencies..."
 npm ci
-echo "==> Building..."
-npm run build
+
+echo "==> Building (Node heap raised to 4GB to avoid OOM during type-check)..."
+NODE_OPTIONS="--max-old-space-size=4096" npm run build
+
 echo "==> Installing Caddy config..."
 bash ops/caddy/install-caddy-config.sh "$(pwd)"
+
 echo "==> Seeding port-DA estimates..."
 SESSIONS_DB_PATH=data/sessions.db npx tsx scripts/seed-port-da.ts
+
 echo "==> Reloading PM2..."
-pm2 reload quantika-demo
-pm2 save
+npx pm2 reload quantika-demo
+npx pm2 save
+
 echo "==> Health check..."
 sleep 2
 curl -fsS http://localhost:3000/api/health > /dev/null && echo "✓ DEPLOY OK"


### PR DESCRIPTION
## Summary

Закрывает три точки падения `scripts/deploy-vps.sh` при первом prod-run после βf2 (PR #49). Деплой пришлось доделывать руками — этот PR превращает скрипт в по-настоящему идемпотентный one-shot.

- **Node OOM на `npm run build`** → подняли heap до 4GB через `NODE_OPTIONS=--max-old-space-size=4096` (VPS 7.8GB RAM, дефолтные 2GB упирались на TypeScript-фазе; ручной прогон с 4GB укладывается в ~80s).
- **pm2 не в PATH у root** → `pm2 reload/save` заменены на `npx pm2 …`. PM2 не нужно тащить в `package.json` — `npx pm2` находит его в глобально установленном бинаре.
- **`caddy validate` ломался на чужих env vars** → теперь валидируем только наш сегмент: `caddy validate --adapter caddyfile --config .../Caddyfile.demo`. Главный Caddyfile (с `basic_auth` для allegro.quantika.org) больше не задевается. Плюс `.bak` бэкап + rollback при reload failure.
- **Bootstrap chicken-and-egg** → README теперь содержит one-liner для первого запуска, а сам скрипт перед основным pull вытягивает свежие версии deploy-ассетов из `origin/main` — самообновление для всех последующих фиксов в этом скрипте.

## Test plan

- [x] `bash -n` clean на оба скрипта
- [x] Manual verify во время βf2 deploy: 4GB heap билд проходит без OOM, `npx pm2 reload` работает с чистой root-сессии
- [ ] После merge — прогон скрипта на prod VPS дважды (clean state + repeat) для подтверждения идемпотентности
- [ ] Negative test: сломать `Caddyfile.demo` → скрипт должен упасть на validate, не задев live Caddy (rollback path)

`shellcheck` локально прогнать не удалось (брю-лок от параллельной `node@22` install сессии, докер не установлен) — `bash -n` чистый, изменения review-ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
