### PR TITLE
fix(csrf): edge runtime compat — globalThis.crypto.getRandomValues (BUILD-01)

### DIFF
--- a/__tests__/csrf/edge-runtime-compat.test.ts
+++ b/__tests__/csrf/edge-runtime-compat.test.ts
@@ -1,0 +1,38 @@
+import { generateCsrfToken } from '@/lib/csrf';
+
+describe('CSRF token edge runtime compatibility (BUILD-01)', () => {
+  it('does not import node:crypto', () => {
+    // Static check — load the module source and ensure no `from 'crypto'`
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '../../lib/csrf.ts'), 'utf8');
+    expect(src).not.toMatch(/from\s+['"]crypto['"]|require\(['"]crypto['"]\)/);
+  });
+
+  it('generates 64-char hex token', () => {
+    const token = generateCsrfToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('generates unique tokens (entropy check)', () => {
+    const tokens = new Set<string>();
+    for (let i = 0; i < 100; i++) tokens.add(generateCsrfToken());
+    expect(tokens.size).toBe(100);
+  });
+
+  it('uses globalThis.crypto.getRandomValues (works in edge runtime)', () => {
+    // Mock globalThis.crypto to verify it's the path used
+    const original = globalThis.crypto.getRandomValues.bind(globalThis.crypto);
+    let called = 0;
+    globalThis.crypto.getRandomValues = (arr: any) => {
+      called++;
+      return original(arr);
+    };
+    try {
+      generateCsrfToken();
+      expect(called).toBeGreaterThan(0);
+    } finally {
+      globalThis.crypto.getRandomValues = original;
+    }
+  });
+});

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -1,13 +1,15 @@
-import { randomBytes } from 'crypto';
 import type { NextRequest } from 'next/server';
 
 const TOKEN_REGEX = /^[0-9a-f]{64}$/;
 
 /**
  * Generates a cryptographically secure CSRF token (64-char hex, 32 bytes).
+ * Uses Web Crypto API (globalThis.crypto) — compatible with Edge Runtime and Node 16+.
  */
 export function generateCsrfToken(): string {
-  return randomBytes(32).toString('hex');
+  const arr = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(arr);
+  return Array.from(arr, b => b.toString(16).padStart(2, '0')).join('');
 }
 
 /**


### PR DESCRIPTION
Closes BUILD-01 from sixth-test-run.

## Problem

`middleware.ts` runs in Edge Runtime (Next.js default). It imports `lib/csrf.ts` which used `randomBytes` from Node.js built-in `crypto` module — unavailable in Edge Runtime. Turbopack fails the build.

## Fix

Replace `import { randomBytes } from 'crypto'` with `globalThis.crypto.getRandomValues()` (Web Crypto API) — available in Edge Runtime, browsers, and Node 16+.

## Tests (4 regression tests in `__tests__/csrf/edge-runtime-compat.test.ts`)

- Static source check: no `from 'crypto'` import
- Generates valid 64-char hex token
- Entropy check: 100 unique tokens in 100 calls
- Mock verify: `globalThis.crypto.getRandomValues` is actually called

## Cross-cutting

7 other `crypto` imports found in `app/api/` routes and non-middleware libs — all safe (Node.js API routes, not edge runtime). Middleware chain is clean: `middleware.ts` → `lib/csrf.ts` (fixed) + `lib/rate-limit.ts` (no crypto).

## Build

`npm run build` passes after fix.