### PR TITLE
fix(wave-γ): close 6 adversarial-QA findings before ROUTE_MAP_ENABLED

### DIFF
--- a/app/api/ai/__tests__/generate-route-map.test.ts
+++ b/app/api/ai/__tests__/generate-route-map.test.ts
@@ -57,7 +57,8 @@ import {
   POST,
   isRouteMapEnabled,
   buildRouteMapPrompt,
-  checkAndRecordRateLimit,
+  checkRateLimit,
+  recordRateLimit,
   generateImageWithImagen,
   uploadAndGetUrl,
   type RouteMapInput,
@@ -169,53 +170,49 @@ describe('buildRouteMapPrompt()', () => {
 
 // ─── Unit tests: rate limiting ────────────────────────────────────────────────
 
-describe('checkAndRecordRateLimit()', () => {
+describe('checkRateLimit() / recordRateLimit() — QA H-1 split', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Default: table creation succeeds
     mockDb.exec.mockReturnValue(undefined);
   });
 
-  it('returns true (allowed) when no existing record', () => {
+  it('checkRateLimit returns true (allowed) when no existing record', () => {
     const mockGet = jest.fn().mockReturnValue(null);
-    const mockRun = jest.fn().mockReturnValue({ changes: 1 });
-    mockDb.prepare.mockReturnValue({ get: mockGet, run: mockRun });
-
-    const result = checkAndRecordRateLimit('match-1');
-    expect(result).toBe(true);
-    expect(mockRun).toHaveBeenCalledWith('match-1', expect.any(Number));
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: jest.fn() });
+    expect(checkRateLimit('sess-1:match-1')).toBe(true);
   });
 
-  it('returns true (allowed) when last generation was more than 1 hour ago', () => {
-    const oldTime = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago
-    const mockGet = jest.fn().mockReturnValue({ match_id: 'match-1', last_gen_at: oldTime });
-    const mockRun = jest.fn().mockReturnValue({ changes: 1 });
-    mockDb.prepare.mockReturnValue({ get: mockGet, run: mockRun });
-
-    const result = checkAndRecordRateLimit('match-1');
-    expect(result).toBe(true);
+  it('checkRateLimit returns true when last generation was more than 1 hour ago', () => {
+    const oldTime = Date.now() - 2 * 60 * 60 * 1000;
+    const mockGet = jest.fn().mockReturnValue({ match_id: 'sess-1:match-1', last_gen_at: oldTime });
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: jest.fn() });
+    expect(checkRateLimit('sess-1:match-1')).toBe(true);
   });
 
-  it('returns false (rate limited) when last generation was within 1 hour', () => {
-    const recentTime = Date.now() - 10 * 60 * 1000; // 10 minutes ago
-    const mockGet = jest.fn().mockReturnValue({ match_id: 'match-1', last_gen_at: recentTime });
-    mockDb.prepare.mockReturnValue({ get: mockGet });
-
-    const result = checkAndRecordRateLimit('match-1');
-    expect(result).toBe(false);
+  it('checkRateLimit returns false (rate limited) when within 1 hour', () => {
+    const recentTime = Date.now() - 10 * 60 * 1000;
+    const mockGet = jest.fn().mockReturnValue({ match_id: 'sess-1:match-1', last_gen_at: recentTime });
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: jest.fn() });
+    expect(checkRateLimit('sess-1:match-1')).toBe(false);
   });
 
-  it('records attempt with current timestamp when allowed', () => {
+  it('checkRateLimit does NOT write to the table (read-only)', () => {
     const mockGet = jest.fn().mockReturnValue(null);
-    const mockRun = jest.fn().mockReturnValue({ changes: 1 });
+    const mockRun = jest.fn();
     mockDb.prepare.mockReturnValue({ get: mockGet, run: mockRun });
+    checkRateLimit('sess-1:match-1');
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it('recordRateLimit writes the key with current timestamp', () => {
+    const mockRun = jest.fn().mockReturnValue({ changes: 1 });
+    mockDb.prepare.mockReturnValue({ get: jest.fn(), run: mockRun });
 
     const before = Date.now();
-    checkAndRecordRateLimit('match-2');
+    recordRateLimit('sess-1:match-2');
     const after = Date.now();
 
-    expect(mockRun).toHaveBeenCalledWith('match-2', expect.any(Number));
+    expect(mockRun).toHaveBeenCalledWith('sess-1:match-2', expect.any(Number));
     const ts = (mockRun.mock.calls[0] as [string, number])[1];
     expect(ts).toBeGreaterThanOrEqual(before);
     expect(ts).toBeLessThanOrEqual(after);
@@ -380,12 +377,11 @@ describe('POST /api/ai/generate-route-map', () => {
     expect(body.error).toBe('Image generation failed');
   });
 
-  it('returns 500 with error details when Imagen project is not configured', async () => {
+  it('QA M-2: returns 500 WITHOUT details key (no internal-path leak)', async () => {
     process.env.ROUTE_MAP_ENABLED = 'true';
     delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.ROUTE_MAP_GCS_BUCKET;
 
-    // Rate limit: allowed
     const mockGet = jest.fn().mockReturnValue(null);
     const mockRun = jest.fn().mockReturnValue({ changes: 1 });
     mockDb.prepare.mockReturnValue({ get: mockGet, run: mockRun });
@@ -395,6 +391,91 @@ describe('POST /api/ai/generate-route-map', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('Image generation failed');
-    expect(body.details).toContain('GOOGLE_CLOUD_PROJECT');
+    expect(body).not.toHaveProperty('details');
+    expect(JSON.stringify(body)).not.toContain('GOOGLE_CLOUD_PROJECT');
+  });
+
+  // ── QA H-1: rate-limit recorded only AFTER Imagen success ──────────────────
+  it('QA H-1: does NOT record rate-limit row when Imagen call fails', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    delete process.env.GOOGLE_CLOUD_PROJECT; // forces generateImageWithImagen to throw
+
+    const mockGet = jest.fn().mockReturnValue(null);
+    const mockRun = jest.fn();
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: mockRun });
+
+    const req = makeRequest({ matchId: 'm-h1', loading_port: 'Port Klang', discharge_port: 'Jebel Ali' });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    // No INSERT/REPLACE was issued — the user keeps their hourly quota.
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  // ── QA H-2: rate-limit key includes sessionId ──────────────────────────────
+  it('QA H-2: rate-limit key is `${sessionId}:${matchId}` (cross-user isolation)', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    delete process.env.GOOGLE_CLOUD_PROJECT; // Imagen will throw (we still see the rate-limit lookup key)
+
+    const mockGet = jest.fn().mockReturnValue(null);
+    const mockRun = jest.fn();
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: mockRun });
+
+    const req = makeRequest(
+      { matchId: 'shared-match', loading_port: 'Port Klang', discharge_port: 'Jebel Ali' },
+      'sess-A',
+    );
+    await POST(req);
+    expect(mockGet).toHaveBeenCalledWith('sess-A:shared-match');
+  });
+
+  // ── QA H-3: prompt-injection guards on port fields ─────────────────────────
+  it('QA H-3: rejects loading_port containing < or >', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    const req = makeRequest({
+      matchId: 'm-h3',
+      loading_port: '<script>alert(1)</script>',
+      discharge_port: 'Jebel Ali',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+  });
+
+  it('QA H-3: rejects discharge_port longer than 50 chars', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    const req = makeRequest({
+      matchId: 'm-h3',
+      loading_port: 'Port Klang',
+      discharge_port: 'A'.repeat(51),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+  });
+
+  it('QA H-3: rejects ports with newlines (Ignore previous instructions… style)', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    const req = makeRequest({
+      matchId: 'm-h3',
+      loading_port: 'Port\nIgnore previous',
+      discharge_port: 'Jebel Ali',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+  });
+
+  it('QA H-3: accepts plain ASCII port names with hyphens and digits', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    delete process.env.GOOGLE_CLOUD_PROJECT; // 500 expected, but parse must pass
+
+    const mockGet = jest.fn().mockReturnValue(null);
+    mockDb.prepare.mockReturnValue({ get: mockGet, run: jest.fn() });
+
+    const req = makeRequest({
+      matchId: 'm-ok',
+      loading_port: 'Las Palmas-2',
+      discharge_port: 'Hong Kong 9',
+    });
+    const res = await POST(req);
+    // Validation passes (parse-success), then Imagen fails → 500 (not 422).
+    expect(res.status).toBe(500);
   });
 });

--- a/app/api/ai/generate-route-map/route.ts
+++ b/app/api/ai/generate-route-map/route.ts
@@ -27,12 +27,33 @@ export function isRouteMapEnabled(): boolean {
 
 // ─── Validation schema ────────────────────────────────────────────────────────
 
+/**
+ * QA H-3: ports go straight into the Imagen prompt. Cap length and restrict
+ * charset to letters / digits / spaces / hyphens to defang prompt injection
+ * (e.g. `<script>`, RTL override, "Ignore previous instructions…").
+ */
+const PORT_NAME = z.string().min(1).max(50).regex(
+  /^[A-Za-z0-9 \-]+$/,
+  'must be 1-50 chars; letters, digits, space, and hyphen only',
+);
+
+/** matchId stays opaque but bounded — prevents pathological keys in the rate-limit table. */
+const MATCH_ID = z.string().min(1).max(128).regex(
+  /^[A-Za-z0-9_:-]+$/,
+  'must be 1-128 chars; letters, digits, _, :, - only',
+);
+
+const ETA_VALUE = z.string().min(1).max(50).regex(
+  /^[A-Za-z0-9 :,\-]+$/,
+  'must be 1-50 chars; letters, digits, space, ":", ",", and hyphen only',
+);
+
 const RequestSchema = z.object({
-  matchId: z.string().min(1),
-  origin: z.string().optional().default('Unknown'),
-  loading_port: z.string().min(1),
-  discharge_port: z.string().min(1),
-  eta: z.string().optional(),
+  matchId: MATCH_ID,
+  origin: PORT_NAME.optional().default('Unknown'),
+  loading_port: PORT_NAME,
+  discharge_port: PORT_NAME,
+  eta: ETA_VALUE.optional(),
 });
 
 /** Output type (after Zod default resolution — origin is always string). */
@@ -45,34 +66,49 @@ export type RouteMapInput = z.input<typeof RequestSchema>;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 /**
- * Ensure the rate limit table exists and check+record a generation attempt.
- * Returns true if allowed (and records the attempt), false if rate-limited.
+ * QA H-2: rate-limit key is `${sessionId}:${matchId}`. The session id is the
+ * only user-identifier surface we have on the server. Without it, user A can
+ * burn user B's matchId quota by guessing or scraping ids.
+ *
+ * The `match_id` column stores this composite key (no migration: rows from PR
+ * #85 simply use the legacy `<matchId>` shape and remain harmless — new code
+ * always writes `<sessionId>:<matchId>` keys).
  */
-export function checkAndRecordRateLimit(matchId: string): boolean {
-  const db = getStore().getDatabase();
+function buildRateLimitKey(sessionId: string, matchId: string): string {
+  return `${sessionId}:${matchId}`;
+}
 
-  // Idempotent table creation
+function ensureRateLimitTable(): void {
+  const db = getStore().getDatabase();
   db.exec(`
     CREATE TABLE IF NOT EXISTS route_map_rate_limit (
       match_id    TEXT PRIMARY KEY,
       last_gen_at INTEGER NOT NULL
     )
   `);
+}
 
+/**
+ * QA H-1: split the read and the write. Returns true if a fresh generation is
+ * allowed. The caller MUST call `recordRateLimit` only after the Imagen call
+ * succeeds — otherwise a transient 5xx burns the user's hourly quota.
+ */
+export function checkRateLimit(key: string): boolean {
+  ensureRateLimitTable();
+  const db = getStore().getDatabase();
   const cutoff = Date.now() - RATE_LIMIT_WINDOW_MS;
   const existing = db.prepare<[string], { match_id: string; last_gen_at: number }>(
-    'SELECT match_id, last_gen_at FROM route_map_rate_limit WHERE match_id = ?'
-  ).get(matchId);
+    'SELECT match_id, last_gen_at FROM route_map_rate_limit WHERE match_id = ?',
+  ).get(key);
+  return !(existing && existing.last_gen_at > cutoff);
+}
 
-  if (existing && existing.last_gen_at > cutoff) {
-    return false; // rate-limited
-  }
-
+export function recordRateLimit(key: string): void {
+  ensureRateLimitTable();
+  const db = getStore().getDatabase();
   db.prepare(
-    'INSERT OR REPLACE INTO route_map_rate_limit (match_id, last_gen_at) VALUES (?, ?)'
-  ).run(matchId, Date.now());
-
-  return true; // allowed
+    'INSERT OR REPLACE INTO route_map_rate_limit (match_id, last_gen_at) VALUES (?, ?)',
+  ).run(key, Date.now());
 }
 
 // ─── Imagen 4 image generation ────────────────────────────────────────────────
@@ -224,6 +260,7 @@ export async function POST(request: NextRequest) {
 
   const authResult = requireSession(request);
   if (authResult instanceof NextResponse) return authResult;
+  const { sessionId } = authResult;
 
   // Feature flag
   if (!isRouteMapEnabled()) {
@@ -240,17 +277,29 @@ export async function POST(request: NextRequest) {
 
   const parsed = RequestSchema.safeParse(body);
   if (!parsed.success) {
+    // QI follow-up: return only the offending field paths, not the full zod
+    // issue list (which would leak whitelist regexes and message strings).
     return NextResponse.json(
-      { error: 'Invalid request', details: parsed.error.issues },
+      {
+        error: 'Invalid request',
+        fields: parsed.error.issues.map((i) => i.path.join('.')),
+      },
       { status: 422 }
     );
   }
 
   const data = parsed.data;
 
-  // Rate limit check
-  const allowed = checkAndRecordRateLimit(data.matchId);
-  if (!allowed) {
+  // QA H-1+H-2: check rate limit using session-scoped key, but DO NOT record
+  // until the Imagen call succeeds. Recording up-front lets a transient 5xx
+  // (or an attacker griefing on someone else's matchId) burn the hourly quota.
+  // KNOWN race: two concurrent POSTs with the same key can both pass the
+  // read-only check and trigger Imagen twice. The DB write is idempotent
+  // (`INSERT OR REPLACE`), so subsequent rate-limit state is correct, but
+  // the cost-amplification window during simultaneous calls is acknowledged
+  // and accepted (single-user attack-cost ratio is 1:1, not amplification).
+  const rateKey = buildRateLimitKey(sessionId, data.matchId);
+  if (!checkRateLimit(rateKey)) {
     return NextResponse.json(
       { error: 'Rate limit exceeded. You can generate one route map per match per hour.' },
       { status: 429 }
@@ -266,15 +315,31 @@ export async function POST(request: NextRequest) {
     const imageUrl = await uploadAndGetUrl(imageBytes, data.matchId);
     const latencyMs = Date.now() - start;
 
-    logger.info({ matchId: data.matchId, latencyMs }, '[route-map] image generated');
+    // Only record the rate-limit hit AFTER the expensive call succeeded.
+    // QI follow-up: a DB write failure here must not turn a successful image
+    // into a 500 — the user already paid for the generation. Log and move on.
+    // Trade-off: the user may exceed the per-hour quota next call, which is
+    // acceptable vs. losing a successfully generated image.
+    try {
+      recordRateLimit(rateKey);
+    } catch (recordErr) {
+      logger.error(
+        { err: recordErr, sessionId, matchId: data.matchId },
+        '[route-map] recordRateLimit failed (image still returned)',
+      );
+    }
+
+    logger.info({ matchId: data.matchId, sessionId, latencyMs }, '[route-map] image generated');
 
     return NextResponse.json({ imageUrl, latencyMs });
   } catch (err) {
     const latencyMs = Date.now() - start;
-    logger.error({ err, matchId: data.matchId, latencyMs }, '[route-map] generation failed');
+    // QA M-2: log full error server-side (Vertex SDK errors leak project-id,
+    // bucket URL, internal paths); return only a generic message to the client.
+    logger.error({ err, matchId: data.matchId, sessionId, latencyMs }, '[route-map] generation failed');
 
     return NextResponse.json(
-      { error: 'Image generation failed', details: String(err) },
+      { error: 'Image generation failed' },
       { status: 500 }
     );
   }

--- a/lib/__tests__/ai-provider.test.ts
+++ b/lib/__tests__/ai-provider.test.ts
@@ -359,3 +359,151 @@ describe('getModel', () => {
     expect(model.length).toBeGreaterThan(0);
   });
 });
+
+// ─── QA L-1: cost_usd computation ────────────────────────────────────────────
+
+describe('computeCostUsd — QA L-1', () => {
+  it('returns null when prompt or completion tokens missing', () => {
+    const { computeCostUsd } = require('@/lib/ai-provider');
+    expect(computeCostUsd('gemini', 'gemini-2.5-flash', null, 100)).toBeNull();
+    expect(computeCostUsd('gemini', 'gemini-2.5-flash', 100, null)).toBeNull();
+    expect(computeCostUsd('gemini', 'gemini-2.5-flash', undefined, undefined)).toBeNull();
+  });
+
+  it('returns null for an unknown (provider, model) combo', () => {
+    const { computeCostUsd } = require('@/lib/ai-provider');
+    expect(computeCostUsd('gemini', 'made-up-model', 1000, 500)).toBeNull();
+    expect(computeCostUsd('openai', 'gpt-5.5', 1000, 500)).toBeNull();
+  });
+
+  it('computes gemini-2.5-flash cost at $0.075 in / $0.30 out per 1M', () => {
+    const { computeCostUsd } = require('@/lib/ai-provider');
+    // 1000*0.075/1M + 500*0.30/1M = 0.000075 + 0.00015 = 0.000225
+    expect(computeCostUsd('gemini', 'gemini-2.5-flash', 1000, 500)).toBeCloseTo(0.000225, 6);
+  });
+
+  it('computes gemini-2.5-pro cost at $1.25 in / $5 out per 1M', () => {
+    const { computeCostUsd } = require('@/lib/ai-provider');
+    // 10000*1.25/1M + 2000*5/1M = 0.0125 + 0.01 = 0.0225
+    expect(computeCostUsd('gemini', 'gemini-2.5-pro', 10000, 2000)).toBeCloseTo(0.0225, 6);
+  });
+
+  it('computes bedrock claude-opus-4-7 cost at $15 in / $75 out per 1M', () => {
+    const { computeCostUsd } = require('@/lib/ai-provider');
+    // 1000*15/1M + 500*75/1M = 0.015 + 0.0375 = 0.0525
+    expect(computeCostUsd(
+      'bedrock',
+      'us.anthropic.claude-opus-4-7-20260415-v1:0',
+      1000,
+      500,
+    )).toBeCloseTo(0.0525, 6);
+  });
+
+  it('returns 0 for a zero-token call (rate × 0 = 0)', () => {
+    const { computeCostUsd } = require('@/lib/ai-provider');
+    expect(computeCostUsd('gemini', 'gemini-2.5-flash', 0, 0)).toBe(0);
+  });
+});
+
+describe('callAiJson + ai_audit cost_usd integration — QA L-1', () => {
+  it('writes non-null cost_usd when Gemini returns usage metadata', async () => {
+    setEnv({
+      AI_PROVIDER: 'gemini',
+      GOOGLE_APPLICATION_CREDENTIALS: '/dev/null',
+      GOOGLE_CLOUD_PROJECT: 'test-project',
+      AI_MODEL_GEMINI_DEFAULT: 'gemini-2.5-flash',
+    });
+
+    const { GoogleGenAI } = require('@google/genai');
+    (GoogleGenAI as jest.Mock).mockImplementationOnce(() => ({
+      models: {
+        generateContent: jest.fn().mockResolvedValue({
+          text: '{"ok":true}',
+          usageMetadata: { promptTokenCount: 1000, candidatesTokenCount: 500 },
+        }),
+      },
+    }));
+
+    const { callAiJson } = require('@/lib/ai-provider');
+    await callAiJson('classify', 'sys', 'user');
+
+    const row = testDb
+      .prepare('SELECT prompt_tokens, completion_tokens, cost_usd FROM ai_audit ORDER BY id DESC LIMIT 1')
+      .get() as { prompt_tokens: number; completion_tokens: number; cost_usd: number };
+
+    expect(row.prompt_tokens).toBe(1000);
+    expect(row.completion_tokens).toBe(500);
+    expect(row.cost_usd).toBeCloseTo(0.000225, 6);
+  });
+
+  it('writes null cost_usd when Gemini omits usage metadata', async () => {
+    setEnv({
+      AI_PROVIDER: 'gemini',
+      GOOGLE_APPLICATION_CREDENTIALS: '/dev/null',
+      GOOGLE_CLOUD_PROJECT: 'test-project',
+      AI_MODEL_GEMINI_DEFAULT: 'gemini-2.5-flash',
+    });
+
+    const { GoogleGenAI } = require('@google/genai');
+    (GoogleGenAI as jest.Mock).mockImplementationOnce(() => ({
+      models: {
+        generateContent: jest.fn().mockResolvedValue({ text: '{"ok":true}' }),
+      },
+    }));
+
+    const { callAiJson } = require('@/lib/ai-provider');
+    await callAiJson('classify', 'sys', 'user');
+
+    const row = testDb
+      .prepare('SELECT prompt_tokens, completion_tokens, cost_usd FROM ai_audit ORDER BY id DESC LIMIT 1')
+      .get() as { prompt_tokens: number | null; completion_tokens: number | null; cost_usd: number | null };
+
+    expect(row.prompt_tokens).toBeNull();
+    expect(row.completion_tokens).toBeNull();
+    expect(row.cost_usd).toBeNull();
+  });
+
+  it('writes non-null cost_usd from Bedrock usage', async () => {
+    setEnv({
+      AI_PROVIDER: 'bedrock',
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'k',
+      AWS_SECRET_ACCESS_KEY: 's',
+      BEDROCK_MODEL_ID: 'us.anthropic.claude-opus-4-7-20260415-v1:0',
+    });
+
+    const { BedrockRuntimeClient } = require('@aws-sdk/client-bedrock-runtime');
+    (BedrockRuntimeClient as jest.Mock).mockImplementationOnce(() => ({
+      send: jest.fn().mockResolvedValue({
+        body: new TextEncoder().encode(JSON.stringify({
+          content: [{ text: '{"ok":true}' }],
+          usage: { input_tokens: 1000, output_tokens: 500 },
+        })),
+      }),
+    }));
+
+    const { callAiJson } = require('@/lib/ai-provider');
+    await callAiJson('match', 'sys', 'user');
+
+    const row = testDb
+      .prepare('SELECT prompt_tokens, completion_tokens, cost_usd FROM ai_audit ORDER BY id DESC LIMIT 1')
+      .get() as { prompt_tokens: number; completion_tokens: number; cost_usd: number };
+
+    expect(row.prompt_tokens).toBe(1000);
+    expect(row.completion_tokens).toBe(500);
+    expect(row.cost_usd).toBeCloseTo(0.0525, 6);
+  });
+
+  it('rollback path: AI_PROVIDER=openai still writes audit row with null cost_usd (no regression)', async () => {
+    setEnv({ AI_PROVIDER: 'openai' });
+    const { callAiJson } = require('@/lib/ai-provider');
+    await callAiJson('classify', 'sys', 'user');
+
+    const row = testDb
+      .prepare('SELECT provider, cost_usd FROM ai_audit ORDER BY id DESC LIMIT 1')
+      .get() as { provider: string; cost_usd: number | null };
+
+    expect(row.provider).toBe('openai');
+    expect(row.cost_usd).toBeNull();
+  });
+});

--- a/lib/agent/__tests__/plan-first.test.ts
+++ b/lib/agent/__tests__/plan-first.test.ts
@@ -212,6 +212,28 @@ describe('planFirst() — gemini provider', () => {
     const result = await planFirst('Get CII rating');
     expect(result).toContain('check-cii');
   });
+
+  // ── QA M-1: exception swallowing ─────────────────────────────────────────
+  it('QA M-1: falls back to detectKinds when callAiJson THROWS (network/Vertex 5xx)', async () => {
+    mockCallAiJson.mockRejectedValueOnce(new Error('Vertex AI 503 Service Unavailable'));
+    const result = await planFirst('Run sanction check on charterer');
+    expect(result).toContain('check-sanctions');
+    // Did not re-throw — caller never sees the exception.
+  });
+
+  it('QA M-1: falls back to detectKinds on AbortError / timeout', async () => {
+    const err = new Error('Aborted');
+    err.name = 'AbortError';
+    mockCallAiJson.mockRejectedValueOnce(err);
+    const result = await planFirst('Compare Suez vs Cape route');
+    expect(result).toContain('compare-routes');
+  });
+
+  it('QA M-1: returns ["noop"] when LLM throws on a non-keyword query', async () => {
+    mockCallAiJson.mockRejectedValueOnce(new Error('boom'));
+    const result = await planFirst('Hello there');
+    expect(result).toEqual(['noop']);
+  });
 });
 
 // ─── planFirst() — openai provider ────────────────────────────────────────────

--- a/lib/agent/plan-first.ts
+++ b/lib/agent/plan-first.ts
@@ -23,6 +23,7 @@ import {
   getCachedStep,
 } from './idempotency';
 import { callAiJson } from '@/lib/ai-provider';
+import { logger } from '@/lib/logger';
 import { PLAN_STEP_KINDS } from './plan-types';
 import type {
   ExecutionResult,
@@ -155,13 +156,23 @@ export async function planFirst(query: string): Promise<PlanStepKind[]> {
     return detectKinds(query);
   }
 
-  // LLM path — delegate to ai-provider shim
-  // The shim reads AGENT_PLANNER_PROVIDER to pick the right provider
-  const response = await callAiJson<LlmPlannerResponse>(
-    'AGENT_PLANNER',
-    AGENT_PLANNER_SYSTEM,
-    query,
-  );
+  // LLM path — delegate to ai-provider shim.
+  // QA M-1: any throw from the LLM call (network error, Vertex 5xx, timeout)
+  // must fall back to the deterministic regex planner instead of bubbling up.
+  let response: LlmPlannerResponse | null = null;
+  try {
+    response = await callAiJson<LlmPlannerResponse>(
+      'AGENT_PLANNER',
+      AGENT_PLANNER_SYSTEM,
+      query,
+    );
+  } catch (err) {
+    logger.warn(
+      { err, provider, query: query.slice(0, 200) },
+      '[plan-first] LLM planner call failed, falling back to detectKinds()',
+    );
+    return detectKinds(query);
+  }
 
   if (!response || !Array.isArray(response.kinds)) {
     // Defensive fallback: LLM returned unexpected shape

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -47,6 +47,53 @@ interface AiAuditRow {
   err: string | null;
 }
 
+/**
+ * QA L-1: token usage extracted from each provider's native response.
+ * Internal-only; not part of the public callAi* signatures.
+ */
+export interface Usage {
+  promptTokens: number;
+  completionTokens: number;
+}
+
+/**
+ * QA L-1: per-(provider, model) USD pricing per 1M tokens.
+ *
+ * Rates as of 2026-05 (input / output). When the user hits a model not in the
+ * table, `computeCostUsd` returns null — we deliberately do not guess.
+ *
+ * - gemini-2.5-flash: Vertex AI public pricing $0.075 / $0.30 per 1M tokens
+ * - gemini-2.5-pro:   $1.25 / $5.00 per 1M tokens
+ * - claude-opus-4-7 (Bedrock): $15 / $75 per 1M tokens
+ *
+ * OpenAI rates are intentionally absent: lib/openai.ts doesn't surface usage
+ * tokens, so we cannot bill accurately and prefer null over a guess.
+ */
+const COST_TABLE_PER_M_TOKENS: Record<string, { in: number; out: number }> = {
+  'gemini:gemini-2.5-flash': { in: 0.075, out: 0.30 },
+  'gemini:gemini-2.5-flash-lite': { in: 0.0375, out: 0.15 },
+  'gemini:gemini-2.5-pro': { in: 1.25, out: 5.0 },
+  'bedrock:us.anthropic.claude-opus-4-7-20260415-v1:0': { in: 15, out: 75 },
+  'bedrock:us.anthropic.claude-sonnet-4-6-20260101-v1:0': { in: 3, out: 15 },
+};
+
+export function computeCostUsd(
+  provider: Provider,
+  model: string,
+  promptTokens: number | null | undefined,
+  completionTokens: number | null | undefined,
+): number | null {
+  if (promptTokens == null || completionTokens == null) return null;
+  if (!Number.isFinite(promptTokens) || !Number.isFinite(completionTokens)) return null;
+  // QI follow-up: a malformed SDK response with negative counts must not yield a negative cost.
+  if (promptTokens < 0 || completionTokens < 0) return null;
+  const rate = COST_TABLE_PER_M_TOKENS[`${provider}:${model}`];
+  if (!rate) return null;
+  const cost = (promptTokens * rate.in + completionTokens * rate.out) / 1_000_000;
+  // Round to 6 decimal places — sub-microcent precision is meaningless.
+  return Math.round(cost * 1_000_000) / 1_000_000;
+}
+
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 function toScopeEnv(scope: string): string {
@@ -177,12 +224,25 @@ async function callOpenAiText(
   );
 }
 
+interface GeminiUsageMetadata {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+}
+
+function extractGeminiUsage(meta: GeminiUsageMetadata | undefined): Usage | undefined {
+  if (!meta) return undefined;
+  const p = meta.promptTokenCount;
+  const c = meta.candidatesTokenCount;
+  if (typeof p !== 'number' || typeof c !== 'number') return undefined;
+  return { promptTokens: p, completionTokens: c };
+}
+
 async function callGeminiText(
   system: string,
   user: string,
   model: string,
   opts?: AiOpts,
-): Promise<string> {
+): Promise<{ text: string; usage?: Usage }> {
   assertGeminiEnv();
   const { GoogleGenAI } = require('@google/genai') as {
     GoogleGenAI: new (opts: { vertexai: boolean; project: string; location: string }) => {
@@ -191,7 +251,7 @@ async function callGeminiText(
           model: string;
           contents: Array<{ role: string; parts: Array<{ text: string }> }>;
           config?: { systemInstruction?: string };
-        }) => Promise<{ text: string }>;
+        }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
       };
     };
   };
@@ -208,7 +268,7 @@ async function callGeminiText(
     config: { systemInstruction: system },
   });
 
-  return response.text ?? '';
+  return { text: response.text ?? '', usage: extractGeminiUsage(response.usageMetadata) };
 }
 
 async function callGeminiVision(
@@ -216,7 +276,7 @@ async function callGeminiVision(
   user: string,
   images: ImageInput[],
   model: string,
-): Promise<string> {
+): Promise<{ text: string; usage?: Usage }> {
   assertGeminiEnv();
   const { GoogleGenAI } = require('@google/genai') as {
     GoogleGenAI: new (opts: { vertexai: boolean; project: string; location: string }) => {
@@ -225,7 +285,7 @@ async function callGeminiVision(
           model: string;
           contents: Array<{ role: string; parts: unknown[] }>;
           config?: { systemInstruction?: string };
-        }) => Promise<{ text: string }>;
+        }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
       };
     };
   };
@@ -249,14 +309,27 @@ async function callGeminiVision(
     config: { systemInstruction: system },
   });
 
-  return response.text ?? '';
+  return { text: response.text ?? '', usage: extractGeminiUsage(response.usageMetadata) };
+}
+
+interface BedrockUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+function extractBedrockUsage(usage: BedrockUsage | undefined): Usage | undefined {
+  if (!usage) return undefined;
+  const p = usage.input_tokens;
+  const c = usage.output_tokens;
+  if (typeof p !== 'number' || typeof c !== 'number') return undefined;
+  return { promptTokens: p, completionTokens: c };
 }
 
 async function callBedrockText(
   system: string,
   user: string,
   model: string,
-): Promise<string> {
+): Promise<{ text: string; usage?: Usage }> {
   assertBedrockEnv();
   const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
     BedrockRuntimeClient: new (opts: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } }) => {
@@ -289,14 +362,14 @@ async function callBedrockText(
 
   const response = await client.send(cmd);
   const decoded = new TextDecoder().decode(response.body);
-  const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }> };
-  return parsed.content?.[0]?.text ?? '';
+  const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
+  return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
 }
 
 async function callBedrockAudio(
   audioBuffer: Buffer,
   model: string,
-): Promise<string> {
+): Promise<{ text: string; usage?: Usage }> {
   assertBedrockEnv();
   const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
     BedrockRuntimeClient: new (opts: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } }) => {
@@ -335,8 +408,8 @@ async function callBedrockAudio(
 
   const response = await client.send(cmd);
   const decoded = new TextDecoder().decode(response.body);
-  const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }> };
-  return parsed.content?.[0]?.text ?? '';
+  const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
+  return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
 }
 
 // ─── Public callAi* functions ─────────────────────────────────────────────────
@@ -368,18 +441,21 @@ export async function callAiJson<T>(
   let ok = false;
   let err: string | null = null;
   let result: T;
+  let usage: Usage | undefined;
 
   try {
     switch (provider) {
       case 'gemini': {
-        const text = await callGeminiText(system, user, model, opts);
-        const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+        const r = await callGeminiText(system, user, model, opts);
+        usage = r.usage;
+        const cleaned = r.text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
         result = JSON.parse(cleaned) as T;
         break;
       }
       case 'bedrock': {
-        const text = await callBedrockText(system, user, model);
-        const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+        const r = await callBedrockText(system, user, model);
+        usage = r.usage;
+        const cleaned = r.text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
         result = JSON.parse(cleaned) as T;
         break;
       }
@@ -398,9 +474,9 @@ export async function callAiJson<T>(
       scope,
       provider,
       model,
-      prompt_tokens: null,
-      completion_tokens: null,
-      cost_usd: null,
+      prompt_tokens: usage?.promptTokens ?? null,
+      completion_tokens: usage?.completionTokens ?? null,
+      cost_usd: computeCostUsd(provider, model, usage?.promptTokens, usage?.completionTokens),
       latency_ms: Date.now() - t0,
       ok,
       err,
@@ -422,16 +498,23 @@ export async function callAiText(
   const t0 = Date.now();
   let ok = false;
   let err: string | null = null;
+  let usage: Usage | undefined;
 
   try {
     let result: string;
     switch (provider) {
-      case 'gemini':
-        result = await callGeminiText(system, user, model, opts);
+      case 'gemini': {
+        const r = await callGeminiText(system, user, model, opts);
+        usage = r.usage;
+        result = r.text;
         break;
-      case 'bedrock':
-        result = await callBedrockText(system, user, model);
+      }
+      case 'bedrock': {
+        const r = await callBedrockText(system, user, model);
+        usage = r.usage;
+        result = r.text;
         break;
+      }
       case 'openai':
       default:
         result = await callOpenAiText(scope, system, user, opts);
@@ -447,9 +530,9 @@ export async function callAiText(
       scope,
       provider,
       model,
-      prompt_tokens: null,
-      completion_tokens: null,
-      cost_usd: null,
+      prompt_tokens: usage?.promptTokens ?? null,
+      completion_tokens: usage?.completionTokens ?? null,
+      cost_usd: computeCostUsd(provider, model, usage?.promptTokens, usage?.completionTokens),
       latency_ms: Date.now() - t0,
       ok,
       err,
@@ -472,13 +555,17 @@ export async function callAiVision(
   const t0 = Date.now();
   let ok = false;
   let err: string | null = null;
+  let usage: Usage | undefined;
 
   try {
     let result: string;
     switch (provider) {
-      case 'gemini':
-        result = await callGeminiVision('', prompt, images, model);
+      case 'gemini': {
+        const r = await callGeminiVision('', prompt, images, model);
+        usage = r.usage;
+        result = r.text;
         break;
+      }
       case 'bedrock': {
         assertBedrockEnv();
         const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
@@ -519,7 +606,8 @@ export async function callAiVision(
 
         const response = await client.send(cmd);
         const decoded = new TextDecoder().decode(response.body);
-        const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }> };
+        const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
+        usage = extractBedrockUsage(parsed.usage);
         result = parsed.content?.[0]?.text ?? '';
         break;
       }
@@ -552,9 +640,9 @@ export async function callAiVision(
       scope,
       provider,
       model,
-      prompt_tokens: null,
-      completion_tokens: null,
-      cost_usd: null,
+      prompt_tokens: usage?.promptTokens ?? null,
+      completion_tokens: usage?.completionTokens ?? null,
+      cost_usd: computeCostUsd(provider, model, usage?.promptTokens, usage?.completionTokens),
       latency_ms: Date.now() - t0,
       ok,
       err,
@@ -577,13 +665,17 @@ export async function callAiAudio(
   const t0 = Date.now();
   let ok = false;
   let err: string | null = null;
+  let usage: Usage | undefined;
 
   try {
     let result: string;
     switch (provider) {
-      case 'bedrock':
-        result = await callBedrockAudio(audioBuffer, model);
+      case 'bedrock': {
+        const r = await callBedrockAudio(audioBuffer, model);
+        usage = r.usage;
+        result = r.text;
         break;
+      }
       case 'gemini': {
         assertGeminiEnv();
         const { GoogleGenAI } = require('@google/genai') as {
@@ -592,7 +684,7 @@ export async function callAiAudio(
               generateContent: (params: {
                 model: string;
                 contents: Array<{ role: string; parts: unknown[] }>;
-              }) => Promise<{ text: string }>;
+              }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
             };
           };
         };
@@ -614,6 +706,7 @@ export async function callAiAudio(
             ],
           }],
         });
+        usage = extractGeminiUsage(response.usageMetadata);
         result = response.text ?? '';
         break;
       }
@@ -642,9 +735,9 @@ export async function callAiAudio(
       scope,
       provider,
       model,
-      prompt_tokens: null,
-      completion_tokens: null,
-      cost_usd: null,
+      prompt_tokens: usage?.promptTokens ?? null,
+      completion_tokens: usage?.completionTokens ?? null,
+      cost_usd: computeCostUsd(provider, model, usage?.promptTokens, usage?.completionTokens),
       latency_ms: Date.now() - t0,
       ok,
       err,


### PR DESCRIPTION
## Summary

Follow-up to PR #85 (wave-γ Vertex AI). Adversarial QA Round 2 returned `MERGE` verdict but flagged 6 mandatory items before flipping `ROUTE_MAP_ENABLED=true` in prod. This closes all of them, plus 4 lower-severity items found during the second-pass QI review of this branch.

### Findings closed

| ID | Severity | Where | Fix |
|---|---|---|---|
| H-1 | HIGH | `route-map` route | rate-limit recorded **after** Imagen success only |
| H-2 | HIGH | `route-map` route | key = `${sessionId}:${matchId}` — cross-user grief impossible |
| H-3 | HIGH | `route-map` route | zod whitelist `^[A-Za-z0-9 \-]+$`, ≤50 chars on ports — prompt-injection defanged |
| M-1 | MEDIUM | `lib/agent/plan-first.ts` | try/catch around `callAiJson` → fallback to `detectKinds` |
| M-2 | MEDIUM | `route-map` route | `details: String(err)` removed from 500 body |
| L-1 | LOW | `lib/ai-provider.ts` | real `cost_usd` + token counts in `ai_audit` (gemini/bedrock); openai stays null |

### QI second-pass follow-ups (also applied)

- 422 returns `fields: string[]` (path only) instead of full zod issue list (whitelist regex no longer leaks).
- `recordRateLimit` wrapped in try/catch — a DB write failure cannot turn a successful image into a 500.
- Negative token counts → `cost_usd: null` (defensive against malformed SDK responses).
- Parallel-POST race documented in code as accepted trade-off (1:1 amplification, idempotent DB write).

### Boundary respect

`lib/ai-provider.ts` was edited beyond the literal "writeAuditRecord + cost_usd" by changing internal helper return types from `Promise<string>` → `Promise<{text, usage?}>` so usage tokens can flow through. Public `callAi*` signatures unchanged. `Usage` interface and `computeCostUsd` are exported for tests.

### Rollback

`AI_PROVIDER=openai` path unchanged — audit row still writes with `cost_usd=null` (no usage data available from `lib/openai.ts`). `ROUTE_MAP_ENABLED=false` remains the default; this PR does not flip the flag.

## Test plan

- [x] `npm test` — 2504 passed (was 2484 baseline; +20 new tests across the 3 files)
- [x] `npx tsc --noEmit` — clean
- [ ] CI green (TypeCheck + Test + Build)
- [ ] Manual: `ROUTE_MAP_ENABLED=true npm run dev` + POST `loading_port="<script>"` → 422
- [ ] Manual: same matchId from two sessions → independent rate-limit windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)