### PR TITLE
feat(γ-1.5-A): full demo cache seed — classifications + vessels + processedEmails

### DIFF
--- a/__tests__/api/classify-demo-cache.test.ts
+++ b/__tests__/api/classify-demo-cache.test.ts
@@ -1,0 +1,200 @@
+/**
+ * wave-γ-1.5-A: integration tests for classify demo pre-parse cache.
+ *
+ * Cycle 1: /api/ai/classify early-returns for demo session — no LLM call
+ * Cycle 2: /api/ai/classify still hits LLM for non-demo session (regression guard)
+ * Cycle 3: /api/ai/classify still hits LLM when classifications empty (falls through)
+ */
+
+import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import type { SessionData } from '@/lib/types';
+import type { requireSession as RequireSessionFn } from '@/lib/session';
+
+// ── Shared mocks ──────────────────────────────────────────────────────────
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn().mockReturnValue(true),
+  generateCsrfToken: jest.fn().mockReturnValue('mock-csrf'),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+  updateSession: jest.fn(),
+  createSession: jest.fn().mockReturnValue('mock-session-id'),
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/openai', () => ({
+  callAiJson: jest.fn(),
+  callAiText: jest.fn(),
+  LLMTimeoutError: class LLMTimeoutError extends Error {},
+}));
+
+import { requireSession, updateSession } from '@/lib/session';
+import { callAiJson } from '@/lib/openai';
+const mockRequireSession = requireSession as jest.MockedFunction<typeof RequireSessionFn>;
+const mockUpdateSession = updateSession as jest.Mock;
+const mockCallAiJson = callAiJson as jest.Mock;
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: 'session_id=mock-session-id',
+    },
+  });
+}
+
+function makeSession(overrides: Partial<SessionData>): SessionData {
+  return {
+    accessToken: 'tok',
+    emails: [
+      {
+        id: 'sample-01',
+        threadId: 'thread-01',
+        from: 'sender@example.com',
+        fromName: 'Sender',
+        fromEmail: 'sender@example.com',
+        to: 'broker@example.com',
+        subject: 'Cargo inquiry',
+        date: new Date().toISOString(),
+        body: 'Test body',
+        snippet: 'Test',
+        labelIds: ['INBOX'],
+      },
+    ],
+    parsedCargos: [],
+    parsedVessels: [],
+    parsedRecaps: [],
+    classifications: [],
+    isSampleData: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as unknown as SessionData;
+}
+
+function makeClassifications(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    emailId: `sample-${String(i + 1).padStart(2, '0')}`,
+    category: 'CARGO_INQUIRY' as const,
+    isUnanswered: false,
+    urgency: 'low' as const,
+    daysWithoutReply: null,
+    confidence: 1.0,
+    originalSender: null,
+    originalSenderCompany: null,
+  }));
+}
+
+// ── Cycle 1: /api/ai/classify early-return for demo session ──────────────────
+
+describe('Cycle 1: /api/ai/classify — demo guard early-return', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns {count:32, cached:true} without LLM call when isSampleData=true + classifications pre-seeded', async () => {
+    const classifications = makeClassifications(32);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({ isSampleData: true, classifications }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/classify/route');
+    const req = makeRequest('/api/ai/classify');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBe(true);
+    expect(json.count).toBe(32);
+    expect(mockCallAiJson).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call updateSession when returning cached response', async () => {
+    const classifications = makeClassifications(32);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({ isSampleData: true, classifications }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/classify/route');
+    const req = makeRequest('/api/ai/classify');
+    await POST(req);
+
+    expect(mockUpdateSession).not.toHaveBeenCalled();
+  });
+});
+
+// ── Cycle 2: /api/ai/classify falls through when classifications empty ─────────
+
+describe('Cycle 2: /api/ai/classify — empty classifications falls through to LLM', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCallAiJson.mockResolvedValue({ classifications: [] });
+  });
+
+  it('does NOT early-return when isSampleData=true but classifications=[] (falls through)', async () => {
+    mockRequireSession.mockReturnValue({
+      session: makeSession({ isSampleData: true, classifications: [] }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/classify/route');
+    const req = makeRequest('/api/ai/classify');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBeUndefined();
+  });
+});
+
+// ── Cycle 3: regression — non-demo session bypasses guard ─────────────────────
+
+describe('Cycle 3: /api/ai/classify — non-demo session bypasses guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCallAiJson.mockResolvedValue({ classifications: [] });
+  });
+
+  it('non-demo session (isSampleData=false) does NOT return cached:true', async () => {
+    const classifications = makeClassifications(32);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({ isSampleData: false, classifications }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/classify/route');
+    const req = makeRequest('/api/ai/classify');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBeUndefined();
+  });
+
+  it('session without isSampleData (undefined) also bypasses the demo guard', async () => {
+    const classifications = makeClassifications(32);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({
+        isSampleData: undefined as unknown as boolean,
+        classifications,
+      }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/classify/route');
+    const req = makeRequest('/api/ai/classify');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBeUndefined();
+  });
+});

--- a/__tests__/api/parse-cargo-demo-cache.test.ts
+++ b/__tests__/api/parse-cargo-demo-cache.test.ts
@@ -152,6 +152,69 @@ describe('Cycle 4: /api/ai/parse-cargo — demo guard early-return', () => {
   });
 });
 
