### PR TITLE
fix(hydration): formatNumber helper closes React #418 SSR/CSR drift (γ-cleanup-2 F2)

### DIFF
--- a/__tests__/utils/format-number.test.ts
+++ b/__tests__/utils/format-number.test.ts
@@ -1,0 +1,39 @@
+import { formatNumber } from '@/lib/utils';
+
+describe('formatNumber — locale-stable parity (γ-cleanup-2 F2)', () => {
+  it('formats integers with en-US comma thousands', () => {
+    expect(formatNumber(9500)).toBe('9,500');
+    expect(formatNumber(1234567)).toBe('1,234,567');
+  });
+
+  it('formats decimals with maxFractionDigits', () => {
+    expect(formatNumber(9500.45, { maximumFractionDigits: 2 })).toBe('9,500.45');
+    expect(formatNumber(9500.456, { maximumFractionDigits: 0 })).toBe('9,500');
+  });
+
+  it('handles zero', () => {
+    expect(formatNumber(0)).toBe('0');
+  });
+
+  it('handles negative numbers', () => {
+    expect(formatNumber(-1500)).toBe('-1,500');
+  });
+
+  it('handles NaN/undefined defensively', () => {
+    expect(formatNumber(NaN)).toBe('0');
+    expect(formatNumber(undefined as unknown as number)).toBe('0');
+    expect(formatNumber(null as unknown as number)).toBe('0');
+  });
+
+  it('matches old toLocaleString("en-US") output for parity', () => {
+    const n = 12345.67;
+    expect(formatNumber(n)).toBe(n.toLocaleString('en-US'));
+  });
+
+  it('is stable regardless of system locale', () => {
+    // Mock Intl.NumberFormat default
+    const original = Intl.NumberFormat;
+    // even when default locale would differ, formatNumber forces en-US
+    expect(formatNumber(9500)).toBe('9,500');
+  });
+});

--- a/app/api/ai/recap/route.ts
+++ b/app/api/ai/recap/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
       const participants = Array.from(new Set(sortedEmails.map(e => e.from)));
       const dates = sortedEmails.map(e => e.date).filter(Boolean);
       const dateRange = dates.length > 0
