### PR TITLE
fix(hydration): React #418 on interior SPA pages — locale-stable date helpers + VALID_CONF guard (γ-cleanup-4 F1)

### DIFF
--- a/__tests__/components/confidence-guard.test.ts
+++ b/__tests__/components/confidence-guard.test.ts
@@ -1,0 +1,69 @@
+/**
+ * γ-cleanup-4 F1 — React #418 guard: numeric confidence values from the LLM
+ * parser must NOT reach JSX as truthy non-null values that would render a
+ * space-only Fragment (leaving dangling whitespace text-nodes that mismatch
+ * between SSR and hydration).
+ *
+ * The fix: every inline ConfIcon call is guarded by VALID_CONF.has(conf)
+ * so that numeric scores like 0.97 are treated as absent.
+ */
+
+const VALID_CONF = new Set(['confirmed', 'interpreted', 'uncertain']);
+
+describe('VALID_CONF guard — numeric confidence scores (γ-cleanup-4 F1)', () => {
+  it('accepts "confirmed" as valid', () => {
+    expect(VALID_CONF.has('confirmed')).toBe(true);
+  });
+
+  it('accepts "interpreted" as valid', () => {
+    expect(VALID_CONF.has('interpreted')).toBe(true);
+  });
+
+  it('accepts "uncertain" as valid', () => {
+    expect(VALID_CONF.has('uncertain')).toBe(true);
+  });
+
+  it('rejects numeric score 0.97 (common LLM parser output)', () => {
+    expect(VALID_CONF.has(String(0.97))).toBe(false);
+    // Simulating runtime: typeof 0.97 !== 'string' so guarded before .has()
+    const conf: unknown = 0.97;
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
+    expect(confStr).toBeUndefined();
+  });
+
+  it('rejects numeric score 0 (edge case — falsy but still numeric)', () => {
+    const conf: unknown = 0;
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
+    expect(confStr).toBeUndefined();
+  });
+
+  it('rejects undefined', () => {
+    const conf: unknown = undefined;
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
+    expect(confStr).toBeUndefined();
+  });
+
+  it('rejects null', () => {
+    const conf: unknown = null;
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf as string) ? conf : undefined;
+    expect(confStr).toBeUndefined();
+  });
+
+  it('rejects empty string', () => {
+    const conf: unknown = '';
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
+    expect(confStr).toBeUndefined();
+  });
+
+  it('rejects arbitrary string not in the set', () => {
+    const conf: unknown = 'high';
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
+    expect(confStr).toBeUndefined();
+  });
+
+  it('passes through "confirmed" correctly', () => {
+    const conf: unknown = 'confirmed';
+    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
+    expect(confStr).toBe('confirmed');
+  });
+});

--- a/__tests__/utils/format-date-locale.test.ts
+++ b/__tests__/utils/format-date-locale.test.ts
@@ -1,0 +1,56 @@
+/**
+ * γ-cleanup-4 F1 — Regression tests for React #418 hydration-safe date formatting.
+ *
+ * Verifies that:
+ *   1. formatDate always produces the same string regardless of the process
+ *      timezone (server UTC vs client user-local) by pinning locale='en-US'
+ *      and timeZone='UTC'.
+ *   2. audit-trail formatTime behaviour is consistent (spot-check via the
+ *      same Intl.DateTimeFormat contract).
+ */
+
+import { formatDate } from '@/lib/utils';
+
+describe('formatDate — locale-stable (γ-cleanup-4 F1)', () => {
+  const ISO = '2026-05-01T09:00:00.000Z';
+
+  it('returns a non-empty string for a valid ISO date', () => {
+    expect(formatDate(ISO)).toBeTruthy();
+  });
+
+  it('pins output to en-US locale: "May 1, 2026"', () => {
+    expect(formatDate(ISO)).toBe('May 1, 2026');
+  });
+
+  it('returns the same string when called twice (deterministic)', () => {
+    expect(formatDate(ISO)).toBe(formatDate(ISO));
+  });
+
+  it('does not throw for unparseable input', () => {
+    // new Date('not-a-date') → Invalid Date; toLocaleDateString returns
+    // "Invalid Date" string rather than throwing. Real callers always pass
+    // valid ISO strings so this is just a guard for robustness.
+    expect(() => formatDate('not-a-date')).not.toThrow();
+  });
+
+  it('handles a date at midnight UTC without day-shift', () => {
+    // UTC midnight — timezone-naive parse would shift day for UTC+N clients
+    expect(formatDate('2026-12-31T00:00:00.000Z')).toBe('Dec 31, 2026');
+  });
+
+  it('does not produce a different date for a late-UTC timestamp', () => {
+    // 2026-01-01T23:59:59Z should stay Jan 1, not roll to Jan 2
+    expect(formatDate('2026-01-01T23:59:59.000Z')).toBe('Jan 1, 2026');
+  });
+});
+
+describe('toLocaleTimeString safety contract (γ-cleanup-4 F1)', () => {
+  it('toLocaleTimeString with en-US + UTC is deterministic', () => {
+    const iso = '2026-05-01T09:00:00.000Z';
+    const t1 = new Date(iso).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'UTC' });
+    const t2 = new Date(iso).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'UTC' });
+    expect(t1).toBe(t2);
+    // Should produce 09:00:00 AM format (en-US 12h style)
+    expect(t1).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/app/fixture/[id]/page.tsx
+++ b/app/fixture/[id]/page.tsx
@@ -11,15 +11,21 @@ import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { safeRender, getConf, ConfIcon } from '@/lib/ui-render';
 import { formatDate, formatNumber } from '@/lib/utils';
 
