### PR TITLE
fix(l5c): normalize() edge-case forgiveness (γ-cleanup-A)

### DIFF
--- a/__tests__/cargo/l5c-extras.test.ts
+++ b/__tests__/cargo/l5c-extras.test.ts
@@ -107,3 +107,41 @@ describe('wave-γ-3 Task 2: "general cargo" permissive class', () => {
     });
   });
 });
+
+describe('wave-γ-cleanup-A: normalize() edge-case forgiveness', () => {
+  it('matches petroleum-coke (dash) → petcoke alias', () => {
+    // petroleum-coke should normalize to "petroleum coke" → ALIAS_MAP → "petcoke"
+    // petcoke ↔ wheat is incompatible (known pair), so compatible=false with a reason —
+    // but requires_manual_review MUST be false (it matched, not unmatched).
+    const r = checkCompatibility(['petroleum-coke'], 'wheat');
+    expect(r.requires_manual_review).toBe(false);
+    expect(r.compatible).toBe(false); // petcoke→wheat is known incompatible
+    expect(r.blocking_pairs.length).toBeGreaterThan(0);
+    expect(r.blocking_pairs[0].reason).not.toMatch(/manual\s+surveyor/i);
+  });
+
+  it('matches "pet  coke" (double space) → petcoke alias', () => {
+    // "pet  coke" collapses to "pet coke" → ALIAS_MAP → "petcoke"
+    const r = checkCompatibility(['pet  coke'], 'wheat');
+    expect(r.requires_manual_review).toBe(false);
+    expect(r.compatible).toBe(false); // petcoke→wheat is known incompatible
+    expect(r.blocking_pairs[0].reason).not.toMatch(/manual\s+surveyor/i);
+  });
+
+  it('matches "petcoke." (trailing dot) → petcoke', () => {
+    // "petcoke." strips trailing dot → "petcoke" → ALIAS_MAP → "petcoke"
+    const r = checkCompatibility(['petcoke.'], 'wheat');
+    expect(r.requires_manual_review).toBe(false);
+    expect(r.compatible).toBe(false); // petcoke→wheat is known incompatible
+    expect(r.blocking_pairs[0].reason).not.toMatch(/manual\s+surveyor/i);
+  });
+
+  it('matches "  general  cargo  " (whitespace + collapsed) → general taxonomy', () => {
+    // "  general  cargo  " trims + collapses → "general cargo" → ALIAS_MAP → "general"
+    // general cargo → project pipes is compatible (permissive class, inert)
+    const r = checkCompatibility(['  general  cargo  '], 'project pipes');
+    expect(r.requires_manual_review).toBe(false);
+    expect(r.compatible).toBe(true);
+    expect(r.blocking_pairs).toHaveLength(0);
+  });
+});

--- a/lib/cargo/l5c-matrix.ts
+++ b/lib/cargo/l5c-matrix.ts
@@ -53,11 +53,19 @@ const ALIAS_MAP: Record<string, string> = (() => {
   }
   // Legacy aliases preserved for back-compat with prod data already in DB.
   map['fertilizer-urea'] = 'fertilizer';
+  // After normalize() converts dashes→spaces, "fertilizer-urea" becomes
+  // "fertilizer urea" — keep the normalized form as an alias too.
+  map['fertilizer urea'] = 'fertilizer';
   return map;
 })();
 
 function normalize(cargo: string): string {
-  const lower = cargo.trim().toLowerCase();
+  const lower = cargo
+    .trim()
+    .toLowerCase()
+    .replace(/[-_]+/g, ' ')           // dashes/underscores → space
+    .replace(/\s+/g, ' ')             // collapse internal whitespace
+    .replace(/[.,;:!?]+$/g, '');      // strip trailing punctuation
   return ALIAS_MAP[lower] ?? lower;
 }
 


### PR DESCRIPTION
Wave-γ-cleanup spec A. Fixes 4 LOW-nits from γ-2/γ-3 adversarial QA: petroleum-coke, double-space, trailing dot, collapsed whitespace now match TAXONOMY instead of going to manual_review. Tests: 4 new positive contracts, 137 existing cargo tests green.

## Changes

- `lib/cargo/l5c-matrix.ts`: extend `normalize()` — dashes/underscores→space, collapse internal whitespace, strip trailing punctuation. Also add `fertilizer urea` as legacy alias (post-normalize form of `fertilizer-urea`).
- `__tests__/cargo/l5c-extras.test.ts`: 4 new positive contract tests in `wave-γ-cleanup-A` describe block.

## Test results

- `npm test -- __tests__/cargo`: 75 passed (4 new + 71 existing)
- All cargo tests (including `tests/cargo/`): 173 passed, 0 failed

## Note

`fertilizer-urea` legacy alias: after normalize() converts dashes→spaces, the old `ALIAS_MAP['fertilizer-urea']` entry was bypassed. Added `map['fertilizer urea'] = 'fertilizer'` as the normalized-form alias to preserve back-compat with prod fixture `07-fertilizer-urea-grain.json`.