+// ── Cycle 4b: /api/sample seeds all 4 session fields (wave-γ-1.5-A) ──────────
+
+describe('Cycle 4b: /api/sample — full cache seed (classifications + parsedVessels + processedEmails)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateSession.mockReturnValue(true);
+  });
+
+  it('updateSession payload includes classifications with 32 entries', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const req = new NextRequest('http://localhost/api/sample', {
+      method: 'POST',
+      headers: { cookie: 'csrf_token=mock-csrf', 'x-csrf-token': 'mock-csrf' },
+    });
+    await POST(req);
+
+    const callArgs = mockUpdateSession.mock.calls[mockUpdateSession.mock.calls.length - 1];
+    const payload = callArgs[1] as Partial<SessionData>;
+    expect(payload.classifications).toHaveLength(32);
+  });
+
+  it('updateSession payload includes parsedVessels with 9 entries', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const req = new NextRequest('http://localhost/api/sample', {
+      method: 'POST',
+      headers: { cookie: 'csrf_token=mock-csrf', 'x-csrf-token': 'mock-csrf' },
+    });
+    await POST(req);
+
+    const callArgs = mockUpdateSession.mock.calls[mockUpdateSession.mock.calls.length - 1];
+    const payload = callArgs[1] as Partial<SessionData>;
+    expect(payload.parsedVessels).toHaveLength(9);
+  });
+
+  it('updateSession payload includes processedEmails with 32 entries', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const req = new NextRequest('http://localhost/api/sample', {
+      method: 'POST',
+      headers: { cookie: 'csrf_token=mock-csrf', 'x-csrf-token': 'mock-csrf' },
+    });
+    await POST(req);
+
+    const callArgs = mockUpdateSession.mock.calls[mockUpdateSession.mock.calls.length - 1];
+    const payload = callArgs[1] as Partial<SessionData>;
+    expect(payload.processedEmails).toHaveLength(32);
+  });
+
+  it('classifications include sample-01 as CARGO_INQUIRY', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const req = new NextRequest('http://localhost/api/sample', {
+      method: 'POST',
+      headers: { cookie: 'csrf_token=mock-csrf', 'x-csrf-token': 'mock-csrf' },
+    });
+    await POST(req);
+
+    const callArgs = mockUpdateSession.mock.calls[mockUpdateSession.mock.calls.length - 1];
+    const payload = callArgs[1] as Partial<SessionData>;
+    const cls = payload.classifications!.find(c => c.emailId === 'sample-01');
+    expect(cls).toBeDefined();
+    expect(cls!.category).toBe('CARGO_INQUIRY');
+  });
+});
+
 // ── Cycle 5: regression — non-demo session still hits LLM ─────────────────
 
 describe('Cycle 5: /api/ai/parse-cargo — non-demo session bypasses guard', () => {

--- a/__tests__/api/parse-vessel-demo-cache.test.ts
+++ b/__tests__/api/parse-vessel-demo-cache.test.ts
@@ -1,0 +1,243 @@
+/**
+ * wave-γ-1.5-A: integration tests for parse-vessel demo pre-parse cache.
+ *
+ * Cycle 1: /api/ai/parse-vessel early-returns for demo session — no LLM call
+ * Cycle 2: /api/ai/parse-vessel still hits LLM when parsedVessels empty (falls through)
+ * Cycle 3: regression — non-demo session bypasses guard
+ */
+
+import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import type { SessionData, ParsedVessel } from '@/lib/types';
+import type { requireSession as RequireSessionFn } from '@/lib/session';
+
+// ── Shared mocks ──────────────────────────────────────────────────────────
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn().mockReturnValue(true),
+  generateCsrfToken: jest.fn().mockReturnValue('mock-csrf'),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+  updateSession: jest.fn(),
+  createSession: jest.fn().mockReturnValue('mock-session-id'),
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/openai', () => ({
+  callAiJson: jest.fn(),
+  callAiText: jest.fn(),
+  LLMTimeoutError: class LLMTimeoutError extends Error {},
+}));
+
+// Mock Equasis validation — not relevant for demo cache path
+jest.mock('@/lib/validation/equasis-client', () => ({
+  lookupVesselByImo: jest.fn().mockResolvedValue(null),
+  compareVesselRecord: jest.fn().mockReturnValue(null),
+}));
+
+import { requireSession, updateSession } from '@/lib/session';
+import { callAiText } from '@/lib/openai';
+const mockRequireSession = requireSession as jest.MockedFunction<typeof RequireSessionFn>;
+const mockUpdateSession = updateSession as jest.Mock;
+const mockCallAiText = callAiText as jest.Mock;
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: 'session_id=mock-session-id',
+    },
+  });
+}
+
+function makeSession(overrides: Partial<SessionData>): SessionData {
+  return {
+    accessToken: 'tok',
+    emails: [],
+    parsedCargos: [],
+    parsedVessels: [],
+    parsedRecaps: [],
+    classifications: [
+      {
+        emailId: 'sample-13',
+        category: 'VESSEL_POSITION',
+        isUnanswered: false,
+        urgency: 'low',
+        daysWithoutReply: null,
+        confidence: 1.0,
+        originalSender: null,
+        originalSenderCompany: null,
+      },
+    ],
+    isSampleData: false,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as unknown as SessionData;
+}
+
+function makeParsedVessels(count: number): ParsedVessel[] {
+  return Array.from({ length: count }, (_, i) => ({
+    emailId: `sample-${String(i + 13).padStart(2, '0')}`,
+    itemIndex: 0,
+    vesselName: { value: `TEST VESSEL ${i}`, confidence: 'confirmed' as const },
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: null,
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: null,
+    speedBallast: null,
+    consumption: null,
+    deckCapacity: null,
+    specialFeatures: [],
+    ciiRating: null,
+    verificationWarning: null,
+  }));
+}
+
+// ── Cycle 1: /api/ai/parse-vessel early-return for demo session ────────────────
+
+describe('Cycle 1: /api/ai/parse-vessel — demo guard early-return', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns {count:9, cached:true} without LLM call when isSampleData=true + parsedVessels pre-seeded', async () => {
+    const parsedVessels = makeParsedVessels(9);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({ isSampleData: true, parsedVessels }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/parse-vessel/route');
+    const req = makeRequest('/api/ai/parse-vessel');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBe(true);
+    expect(json.count).toBe(9);
+    expect(mockCallAiText).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call updateSession when returning cached response', async () => {
+    const parsedVessels = makeParsedVessels(9);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({ isSampleData: true, parsedVessels }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/parse-vessel/route');
+    const req = makeRequest('/api/ai/parse-vessel');
+    await POST(req);
+
+    expect(mockUpdateSession).not.toHaveBeenCalled();
+  });
+});
+
+// ── Cycle 2: falls through when parsedVessels empty ──────────────────────────
+
+describe('Cycle 2: /api/ai/parse-vessel — empty parsedVessels falls through', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCallAiText.mockResolvedValue('[]');
+  });
+
+  it('does NOT early-return when isSampleData=true but parsedVessels=[] (falls through)', async () => {
+    mockRequireSession.mockReturnValue({
+      session: makeSession({
+        isSampleData: true,
+        parsedVessels: [],
+        classifications: [],
+      }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/parse-vessel/route');
+    const req = makeRequest('/api/ai/parse-vessel');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBeUndefined();
+  });
+});
+
+// ── Cycle 3: regression — non-demo session bypasses guard ─────────────────────
+
+describe('Cycle 3: /api/ai/parse-vessel — non-demo session bypasses guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCallAiText.mockResolvedValue('[]');
+  });
+
+  it('non-demo session (isSampleData=false) does NOT return cached:true', async () => {
+    const parsedVessels = makeParsedVessels(9);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({
+        isSampleData: false,
+        parsedVessels,
+        classifications: [],
+      }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/parse-vessel/route');
+    const req = makeRequest('/api/ai/parse-vessel');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBeUndefined();
+  });
+
+  it('session without isSampleData (undefined) also bypasses the demo guard', async () => {
+    const parsedVessels = makeParsedVessels(9);
+
+    mockRequireSession.mockReturnValue({
+      session: makeSession({
+        isSampleData: undefined as unknown as boolean,
+        parsedVessels,
+        classifications: [],
+      }),
+      sessionId: 'mock-session-id',
+    });
+
+    const { POST } = await import('@/app/api/ai/parse-vessel/route');
+    const req = makeRequest('/api/ai/parse-vessel');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cached).toBeUndefined();
+  });
+});

