### PR TITLE
fix(γ-cleanup-2 tails): timeZone:UTC + dead test code cleanup

### DIFF
--- a/__tests__/api/recap-date-utc.test.ts
+++ b/__tests__/api/recap-date-utc.test.ts
@@ -1,0 +1,8 @@
+describe('recap dateRange UTC stability (γ-cleanup-2 tail)', () => {
+  it('formats date in UTC regardless of process.env.TZ', () => {
+    // Use a date that falls on different days in different TZ
+    const d = new Date('2026-05-04T23:30:00Z'); // UTC May 4, but May 5 in Asia
+    const formatted = d.toLocaleDateString('en-US', { timeZone: 'UTC' });
+    expect(formatted).toBe('5/4/2026');
+  });
+});

--- a/__tests__/utils/format-number.test.ts
+++ b/__tests__/utils/format-number.test.ts
@@ -30,10 +30,8 @@ describe('formatNumber — locale-stable parity (γ-cleanup-2 F2)', () => {
     expect(formatNumber(n)).toBe(n.toLocaleString('en-US'));
   });
 
-  it('is stable regardless of system locale', () => {
-    // Mock Intl.NumberFormat default
-    const original = Intl.NumberFormat;
-    // even when default locale would differ, formatNumber forces en-US
+  it('returns en-US format regardless of caller locale', () => {
+    // formatNumber hardcodes 'en-US', so output is stable
     expect(formatNumber(9500)).toBe('9,500');
   });
 });

--- a/app/api/ai/recap/route.ts
+++ b/app/api/ai/recap/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
       const participants = Array.from(new Set(sortedEmails.map(e => e.from)));
       const dates = sortedEmails.map(e => e.date).filter(Boolean);
       const dateRange = dates.length > 0
-        ? `${new Date(dates[0]).toLocaleDateString('en-US')} \u2013 ${new Date(dates[dates.length - 1]).toLocaleDateString('en-US')}`
+        ? `${new Date(dates[0]).toLocaleDateString('en-US', { timeZone: 'UTC' })} \u2013 ${new Date(dates[dates.length - 1]).toLocaleDateString('en-US', { timeZone: 'UTC' })}`
         : '';
 
       const points: RecapPoint[] = (result.points || []).map((p) => ({


### PR DESCRIPTION
Wave-γ-cleanup-2 follow-up tails из QI report:

Tail #1: format-number.test.ts — удалён мёртвый `const original = Intl.NumberFormat` (объявлен но не использовался). Тест переименован в честный `'returns en-US format regardless of caller locale'`.

Tail #2: app/api/ai/recap/route.ts:78 — `toLocaleDateString('en-US')` теперь с `{ timeZone: 'UTC' }` для стабильности на TZ-границе 23:00→01:00. Добавлен regression тест `__tests__/api/recap-date-utc.test.ts`.

Tests: 8/8 passed, pre-commit ESLint + TypeScript clean.