### PR TITLE
fix(routing): /matches redirects to /dashboard (γ-cleanup-4 F3)

### DIFF
--- a/__tests__/routing/matches-redirect.test.tsx
+++ b/__tests__/routing/matches-redirect.test.tsx
@@ -1,0 +1,11 @@
+describe('/matches redirect (γ-cleanup-4 F3)', () => {
+  it('app/matches/page.tsx exists and uses next/navigation redirect', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const filePath = path.join(__dirname, '../../app/matches/page.tsx');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const src = fs.readFileSync(filePath, 'utf8');
+    expect(src).toMatch(/from\s+['"]next\/navigation['"]/);
+    expect(src).toMatch(/redirect\s*\(\s*['"]\/dashboard['"]\s*\)/);
+  });
+});

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * γ-cleanup-4 F3: /matches list page is not implemented (only /match/[id]).
+ * Users hitting /matches directly are redirected to /dashboard where
+ * they can find Top Priorities → matches via the action panel.
+ */
+export default function MatchesRedirect(): never {
+  redirect('/dashboard');
+}


### PR DESCRIPTION
Closes LOW finding from 7th test run: /matches returned 404. List page not implemented (only /match/[id] singular). Adds server-side redirect to /dashboard via next/navigation. 1 contract test.