--- a/__tests__/sample-data/demo-parsed-cargoes.test.ts
+++ b/__tests__/sample-data/demo-parsed-cargoes.test.ts
@@ -1,13 +1,23 @@
 /**
  * wave-γ-3-demo: unit tests for resolveDemoParsedCargoes loader.
+ * wave-γ-1.5-A: extended with tests for resolveDemoClassifications,
+ *               resolveDemoParsedVessels, resolveDemoProcessedEmails.
  *
  * Tests:
  * 1. date resolution: +Nd offsets → ISO dates based on `now`
  * 2. schema parity: all returned records satisfy ParsedCargo shape
  * 3. no mutation of the fixture JSON
+ * 4. classifications: 32 records, correct categories
+ * 5. parsedVessels: 9 records, openDate resolved relative to `now`
+ * 6. processedEmails: delegates to buildProcessedEmails, correct emailIds
  */
 
-import { resolveDemoParsedCargoes } from '@/lib/sample-data/demo-parsed-cargoes';
+import {
+  resolveDemoParsedCargoes,
+  resolveDemoClassifications,
+  resolveDemoParsedVessels,
+  resolveDemoProcessedEmails,
+} from '@/lib/sample-data/demo-parsed-cargoes';
 import type { ParsedCargo } from '@/lib/types';
 
 const NOW = new Date('2026-05-10T00:00:00.000Z');
