### PR TITLE
feat(γ-1.5-B): LLM timeoutMs ↔ maxDuration alignment на 9 callers

### DIFF
--- a/__tests__/api/llm-timeout-alignment.test.ts
+++ b/__tests__/api/llm-timeout-alignment.test.ts
@@ -1,0 +1,350 @@
+/**
+ * wave-γ-1.5-B: positive contract tests — each LLM call site must pass
+ * timeoutMs aligned with the route's maxDuration.
+ *
+ * Formula: endpointLlmTimeout(maxDuration) = Math.max(5000, (maxDuration-5)*1000)
+ *   maxDuration=30  → 25_000  (draft-quote, draft-reply)
+ *   maxDuration=60  → 55_000  (recap, parse-vessel)
+ *   maxDuration=120 → 115_000 (match, parse-recap, classify)
+ *   lib sub-calls   → 20_000  hard-coded (image-ocr, voice-transcribe)
+ */
+
+import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+import type { SessionData } from '@/lib/types';
+
+// ── Global mocks (hoisted before any imports) ─────────────────────────────
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn().mockReturnValue(true),
+  generateCsrfToken: jest.fn().mockReturnValue('mock-csrf'),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+  updateSession: jest.fn(),
+  createSession: jest.fn().mockReturnValue('mock-session-id'),
+  getSession: jest.fn(),
+}));
+
+jest.mock('@/lib/openai', () => {
+  const ActualErr = jest.requireActual('@/lib/openai').LLMTimeoutError;
+  return {
+    LLMTimeoutError: ActualErr,
+    callAiText: jest.fn(),
+    callAiJson: jest.fn(),
+  };
+});
+
+// Extra mocks needed for route internals
+jest.mock('@/lib/parsing/parse-vessel-helpers', () => ({
+  buildVesselPrompt: jest.fn().mockReturnValue('vessel-prompt'),
+  parseVesselAIResponse: jest.fn().mockReturnValue([]),
+}));
+jest.mock('@/lib/parsing/geared-fallback', () => ({
+  applyGearedFallback: jest.fn().mockReturnValue([]),
+}));
+jest.mock('@/lib/validation/equasis-client', () => ({
+  lookupVesselByImo: jest.fn().mockResolvedValue(null),
+  compareVesselRecord: jest.fn(),
+}));
+jest.mock('@/lib/matching/pair-analyzer', () => ({
+  analyzePairs: jest.fn().mockImplementation(
+    async (_cargos: unknown, _vessels: unknown, aiScorer: (args: unknown) => Promise<unknown>) => {
+      await aiScorer({ cargoData: [], vesselData: [], readinessData: {} });
+      return { matches: [], blockedMatches: [] };
+    },
+  ),
+}));
+jest.mock('@/lib/parsing/parse-recap-helpers', () => ({
+  parseRecapAIResponse: jest.fn().mockReturnValue({ emailId: 'email-01' }),
+}));
+jest.mock('@/lib/commission', () => ({
+  summarizeCommissions: jest.fn().mockReturnValue(null),
+}));
+jest.mock('@/lib/classification-service', () => ({
+  classifyEmails: jest.fn().mockReturnValue({ classifications: [], processedEmails: [] }),
+  buildProcessedEmails: jest.fn().mockReturnValue([]),
+  AiClassification: {},
+}));
+
+// ── Static imports (after mocks) ──────────────────────────────────────────
+
+import { requireSession } from '@/lib/session';
+import { callAiJson, callAiText } from '@/lib/openai';
+import { POST as draftQuotePOST } from '@/app/api/ai/draft-quote/route';
+import { POST as draftReplyPOST } from '@/app/api/ai/draft-reply/route';
+import { POST as recapPOST } from '@/app/api/ai/recap/route';
+import { POST as parseVesselPOST } from '@/app/api/ai/parse-vessel/route';
+import { POST as matchPOST } from '@/app/api/ai/match/route';
+import { POST as parseRecapPOST } from '@/app/api/ai/parse-recap/route';
+import { POST as classifyPOST } from '@/app/api/ai/classify/route';
+import { extractTextFromImage } from '@/lib/whatsapp/image-ocr';
+import { transcribeAudio } from '@/lib/whatsapp/voice-transcribe';
+
+const mockRequireSession = requireSession as jest.Mock;
+const mockCallAiJson = callAiJson as jest.Mock;
+const mockCallAiText = callAiText as jest.Mock;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRequest(path: string, body: unknown = {}): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-csrf-token': 'mock-csrf' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeSession(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    accessToken: 'tok',
+    emails: [
+      {
+        id: 'email-01',
+        threadId: 'thread-01',
+        from: 'sender@example.com',
+        fromName: 'Sender',
+        fromEmail: 'sender@example.com',
+        to: 'broker@example.com',
+        subject: 'Test cargo',
+        date: new Date().toISOString(),
+        body: 'Test body',
+        snippet: 'Test',
+        labelIds: ['INBOX'],
+      },
+    ],
+    parsedCargos: [],
+    parsedVessels: [],
+    parsedRecaps: [],
+    parsedFixtureRecaps: [],
+    classifications: [],
+    matches: [],
+    blockedMatches: [],
+    isSampleData: false,
+    createdAt: new Date(),
+    recaps: [],
+    ...overrides,
+  } as unknown as SessionData;
+}
+
+function setupSession(overrides: Partial<SessionData> = {}): void {
+  mockRequireSession.mockReturnValue({
+    session: makeSession(overrides),
+    sessionId: 'mock-session-id',
+  } as any);
+}
+
+function lastCallOptions(mock: jest.Mock): { timeoutMs?: number } | undefined {
+  const calls = mock.mock.calls;
+  if (calls.length === 0) return undefined;
+  const lastCall = calls[calls.length - 1];
+  return lastCall[lastCall.length - 1] as { timeoutMs?: number } | undefined;
+}
+
+beforeEach(() => {
+  mockCallAiText.mockReset();
+  mockCallAiJson.mockReset();
+  mockCallAiText.mockResolvedValue('AI response text');
+  mockCallAiJson.mockResolvedValue({});
+});
+
+// ── 1. draft-quote (maxDuration=30 → 25_000) ──────────────────────────────
+
+describe('draft-quote route (maxDuration=30)', () => {
+  it('passes timeoutMs=25_000 to callAiText', async () => {
+    setupSession({
+      parsedCargos: [{ emailId: 'email-01', missingInfo: [] } as any],
+    });
+
+    await draftQuotePOST(makeRequest('/api/ai/draft-quote', { emailId: 'email-01' }));
+
+    expect(mockCallAiText).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(25_000);
+  });
+});
+
+// ── 2. draft-reply (maxDuration=30 → 25_000, TWO call paths) ─────────────
+
+describe('draft-reply route (maxDuration=30)', () => {
+  it('case 1: emailId path — callAiText gets timeoutMs=25_000', async () => {
+    setupSession({
+      parsedCargos: [{ emailId: 'email-01', missingInfo: ['port_loading'] } as any],
+    });
+
+    await draftReplyPOST(makeRequest('/api/ai/draft-reply', { emailId: 'email-01' }));
+
+    expect(mockCallAiText).toHaveBeenCalledTimes(1);
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(25_000);
+  });
+
+  it('case 2: pendingItems path — callAiText gets timeoutMs=25_000', async () => {
+    setupSession();
+
+    await draftReplyPOST(
+      makeRequest('/api/ai/draft-reply', {
+        pendingItems: [{ topic: 'freight_rate', value: '$30/mt' }],
+      }),
+    );
+
+    expect(mockCallAiText).toHaveBeenCalledTimes(1);
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(25_000);
+  });
+});
+
+// ── 3. recap (maxDuration=60 → 55_000) ───────────────────────────────────
+
+describe('recap route (maxDuration=60)', () => {
+  it('passes timeoutMs=55_000 to callAiJson', async () => {
+    // Need ≥ MIN_THREAD_LENGTH_FOR_RECAP (=5) emails in same thread
+    setupSession({
+      emails: [
+        {
+          id: 'e1', threadId: 'thread-A', from: 'a@x.com', fromName: 'A', fromEmail: 'a@x.com',
+          to: 'b@x.com', subject: 'Nego', date: new Date('2024-01-01').toISOString(),
+          body: 'msg1', snippet: 'm1', labelIds: [],
+        },
+        {
+          id: 'e2', threadId: 'thread-A', from: 'b@x.com', fromName: 'B', fromEmail: 'b@x.com',
+          to: 'a@x.com', subject: 'Re: Nego', date: new Date('2024-01-02').toISOString(),
+          body: 'msg2', snippet: 'm2', labelIds: [],
+        },
+        {
+          id: 'e3', threadId: 'thread-A', from: 'a@x.com', fromName: 'A', fromEmail: 'a@x.com',
+          to: 'b@x.com', subject: 'Re2: Nego', date: new Date('2024-01-03').toISOString(),
+          body: 'msg3', snippet: 'm3', labelIds: [],
+        },
+        {
+          id: 'e4', threadId: 'thread-A', from: 'b@x.com', fromName: 'B', fromEmail: 'b@x.com',
+          to: 'a@x.com', subject: 'Re3: Nego', date: new Date('2024-01-04').toISOString(),
+          body: 'msg4', snippet: 'm4', labelIds: [],
+        },
+        {
+          id: 'e5', threadId: 'thread-A', from: 'a@x.com', fromName: 'A', fromEmail: 'a@x.com',
+          to: 'b@x.com', subject: 'Re4: Nego', date: new Date('2024-01-05').toISOString(),
+          body: 'msg5', snippet: 'm5', labelIds: [],
+        },
+      ],
+    } as any);
+    mockCallAiJson.mockResolvedValue({ points: [], summary: 'OK' });
+
+    await recapPOST(makeRequest('/api/ai/recap'));
+
+    expect(mockCallAiJson).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiJson);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(55_000);
+  });
+});
+
+// ── 4. parse-vessel (maxDuration=60 after γ-1.5-A → 55_000) ─────────────
+
+describe('parse-vessel route (maxDuration=60)', () => {
+  it('passes timeoutMs=55_000 to callAiText', async () => {
+    setupSession({
+      isSampleData: false,
+      parsedVessels: [],
+      classifications: [{ emailId: 'email-01', category: 'VESSEL_POSITION' } as any],
+    });
+
+    await parseVesselPOST(makeRequest('/api/ai/parse-vessel'));
+
+    expect(mockCallAiText).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(55_000);
+  });
+});
+
+// ── 5. match (maxDuration=120 → 115_000) ─────────────────────────────────
+
+describe('match route (maxDuration=120)', () => {
+  it('passes timeoutMs=115_000 to callAiJson (via aiScorer)', async () => {
+    setupSession({
+      parsedCargos: [{
+        emailId: 'e1', commodity: 'grain', quantityMt: 50000,
+        laycanStart: '2024-08-01', laycanEnd: '2024-08-15',
+        portLoading: 'Istanbul', portDischarge: 'Lagos',
+      } as any],
+      parsedVessels: [{
+        emailId: 'e2', vesselName: 'MV Test', dwt: 60000,
+        positionPort: 'Istanbul', openDate: '2024-08-01',
+      } as any],
+    });
+    mockCallAiJson.mockResolvedValue({ matches: [] });
+
+    await matchPOST(makeRequest('/api/ai/match'));
+
+    expect(mockCallAiJson).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiJson);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(115_000);
+  });
+});
+
+// ── 6. parse-recap (maxDuration=120 → 115_000) ───────────────────────────
+
+describe('parse-recap route (maxDuration=120)', () => {
+  it('passes timeoutMs=115_000 to callAiText', async () => {
+    setupSession({
+      classifications: [{ emailId: 'email-01', category: 'FIXTURE_RECAP' } as any],
+    });
+
+    await parseRecapPOST(makeRequest('/api/ai/parse-recap'));
+
+    expect(mockCallAiText).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(115_000);
+  });
+});
+
+// ── 7. classify (maxDuration=120 → 115_000) ───────────────────────────────
+
+describe('classify route (maxDuration=120)', () => {
+  it('passes timeoutMs=115_000 to callAiJson', async () => {
+    setupSession({
+      isSampleData: false,
+      classifications: [],
+    });
+    mockCallAiJson.mockResolvedValue({ classifications: [] });
+
+    await classifyPOST(makeRequest('/api/ai/classify'));
+
+    expect(mockCallAiJson).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiJson);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(115_000);
+  });
+});
+
+// ── 8. image-ocr lib (sub-call in 30s forward-parser → 20_000) ───────────
+
+describe('image-ocr lib (sub-call, hard-coded 20_000)', () => {
+  it('passes timeoutMs=20_000 to callAiText', async () => {
+    await extractTextFromImage('https://example.com/image.jpg');
+
+    expect(mockCallAiText).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(20_000);
+  });
+});
+
+// ── 9. voice-transcribe lib (sub-call, hard-coded 20_000) ─────────────────
+
+describe('voice-transcribe lib (sub-call, hard-coded 20_000)', () => {
+  it('passes timeoutMs=20_000 to callAiText', async () => {
+    await transcribeAudio('https://example.com/audio.ogg', 'audio/ogg');
+
+    expect(mockCallAiText).toHaveBeenCalled();
+    const opts = lastCallOptions(mockCallAiText);
+    expect(opts).toBeDefined();
+    expect(opts!.timeoutMs).toBe(20_000);
+  });
+});

