### PR TITLE
fix(l5c): normalize() leading-dash regression guard (γ-cleanup-2 F3)

### DIFF
--- a/__tests__/cargo/l5c-extras.test.ts
+++ b/__tests__/cargo/l5c-extras.test.ts
@@ -108,6 +108,23 @@ describe('wave-γ-3 Task 2: "general cargo" permissive class', () => {
   });
 });
 
+describe('wave-γ-cleanup-2 F3: leading/trailing dash trim', () => {
+  it('matches "-petcoke-" (leading + trailing dash) → petcoke alias', () => {
+    const r = checkCompatibility(['-petcoke-'], 'grain');
+    expect(r.requires_manual_review).toBe(false);
+  });
+
+  it('matches "-iron-ore-" (leading dash + internal dashes) → iron ore', () => {
+    const r = checkCompatibility(['-iron-ore-'], 'wheat');
+    expect(r.requires_manual_review).toBe(false);
+  });
+
+  it('matches "_petcoke_" (leading + trailing underscore)', () => {
+    const r = checkCompatibility(['_petcoke_'], 'grain');
+    expect(r.requires_manual_review).toBe(false);
+  });
+});
+
 describe('wave-γ-cleanup-A: normalize() edge-case forgiveness', () => {
   it('matches petroleum-coke (dash) → petcoke alias', () => {
     // petroleum-coke should normalize to "petroleum coke" → ALIAS_MAP → "petcoke"

--- a/lib/cargo/l5c-matrix.ts
+++ b/lib/cargo/l5c-matrix.ts
@@ -65,7 +65,8 @@ function normalize(cargo: string): string {
     .toLowerCase()
     .replace(/[-_]+/g, ' ')           // dashes/underscores → space
     .replace(/\s+/g, ' ')             // collapse internal whitespace
-    .replace(/[.,;:!?]+$/g, '');      // strip trailing punctuation
+    .replace(/[.,;:!?]+$/g, '')       // strip trailing punctuation
+    .trim();                          // strip leading/trailing whitespace from dash→space conversion
   return ALIAS_MAP[lower] ?? lower;
 }
 


### PR DESCRIPTION
Wave-γ-cleanup-2 F3. Closes MEDIUM finding from γ-cleanup-A QA: `normalize('-petcoke-')` возвращал ` petcoke ` (с leading/trailing пробелами от dash→space conversion которые не trim'ились).

**Fix:** второй `.trim()` в конце цепочки normalize(). 3 новых positive contract-теста (leading-dash, mix dashes, underscores).