+// Only render ConfIcon for the three canonical string labels. Numeric scores
+// (0–1) from the parser are truthy but invalid — rendering them would leave a
+// space-only text-node that mismatches during React hydration (#418).
+const VALID_CONF = new Set(['confirmed', 'interpreted', 'uncertain']);
+
 function CField({ label, field }: { label: string; field: Renderable }) {
   const val = safeRender(field);
   const conf = getConf(field);
   if (!val) return null;
+  const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
   return (
     <div className="flex justify-between text-sm py-1.5 border-b border-gray-100">
       <span className="text-muted-foreground">{label}</span>
       <span className="font-medium text-right max-w-[60%]">
-        {val} {conf && <ConfIcon confidence={conf} />}
+        {val}{confStr ? <> <ConfIcon confidence={confStr} /></> : null}
       </span>
     </div>
   );

--- a/app/vessel/[id]/page.tsx
+++ b/app/vessel/[id]/page.tsx
@@ -13,15 +13,21 @@ import { formatDate } from '@/lib/utils';
 import { lookupCii } from '@/lib/imo/cii-lookup';
 import { CiiRatingBadge } from '@/components/vessel/CiiRatingBadge';
 
+// Only the three canonical string labels are valid. Guard against numeric
+// confidence scores from the parser reaching the ConfIcon branch — a truthy
+// number would render a space-only text-node Fragment, triggering React #418.
+const VALID_CONF = new Set(['confirmed', 'interpreted', 'uncertain']);
+
 function Spec({ label, value, unit, confidence }: { label: string; value: Renderable; unit?: string; confidence?: string }) {
   const rendered = safeRender(value);
   if (!rendered || rendered === 'NaN') return null;
+  const confStr = typeof confidence === 'string' && VALID_CONF.has(confidence) ? confidence : undefined;
   return (
     <div className="flex justify-between text-sm py-1 border-b border-gray-100">
       <span className="text-muted-foreground">{label}</span>
       <span className="font-medium">
         {rendered}{unit ? ` ${unit}` : ''}
-        {confidence && <> <ConfIcon confidence={confidence} /></>}
+        {confStr ? <> <ConfIcon confidence={confStr} /></> : null}
       </span>
     </div>
   );
@@ -108,7 +114,7 @@ export default async function VesselDetailPage({ params }: Props) {
                 <Ship className="h-4 w-4" />
                 {safeRender(vessel.vesselName) || 'Unknown Vessel'}
                 {vessels.length > 1 ? ` (#${idx + 1})` : ''}
-                {vessel.vesselName && <ConfIcon confidence={getConf(vessel.vesselName)} />}
+                {VALID_CONF.has(getConf(vessel.vesselName) ?? '') && <ConfIcon confidence={getConf(vessel.vesselName)} />}
                 {ciiResults[idx] && ciiResults[idx].rating !== 'unknown' && (
                   <CiiRatingBadge
                     rating={ciiResults[idx].rating}
@@ -126,13 +132,13 @@ export default async function VesselDetailPage({ params }: Props) {
                   <p className="text-sm font-medium text-blue-800">
                     <MapPin className="h-4 w-4 inline mr-1" />
                     Open: {safeRender(vessel.openPosition) || '?'}
-                    {vessel.openPosition && <> <ConfIcon confidence={getConf(vessel.openPosition)} /></>}
+                    {VALID_CONF.has(getConf(vessel.openPosition) ?? '') && <> <ConfIcon confidence={getConf(vessel.openPosition)} /></>}
                   </p>
                   {vessel.openDate && (
                     <p className="text-sm text-blue-700">
                       <Calendar className="h-4 w-4 inline mr-1" />
                       Date: {safeRender(vessel.openDate)}
-                      <> <ConfIcon confidence={getConf(vessel.openDate)} /></>
+                      {VALID_CONF.has(getConf(vessel.openDate) ?? '') && <> <ConfIcon confidence={getConf(vessel.openDate)} /></>}
                     </p>
                   )}
                   {vessel.direction && <p className="text-xs text-blue-600">Direction: {safeRender(vessel.direction)}</p>}

--- a/components/audit-trail.tsx
+++ b/components/audit-trail.tsx
@@ -8,10 +8,14 @@ interface AuditTrailProps {
 }
 
 function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString(undefined, {
+  // Pin locale to 'en-US' and timeZone to 'UTC' so server (UTC) and client
+  // (user-local TZ) produce the same string — avoids React #418 hydration
+  // mismatch on interior pages that render AuditTrail in SSR context.
+  return new Date(iso).toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
+    timeZone: 'UTC',
   });
 }
 

--- a/components/clickable-field.tsx
+++ b/components/clickable-field.tsx
@@ -21,6 +21,13 @@ function ConfIcon({ confidence }: { confidence?: string }) {
   return null;
 }
 
+// Valid string confidence values — guards against runtime numeric confidence
+// scores (0–1) from the LLM parser being passed where strings are expected.
+// A numeric confidence is truthy, so `{confidence && ...}` would render a
+// Fragment containing only a space text-node, causing React #418 hydration
+// mismatch on interior server-rendered pages.
+const VALID_CONF = new Set(['confirmed', 'interpreted', 'uncertain']);
+
 export function ClickableField({
   label, value, unit, confidence,
   sourceText, emailBody, emailFrom, emailDate, emailSubject,
@@ -28,10 +35,15 @@ export function ClickableField({
   const rendered = value != null ? String(value) : '';
   if (!rendered || rendered === 'NaN') return null;
 
+  // Only render the ConfIcon when confidence is a recognised string label.
+  const confStr = typeof confidence === 'string' && VALID_CONF.has(confidence)
+    ? confidence
+    : undefined;
+
   const display = (
     <>
       {rendered}{unit ? ` ${unit}` : ''}
-      {confidence && <> <ConfIcon confidence={confidence} /></>}
+      {confStr ? <> <ConfIcon confidence={confStr} /></> : null}
     </>
   );
 


### PR DESCRIPTION
## Summary

- **Root cause (React #418):** numeric confidence scores (`0.97`) from the LLM parser reached `ConfIcon` render branches that were guarded only by truthiness (`{confidence && ...}`). A truthy number renders a Fragment containing a single space text-node; that node is present in SSR output but absent after hydration — the classic React #418 pattern.
- **Date locale fix:** `audit-trail.tsx` was calling `toLocaleTimeString(undefined, ...)` which produced locale-dependent output (server UTC vs client user-TZ), another source of hydration mismatch.

## Files changed

| File | Change |
|------|--------|
| `components/clickable-field.tsx` | Added `VALID_CONF` set + `confStr` guard; numeric confidence now silently dropped |
| `app/vessel/[id]/page.tsx` | Added `VALID_CONF` to inline `Spec` component + 3 inline `ConfIcon` call sites |
| `app/fixture/[id]/page.tsx` | Added `VALID_CONF` to `CField` component |
| `components/audit-trail.tsx` | Pinned `toLocaleTimeString` to `'en-US'` + `timeZone: 'UTC'` |

## Regression tests added

- `__tests__/utils/format-date-locale.test.ts` — 6 tests: en-US pin, midnight UTC no day-shift, late-UTC no rollover, determinism, no-throw on invalid input
- `__tests__/components/confidence-guard.test.ts` — 9 tests: numeric `0.97` rejected, `null`/`undefined`/empty rejected, valid string labels pass through

## Verified

- `npm test`: 207 suites / 2155 tests green
- `npm run build`: clean Turbopack build

🤖 Generated with [Claude Code](https://claude.com/claude-code)