### PR TITLE
fix(caddy): add post-reload sanity check for demo.quantika.org block

### DIFF
--- a/ops/caddy/install-caddy-config.sh
+++ b/ops/caddy/install-caddy-config.sh
@@ -38,7 +38,24 @@ if ! systemctl reload caddy; then
     exit 1
 fi
 
-# Reload succeeded — drop the backup.
+# Sanity check: confirm demo.quantika.org block is actually loaded after reload.
+# Catches the case where the import line vanishes from the main Caddyfile
+# (observed once 2026-05-03 — root cause unknown).
+if ! caddy adapt --config "${MAIN}" --adapter caddyfile 2>/dev/null | grep -q '"demo\.quantika\.org"'; then
+    echo "✗ post-reload sanity: demo.quantika.org block NOT in adapted config — restoring backup" >&2
+    if [ -f "${DST}.bak" ]; then
+        mv "${DST}.bak" "${DST}"
+        systemctl reload caddy || true
+    fi
+    # Re-add import line if it disappeared from MAIN
+    if ! grep -q "^import ${DST}\$" "${MAIN}"; then
+        echo "import ${DST}" >> "${MAIN}"
+        systemctl reload caddy || true
+    fi
+    exit 1
+fi
+
+# Sanity check passed — safe to drop the backup.
 rm -f "${DST}.bak"
 
 echo "✓ Caddy config installed and reloaded"


### PR DESCRIPTION
## Summary

- On 2026-05-03, the `import /etc/caddy/Caddyfile.demo` line vanished from `/etc/caddy/Caddyfile` during a prod deploy. Caddy reloaded cleanly but only served `allegro.quantika.org` — `demo.quantika.org` was missing from the adapted config, causing SNI mismatch → Cloudflare 525 error. Restored manually.
- Adds a `caddy adapt` post-reload sanity check that verifies the `demo.quantika.org` block is present in the running config after every deploy.
- If the block is absent, the script restores the backup, re-appends the missing import line if needed, and exits non-zero — preventing silent broken deploys.

## Test plan

- [ ] Manual VPS run with the import line deliberately removed from `/etc/caddy/Caddyfile` before running the script → script should detect missing block, restore backup, re-add import, and exit 1 with error message.
- [ ] Normal VPS run with intact `/etc/caddy/Caddyfile` → script completes with `✓ Caddy config installed and reloaded`, backup removed.
- [ ] `bash -n ops/caddy/install-caddy-config.sh` passes locally (verified).

Incident reference: `demo.quantika.org` CF 525 on 2026-05-03 (documented in project memory `project_quantika_demo_wave_beta_fixes_2026_05_02.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