@@ -90,6 +100,181 @@ describe('resolveDemoParsedCargoes — schema parity with ParsedCargo', () => {
     const validTypes = new Set(['FCL', 'LCL', 'BREAK_BULK', 'BULK', 'PROJECT', 'AIR', 'RORO', 'OTHER']);
     for (const cargo of result) {
       expect(validTypes.has(cargo.cargoType)).toBe(true);
+    }
+  });
+});
+
+// ── wave-γ-1.5-A: resolveDemoClassifications ─────────────────────────────────
+
+describe('resolveDemoClassifications — 32 records, correct schema', () => {
+  it('returns exactly 32 Classification records (one per sample email)', () => {
+    const result = resolveDemoClassifications();
+    expect(result).toHaveLength(32);
+  });
+
+  it('sample-01 is classified as CARGO_INQUIRY', () => {
+    const result = resolveDemoClassifications();
+    const c = result.find(r => r.emailId === 'sample-01');
+    expect(c).toBeDefined();
+    expect(c!.category).toBe('CARGO_INQUIRY');
+  });
+
+  it('sample-13 is classified as VESSEL_POSITION', () => {
+    const result = resolveDemoClassifications();
+    const c = result.find(r => r.emailId === 'sample-13');
+    expect(c).toBeDefined();
+    expect(c!.category).toBe('VESSEL_POSITION');
+  });
+
+  it('sample-21 is classified as FIXTURE_RECAP', () => {
+    const result = resolveDemoClassifications();
+    const c = result.find(r => r.emailId === 'sample-21');
+    expect(c).toBeDefined();
+    expect(c!.category).toBe('FIXTURE_RECAP');
+  });
+
+  it('sample-32 is classified as VESSEL_CERTIFICATE', () => {
+    const result = resolveDemoClassifications();
+    const c = result.find(r => r.emailId === 'sample-32');
+    expect(c).toBeDefined();
+    expect(c!.category).toBe('VESSEL_CERTIFICATE');
+  });
+
+  it('all records have confidence of 1.0', () => {
+    const result = resolveDemoClassifications();
+    for (const c of result) {
+      expect(c.confidence).toBe(1.0);
+    }
+  });
+
+  it('all emailIds are unique (no duplicate emailId entries)', () => {
+    const result = resolveDemoClassifications();
+    const ids = result.map(c => c.emailId);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(32);
+  });
+
+  it('category values are valid EmailCategory enum values', () => {
+    const valid = new Set(['CARGO_INQUIRY', 'VESSEL_POSITION', 'FIXTURE_RECAP', 'CLIENT_REPLY', 'DOCUMENT', 'TCT_REQUEST', 'VESSEL_CERTIFICATE', 'OTHER']);
+    const result = resolveDemoClassifications();
+    for (const c of result) {
+      expect(valid.has(c.category)).toBe(true);
+    }
+  });
+
+  it('does not mutate the fixture JSON between calls', () => {
+    const r1 = resolveDemoClassifications();
+    const r2 = resolveDemoClassifications();
+    expect(r1).toEqual(r2);
+  });
+});
+
+// ── wave-γ-1.5-A: resolveDemoParsedVessels ────────────────────────────────────
+
+describe('resolveDemoParsedVessels — date resolution and schema', () => {
+  const NOW = new Date('2026-05-10T00:00:00.000Z');
+
+  it('returns exactly 9 ParsedVessel records (8 emails, sample-16 has 2 vessels)', () => {
+    const result = resolveDemoParsedVessels(NOW);
+    expect(result).toHaveLength(9);
+  });
+
+  it('sample-13 vessel (CARPATHIAN STAR) has correct vesselName and IMO', () => {
+    const result = resolveDemoParsedVessels(NOW);
+    const v = result.find(r => r.emailId === 'sample-13' && r.itemIndex === 0);
+    expect(v).toBeDefined();
+    expect(v!.vesselName).toEqual({ value: 'CARPATHIAN STAR', confidence: 'confirmed' });
+    expect(v!.imo).toBe('9234563');
+  });
+
+  it('sample-16 has two vessels (ATLAS itemIndex=0 and ZEUS itemIndex=1)', () => {
+    const result = resolveDemoParsedVessels(NOW);
+    const atlas = result.find(r => r.emailId === 'sample-16' && r.itemIndex === 0);
+    const zeus = result.find(r => r.emailId === 'sample-16' && r.itemIndex === 1);
+    expect(atlas).toBeDefined();
+    expect(zeus).toBeDefined();
+    expect(atlas!.vesselName!.value).toBe('ATLAS');
+    expect(zeus!.vesselName!.value).toBe('ZEUS');
+  });
+
+  it('openDate is resolved to an absolute ISO date string', () => {
+    const result = resolveDemoParsedVessels(NOW);
+    for (const v of result) {
+      if (v.openDate !== null) {
+        expect(v.openDate.value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(new Date(v.openDate.value).getTime()).toBeGreaterThanOrEqual(NOW.getTime());
+      }
+    }
+  });
+
+  it('sample-20 (CARBON LADY) has ciiRating D', () => {
+    const result = resolveDemoParsedVessels(NOW);
+    const v = result.find(r => r.emailId === 'sample-20');
+    expect(v).toBeDefined();
+    expect(v!.ciiRating).toBe('D');
+  });
+
+  it('uses the provided now date for openDate resolution', () => {
+    const now1 = new Date('2026-05-10T00:00:00.000Z');
+    const now2 = new Date('2026-06-01T00:00:00.000Z');
+    const r1 = resolveDemoParsedVessels(now1);
+    const r2 = resolveDemoParsedVessels(now2);
+    // openDate values should differ
+    const dates1 = r1.map(v => v.openDate?.value).filter(Boolean);
+    const dates2 = r2.map(v => v.openDate?.value).filter(Boolean);
+    expect(dates1).not.toEqual(dates2);
+  });
+});
+
+// ── wave-γ-1.5-A: resolveDemoProcessedEmails ─────────────────────────────────
+
+describe('resolveDemoProcessedEmails — delegates to buildProcessedEmails', () => {
+  const NOW = new Date('2026-05-10T00:00:00.000Z');
+
+  function makeSampleEmail(id: string) {
+    return {
+      id,
+      threadId: `thread-${id}`,
+      from: `sender@example.com`,
+      fromName: 'Sender',
+      fromEmail: 'sender@example.com',
+      to: 'broker@example.com',
+      subject: `Subject for ${id}`,
+      date: new Date(NOW.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      body: '',
+      snippet: '',
+      labelIds: ['INBOX'],
+    };
+  }
+
+  const SAMPLE_IDS = Array.from({ length: 32 }, (_, i) => `sample-${String(i + 1).padStart(2, '0')}`);
+  const emails = SAMPLE_IDS.map(makeSampleEmail);
+
+  it('returns exactly 32 ProcessedEmail records (one per classification)', () => {
+    const result = resolveDemoProcessedEmails(NOW, emails);
+    expect(result).toHaveLength(32);
+  });
+
+  it('sample-01 processedEmail has type CARGO_INQUIRY', () => {
+    const result = resolveDemoProcessedEmails(NOW, emails);
+    const pe = result.find(p => p.emailId === 'sample-01');
+    expect(pe).toBeDefined();
+    expect(pe!.type).toBe('CARGO_INQUIRY');
+  });
+
+  it('sample-01 processedEmail has expirySource of laycan (cargo has laycan field)', () => {
+    const result = resolveDemoProcessedEmails(NOW, emails);
+    const pe = result.find(p => p.emailId === 'sample-01');
+    expect(pe).toBeDefined();
+    // calculateExpiry returns 'laycan' as source when laycan string is present on parsedCargo
+    expect(pe!.expirySource).toBe('laycan');
+  });
+
+  it('all returned emailIds match the 32 classification emailIds', () => {
+    const result = resolveDemoProcessedEmails(NOW, emails);
+    const classificationIds = new Set(resolveDemoClassifications().map(c => c.emailId));
+    for (const pe of result) {
+      expect(classificationIds.has(pe.emailId)).toBe(true);
     }
   });
 });

--- a/app/api/ai/classify/route.ts
+++ b/app/api/ai/classify/route.ts
@@ -43,6 +43,12 @@ export async function POST(request: NextRequest) {
   const authResult = requireSession(request);
   if (authResult instanceof NextResponse) return authResult;
   const { session, sessionId } = authResult;
+
+  // wave-γ-1.5-A: demo guests get pre-seeded classifications — skip live LLM entirely.
+  if (session.isSampleData === true && session.classifications.length > 0) {
+    return NextResponse.json({ count: session.classifications.length, cached: true });
+  }
+
   if (session.emails.length === 0) return NextResponse.json({ error: 'No emails to classify' }, { status: 400 });
 
   const emailInput: EmailInput[] = session.emails.map(email => ({

--- a/app/api/ai/parse-vessel/route.ts
+++ b/app/api/ai/parse-vessel/route.ts
@@ -11,12 +11,19 @@ import { buildVesselPrompt, parseVesselAIResponse } from '@/lib/parsing/parse-ve
 import { buildProcessedEmails } from '@/lib/classification-service';
 import pLimit from 'p-limit';
 
+export const maxDuration = 60;
+
 export async function POST(request: NextRequest) {
   if (!validateCsrf(request)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
   const result = requireSession(request);
   if (result instanceof NextResponse) return result;
   const { session, sessionId } = result;
+
+  // wave-γ-1.5-A: demo guests get pre-seeded vessel positions — skip live LLM entirely.
+  if (session.isSampleData === true && session.parsedVessels.length > 0) {
+    return NextResponse.json({ count: session.parsedVessels.length, cached: true });
+  }
 
   const vesselIds = session.classifications
     .filter(c => c.category === 'VESSEL_POSITION')

--- a/app/api/sample/route.ts
+++ b/app/api/sample/route.ts
@@ -8,7 +8,12 @@ import clientReplies from '@/lib/sample-data/client-replies.json';
 import documents from '@/lib/sample-data/documents.json';
 import vesselCerts from '@/lib/sample-data/vessel-certs.json';
 import { rebaseDates } from '@/lib/sample-data/rebase';
-import { resolveDemoParsedCargoes } from '@/lib/sample-data/demo-parsed-cargoes';
+import {
+  resolveDemoParsedCargoes,
+  resolveDemoClassifications,
+  resolveDemoParsedVessels,
+  resolveDemoProcessedEmails,
+} from '@/lib/sample-data/demo-parsed-cargoes';
 import type { SampleEmailRaw } from '@/lib/sample-data/types';
 
 export const dynamic = 'force-dynamic';
@@ -27,7 +32,18 @@ export async function POST(request: NextRequest) {
   const sessionId = createSession('sample-data-token');
   const today = new Date();
   const SAMPLE_EMAILS = rebaseDates(SAMPLE_EMAILS_RAW, today);
-  updateSession(sessionId, { emails: SAMPLE_EMAILS, isSampleData: true, parsedCargos: resolveDemoParsedCargoes(today) });
+  const parsedCargos = resolveDemoParsedCargoes(today);
+  const classifications = resolveDemoClassifications();
+  const parsedVessels = resolveDemoParsedVessels(today);
+  const processedEmails = resolveDemoProcessedEmails(today, SAMPLE_EMAILS);
+  updateSession(sessionId, {
+    emails: SAMPLE_EMAILS,
+    isSampleData: true,
+    parsedCargos,
+    classifications,
+    parsedVessels,
+    processedEmails,
+  });
 
   const csrfToken = generateCsrfToken();
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://demo.quantika.org';

--- a/lib/sample-data/demo-classifications.json
+++ b/lib/sample-data/demo-classifications.json
@@ -1,0 +1,322 @@
+[
+  {
+    "emailId": "sample-01",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "high",
+    "daysWithoutReply": 2,
+    "confidence": 1.0,
+    "originalSender": "Black Sea Shipping <chartering@bsshipping.ro>",
+    "originalSenderCompany": "Black Sea Shipping"
+  },
+  {
+    "emailId": "sample-02",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "high",
+    "daysWithoutReply": 1,
+    "confidence": 1.0,
+    "originalSender": "Gulf Steel Trading <cargo@gulfsteeltrading.ae>",
+    "originalSenderCompany": "Gulf Steel Trading"
+  },
+  {
+    "emailId": "sample-03",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Singapore Metals <chartering@sgmetals.sg>",
+    "originalSenderCompany": "Singapore Metals"
+  },
+  {
+    "emailId": "sample-04",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "medium",
+    "daysWithoutReply": 3,
+    "confidence": 1.0,
+    "originalSender": "Egypt Cement Corp <freight@egyptcement.eg>",
+    "originalSenderCompany": "Egypt Cement Corp"
+  },
+  {
+    "emailId": "sample-05",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "high",
+    "daysWithoutReply": 1,
+    "confidence": 1.0,
+    "originalSender": "Tyrrhenian Industrial <logistics@tyrrhenianindustrial.it>",
+    "originalSenderCompany": "Tyrrhenian Industrial"
+  },
+  {
+    "emailId": "sample-06",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Nordic Timber Trade <chartering@nordictimber.fi>",
+    "originalSenderCompany": "Nordic Timber Trade"
+  },
+  {
+    "emailId": "sample-07",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "high",
+    "daysWithoutReply": 2,
+    "confidence": 1.0,
+    "originalSender": "Danube Agro Export <freight@danubeagro.sk>",
+    "originalSenderCompany": "Danube Agro Export"
+  },
+  {
+    "emailId": "sample-08",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Adriatic Chemical <chartering@adriatichem.hr>",
+    "originalSenderCompany": "Adriatic Chemical"
+  },
+  {
+    "emailId": "sample-09",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "medium",
+    "daysWithoutReply": 4,
+    "confidence": 1.0,
+    "originalSender": "Levant Freight Partners <ops@levantfreight.lb>",
+    "originalSenderCompany": "Levant Freight Partners"
+  },
+  {
+    "emailId": "sample-10",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Caspian Grain Corp <chartering@caspiangrain.kz>",
+    "originalSenderCompany": "Caspian Grain Corp"
+  },
+  {
+    "emailId": "sample-11",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": true,
+    "urgency": "high",
+    "daysWithoutReply": 1,
+    "confidence": 1.0,
+    "originalSender": "West Africa Commodities <freight@wacommodities.gh>",
+    "originalSenderCompany": "West Africa Commodities"
+  },
+  {
+    "emailId": "sample-12",
+    "category": "CARGO_INQUIRY",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Iberian Steel Group <chartering@iberiansteel.es>",
+    "originalSenderCompany": "Iberian Steel Group"
+  },
+  {
+    "emailId": "sample-13",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Balkan Tramp Lines <ops@balkantramp.gr>",
+    "originalSenderCompany": "Balkan Tramp Lines"
+  },
+  {
+    "emailId": "sample-14",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Emirates Tramp <chartering@emiratestramp.ae>",
+    "originalSenderCompany": "Emirates Tramp"
+  },
+  {
+    "emailId": "sample-15",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Comoros Bulk Carriers <freight@comorosbulk.km>",
+    "originalSenderCompany": "Comoros Bulk Carriers"
+  },
+  {
+    "emailId": "sample-16",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Tyrrhenian Tramp Lines <ops@tyrrhenian-tramp.it>",
+    "originalSenderCompany": "Tyrrhenian Tramp Lines"
+  },
+  {
+    "emailId": "sample-17",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Lagos Maritime Brokers <ops@lagosbrokers.ng>",
+    "originalSenderCompany": "Lagos Maritime Brokers"
+  },
+  {
+    "emailId": "sample-18",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Iran Bulk Carriers <ops@iranbulk.ir>",
+    "originalSenderCompany": "Iran Bulk Carriers"
+  },
+  {
+    "emailId": "sample-19",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Finnlines Tramp Desk <chartering@finnlinestramp.fi>",
+    "originalSenderCompany": "Finnlines Tramp Desk"
+  },
+  {
+    "emailId": "sample-20",
+    "category": "VESSEL_POSITION",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Scheldt Tramp Carriers <ops@scheldttramp.be>",
+    "originalSenderCompany": "Scheldt Tramp Carriers"
+  },
+  {
+    "emailId": "sample-21",
+    "category": "FIXTURE_RECAP",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Pontus Shipping <chartering@pontus-shipping.gr>",
+    "originalSenderCompany": "Pontus Shipping"
+  },
+  {
+    "emailId": "sample-22",
+    "category": "FIXTURE_RECAP",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Gulf Star Brokers <desk@gulfstarbrokers.ae>",
+    "originalSenderCompany": "Gulf Star Brokers"
+  },
+  {
+    "emailId": "sample-23",
+    "category": "FIXTURE_RECAP",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Singapore Bulk Brokers <chartering@sgbulkbrokers.sg>",
+    "originalSenderCompany": "Singapore Bulk Brokers"
+  },
+  {
+    "emailId": "sample-24",
+    "category": "FIXTURE_RECAP",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Med Chartering <ops@medchartering.mt>",
+    "originalSenderCompany": "Med Chartering"
+  },
+  {
+    "emailId": "sample-25",
+    "category": "FIXTURE_RECAP",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Nordic Brokers <chartering@nordicbrokers.dk>",
+    "originalSenderCompany": "Nordic Brokers"
+  },
+  {
+    "emailId": "sample-26",
+    "category": "CLIENT_REPLY",
+    "isUnanswered": false,
+    "urgency": "high",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Ahmed Al-Rashidi <ahmed.alrashidi@gulftrade.ae>",
+    "originalSenderCompany": "Gulf Trade LLC"
+  },
+  {
+    "emailId": "sample-27",
+    "category": "CLIENT_REPLY",
+    "isUnanswered": true,
+    "urgency": "high",
+    "daysWithoutReply": 1,
+    "confidence": 1.0,
+    "originalSender": "Ekaterina Volkov <e.volkov@bsshipping.ro>",
+    "originalSenderCompany": "Black Sea Shipping"
+  },
+  {
+    "emailId": "sample-28",
+    "category": "CLIENT_REPLY",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Lars Andersen <l.andersen@nordictimber.fi>",
+    "originalSenderCompany": "Nordic Timber Trade"
+  },
+  {
+    "emailId": "sample-29",
+    "category": "CLIENT_REPLY",
+    "isUnanswered": false,
+    "urgency": "medium",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Marco Ferretti <m.ferretti@adriatichem.hr>",
+    "originalSenderCompany": "Adriatic Chemical"
+  },
+  {
+    "emailId": "sample-30",
+    "category": "DOCUMENT",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "DHL Express <docsupport@dhl.com>",
+    "originalSenderCompany": "DHL Express"
+  },
+  {
+    "emailId": "sample-31",
+    "category": "DOCUMENT",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "Port Constanta Authority <docs@portconstanta.ro>",
+    "originalSenderCompany": "Port Constanta Authority"
+  },
+  {
+    "emailId": "sample-32",
+    "category": "VESSEL_CERTIFICATE",
+    "isUnanswered": false,
+    "urgency": "low",
+    "daysWithoutReply": null,
+    "confidence": 1.0,
+    "originalSender": "DNV GL <certificates@dnvgl.com>",
+    "originalSenderCompany": "DNV GL"
+  }
+]

--- a/lib/sample-data/demo-parsed-cargoes.ts
+++ b/lib/sample-data/demo-parsed-cargoes.ts
@@ -5,15 +5,26 @@
  * (+Nd format) to absolute ISO date strings based on the seed `now` date.
  * Laycan resolution happens at SEED time (when /api/sample is called),
  * never at read time, so the 9 consumer sites remain untouched.
+ *
+ * wave-γ-1.5-A: extended with resolveDemoClassifications,
+ * resolveDemoParsedVessels, and resolveDemoProcessedEmails.
  */
 
-import type { ParsedCargo } from '@/lib/types';
+import type { ParsedCargo, Classification, ParsedVessel, ProcessedEmail, Email } from '@/lib/types';
+import { buildProcessedEmails } from '@/lib/classification-service';
 import fixtureRaw from './demo-parsed-cargoes.json';
+import classificationsFixture from './demo-classifications.json';
+import vesselsFixtureRaw from './demo-parsed-vessels.json';
 
 /** Internal fixture shape — adds relative laycan fields, omits resolved laycan */
 interface FixtureRecord extends Omit<ParsedCargo, 'laycan'> {
   laycanRelativeStart: string | null;
   laycanRelativeEnd: string | null;
+}
+
+/** Internal vessel fixture shape — openDate is stored as relative offset */
+interface VesselFixtureRecord extends Omit<ParsedVessel, 'openDate'> {
+  openDateRelative: string | null;
 }
 
 /**
@@ -22,7 +33,7 @@ interface FixtureRecord extends Omit<ParsedCargo, 'laycan'> {
  */
 function resolveOffset(base: Date, offset: string): string {
   const match = /^\+(\d+)d$/.exec(offset);
-  if (!match) throw new Error(`Invalid laycan offset: "${offset}"`);
+  if (!match) throw new Error(`Invalid offset: "${offset}"`);
   const days = parseInt(match[1], 10);
   const result = new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
   return result.toISOString().slice(0, 10);
@@ -43,9 +54,52 @@ export function resolveDemoParsedCargoes(now: Date): ParsedCargo[] {
     }
 
     // Destructure out the relative fields, spread the rest as ParsedCargo
-     
+
     const { laycanRelativeStart, laycanRelativeEnd, ...rest } = record;
 
     return { ...rest, laycan } as ParsedCargo;
   });
+}
+
+/**
+ * Returns 32 pre-seeded classifications — one per sample email.
+ * No date resolution needed: classifications have no date-relative fields.
+ * Safe to call multiple times — does not mutate the fixture JSON.
+ */
+export function resolveDemoClassifications(): Classification[] {
+  return classificationsFixture as unknown as Classification[];
+}
+
+/**
+ * Returns 9 pre-parsed vessel positions with openDate resolved relative to `now`.
+ * Safe to call multiple times — does not mutate the fixture JSON.
+ */
+export function resolveDemoParsedVessels(now: Date): ParsedVessel[] {
+  return (vesselsFixtureRaw as unknown as VesselFixtureRecord[]).map((record) => {
+    let openDate: ParsedVessel['openDate'] = null;
+
+    if (record.openDateRelative !== null && record.openDateRelative !== undefined) {
+      const resolved = resolveOffset(now, record.openDateRelative);
+      openDate = { value: resolved, confidence: 'confirmed' };
+    }
+
+    const { openDateRelative, ...rest } = record;
+
+    return { ...rest, openDate } as ParsedVessel;
+  });
+}
+
+/**
+ * Returns ProcessedEmail[] built from pre-seeded classifications + parsed arrays.
+ * Delegates to buildProcessedEmails (lib/classification-service.ts:81) — pure function.
+ * Accepts `emails` so freshness / expiryDate can be derived from email.date.
+ */
+export function resolveDemoProcessedEmails(
+  now: Date,
+  emails: Email[],
+): ProcessedEmail[] {
+  const classifications = resolveDemoClassifications();
+  const parsedCargos = resolveDemoParsedCargoes(now);
+  const parsedVessels = resolveDemoParsedVessels(now);
+  return buildProcessedEmails(emails, classifications, parsedCargos, parsedVessels);
 }

--- a/lib/sample-data/demo-parsed-vessels.json
+++ b/lib/sample-data/demo-parsed-vessels.json
@@ -1,0 +1,506 @@
+[
+  {
+    "emailId": "sample-13",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "CARPATHIAN STAR",
+      "confidence": "confirmed"
+    },
+    "imo": "9234563",
+    "flag": "Marshall Islands",
+    "built": 2007,
+    "classSociety": "DNV",
+    "pandi": "Gard",
+    "dwtSummer": {
+      "value": 8500,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 8050,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 6.2,
+      "confidence": "confirmed"
+    },
+    "loa": 121.4,
+    "beam": 17.6,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 10400,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 25t",
+    "hatchType": null,
+    "vesselType": "MPP",
+    "openPosition": {
+      "value": "Piraeus, Greece",
+      "confidence": "confirmed"
+    },
+    "direction": "Med, Black Sea, WAfrica",
+    "restrictions": [],
+    "lastCargoes": "steel products, bagged cargo, breakbulk",
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+3d"
+  },
+  {
+    "emailId": "sample-14",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "PROMPT TRADER",
+      "confidence": "confirmed"
+    },
+    "imo": "9345673",
+    "flag": "Bahamas",
+    "built": 2010,
+    "classSociety": "BV",
+    "pandi": "Skuld",
+    "dwtSummer": {
+      "value": 12000,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 11300,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 7.1,
+      "confidence": "confirmed"
+    },
+    "loa": 133.8,
+    "beam": 19.4,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 3,
+    "hatchesCount": 3,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 14600,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 30t",
+    "hatchType": null,
+    "vesselType": "General Cargo",
+    "openPosition": {
+      "value": "Khor Fakkan, UAE",
+      "confidence": "confirmed"
+    },
+    "direction": "MENA, WAfrica, Med",
+    "restrictions": [],
+    "lastCargoes": "steel pipes, general cargo, bagged cargo",
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+0d"
+  },
+  {
+    "emailId": "sample-15",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "BLACK SEA WIND",
+      "confidence": "confirmed"
+    },
+    "imo": "9876541",
+    "flag": "Comoros",
+    "built": 2003,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 32000,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 30200,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 9.8,
+      "confidence": "confirmed"
+    },
+    "loa": 185.2,
+    "beam": 26.4,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 5,
+    "hatchesCount": 5,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 38500,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "Bulk Carrier",
+    "openPosition": {
+      "value": "Constanta, Romania",
+      "confidence": "confirmed"
+    },
+    "direction": "Black Sea, Med",
+    "restrictions": ["Shore gear required at all ports"],
+    "lastCargoes": "bulk cargo",
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+2d"
+  },
+  {
+    "emailId": "sample-16",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "ATLAS",
+      "confidence": "confirmed"
+    },
+    "imo": "9123453",
+    "flag": "Italy",
+    "built": 2006,
+    "classSociety": "RINA",
+    "pandi": "Lloyd's",
+    "dwtSummer": {
+      "value": 5200,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 4900,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 5.4,
+      "confidence": "confirmed"
+    },
+    "loa": 96.0,
+    "beam": 14.2,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 6100,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 20t",
+    "hatchType": null,
+    "vesselType": "General Cargo",
+    "openPosition": {
+      "value": "Genoa, Italy",
+      "confidence": "confirmed"
+    },
+    "direction": "Med",
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+4d"
+  },
+  {
+    "emailId": "sample-16",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "ZEUS",
+      "confidence": "confirmed"
+    },
+    "imo": "9234513",
+    "flag": "Italy",
+    "built": 2008,
+    "classSociety": "RINA",
+    "pandi": "Lloyd's",
+    "dwtSummer": {
+      "value": 6800,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 6450,
+      "confidence": "interpreted"
+    },
+    "draftMax": {
+      "value": 5.8,
+      "confidence": "interpreted"
+    },
+    "loa": 108.0,
+    "beam": 15.6,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 25t",
+    "hatchType": null,
+    "vesselType": "General Cargo",
+    "openPosition": {
+      "value": "Genoa, Italy",
+      "confidence": "confirmed"
+    },
+    "direction": "Med",
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+4d"
+  },
+  {
+    "emailId": "sample-17",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "LAGGARD STAR",
+      "confidence": "confirmed"
+    },
+    "imo": "9156785",
+    "flag": "Malta",
+    "built": 2009,
+    "classSociety": "LR",
+    "pandi": "West of England",
+    "dwtSummer": {
+      "value": 15000,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 14200,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 7.8,
+      "confidence": "confirmed"
+    },
+    "loa": 148.0,
+    "beam": 22.4,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 3,
+    "hatchesCount": 3,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 18200,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 30t",
+    "hatchType": null,
+    "vesselType": "General Cargo",
+    "openPosition": {
+      "value": "Lagos, Nigeria (Apapa)",
+      "confidence": "confirmed"
+    },
+    "direction": "WAfrica, Med",
+    "restrictions": [],
+    "lastCargoes": "steel products, bagged cargo, breakbulk, general cargo",
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+5d"
+  },
+  {
+    "emailId": "sample-18",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "PERSIAN ROSE",
+      "confidence": "confirmed"
+    },
+    "imo": "9256781",
+    "flag": "Iran",
+    "built": 2004,
+    "classSociety": "IRS",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 22000,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 20800,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 8.6,
+      "confidence": "confirmed"
+    },
+    "loa": 165.4,
+    "beam": 24.8,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 4,
+    "hatchesCount": 4,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 26800,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 25t",
+    "hatchType": null,
+    "vesselType": "General Cargo",
+    "openPosition": {
+      "value": "Bandar Abbas, Iran",
+      "confidence": "confirmed"
+    },
+    "direction": "Persian Gulf, Indian Ocean",
+    "restrictions": [],
+    "lastCargoes": "bulk, general cargo",
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+6d"
+  },
+  {
+    "emailId": "sample-19",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "NORDIC ICE",
+      "confidence": "confirmed"
+    },
+    "imo": "9356787",
+    "flag": "Finland",
+    "built": 2012,
+    "classSociety": "BV",
+    "pandi": "Skuld",
+    "dwtSummer": {
+      "value": 28500,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 27100,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 9.4,
+      "confidence": "confirmed"
+    },
+    "loa": 178.6,
+    "beam": 26.0,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 4,
+    "hatchesCount": 4,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 34200,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 30t",
+    "hatchType": null,
+    "vesselType": "Bulk Carrier",
+    "openPosition": {
+      "value": "Helsinki, Finland",
+      "confidence": "confirmed"
+    },
+    "direction": "Baltic, N.Europe, Med",
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": ["Ice Class 1A FS (Finnish-Swedish)"],
+    "ciiRating": null,
+    "verificationWarning": null,
+    "openDateRelative": "+7d"
+  },
+  {
+    "emailId": "sample-20",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "CARBON LADY",
+      "confidence": "confirmed"
+    },
+    "imo": "9456783",
+    "flag": "Marshall Islands",
+    "built": 2001,
+    "classSociety": "LR",
+    "pandi": "North",
+    "dwtSummer": {
+      "value": 17500,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 16600,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 8.1,
+      "confidence": "confirmed"
+    },
+    "loa": 153.8,
+    "beam": 23.2,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 3,
+    "hatchesCount": 3,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 21400,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 30t",
+    "hatchType": null,
+    "vesselType": "General Cargo",
+    "openPosition": {
+      "value": "Antwerp, Belgium",
+      "confidence": "confirmed"
+    },
+    "direction": "N.Europe, Med",
+    "restrictions": ["Subject to corrective action plan per IMO MEPC.338(76)"],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": "D",
+    "verificationWarning": null,
+    "openDateRelative": "+2d"
+  }
+]


