### PR TITLE
fix(dashboard): hide unimplemented Market Intelligence cards (γ-cleanup-4 F2)

### DIFF
--- a/__tests__/components/dashboard-market-intelligence.test.tsx
+++ b/__tests__/components/dashboard-market-intelligence.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * TDD tests for γ-cleanup-4 F2: MarketIntelligence dashboard cleanup.
+ *
+ * All 4 KPI cards showed "Unavailable": Bunker Rotterdam + EUA EU ETS have
+ * url=null (no backend), BHSI returns 503 (not implemented in benchmark.ts).
+ * Fix: keep only Toepfer TMI (the only working indicator).
+ *
+ * Uses static JSX source analysis (fs.readFileSync) so no jsdom / React
+ * setup overhead; the component file is the source of truth.
+ *
+ * We check for KpiCard label="…" patterns specifically — so TODO/JSDoc
+ * comments mentioning removed labels do not cause false positives.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const componentPath = path.join(process.cwd(), 'components/dashboard/MarketIntelligence.tsx');
+const source = fs.readFileSync(componentPath, 'utf8');
+
+// Extract only the JSX/TSX portion — strip single-line and multi-line comments
+// so TODO comments mentioning old label names don't cause false positives.
+const withoutComments = source
+  .replace(/\/\*[\s\S]*?\*\//g, '')   // block comments
+  .replace(/\/\/.*$/gm, '');           // line comments
+
+describe('MarketIntelligence dashboard cleanup (γ-cleanup-4 F2)', () => {
+  it('contains Toepfer TMI KpiCard (the only implemented indicator)', () => {
+    expect(withoutComments).toContain('Toepfer TMI');
+  });
+
+  it('does NOT render Bunker Rotterdam KpiCard (url=null, no backend)', () => {
+    expect(withoutComments).not.toContain('Bunker Rotterdam');
+  });
+
+  it('does NOT render EUA EU ETS KpiCard (url=null, no backend)', () => {
+    expect(withoutComments).not.toContain('EUA EU ETS');
+  });
+
+  it('does NOT render BHSI KpiCard (backend returns 503)', () => {
+    expect(withoutComments).not.toContain('BHSI');
+  });
+});

--- a/components/dashboard/MarketIntelligence.tsx
+++ b/components/dashboard/MarketIntelligence.tsx
@@ -19,15 +19,15 @@ interface MarketIntelligenceProps {
 export function MarketIntelligence({ noActiveDeals }: MarketIntelligenceProps) {
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <KpiCard
           label="Toepfer TMI"
           url="/api/market/benchmark?indicator=TOEPFER_TMI"
           unit="USD/day"
         />
-        <KpiCard label="Bunker Rotterdam" url={null} unit="USD/t" />
-        <KpiCard label="EUA EU ETS" url={null} unit="EUR/t" />
-        <KpiCard label="BHSI" url="/api/market/benchmark?indicator=BHSI" unit="index" />
+        {/* TODO(γ-cleanup-4 F2): Bunker Rotterdam, EUA EU ETS, BHSI placeholder cards
+            removed — backend not implemented. Restore when /api/market/benchmark
+            supports those indicators. */}
       </div>
       {noActiveDeals && (
         <p className="text-sm text-gray-500 text-center py-2">

--- a/components/dashboard/__tests__/MarketIntelligence.test.tsx
+++ b/components/dashboard/__tests__/MarketIntelligence.test.tsx
@@ -26,19 +26,22 @@ describe('MarketIntelligence', () => {
     expect(screen.getByText(/Toepfer TMI/i)).toBeTruthy();
   });
 
-  it('shows Bunker Rotterdam KPI', () => {
+  // γ-cleanup-4 F2: Bunker Rotterdam, EUA, BHSI cards removed —
+  // backend not implemented (url=null placeholders / 503-only).
+  // Negative-contract tests guard against re-introduction without backend fix.
+  it('does NOT render Bunker Rotterdam (γ-cleanup-4 F2 — removed pending backend)', () => {
     render(<MarketIntelligence />);
-    expect(screen.getByText(/Bunker Rotterdam/i)).toBeTruthy();
+    expect(screen.queryByText(/Bunker Rotterdam/i)).toBeNull();
   });
 
-  it('shows EUA KPI', () => {
+  it('does NOT render EUA (γ-cleanup-4 F2 — removed pending backend)', () => {
     render(<MarketIntelligence />);
-    expect(screen.getByText(/EUA/i)).toBeTruthy();
+    expect(screen.queryByText(/EUA/i)).toBeNull();
   });
 
-  it('shows BHSI KPI', () => {
+  it('does NOT render BHSI (γ-cleanup-4 F2 — removed pending backend)', () => {
     render(<MarketIntelligence />);
-    expect(screen.getByText(/BHSI/i)).toBeTruthy();
+    expect(screen.queryByText(/BHSI/i)).toBeNull();
   });
 
   it('shows empty-state suggestion when no active deals', () => {
@@ -57,15 +60,15 @@ describe('MarketIntelligence', () => {
     expect(loadingEls).toHaveLength(0);
   });
 
-  it('shows no "Loading…" text after fetch resolves (fetch success for BHSI)', async () => {
+  it('shows no "Loading…" text after fetch resolves (fetch success for Toepfer TMI)', async () => {
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
-      if (url.includes('BHSI')) {
+      if (url.includes('TOEPFER_TMI')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({
-            indicator: 'BHSI',
+            indicator: 'TOEPFER_TMI',
             value: 1234,
-            unit: 'index',
+            unit: 'USD/day',
             period: 'Apr 2026',
             sourceUrl: 'https://example.com',
             fetchedAt: new Date().toISOString(),
@@ -83,7 +86,7 @@ describe('MarketIntelligence', () => {
     const loadingEls = screen.queryAllByText(/Loading…/);
     expect(loadingEls).toHaveLength(0);
 
-    // BHSI card should now show the live value
+    // Toepfer TMI card should now show the live value
     expect(screen.getByText('1,234')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes LOW finding from 7th test run: all 4 Market Intelligence KPIs showed 'Unavailable'. Removed Bunker Rotterdam + EUA EU ETS (url=null placeholders) and BHSI (backend returns 503 — not implemented in lib/market/benchmark.ts). Only Toepfer TMI remains. TODO comment marks restoration condition.

Grid changed from `grid-cols-2 sm:grid-cols-4` to `grid-cols-1 sm:grid-cols-2` to avoid empty grid cells.

**Tests:** 4 TDD tests (static JSX analysis with comment-stripping) — 4/4 GREEN.
**Type-check:** clean.