### PR TITLE
fix(types): extract route helpers (Next.js 16 strict route-types)

### DIFF
--- a/__tests__/api/parse-cargo-concurrency.test.ts
+++ b/__tests__/api/parse-cargo-concurrency.test.ts
@@ -11,7 +11,7 @@
  * unit-tested without spinning up a Next request.
  */
 
-import { withRetry429, PARSE_CARGO_CONCURRENCY } from '@/app/api/ai/parse-cargo/route';
+import { withRetry429, PARSE_CARGO_CONCURRENCY } from '@/lib/parse-cargo-helpers';
 
 describe('wave-γ-3 Task B1: parse-cargo concurrency limit', () => {
   it('exposes PARSE_CARGO_CONCURRENCY = 8 (was 3 — caused 524 with 13 demo emails)', () => {

--- a/__tests__/components/cargo-special-render.test.tsx
+++ b/__tests__/components/cargo-special-render.test.tsx
@@ -9,7 +9,7 @@
  * need to mount the server component in jsdom.
  */
 
-import { renderSpecialRequirements } from '@/app/cargo/[id]/page';
+import { renderSpecialRequirements } from '@/lib/cargo-render';
 
 describe('renderSpecialRequirements (βf2-02)', () => {
   it('TDD-1: array of {label} objects → readable comma-separated text, no [object Object]', () => {

--- a/app/api/ai/parse-cargo/__tests__/route.test.ts
+++ b/app/api/ai/parse-cargo/__tests__/route.test.ts
@@ -30,7 +30,8 @@ jest.mock('@/lib/session', () => {
 });
 
 import * as routeModule from '@/app/api/ai/parse-cargo/route';
-import { POST, MAX_EMAIL_BODY_CHARS, LLM_TIMEOUT_MS } from '@/app/api/ai/parse-cargo/route';
+import { POST } from '@/app/api/ai/parse-cargo/route';
+import { MAX_EMAIL_BODY_CHARS, LLM_TIMEOUT_MS } from '@/lib/parse-cargo-helpers';
 import { callAiJson } from '@/lib/openai';
 import { getSession, updateSession } from '@/lib/session';
 import type { SessionData } from '@/lib/types';

--- a/app/api/ai/parse-cargo/route.ts
+++ b/app/api/ai/parse-cargo/route.ts
@@ -4,6 +4,12 @@ import { requireSession, updateSession } from '@/lib/session';
 import { callAiJson, LLMTimeoutError } from '@/lib/openai';
 import { CARGO_INQUIRY_PARSER_PROMPT } from '@/lib/prompts';
 import { AI_MODEL_LIGHT } from '@/lib/constants';
+import {
+  MAX_EMAIL_BODY_CHARS,
+  LLM_TIMEOUT_MS,
+  PARSE_CARGO_CONCURRENCY,
+  withRetry429,
+} from '@/lib/parse-cargo-helpers';
 import { CargoType, Email, ParsedCargo, Range } from '@/lib/types';
 import { toConfidence, extractNum } from '@/lib/parsing-utils';
 import { calibrateAll } from '@/lib/validation/confidence-calibration';
@@ -49,81 +55,6 @@ function extractStr(v: unknown): string | null {
 // route well below it so the runtime can still emit a clean 200 fallback
 // instead of bubbling a 524 to the browser.
 export const maxDuration = 55;
-
-// βf-11: Per-email body cap before we hand the prompt to the LLM. Real-inbox
-// emails sometimes carry quoted threads/footers in the 50k–100k char range,
-// which pushes the prompt over cliproxy/gpt-5.5 budgets and stalls the route.
-// 12 000 chars ≈ 3 000 tokens — comfortably under the model's working window
-// while still preserving the lead paragraph + first reply where intent lives.
-export const MAX_EMAIL_BODY_CHARS = 12_000;
-
-// βf-11: Per-email LLM timeout. We race callAiJson against this; on timeout we
-// fall back to regex-only enrichment (applyCargoRateFallback / TypeFallback)
-// so the route returns 200 with whatever we can salvage instead of stalling
-// past maxDuration.
-export const LLM_TIMEOUT_MS = 45_000;
-
-/**
- * wave-γ-3 (B1): per-route concurrency cap on parallel LLM calls.
- * Was 3 — for a 13-email demo session that cost ~5 sequential rounds × 20s
- * each, hitting Cloudflare 524 stably. Bumped to 8 → ceil(13/8)=2 rounds.
- */
-export const PARSE_CARGO_CONCURRENCY = 8;
-
-/**
- * wave-γ-3 (B1): retry an LLM call when cliproxy returns 429 (rate limit).
- * Higher pLimit concurrency means more chance of brief upstream throttling;
- * a jittered backoff retry absorbs the blip without surfacing it as a parse
- * failure. Non-429 errors propagate immediately so real failures stay loud.
- */
-export interface Retry429Options {
-  maxRetries?: number;
-  /** Alias for maxRetries (γ-cleanup-B). */
-  maxAttempts?: number;
-  baseDelayMs?: number;
-}
-export async function withRetry429<T>(
-  fn: () => Promise<T>,
-  opts: Retry429Options = {},
-): Promise<T> {
-  // maxAttempts is the total number of calls; maxRetries is retries after the first.
-  // Support both: if maxAttempts is given, derive maxRetries from it.
-  const maxRetries =
-    opts.maxRetries ?? (opts.maxAttempts != null ? opts.maxAttempts - 1 : 2);
-  const baseDelayMs = opts.baseDelayMs ?? 200;
-  let lastErr: unknown;
-  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastErr = err;
-      // γ-cleanup-B: check error.status / error.statusCode FIRST (authoritative).
-      // Regex is a message-based fallback ONLY when status is not present — avoids
-      // false-positive on e.g. "RFQ #429 not found" where 429 is an order ID,
-      // not a rate-limit HTTP status code.
-      const status =
-        (err as { status?: number; statusCode?: number })?.status ??
-        (err as { statusCode?: number })?.statusCode;
-      const isStatusRateLimit = status === 429;
-      const msg = String((err as { message?: string } | null)?.message ?? err ?? '');
-      // Message-based detection (fallback when status is absent).
-      // Lookbehind (?<![#\w]) prevents false-positives like "RFQ #429 not found"
-      // where 429 is an order ID preceded by '#', not an HTTP rate-limit code.
-      const isMessageRateLimit = /(?<![#\w])429\b|rate[-_\s]?limit/i.test(msg);
-      const isRateLimit = isStatusRateLimit || isMessageRateLimit;
-      if (!isRateLimit || attempt === maxRetries) throw err;
-      // Jittered exponential backoff: baseDelay × 2^attempt × (1..2 random).
-      const delayMs = baseDelayMs * Math.pow(2, attempt) * (1 + Math.random());
-      // γ-cleanup-B: .unref() lets jest worker exit cleanly (timer does not keep
-      // the event loop alive when the test suite finishes).
-      await new Promise<void>((resolve) => {
-        const t = setTimeout(resolve, delayMs);
-        if (typeof t.unref === 'function') t.unref();
-      });
-    }
-  }
-  throw lastErr;
-}
 
 /** Truncate raw email body to keep prompts within model budget. */
 function truncateBody(body: string): string {

--- a/app/cargo/[id]/page.tsx
+++ b/app/cargo/[id]/page.tsx
@@ -12,34 +12,7 @@ import { cfValue } from '@/lib/types';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { ClickableField } from '@/components/clickable-field';
 import { safeRender, getConf, ConfIcon } from '@/lib/ui-render';
-
-/**
- * βf2-02: Normalise specialRequirements before rendering.
- * The LLM parser sometimes returns an array of objects ({label, name, ...})
- * instead of the typed `string | null`. Coerce to readable text so the user
- * never sees "[object Object]" on the cargo page.
- *
- * Exported for unit testing (pure function, no React dependencies).
- */
-export function renderSpecialRequirements(
-  value: unknown,
-): string {
-  if (value == null) return '';
-  if (typeof value === 'string') return value;
-  if (Array.isArray(value)) {
-    if (value.length === 0) return '';
-    return value
-      .map((it) =>
-        typeof it === 'string'
-          ? it
-          : (it as Record<string, unknown>).label ??
-            (it as Record<string, unknown>).name ??
-            JSON.stringify(it),
-      )
-      .join(', ');
-  }
-  return safeRender(value as Parameters<typeof safeRender>[0]);
-}
+import { renderSpecialRequirements } from '@/lib/cargo-render';
 
 interface Props {
   params: Promise<{ id: string }>;

--- a/lib/cargo-render.ts
+++ b/lib/cargo-render.ts
@@ -1,0 +1,31 @@
+import { safeRender } from '@/lib/ui-render';
+
+/**
+ * βf2-02: Normalise specialRequirements before rendering.
+ *
+ * The LLM parser sometimes returns an array of objects ({label, name, ...})
+ * instead of the typed `string | null`. Coerce to readable text so the user
+ * never sees "[object Object]" on the cargo page.
+ *
+ * Extracted from `app/cargo/[id]/page.tsx` (Next.js 16 forbids non-route
+ * exports from page files — TS2344 against generated route-types).
+ *
+ * Pure function, no React deps — unit-testable in isolation.
+ */
+export function renderSpecialRequirements(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '';
+    return value
+      .map((it) =>
+        typeof it === 'string'
+          ? it
+          : ((it as Record<string, unknown>).label ??
+              (it as Record<string, unknown>).name ??
+              JSON.stringify(it)),
+      )
+      .join(', ');
+  }
+  return safeRender(value as Parameters<typeof safeRender>[0]);
+}

--- a/lib/parse-cargo-helpers.ts
+++ b/lib/parse-cargo-helpers.ts
@@ -1,0 +1,90 @@
+/**
+ * Helpers extracted from `app/api/ai/parse-cargo/route.ts`.
+ *
+ * Next.js 16 generates strict route-types that forbid non-route exports
+ * from a `route.ts` file. These constants and helpers were previously
+ * exported from the route for tests and other modules; that triggers
+ * `TS2344` against `OmitWithTag<...>`. Moving them here keeps the public
+ * surface intact while making the route file route-export-clean.
+ *
+ * Do NOT move generic `MAX_EMAIL_BODY_CHARS` here — the parse-cargo value
+ * (12_000) intentionally differs from the email-fetch / classify preview
+ * cap in `lib/constants.ts` (3_000). Keeping it in this dedicated module
+ * preserves that scope distinction.
+ */
+
+// βf-11: Per-email body cap before we hand the prompt to the LLM. Real-inbox
+// emails sometimes carry quoted threads/footers in the 50k–100k char range,
+// which pushes the prompt over cliproxy/gpt-5.5 budgets and stalls the route.
+// 12 000 chars ≈ 3 000 tokens — comfortably under the model's working window
+// while still preserving the lead paragraph + first reply where intent lives.
+export const MAX_EMAIL_BODY_CHARS = 12_000;
+
+// βf-11: Per-email LLM timeout. We race callAiJson against this; on timeout we
+// fall back to regex-only enrichment (applyCargoRateFallback / TypeFallback)
+// so the route returns 200 with whatever we can salvage instead of stalling
+// past maxDuration.
+export const LLM_TIMEOUT_MS = 45_000;
+
+/**
+ * wave-γ-3 (B1): per-route concurrency cap on parallel LLM calls.
+ * Was 3 — for a 13-email demo session that cost ~5 sequential rounds × 20s
+ * each, hitting Cloudflare 524 stably. Bumped to 8 → ceil(13/8)=2 rounds.
+ */
+export const PARSE_CARGO_CONCURRENCY = 8;
+
+/**
+ * wave-γ-3 (B1): retry an LLM call when cliproxy returns 429 (rate limit).
+ * Higher pLimit concurrency means more chance of brief upstream throttling;
+ * a jittered backoff retry absorbs the blip without surfacing it as a parse
+ * failure. Non-429 errors propagate immediately so real failures stay loud.
+ */
+export interface Retry429Options {
+  maxRetries?: number;
+  /** Alias for maxRetries (γ-cleanup-B). */
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}
+
+export async function withRetry429<T>(
+  fn: () => Promise<T>,
+  opts: Retry429Options = {},
+): Promise<T> {
+  // maxAttempts is the total number of calls; maxRetries is retries after the first.
+  // Support both: if maxAttempts is given, derive maxRetries from it.
+  const maxRetries =
+    opts.maxRetries ?? (opts.maxAttempts != null ? opts.maxAttempts - 1 : 2);
+  const baseDelayMs = opts.baseDelayMs ?? 200;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      // γ-cleanup-B: check error.status / error.statusCode FIRST (authoritative).
+      // Regex is a message-based fallback ONLY when status is not present — avoids
+      // false-positive on e.g. "RFQ #429 not found" where 429 is an order ID,
+      // not a rate-limit HTTP status code.
+      const status =
+        (err as { status?: number; statusCode?: number })?.status ??
+        (err as { statusCode?: number })?.statusCode;
+      const isStatusRateLimit = status === 429;
+      const msg = String((err as { message?: string } | null)?.message ?? err ?? '');
+      // Message-based detection (fallback when status is absent).
+      // Lookbehind (?<![#\w]) prevents false-positives like "RFQ #429 not found"
+      // where 429 is an order ID preceded by '#', not an HTTP rate-limit code.
+      const isMessageRateLimit = /(?<![#\w])429\b|rate[-_\s]?limit/i.test(msg);
+      const isRateLimit = isStatusRateLimit || isMessageRateLimit;
+      if (!isRateLimit || attempt === maxRetries) throw err;
+      // Jittered exponential backoff: baseDelay × 2^attempt × (1..2 random).
+      const delayMs = baseDelayMs * Math.pow(2, attempt) * (1 + Math.random());
+      // γ-cleanup-B: .unref() lets jest worker exit cleanly (timer does not keep
+      // the event loop alive when the test suite finishes).
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, delayMs);
+        if (typeof t.unref === 'function') t.unref();
+      });
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary

- Next.js 16 строго запрещает не-route экспорты из route/page файлов — генерирует ошибку `TS2344` против `OmitWithTag<...>` constraint в `.next/types/*`.
- На main 2 файла нарушают это правило и блокируют `npx tsc --noEmit`. Вынесены в dedicated модули.
- Pre-req для Wave γ: preflight `verify_commands = npm run lint && npx tsc --noEmit && npm test` падает на этих 2 ошибках без фикса.

## Что изменилось

| Старое место | Новое место | Что вынесено |
|---|---|---|
| `app/api/ai/parse-cargo/route.ts` | `lib/parse-cargo-helpers.ts` | `MAX_EMAIL_BODY_CHARS`, `LLM_TIMEOUT_MS`, `PARSE_CARGO_CONCURRENCY`, `withRetry429`, `Retry429Options` |
| `app/cargo/[id]/page.tsx` | `lib/cargo-render.ts` | `renderSpecialRequirements` |

Импорты в 2 тестах и одном route-test обновлены на новые пути. Поведение не меняется — чистый extract refactor, без логики.

## Test plan

- [x] `npm run lint` — 0 errors (24 pre-existing warnings)
- [x] `npx tsc --noEmit` — exit 0 (раньше падал на 2 ошибках)
- [x] `npm test` — 2167 passed, 2 skipped, 0 failed (идентично main)
- [x] `npm run build` + повторный `tsc --noEmit` — clean (фикс реальный, а не из-за отсутствующего `.next/types/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)