--- a/__tests__/lib/openai-helpers.test.ts
+++ b/__tests__/lib/openai-helpers.test.ts
@@ -1,0 +1,35 @@
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
+
+describe('endpointLlmTimeout', () => {
+  it('returns 25_000 for maxDuration=30 (draft-quote, draft-reply)', () => {
+    expect(endpointLlmTimeout(30)).toBe(25_000);
+  });
+
+  it('returns 55_000 for maxDuration=60 (recap, parse-vessel)', () => {
+    expect(endpointLlmTimeout(60)).toBe(55_000);
+  });
+
+  it('returns 115_000 for maxDuration=120 (match, parse-recap, classify)', () => {
+    expect(endpointLlmTimeout(120)).toBe(115_000);
+  });
+
+  it('clamps to 5_000 when maxDuration=0 (floor guard)', () => {
+    expect(endpointLlmTimeout(0)).toBe(5_000);
+  });
+
+  it('clamps to 5_000 when maxDuration=5 (exactly at boundary)', () => {
+    expect(endpointLlmTimeout(5)).toBe(5_000);
+  });
+
+  it('clamps to 5_000 when maxDuration=6 ((6-5)*1000=1000 < 5000)', () => {
+    expect(endpointLlmTimeout(6)).toBe(5_000);
+  });
+
+  it('clamps to 5_000 when maxDuration=10 ((10-5)*1000=5000 == floor)', () => {
+    expect(endpointLlmTimeout(10)).toBe(5_000);
+  });
+
+  it('returns 6_000 when maxDuration=11 ((11-5)*1000=6000 > floor)', () => {
+    expect(endpointLlmTimeout(11)).toBe(6_000);
+  });
+});