### PR DESCRIPTION
## Зачем это нужно

Когда наш AI-прокси (cliproxy) в кулдауне — например, после активного использования — demo-дашборд на `demo.quantika.org` показывал пустой inbox. Причина: при заходе на `/api/sample` сеялись только `parsedCargos` (5 грузов), а `classifications`, `parsedVessels` и `processedEmails` оставались пустыми. Как только клиент нажимал «Classify» или «Parse Vessels», роуты пытались вызвать LLM — и падали в кулдауне. Теперь все 4 поля сеются сразу при инициализации demo-сессии, а роуты мгновенно возвращают закешированный результат без единого запроса к AI.

## Что изменилось

- `lib/sample-data/demo-classifications.json` — **NEW**: 32 записи классификации, одна на каждый sample email (12 CARGO_INQUIRY, 8 VESSEL_POSITION, 5 FIXTURE_RECAP, 4 CLIENT_REPLY, 2 DOCUMENT, 1 VESSEL_CERTIFICATE)
- `lib/sample-data/demo-parsed-vessels.json` — **NEW**: 9 записей (8 email → 9 судов, т.к. sample-16 содержит ATLAS + ZEUS), openDate хранится как relative offset `+Nd`
- `lib/sample-data/demo-parsed-cargoes.ts` — **EXTENDED**: 3 новых resolver'а: `resolveDemoClassifications()`, `resolveDemoParsedVessels(now)`, `resolveDemoProcessedEmails(now, emails)`. Последний делегирует в `buildProcessedEmails()` из classification-service
- `app/api/sample/route.ts` — **EXTENDED**: `updateSession` теперь включает все 4 поля вместо одного
- `app/api/ai/classify/route.ts` — **GUARD ADDED**: если `isSampleData=true && classifications.length > 0` → возвращает `{count, cached:true}` без LLM
- `app/api/ai/parse-vessel/route.ts` — **GUARD ADDED** + **`export const maxDuration = 60`** (отсутствовал в отличие от parse-cargo)
- `__tests__/api/classify-demo-cache.test.ts` — **NEW**: 6 тестов по образцу parse-cargo-demo-cache
- `__tests__/api/parse-vessel-demo-cache.test.ts` — **NEW**: 6 тестов аналогично
- `__tests__/sample-data/demo-parsed-cargoes.test.ts` — **EXTENDED**: 17 новых тестов для 3 resolver'ов
- `__tests__/api/parse-cargo-demo-cache.test.ts` — **EXTENDED**: Cycle 4b — full payload assertions (classifications×32, parsedVessels×9, processedEmails×32)

## Test plan

- [ ] После merge и деплоя зайти на `demo.quantika.org` → нажать «Start Demo»
- [ ] Dashboard должен показывать inbox с 32 emails (все категории видны сразу, без ожидания)
- [ ] Нажать «Classify» → должен мгновенно вернуть `{cached:true}` без спиннера LLM
- [ ] Нажать «Parse Vessels» → то же самое, `{cached:true}` мгновенно
- [ ] Проверить freshness-индикаторы — они должны быть «active» (не stale), т.к. processedEmails засеян с правильными датами
- [ ] Проверить в dev tools Network tab: запросы на `/api/ai/classify` и `/api/ai/parse-vessel` должны возвращать 200 без задержки и с `"cached":true` в body

## Scope NOT changed

- `/api/ai/parse-cargo` — guard уже был (wave-γ-3-demo), не тронут
- `/api/ai/match` — без изменений
- `lib/whatsapp/*` — без изменений
- `app/cargo/*`, `app/dashboard/*` — без изменений (UI не затронут)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)