### PR TITLE
fix(commission): coerce object-shaped commission_currency to string (γ-cleanup-2 F1)

### DIFF
--- a/__tests__/parsing/parse-recap-commission-coercion.test.ts
+++ b/__tests__/parsing/parse-recap-commission-coercion.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for commission_currency coercion in parseRecapAIResponse.
+ *
+ * Root cause (N4): LLM sometimes returns commission_currency as a
+ * ConfidenceField object { value: "USD", confidence: "confirmed" } instead of
+ * a plain string, causing "[object Object]" on the dashboard.
+ *
+ * These tests exercise the public API parseRecapAIResponse to verify that
+ * commissionCurrency is always coerced to string | null.
+ */
+
+import { parseRecapAIResponse } from '@/lib/parsing/parse-recap-helpers';
+
+function buildRaw(commissionCurrency: unknown): string {
+  return JSON.stringify({
+    vessel_name: 'MV TEST',
+    commission_currency: commissionCurrency,
+  });
+}
+
+describe('parseRecapAIResponse — commission_currency coercion', () => {
+  it('coerces ConfidenceField object {value, confidence} to the string value', () => {
+    const raw = buildRaw({ value: 'USD', confidence: 'confirmed' });
+    const recap = parseRecapAIResponse(raw, 'email-001');
+    expect(recap.commissionCurrency).toBe('USD');
+    expect(typeof recap.commissionCurrency).toBe('string');
+  });
+
+  it('returns null when commission_currency is null', () => {
+    const raw = buildRaw(null);
+    const recap = parseRecapAIResponse(raw, 'email-002');
+    expect(recap.commissionCurrency).toBeNull();
+  });
+
+  it('passes through an already-string value unchanged', () => {
+    const raw = buildRaw('EUR');
+    const recap = parseRecapAIResponse(raw, 'email-003');
+    expect(recap.commissionCurrency).toBe('EUR');
+  });
+
+  it('returns null for a malformed object without a value key', () => {
+    const raw = buildRaw({ foo: 'bar' });
+    const recap = parseRecapAIResponse(raw, 'email-004');
+    expect(recap.commissionCurrency).toBeNull();
+  });
+
+  it('returns null when commission_currency is undefined (key absent)', () => {
+    const raw = JSON.stringify({ vessel_name: 'MV TEST' });
+    const recap = parseRecapAIResponse(raw, 'email-005');
+    expect(recap.commissionCurrency).toBeNull();
+  });
+
+  it('returns null for a numeric value (defensive: unexpected type)', () => {
+    const raw = buildRaw(42);
+    const recap = parseRecapAIResponse(raw, 'email-006');
+    expect(recap.commissionCurrency).toBeNull();
+  });
+});

--- a/lib/commission.ts
+++ b/lib/commission.ts
@@ -42,7 +42,7 @@ export function calculateCommission(recap: ParsedFixtureRecap): CommissionResult
 
   // If AI already computed commissionAmount, use it directly
   const precomputedAmount = safeNum(recap.commissionAmount);
-  const commissionCurrency = recap.commissionCurrency || currency;
+  const commissionCurrency = (typeof recap.commissionCurrency === 'string' && recap.commissionCurrency) || currency;
 
   if (precomputedAmount && precomputedAmount > 0) {
     const totalFreight = Math.round((precomputedAmount / percent) * 100 * 100) / 100;

--- a/lib/parsing/parse-recap-helpers.ts
+++ b/lib/parsing/parse-recap-helpers.ts
@@ -48,6 +48,19 @@ interface RawFixtureRecap {
 }
 
 /**
+ * Coerce an unknown value to a plain string or null.
+ * Handles ConfidenceField objects { value: string, confidence: ... } that the
+ * LLM sometimes returns instead of a bare string.
+ */
+function extractStrField(v: unknown): string | null {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object' && typeof (v as { value?: unknown }).value === 'string') {
+    return (v as { value: string }).value;
+  }
+  return null;
+}
+
+/**
  * Parse a raw AI JSON response string into a single ParsedFixtureRecap.
  * Returns a minimal record with null fields on malformed JSON.
  */
@@ -100,7 +113,7 @@ export function parseRecapAIResponse(raw: string, emailId: string): ParsedFixtur
     commissionPercent: extractNum(result.commission_percent) ?? extractNum(result.commission_pct),
     commissionBase: result.commission_base || null,
     commissionAmount: extractNum(result.commission_amount),
-    commissionCurrency: result.commission_currency || null,
+    commissionCurrency: extractStrField(result.commission_currency),
     subs: Array.isArray(result.subs) ? result.subs : [],
     confidentiality: result.confidentiality != null ? Boolean(result.confidentiality) : false,
     additionalTerms: Array.isArray(result.additional_terms) ? result.additional_terms : [],


### PR DESCRIPTION
Wave-γ-cleanup-2 F1. Closes N4 bug from research D: dashboard 4/5 recap'ов показывали [object Object] потому что LLM иногда возвращал commission_currency как ConfidenceField object {value, confidence}. Fix: extractStrField() helper в parse-recap-helpers + defensive typeof guard в commission.ts. 6 новых contract-тестов.