-        ? `${new Date(dates[0]).toLocaleDateString()} \u2013 ${new Date(dates[dates.length - 1]).toLocaleDateString()}`
+        ? `${new Date(dates[0]).toLocaleDateString('en-US')} \u2013 ${new Date(dates[dates.length - 1]).toLocaleDateString('en-US')}`
         : '';
 
       const points: RecapPoint[] = (result.points || []).map((p) => ({

--- a/app/cargo/[id]/page.tsx
+++ b/app/cargo/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { sanitizeEmailBody, formatDate } from '@/lib/utils';
+import { sanitizeEmailBody, formatDate, formatNumber } from '@/lib/utils';
 import { cookies } from 'next/headers';
 import { redirect, notFound } from 'next/navigation';
 import Link from 'next/link';
@@ -286,7 +286,7 @@ export default async function CargoDetailPage({ params }: Props) {
                   match.matchLevel === 'possible' ? '🟡 POSSIBLE' : '⚠️ WEAK';
                 const vesselName = vessel ? safeRender(vessel.vesselName) || 'Unknown' : 'Vessel';
                 const dwtRaw = vessel ? cfValue(vessel.dwtSummer) : null;
-                const dwtStr = dwtRaw != null ? Number(dwtRaw).toLocaleString() : '?';
+                const dwtStr = dwtRaw != null ? formatNumber(Number(dwtRaw)) : '?';
                 return (
                   <Link key={i} href={`/match/${session.matches.indexOf(match)}`}>
                     <div className="p-3 rounded-lg border hover:bg-muted transition-colors cursor-pointer">

--- a/app/commission/page.tsx
+++ b/app/commission/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { getSession } from '@/lib/session';
+import { formatNumber } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { ChevronLeft, AlertTriangle } from 'lucide-react';
 
@@ -43,10 +44,10 @@ export default async function CommissionPage() {
                     </div>
                     <div className="text-right">
                       <p className="text-sm font-medium">
-                        {d.commissionPercent}% × {d.freightCurrency} {d.freightAmount.toLocaleString()}
+                        {d.commissionPercent}% × {d.freightCurrency} {formatNumber(d.freightAmount)}
                       </p>
                       <p className="text-sm font-bold text-green-700">
-                        = {d.commissionCurrency} {d.commissionAmount.toLocaleString()}
+                        = {d.commissionCurrency} {formatNumber(d.commissionAmount)}
                       </p>
                     </div>
                   </div>
@@ -59,7 +60,7 @@ export default async function CommissionPage() {
                       {commissionSummary.totalByCurrency.map((t, i) => (
                         <span key={i}>
                           {i > 0 ? ' + ' : ''}
-                          ~{t.currency === 'EUR' ? '€' : '$'}{t.amount.toLocaleString()}
+                          ~{t.currency === 'EUR' ? '€' : '$'}{formatNumber(t.amount)}
                         </span>
                       ))}
                     </span>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { MarketIntelligence } from '@/components/dashboard/MarketIntelligence';
 import { classifyPriority } from '@/lib/sailing/priority-classifier';
 import type { PriorityLevel } from '@/lib/sailing/priority-classifier';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
+import { formatNumber } from '@/lib/utils';
 
 const PRIORITY_ORDER: Record<PriorityLevel, number> = { urgent: 0, attention: 1, ok: 2 };
 
@@ -80,7 +81,7 @@ export default async function DashboardPage() {
     commissionSummary?.totalByCurrency
       .map(
         (t) =>
-          `~${t.currency} ${t.amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`,
+          `~${t.currency} ${formatNumber(t.amount, { maximumFractionDigits: 0 })}`,
       )
       .join(' + ') || null;
 

--- a/app/fixture/[id]/page.tsx
+++ b/app/fixture/[id]/page.tsx
@@ -9,7 +9,7 @@ import { Renderable } from '@/lib/types';
 import { CopyButton } from '@/components/copy-button';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { safeRender, getConf, ConfIcon } from '@/lib/ui-render';
-import { formatDate } from '@/lib/utils';
+import { formatDate, formatNumber } from '@/lib/utils';
 
 function CField({ label, field }: { label: string; field: Renderable }) {
   const val = safeRender(field);
@@ -54,7 +54,7 @@ export default async function FixtureDetailPage({ params }: Props) {
     recap.dischargingRate ? `Discharging: ${safeRender(recap.dischargingRate)} ${safeRender(recap.dischargingTerms) || ''}` : '',
     recap.demurrageRate ? `Demurrage: ${safeRender(recap.demurrageRate)} ${safeRender(recap.demurragePayment) || ''}` : '',
     recap.commission ? `Commission: ${safeRender(recap.commission)}` : '',
-    recap.commissionAmount ? `Calculated: ${safeRender(recap.commissionCurrency) || '$'}${recap.commissionAmount?.toLocaleString()}` : '',
+    recap.commissionAmount ? `Calculated: ${safeRender(recap.commissionCurrency) || '$'}${formatNumber(recap.commissionAmount)}` : '',
   ].filter(Boolean).join('\n') : '';
 
   return (
@@ -167,7 +167,7 @@ export default async function FixtureDetailPage({ params }: Props) {
                   <CField label="Commission" field={recap.commission} />
                   {recap.commissionPercent != null && recap.commissionAmount != null && (
                     <div className="mt-2 p-2 bg-green-100 rounded text-sm">
-                      <strong>Calculated: {safeRender(recap.commissionCurrency) || '$'}{recap.commissionAmount.toLocaleString()}</strong>
+                      <strong>Calculated: {safeRender(recap.commissionCurrency) || '$'}{formatNumber(recap.commissionAmount)}</strong>
                       <span className="text-muted-foreground ml-2">({recap.commissionPercent}% on freight)</span>
                     </div>
                   )}

--- a/app/summary/page.tsx
+++ b/app/summary/page.tsx
@@ -11,6 +11,7 @@ import {
   CALENDLY_URL,
 } from '@/lib/constants';
 import { Lock, MessageCircle, ChevronLeft } from 'lucide-react';
+import { formatNumber } from '@/lib/utils';
 
 export default async function SummaryPage() {
   const cookieStore = await cookies();
@@ -31,7 +32,7 @@ export default async function SummaryPage() {
   const hoursSaved = (minSaved / 60).toFixed(1);
 
   const commissionTotal = commissionSummary?.totalByCurrency
-    .map(t => `${t.currency === 'EUR' ? '€' : '$'}${t.amount.toLocaleString()}`)
+    .map(t => `${t.currency === 'EUR' ? '€' : '$'}${formatNumber(t.amount)}`)
     .join(' + ') || '$0';
 
   return (

--- a/lib/economics/split-bunker.ts
+++ b/lib/economics/split-bunker.ts
@@ -1,4 +1,5 @@
 import type { BunkerPrice } from './bunker';
+import { formatNumber } from '@/lib/utils';
 
 export interface SplitBunkerRoute {
   fromPort: string;
@@ -67,7 +68,7 @@ export function optimizeSplitBunker(input: SplitBunkerInput): SplitBunkerResult 
     : 0;
 
   const recommendation = savingsUsd > 0
-    ? `Bunker at ${cheapest.port} (${cheapest.price.vlsfo} USD/MT) — saves ~$${savingsUsd.toLocaleString()} vs ${mostExpensive.port}`
+    ? `Bunker at ${cheapest.port} (${cheapest.price.vlsfo} USD/MT) — saves ~$${formatNumber(savingsUsd)} vs ${mostExpensive.port}`
     : `Bunker at ${cheapest.port} (${cheapest.price.vlsfo} USD/MT)`;
 
   return { recommendation, savingsUsd, bunkerPlan };

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -17,6 +17,7 @@ import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { validateDates } from '@/lib/sailing/date-sanity';
 import { checkSanctions } from '@/lib/validation/sanctions';
 import { enrichReasons } from '@/lib/matching/reason-enricher';
+import { formatNumber } from '@/lib/utils';
 
 export interface RawMatch {
   cargo_email_id?: string;
@@ -363,10 +364,10 @@ export async function analyzePairs(
     if (dwtVal && cargoWt) {
       const util = Math.round((cargoWt / dwtVal) * 100);
       sweepReasons.push(
-        `DWCC ${dwtVal.toLocaleString()} mt vs cargo ${cargoWt.toLocaleString()} mt — ${util}% utilization`,
+        `DWCC ${formatNumber(dwtVal)} mt vs cargo ${formatNumber(cargoWt)} mt — ${util}% utilization`,
       );
     } else if (dwtVal) {
-      sweepReasons.push(`Vessel ${dwtVal.toLocaleString()} DWT — physical capacity available`);
+      sweepReasons.push(`Vessel ${formatNumber(dwtVal)} DWT — physical capacity available`);
     }
 
     const dist = analysis.readiness?.distanceNm;

--- a/lib/matching/reason-enricher.ts
+++ b/lib/matching/reason-enricher.ts
@@ -2,6 +2,7 @@
  * Post-processes match reasons to ensure each contains at least one number.
  * Enriches numberless reasons with data from structured match fields.
  */
+import { formatNumber } from '@/lib/utils';
 
 export interface MatchContext {
   vesselDwt?: number | null;
@@ -23,7 +24,7 @@ const ENRICHMENT_RULES: Array<{
     pattern: /geared|crane|gear/i,
     enrich: (ctx) => {
       if (ctx.craneCapacity) return `Vessel geared (${ctx.craneCapacity})`;
-      if (ctx.vesselDwt) return `Vessel geared on ${ctx.vesselDwt.toLocaleString()} DWT carrier`;
+      if (ctx.vesselDwt) return `Vessel geared on ${formatNumber(ctx.vesselDwt)} DWT carrier`;
       return null;
     },
   },
@@ -32,10 +33,10 @@ const ENRICHMENT_RULES: Array<{
     enrich: (ctx) => {
       if (ctx.cargoWeightMt && ctx.vesselDwcc) {
         const util = Math.round((ctx.cargoWeightMt / ctx.vesselDwcc) * 100);
-        return `DWCC ${ctx.vesselDwcc.toLocaleString()} mt vs cargo ${ctx.cargoWeightMt.toLocaleString()} mt — ${util}% utilization`;
+        return `DWCC ${formatNumber(ctx.vesselDwcc)} mt vs cargo ${formatNumber(ctx.cargoWeightMt)} mt — ${util}% utilization`;
       }
       if (ctx.cargoWeightMt && ctx.vesselDwt) {
-        return `Cargo ${ctx.cargoWeightMt.toLocaleString()} mt on ${ctx.vesselDwt.toLocaleString()} DWT vessel`;
+        return `Cargo ${formatNumber(ctx.cargoWeightMt)} mt on ${formatNumber(ctx.vesselDwt)} DWT vessel`;
       }
       return null;
     },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -49,6 +49,11 @@ export function safeJsonParse<T>(text: string, fallback: T): T {
   }
 }
 
+export function formatNumber(n: number | null | undefined, opts?: Intl.NumberFormatOptions): string {
+  if (n === null || n === undefined || !Number.isFinite(n)) return '0';
+  return new Intl.NumberFormat('en-US', opts).format(n);
+}
+
 export function sanitizeEmailBody(body: string): string {
   return body
     .replace(/<file:\/\/\/[^>]*>/gi, '')

--- a/lib/whatsapp/router.ts
+++ b/lib/whatsapp/router.ts
@@ -6,6 +6,7 @@ import type { ForwardParseResult } from './forward-parser';
 import { logAuditEvent } from '@/lib/audit';
 import { cfValue } from '@/lib/types';
 import { logger } from '@/lib/logger';
+import { formatNumber } from '@/lib/utils';
 
 function buildParseReply(result: ForwardParseResult): string {
   const cargo = result.parsedCargo;
@@ -19,7 +20,7 @@ function buildParseReply(result: ForwardParseResult): string {
   const dest = cfValue(cargo.destinationPort) ?? '?';
   const laycan = cargo.laycan ?? 'TBD';
 
-  const weightStr = weight ? `${weight.toLocaleString()} mt` : '? mt';
+  const weightStr = weight ? `${formatNumber(weight)} mt` : '? mt';
   const summary = `✅ Parsed: ${weightStr} ${description} ${origin}→${dest} · laycan ${laycan}`;
 
   const missing = result.missingFields.length > 0


### PR DESCRIPTION
Wave-γ-cleanup-2 F2. Closes React error #418 from research E.

**Root cause:** 13+ bare `.toLocaleString()` sites — server (en-US, '9,500') vs ru-RU browser ('9 500') → hydration mismatch.

**Fix:** `formatNumber(n, opts?)` helper в `lib/utils.ts` хардкодит 'en-US'. Заменено 14 sites в 11 файлах (включая lib/whatsapp/router.ts найденный agent'ом). Plus `toLocaleDateString('en-US')` в recap route. βf3-04 `suppressHydrationWarning` patch retained.