### PR TITLE
fix(cron): check-deadlines main() now calls setDb() for idempotency (NEW-02)

### DIFF
--- a/__tests__/deadlines/cron-init-db.test.ts
+++ b/__tests__/deadlines/cron-init-db.test.ts
@@ -1,0 +1,40 @@
+/**
+ * __tests__/deadlines/cron-init-db.test.ts
+ *
+ * NEW-02 contract tests: initDb() exported from scripts/check-deadlines.ts
+ * wires up the dispatch-ledger DB so listDispatches() works in live cron.
+ *
+ * Without initDb() in main(), live cron calls tryRecordDispatch() on an
+ * undefined db → ledger is bypassed → double-dispatch on the next tick.
+ * Unit tests in cron-idempotency.test.ts don't catch this because they
+ * call setDb() manually in beforeEach.
+ *
+ * These tests verify the production wiring by calling initDb() directly.
+ */
+
+import { initDb } from '@/scripts/check-deadlines';
+import { listDispatches } from '@/lib/db/queries/dispatches';
+
+describe('check-deadlines initDb (NEW-02)', () => {
+  it('initializes ledger so listDispatches works after init', () => {
+    const db = initDb(':memory:');
+    // If setDb() was called and migration ran, listDispatches must not throw.
+    expect(() => listDispatches('any-deal', 'any-deadline')).not.toThrow();
+    db.close();
+  });
+
+  it('migration is idempotent — calling initDb twice does not throw', () => {
+    const db1 = initDb(':memory:');
+    db1.close();
+    const db2 = initDb(':memory:');
+    expect(() => listDispatches('any-deal', 'any-deadline')).not.toThrow();
+    db2.close();
+  });
+
+  it('returns empty array for unknown deal (not an error)', () => {
+    const db = initDb(':memory:');
+    const rows = listDispatches('unknown-deal-id', '2099-01-01T00:00:00.000Z');
+    expect(rows).toEqual([]);
+    db.close();
+  });
+});

--- a/scripts/check-deadlines.ts
+++ b/scripts/check-deadlines.ts
@@ -18,10 +18,13 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import Database from 'better-sqlite3';
 import {
   processDeadline,
   type SubsDeadline,
 } from '../lib/deadlines/subs-guardian';
+import { setDb } from '../lib/db/queries/dispatches';
+import migration011 from '../lib/migrations/011-notified-dispatches';
 
 interface CliFlags {
   dryRun: boolean;
@@ -57,8 +60,26 @@ async function loadActiveDeadlines(flags: CliFlags): Promise<SubsDeadline[]> {
   return [];
 }
 
+/**
+ * NEW-02 fix: initialize the DB ledger for idempotent dispatches.
+ * Without this, live cron runs miss setDb() and tryRecordDispatch()
+ * operates on an undefined db → double-dispatch on the next tick.
+ *
+ * Exported so unit tests can verify the wiring without spawning a subprocess.
+ * Accepts an optional dbPath so tests can pass ':memory:'.
+ */
+export function initDb(
+  dbPath: string = process.env.DEADLINES_DB_PATH ?? './data/quantika.db',
+): Database.Database {
+  const db = new Database(dbPath);
+  migration011.up(db); // idempotent — CREATE TABLE IF NOT EXISTS inside
+  setDb(db);
+  return db;
+}
+
 async function main(): Promise<void> {
   const flags = parseFlags(process.argv.slice(2));
+  initDb(); // NEW-02: wire up dispatch ledger before any deadline processing
   const deadlines = await loadActiveDeadlines(flags);
 
   if (deadlines.length === 0) {


### PR DESCRIPTION
## Problem

Closes NEW-02 from sixth-test-run.

`scripts/check-deadlines.ts` `main()` did not initialize the dispatch-ledger DB before delegating to `processDeadline → tryRecordDispatch`. In live cron the `db` module-var was `undefined` → ledger bypassed → double-dispatch on the next tick.

Unit tests in `cron-idempotency.test.ts` passed because they call `setDb()` manually in `beforeEach` — so this was invisible in CI.

## Fix

- Exports `initDb(dbPath?)` helper: opens `better-sqlite3`, runs idempotent `migration011`, calls `setDb(db)`. Returns the `db` instance.
- `main()` calls `initDb()` as its **first step** before `loadActiveDeadlines`.
- `dbPath` defaults to `process.env.DEADLINES_DB_PATH ?? './data/quantika.db'` — configurable without code changes.

## Tests

Adds `__tests__/deadlines/cron-init-db.test.ts` with 3 contract tests:
1. `listDispatches` works after `initDb(':memory:')` (no undefined-db throw)
2. Calling `initDb` twice does not throw (migration idempotency)
3. Returns empty array for unknown deal (not an error)

All 6 deadlines tests green.

## Cross-cutting callers

`tryRecordDispatch` is only called from `lib/deadlines/subs-guardian.ts` (library layer). Only one entry point (`scripts/check-deadlines.ts`) needs `setDb()` — now fixed via `initDb()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)