### PR TITLE
fix: overlapping highlights + scoped MatchTabs ids

### DIFF
--- a/components/__tests__/email-body-viewer.overlapping-highlights.test.tsx
+++ b/components/__tests__/email-body-viewer.overlapping-highlights.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Adversarial QA: EmailBodyViewer overlapping highlights
+ *
+ * buildSegments() in email-body-viewer.tsx sorts highlights by body.indexOf,
+ * then iterates over `remaining` (which shrinks as each highlight is consumed).
+ *
+ * If h1 starts at position 0 and h2 also starts at position 0 (one contains
+ * the other), whichever processes first eats its text out of `remaining`.
+ * The second highlight's text may then not exist in `remaining` → silently skipped.
+ *
+ * Real production case from demo-parsed-cargoes.json (sample-01):
+ *   body fragment: "8,500 mts HRC steel coils, SF 1.20"
+ *   weightMt.sourceText:       "8,500 mts HRC steel coils"       (offset 0)
+ *   cargoDescription.sourceText: "8,500 mts HRC steel coils, SF 1.20" (offset 0)
+ *
+ * Both start at offset 0. Sort order between them is UNDEFINED (stable sort
+ * not guaranteed in all JS engines for equal keys). One silently disappears.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EmailBodyViewer, Highlight } from '../email-body-viewer';
+
+// Ensure window.location.hash is empty so the scroll-on-highlight useEffect doesn't run
+// jsdom already defines window.location; just make sure hash is empty (it is by default)
+// We don't redefine — that causes a TypeError in jsdom.
+
+describe('EmailBodyViewer overlapping highlights — Attack B', () => {
+  describe('contained highlight (one is substring of the other)', () => {
+    const body = '8,500 mts HRC steel coils, SF 1.20';
+
+    const highlights: Highlight[] = [
+      {
+        text: '8,500 mts HRC steel coils',
+        color: 'bg-blue-200',
+        label: 'weight',
+      },
+      {
+        text: '8,500 mts HRC steel coils, SF 1.20',
+        color: 'bg-green-200',
+        label: 'cargo',
+      },
+    ];
+
+    it('BUG PROBE: both marks should render when highlights overlap from position 0', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+
+      // With the overlapping bug, only 1 <mark> renders (the other is silently skipped)
+      // This test FAILS when the bug is present
+      expect(marks.length).toBe(2);
+    });
+
+    it('BUG PROBE: the weight mark (shorter) should be present', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = Array.from(container.querySelectorAll('mark'));
+      const weightMark = marks.find(m => m.getAttribute('title') === 'weight');
+      expect(weightMark).toBeTruthy();
+    });
+
+    it('BUG PROBE: the cargo mark (longer, contains weight) should be present', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = Array.from(container.querySelectorAll('mark'));
+      const cargoMark = marks.find(m => m.getAttribute('title') === 'cargo');
+      expect(cargoMark).toBeTruthy();
+    });
+  });
+
+  describe('exact same position, different lengths — reversed order', () => {
+    // If the LONGER one processes first: it consumes all text.
+    // Then the shorter one can't find itself in remaining "" → skipped.
+    const body = 'Lagos, Nigeria (Apapa)';
+
+    const highlights: Highlight[] = [
+      {
+        text: 'Lagos, Nigeria (Apapa)',  // longer, starts at 0
+        color: 'bg-green-200',
+        label: 'destination-full',
+      },
+      {
+        text: 'Lagos',                   // shorter, starts at 0
+        color: 'bg-yellow-200',
+        label: 'port-name',
+      },
+    ];
+
+    it('BUG PROBE: both marks render regardless of highlight order', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // This will FAIL when the shorter highlight cannot be found in `remaining`
+      // after the longer one processes first
+      expect(marks.length).toBe(2);
+    });
+  });
+
+  describe('non-overlapping highlights — control case', () => {
+    const body = 'Load: Constanta, Romania. Disch: Lagos, Nigeria';
+
+    const highlights: Highlight[] = [
+      {
+        text: 'Constanta',
+        color: 'bg-blue-200',
+        label: 'load-port',
+      },
+      {
+        text: 'Lagos',
+        color: 'bg-green-200',
+        label: 'disch-port',
+      },
+    ];
+
+    it('CONTROL: both non-overlapping highlights render correctly', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // This should always PASS — confirms test infrastructure works
+      expect(marks.length).toBe(2);
+    });
+
+    it('CONTROL: first highlight has correct label', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = Array.from(container.querySelectorAll('mark'));
+      expect(marks[0].getAttribute('title')).toBe('load-port');
+    });
+  });
+
+  describe('same start position, same length (exact duplicate highlights)', () => {
+    const body = 'Steel coils, 8500 mt';
+
+    const highlights: Highlight[] = [
+      {
+        text: 'Steel coils',
+        color: 'bg-blue-200',
+        label: 'cargo-type',
+      },
+      {
+        text: 'Steel coils',
+        color: 'bg-purple-200',
+        label: 'cargo-duplicate',
+      },
+    ];
+
+    it('BUG PROBE: two marks with identical text — at least one renders', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // The second identical highlight can't be found after first consumes it.
+      // Documenting current behavior: only 1 mark rendered.
+      // Whether this is a bug depends on requirements — both references to same
+      // text cannot both be highlighted without overlapping DOM ranges.
+      // We expect at least 1.
+      expect(marks.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('highlight starts in middle of another — partial overlap', () => {
+    const body = 'HRC steel coils SF 1.20';
+    //                     ^^^^^^^^^^^
+    //              ^^^^^^^^^^^
+    // h1: "HRC steel coils" starts at 0
+    // h2: "steel coils SF"  starts at 4
+
+    const highlights: Highlight[] = [
+      {
+        text: 'HRC steel coils',
+        color: 'bg-blue-200',
+        label: 'cargo-name',
+      },
+      {
+        text: 'steel coils SF',
+        color: 'bg-yellow-200',
+        label: 'cargo-with-sf',
+      },
+    ];
+
+    it('BUG PROBE: partially overlapping highlights — second highlight skipped', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // After h1 consumes "HRC steel coils", remaining = " SF 1.20"
+      // h2 looks for "steel coils SF" in " SF 1.20" → not found → skipped
+      // This documents the KNOWN behavior: only 1 mark renders for partial overlaps
+      // Expected correct behavior would be 2 marks, but that requires a different algorithm.
+      // Recording current behavior:
+      const cargoMark = Array.from(marks).find(m => m.getAttribute('title') === 'cargo-name');
+      expect(cargoMark).toBeTruthy(); // first one always renders
+      // Second one is silently dropped — this is the documented bug
+    });
+  });
+});

--- a/components/email-body-viewer.tsx
+++ b/components/email-body-viewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { detectTextDirection } from '@/lib/i18n/rtl-detect';
 
 export interface Highlight {
@@ -14,25 +14,36 @@ interface Props {
   highlights: Highlight[];
 }
 
-function buildSegments(body: string, highlights: Highlight[]) {
-  const sorted = [...highlights]
-    .filter(h => h.text && body.includes(h.text))
-    .sort((a, b) => body.indexOf(a.text) - body.indexOf(b.text));
+type Span = { start: number; end: number; h: Highlight };
+type Node = { span: Span; children: Node[] };
 
-  if (sorted.length === 0) return [{ text: body, highlight: null as Highlight | null }];
-
-  const segments: Array<{ text: string; highlight: Highlight | null }> = [];
-  let remaining = body;
-
-  for (const h of sorted) {
-    const idx = remaining.indexOf(h.text);
-    if (idx === -1) continue;
-    if (idx > 0) segments.push({ text: remaining.slice(0, idx), highlight: null });
-    segments.push({ text: h.text, highlight: h });
-    remaining = remaining.slice(idx + h.text.length);
+function placeSpan(span: Span, nodes: Node[]): boolean {
+  for (const n of nodes) {
+    if (span.start >= n.span.start && span.end <= n.span.end) {
+      return placeSpan(span, n.children);
+    }
+    if (span.start < n.span.end && span.end > n.span.start) {
+      // partial overlap with already-placed sibling — drop
+      return false;
+    }
   }
-  if (remaining) segments.push({ text: remaining, highlight: null });
-  return segments;
+  nodes.push({ span, children: [] });
+  return true;
+}
+
+function buildTree(body: string, highlights: Highlight[]): Node[] {
+  const spans: Span[] = [];
+  for (const h of highlights) {
+    if (!h.text) continue;
+    const start = body.indexOf(h.text);
+    if (start === -1) continue;
+    spans.push({ start, end: start + h.text.length, h });
+  }
+  // Outer (longer at same start) processed first so inner nests inside it.
+  spans.sort((a, b) => a.start - b.start || (b.end - b.start) - (a.end - a.start));
+  const roots: Node[] = [];
+  for (const span of spans) placeSpan(span, roots);
+  return roots;
 }
 
 export function EmailBodyViewer({ body, highlights }: Props) {
@@ -44,25 +55,41 @@ export function EmailBodyViewer({ body, highlights }: Props) {
     }
   }, []);
 
-  const segments = buildSegments(body, highlights);
-  const firstHighlightIdx = segments.findIndex(s => s.highlight !== null);
+  const tree = buildTree(body, highlights);
   const dir = detectTextDirection(body);
+  const ctx = { firstAssigned: false };
+
+  const renderRange = (start: number, end: number, nodes: Node[]): ReactNode[] => {
+    const result: ReactNode[] = [];
+    let cursor = start;
+    let key = 0;
+    for (const n of nodes) {
+      if (cursor < n.span.start) {
+        result.push(<span key={`t-${key++}`}>{body.slice(cursor, n.span.start)}</span>);
+      }
+      const isFirst = !ctx.firstAssigned;
+      if (isFirst) ctx.firstAssigned = true;
+      result.push(
+        <mark
+          key={`m-${key++}-${n.span.start}`}
+          ref={isFirst ? (el) => { firstMarkRef.current = el; } : undefined}
+          className={`${n.span.h.color} rounded px-0.5`}
+          title={n.span.h.label}
+        >
+          {renderRange(n.span.start, n.span.end, n.children)}
+        </mark>
+      );
+      cursor = n.span.end;
+    }
+    if (cursor < end) {
+      result.push(<span key={`t-${key++}`}>{body.slice(cursor, end)}</span>);
+    }
+    return result;
+  };
 
   return (
     <pre dir={dir} className="text-sm whitespace-pre-wrap font-sans leading-relaxed">
-      {segments.map((seg, i) => {
-        if (!seg.highlight) return <span key={i}>{seg.text}</span>;
-        return (
-          <mark
-            key={i}
-            ref={i === firstHighlightIdx ? (el) => { firstMarkRef.current = el; } : undefined}
-            className={`${seg.highlight.color} rounded px-0.5`}
-            title={seg.highlight.label}
-          >
-            {seg.text}
-          </mark>
-        );
-      })}
+      {tree.length === 0 ? body : renderRange(0, body.length, tree)}
     </pre>
   );
 }

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { getConfidenceColorClass } from '@/lib/confidence';
 import type { Match, ParsedVessel, ParsedCargo } from '@/lib/types';
 import { VesselsTab } from './VesselsTab';
@@ -26,6 +26,7 @@ interface MatchTabsProps {
 
 export function MatchTabs({ match, vessel, cargo, cargoEmailId }: MatchTabsProps) {
   const [activeTab, setActiveTab] = useState<TabId>('vessels');
+  const uid = useId();
 
   const confidenceLevel = match.confidence?.level ?? 'missing';
   const borderClass = getConfidenceColorClass(confidenceLevel);
@@ -37,10 +38,10 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId }: MatchTabsProps
         {TABS.map(tab => (
           <button
             key={tab.id}
-            id={`match-tab-${tab.id}`}
+            id={`${uid}-tab-${tab.id}`}
             role="tab"
             aria-selected={activeTab === tab.id}
-            aria-controls={`match-panel-${tab.id}`}
+            aria-controls={`${uid}-panel-${tab.id}`}
             tabIndex={activeTab === tab.id ? 0 : -1}
             onClick={() => setActiveTab(tab.id)}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
@@ -57,8 +58,8 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId }: MatchTabsProps
       {/* Tab content */}
       <div
         role="tabpanel"
-        id={`match-panel-${activeTab}`}
-        aria-labelledby={`match-tab-${activeTab}`}
+        id={`${uid}-panel-${activeTab}`}
+        aria-labelledby={`${uid}-tab-${activeTab}`}
         className="p-4"
       >
         {activeTab === 'vessels' && (

--- a/components/match/__tests__/MatchTabs.duplicate-ids.test.tsx
+++ b/components/match/__tests__/MatchTabs.duplicate-ids.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Adversarial QA: MatchTabs duplicate DOM IDs
+ * Attack: Two MatchTabs instances on same page — do ARIA IDs remain unique?
+ *
+ * MatchTabs uses static id templates:
+ *   id={`match-tab-${tab.id}`}      → "match-tab-vessels" etc.
+ *   id={`match-panel-${activeTab}`} → "match-panel-vessels" etc.
+ *
+ * If two instances are rendered simultaneously, document.getElementById()
+ * returns only the FIRST match — breaking ARIA for the second instance.
+ *
+ * NOTE: In the current app, MatchTabs is only used once per page route
+ * (app/match/[id]/page.tsx). So this is a MEDIUM (pre-existing footgun for
+ * future reuse), not an immediately exploitable bug.
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MatchTabs } from '../MatchTabs';
+import type { Match } from '@/lib/types';
+
+// Mock AuditTrail to avoid real fetch calls
+jest.mock('@/components/audit-trail', () => ({
+  default: ({ inquiryId }: { inquiryId: string }) => (
+    <div data-testid="audit-trail" data-inquiry-id={inquiryId}>Audit Trail</div>
+  ),
+}));
+
+const baseMatch: Match = {
+  cargoEmailId: 'cargo-email-1',
+  cargoItemIndex: 0,
+  vesselEmailId: 'vessel-email-1',
+  vesselItemIndex: 0,
+  score: 85,
+  matchLevel: 'good',
+  matchReasons: ['DWT matches cargo'],
+  issues: [],
+};
+
+const secondMatch: Match = {
+  cargoEmailId: 'cargo-email-2',
+  cargoItemIndex: 0,
+  vesselEmailId: 'vessel-email-2',
+  vesselItemIndex: 0,
+  score: 70,
+  matchLevel: 'possible',
+  matchReasons: ['Port matches'],
+  issues: [],
+};
+
+describe('MatchTabs duplicate DOM IDs — Attack A', () => {
+  it('single instance: tabpanel aria-labelledby resolves to a tab in the same instance', () => {
+    const { container } = render(<MatchTabs match={baseMatch} />);
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel).not.toBeNull();
+
+    const labelledBy = panel!.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    const resolvedTab = document.getElementById(labelledBy!);
+    expect(resolvedTab).not.toBeNull();
+    expect(resolvedTab!.getAttribute('role')).toBe('tab');
+  });
+
+  it('BUG PROBE: two instances — all tab IDs are globally unique', () => {
+    // When two MatchTabs render on the same page, both generate:
+    //   id="match-tab-vessels", id="match-tab-economics", etc.
+    // The second instance's IDs collide with the first.
+    const { container } = render(
+      <div>
+        <MatchTabs match={baseMatch} />
+        <MatchTabs match={secondMatch} />
+      </div>
+    );
+
+    // Collect all button ids
+    const tabButtons = container.querySelectorAll('[role="tab"][id]');
+    const ids = Array.from(tabButtons).map(el => el.getAttribute('id')!);
+
+    // Check for duplicates
+    const uniqueIds = new Set(ids);
+
+    // This FAILS if MatchTabs uses static (non-unique) IDs
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('BUG PROBE: two instances — second instance tabpanel aria-labelledby resolves to a tab WITHIN the second instance', () => {
+    const { container } = render(
+      <div>
+        <MatchTabs match={baseMatch} />
+        <MatchTabs match={secondMatch} />
+      </div>
+    );
+
+    // Get both tabpanels
+    const panels = container.querySelectorAll('[role="tabpanel"]');
+    expect(panels.length).toBe(2);
+
+    const secondPanel = panels[1];
+    const labelledBy = secondPanel.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    // document.getElementById returns FIRST match — with duplicate IDs,
+    // this resolves to the FIRST instance's tab, not the second's
+    const resolvedTab = document.getElementById(labelledBy!);
+    expect(resolvedTab).not.toBeNull();
+
+    // Verify the resolved tab is WITHIN the same container as the second panel
+    // (not inside the first MatchTabs instance)
+    const wrapper = container.firstElementChild!;
+    const firstInstance = wrapper.children[0];
+    const secondInstance = wrapper.children[1];
+    const isInSecondInstance = secondInstance.contains(resolvedTab);
+
+    // This FAILS when IDs collide — resolved tab lands in first instance
+    expect(isInSecondInstance).toBe(true);
+  });
+
+  it('BUG PROBE: two instances — active tab in each instance is correctly identified', () => {
+    const { container } = render(
+      <div>
+        <MatchTabs match={baseMatch} />
+        <MatchTabs match={secondMatch} />
+      </div>
+    );
+
+    const allTabLists = container.querySelectorAll('[role="tablist"]');
+    expect(allTabLists.length).toBe(2);
+
+    // Each tablist should have exactly one selected tab
+    allTabLists.forEach((tablist, i) => {
+      const selectedTabs = tablist.querySelectorAll('[aria-selected="true"]');
+      expect(selectedTabs.length).toBe(1);
+
+      const selectedTab = selectedTabs[0];
+      const controls = selectedTab.getAttribute('aria-controls');
+      expect(controls).toBeTruthy();
+
+      // With colliding IDs, getElementById returns the FIRST instance's panel
+      const resolvedPanel = document.getElementById(controls!);
+      expect(resolvedPanel).not.toBeNull();
+
+      // Check it points to a panel WITHIN the correct instance
+      // MatchTabs root div carries .rounded-lg; closest('div') would grab the inner flex wrapper.
+      const instance = allTabLists[i].closest('.rounded-lg');
+      const isCorrectInstance = instance?.contains(resolvedPanel) ?? false;
+      // This FAILS for instance index 1 when IDs collide
+      expect(isCorrectInstance).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two adversarial-QA findings from 2026-05-05 review (HEAD baseline `ec88e23`).

- **BUG-1 (HIGH)** — `buildSegments()` in `components/email-body-viewer.tsx` silently dropped overlapping highlights: when two highlights shared a start offset (one a prefix of the other) the second `<mark>` never rendered. Real trigger: sample-01 had `weightMt.sourceText="8,500 mts HRC steel coils"` overlapping with `cargoDescription.sourceText="8,500 mts HRC steel coils, SF 1.20"`. Rewrote as a containment forest — contained spans nest inside the parent `<mark>`, partial overlaps drop the later span, disjoint spans become siblings.
- **BUG-2 (MEDIUM, latent)** — `components/match/MatchTabs.tsx` used static DOM ids `match-tab-${tab.id}` / `match-panel-${activeTab}`. Two instances on one page would collide and ARIA `aria-labelledby` / `aria-controls` of the second instance would resolve into the first instance's nodes. Switched to `useId()` so ids are instance-scoped.

Regression tests added under canonical `__tests__/` dirs:
- `components/__tests__/email-body-viewer.overlapping-highlights.test.tsx` — 6 cases (nested same-start, exact-position reversed, control disjoint, exact duplicates, partial overlap)
- `components/match/__tests__/MatchTabs.duplicate-ids.test.tsx` — 4 cases (single-instance ARIA resolution, two-instance unique ids, two-instance aria-labelledby scoping, active-tab-per-instance)

## Test plan

- [x] `npx jest --no-coverage` — 216 suites / 2209 passed (2 skipped, baseline preserved)
- [x] RED verify on `ec88e23`: 6 regression assertions failed before fix
- [x] GREEN after fix: all 12 regression cases pass + existing component tests untouched
- [x] No `match-tab-` / `match-panel-` literals remain outside `MatchTabs.tsx` (cross-layer grep clean)
- [x] No new TODO / FIXME / console.log

No deploy required (demo app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)