--- a/app/api/ai/classify/route.ts
+++ b/app/api/ai/classify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession, updateSession } from '@/lib/session';
 import { callAiJson, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_HEAVY, MAX_EMAIL_BODY_CHARS } from '@/lib/constants';
 import { truncateText } from '@/lib/utils';
@@ -34,6 +35,8 @@ async function classifyBatch(batch: EmailInput[]): Promise<AiClassification[]> {
     CLASSIFICATION_SYSTEM_PROMPT,
     AI_MODEL_HEAVY,
     { classifications: [] },
+    undefined,
+    { timeoutMs: endpointLlmTimeout(120) },
   );
   return result.classifications ?? [];
 }

--- a/app/api/ai/draft-quote/route.ts
+++ b/app/api/ai/draft-quote/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession } from '@/lib/session';
 import { callAiText, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { DRAFT_QUOTE_SYSTEM_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_LIGHT } from '@/lib/constants';
 import { DraftQuoteBodySchema } from '@/lib/api-schemas';
@@ -44,7 +45,7 @@ Address the reply to: ${fromName}
 Generate a professional draft quote email.`;
   
   try {
-    const draft = await callAiText(userPrompt, DRAFT_QUOTE_SYSTEM_PROMPT, AI_MODEL_LIGHT);
+    const draft = await callAiText(userPrompt, DRAFT_QUOTE_SYSTEM_PROMPT, AI_MODEL_LIGHT, { timeoutMs: endpointLlmTimeout(30) });
     return NextResponse.json({ draft });
   } catch (err) {
     if (err instanceof LLMTimeoutError) {

--- a/app/api/ai/draft-reply/route.ts
+++ b/app/api/ai/draft-reply/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession } from '@/lib/session';
 import { callAiText, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { DRAFT_REPLY_SYSTEM_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_LIGHT } from '@/lib/constants';
 import { DraftReplyBodySchema } from '@/lib/api-schemas';
@@ -59,7 +60,7 @@ Missing information: ${JSON.stringify(parsedCargo?.missingInfo || [])}
 Write a follow-up email addressing the client by their first name. Ask for the missing information listed above.`;
     
     try {
-      const draft = await callAiText(userPrompt, DRAFT_REPLY_SYSTEM_PROMPT, AI_MODEL_LIGHT);
+      const draft = await callAiText(userPrompt, DRAFT_REPLY_SYSTEM_PROMPT, AI_MODEL_LIGHT, { timeoutMs: endpointLlmTimeout(30) });
       return NextResponse.json({ draft });
     } catch (err) {
       if (err instanceof LLMTimeoutError) return timeoutResponse();
@@ -76,7 +77,7 @@ ${JSON.stringify(pendingItems, null, 2)}
 Write a follow-up email to resolve the pending items.`;
 
     try {
-      const draft = await callAiText(userPrompt, DRAFT_REPLY_SYSTEM_PROMPT, AI_MODEL_LIGHT);
+      const draft = await callAiText(userPrompt, DRAFT_REPLY_SYSTEM_PROMPT, AI_MODEL_LIGHT, { timeoutMs: endpointLlmTimeout(30) });
       return NextResponse.json({ draft });
     } catch (err) {
       if (err instanceof LLMTimeoutError) return timeoutResponse();

--- a/app/api/ai/match/route.ts
+++ b/app/api/ai/match/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession, updateSession } from '@/lib/session';
 import { callAiJson, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { MATCH_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_HEAVY } from '@/lib/constants';
 import { analyzePairs, AiScorer, RawMatch } from '@/lib/matching/pair-analyzer';
@@ -39,6 +40,8 @@ export async function POST(request: NextRequest) {
       MATCH_PROMPT,
       AI_MODEL_HEAVY,
       { matches: [] },
+      undefined,
+      { timeoutMs: endpointLlmTimeout(120) },
     );
 
     return result.matches || [];

--- a/app/api/ai/parse-recap/route.ts
+++ b/app/api/ai/parse-recap/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession, updateSession } from '@/lib/session';
 import { callAiText, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { FIXTURE_RECAP_PARSER_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_HEAVY } from '@/lib/constants';
 import { ParsedFixtureRecap } from '@/lib/types';
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
     fixtureEmails.map((email) => limit(async () => {
       const userPrompt = `From: ${email.from}\nSubject: ${email.subject}\nDate: ${email.date}\n\n${email.body}`;
       try {
-        const raw = await callAiText(userPrompt, FIXTURE_RECAP_PARSER_PROMPT, AI_MODEL_HEAVY);
+        const raw = await callAiText(userPrompt, FIXTURE_RECAP_PARSER_PROMPT, AI_MODEL_HEAVY, { timeoutMs: endpointLlmTimeout(120) });
         return parseRecapAIResponse(raw, email.id);
       } catch (err) {
         // γ-1: per-email timeout isolation — skip on timeout, do not poison batch.

--- a/app/api/ai/parse-vessel/route.ts
+++ b/app/api/ai/parse-vessel/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession, updateSession } from '@/lib/session';
 import { callAiText, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { VESSEL_POSITION_PARSER_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_LIGHT } from '@/lib/constants';
 import { ParsedVessel, cfValue } from '@/lib/types';
@@ -44,7 +45,7 @@ export async function POST(request: NextRequest) {
       const prompt = buildVesselPrompt(email);
       let raw: string;
       try {
-        raw = await callAiText(prompt, VESSEL_POSITION_PARSER_PROMPT, AI_MODEL_LIGHT);
+        raw = await callAiText(prompt, VESSEL_POSITION_PARSER_PROMPT, AI_MODEL_LIGHT, { timeoutMs: endpointLlmTimeout(60) });
       } catch (err) {
         // γ-1: per-email timeout isolation — a single LLM timeout must NOT
         // poison the whole batch. Skip this email; user retries the route.

--- a/app/api/ai/recap/route.ts
+++ b/app/api/ai/recap/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateCsrf } from '@/lib/csrf';
 import { requireSession, updateSession } from '@/lib/session';
 import { callAiJson, LLMTimeoutError } from '@/lib/openai';
+import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { NEGOTIATION_RECAP_SYSTEM_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_HEAVY, MIN_THREAD_LENGTH_FOR_RECAP } from '@/lib/constants';
 import { Recap, RecapPoint, RecapHistoryEntry, NegotiationStatus } from '@/lib/types';
@@ -66,7 +67,9 @@ export async function POST(request: NextRequest) {
         JSON.stringify(threadInput),
         NEGOTIATION_RECAP_SYSTEM_PROMPT,
         AI_MODEL_HEAVY,
-        { points: [], summary: '' }
+        { points: [], summary: '' },
+        undefined,
+        { timeoutMs: endpointLlmTimeout(60) }
       );
 
       const participants = Array.from(new Set(sortedEmails.map(e => e.from)));

--- a/lib/openai-helpers.ts
+++ b/lib/openai-helpers.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns the LLM timeout (in ms) that aligns with a given Vercel route
+ * `maxDuration` (in seconds), leaving a 5-second buffer for response completion.
+ *
+ * Formula: `Math.max(5_000, (maxDuration - 5) * 1_000)`
+ *
+ * Examples:
+ *   - maxDuration=30  → 25_000 ms  (draft-quote, draft-reply)
+ *   - maxDuration=60  → 55_000 ms  (recap, parse-vessel)
+ *   - maxDuration=120 → 115_000 ms (match, parse-recap, classify)
+ *
+ * The 5_000 ms floor prevents pathologically small (or negative) values when
+ * `maxDuration` is very short (e.g. ≤ 10 s).
+ *
+ * @param maxDuration  Vercel `export const maxDuration` value (seconds).
+ * @returns            LLM timeout in milliseconds.
+ */
+export function endpointLlmTimeout(maxDuration: number): number {
+  return Math.max(5_000, (maxDuration - 5) * 1_000);
+}

--- a/lib/whatsapp/image-ocr.ts
+++ b/lib/whatsapp/image-ocr.ts
@@ -15,6 +15,8 @@ export async function extractTextFromImage(imageUrl: string): Promise<string> {
     return await callAiText(
       `Extract text from this image: ${imageUrl}`,
       OCR_SYSTEM_PROMPT,
+      undefined,
+      { timeoutMs: 20_000 },
     );
   } catch (err) {
     if (err instanceof LLMTimeoutError) return '';

--- a/lib/whatsapp/voice-transcribe.ts
+++ b/lib/whatsapp/voice-transcribe.ts
@@ -20,6 +20,8 @@ export async function transcribeAudio(
     const text = await callAiText(
       `Transcribe the audio from: ${audioUrl}\nMIME type: ${mimeType}`,
       WHISPER_SYSTEM_PROMPT,
+      undefined,
+      { timeoutMs: 20_000 },
     );
     return { text, language: 'auto' };
   } catch (err) {


### PR DESCRIPTION
## Зачем это нужно

Раньше когда AI долго думал на сложном запросе, Vercel молча «убивал» функцию и пользователь видел непонятную ошибку 502/504 без объяснений. Это происходило потому что внутренний таймаут AI (85 секунд) был длиннее, чем максимальное время работы функции (30/60/120 секунд). Теперь каждый endpoint явно задаёт AI-таймаут = (maxDuration - 5 секунд), поэтому graceful обработчик успевает сработать и пользователь видит понятное «AI timeout, please retry».

## Что изменилось

- **NEW `lib/openai-helpers.ts`** — хелпер `endpointLlmTimeout(maxDuration)` с защитой от слишком маленьких значений (floor 5_000 ms)
- **`app/api/ai/draft-quote/route.ts`** — timeoutMs: 25_000 (maxDuration=30)
- **`app/api/ai/draft-reply/route.ts`** — timeoutMs: 25_000 на обоих call'ах (emailId + pendingItems paths)
- **`app/api/ai/recap/route.ts`** — timeoutMs: 55_000 (maxDuration=60)
- **`app/api/ai/parse-vessel/route.ts`** — timeoutMs: 55_000 (maxDuration=60, после γ-1.5-A)
- **`app/api/ai/match/route.ts`** — timeoutMs: 115_000 (maxDuration=120)
- **`app/api/ai/parse-recap/route.ts`** — timeoutMs: 115_000 (maxDuration=120)
- **`app/api/ai/classify/route.ts`** — timeoutMs: 115_000 (maxDuration=120)
- **`lib/whatsapp/image-ocr.ts`** — timeoutMs: 20_000 (sub-call внутри 30s forward-parser)
- **`lib/whatsapp/voice-transcribe.ts`** — timeoutMs: 20_000 (то же)
- **NEW `__tests__/lib/openai-helpers.test.ts`** — 8 тестов clamp boundaries
- **NEW `__tests__/api/llm-timeout-alignment.test.ts`** — 10 per-endpoint positive contract тестов

## NOT changed (уже передают timeoutMs корректно)

- `app/api/ai/parse-cargo/route.ts` — γ-3 done
- `lib/economics/route-decision.ts` — done
- `lib/whatsapp/forward-parser.ts` — done
- `lib/imo/cii-lookup.ts` — done

## Test plan

- [ ] `npm test` — 202 suites, 2110+ tests green
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `npm run lint` — 0 errors (только pre-existing warnings)
- [ ] Verify parse_vessel maxDuration=60 (after γ-1.5-A) → uses 55_000 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)