### PR TITLE
fix(knowledge): distances.ts caller upgraded for new ports.json shape

### DIFF
--- a/__tests__/scripts/knowledge/sources/distances.test.ts
+++ b/__tests__/scripts/knowledge/sources/distances.test.ts
@@ -6,9 +6,13 @@
  * - Idempotency: re-run doesn't duplicate rows
  * - Progress logging
  * - Batch insert in transactions
+ *
+ * Integration smoke: top-200-ports.json → seedDistances default path
  */
 
 import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
 import migration015 from '@/lib/migrations/015-port-distances';
 import migration013 from '@/lib/migrations/013-knowledge-sources';
 
@@ -232,6 +236,66 @@ describe('distances seed script', () => {
 
       // 10 ports = 10×9/2 = 45 unique pairs × 3 routes = 135 rows
       expect(count.cnt).toBe(135);
+    });
+  });
+
+  describe('Integration smoke — top-200-ports.json default path', () => {
+    it('reads ports.json (new object shape) without throwing', async () => {
+      // This test exercises the default file-loading path in seedDistances()
+      // and verifies that the new {locode, name, ...}[] shape is handled correctly.
+      // It does NOT call seedDistances (which needs DB + searoute) — instead it
+      // directly validates that the JSON produces valid LOCODE strings.
+      const portListPath = path.join(process.cwd(), 'data', 'knowledge', 'top-200-ports.json');
+      const content = fs.readFileSync(portListPath, 'utf-8');
+      const raw: unknown[] = JSON.parse(content);
+
+      // New shape: array of objects
+      expect(Array.isArray(raw)).toBe(true);
+      expect(raw.length).toBe(200);
+
+      // Each entry must be an object with a locode string (not a raw string)
+      for (const entry of raw) {
+        expect(typeof entry).toBe('object');
+        expect(entry).not.toBeNull();
+        expect(typeof (entry as { locode: string }).locode).toBe('string');
+      }
+
+      // Extract LOCODEs — this is what the fixed distances.ts must do
+      const locodes = (raw as Array<{ locode: string }>).map((p) => p.locode);
+
+      // 5 well-known LOCODEs must be present
+      for (const known of ['SGSIN', 'NLRTM', 'CNSHA', 'USHOU', 'AEDXB']) {
+        expect(locodes).toContain(known);
+      }
+
+      // Singapore coordinates
+      const singapore = (raw as Array<{ locode: string; lat: number; lon: number }>).find(
+        (p) => p.locode === 'SGSIN'
+      );
+      expect(singapore).toBeDefined();
+      expect(singapore!.lat).toBeCloseTo(1.27, 1);
+      expect(singapore!.lon).toBeCloseTo(103.83, 1);
+    });
+
+    it('generatePairs via seedDistances default path yields valid LOCODE strings (not [object Object])', async () => {
+      // This test calls seedDistances() without portList so it reads top-200-ports.json.
+      // Before the fix: isValidLocode receives "[object Object]" → all skipped → 0 pairs.
+      // After the fix: receives proper LOCODE strings → valid pairs generated.
+      const { seedDistances } = await import('@/scripts/knowledge/sources/distances');
+
+      // Override calculateDistance to count calls — if pairs are generated we get calls
+      const { calculateDistance } = await import('@/lib/knowledge/distances/client');
+      const mockCalc = calculateDistance as jest.MockedFunction<typeof calculateDistance>;
+      mockCalc.mockResolvedValue({ distanceNm: 1000, calculatorVersion: 'searoute-1.0.0' });
+
+      await seedDistances(db);
+
+      // After the fix: 200 valid ports → 200×199/2 = 19900 pairs → calculateDistance called many times
+      // Before the fix: all ports treated as invalid → 0 calls
+      expect(mockCalc).toHaveBeenCalled();
+
+      // At least a few hundred pairs must have been attempted
+      expect(mockCalc.mock.calls.length).toBeGreaterThan(100);
     });
   });
 

--- a/scripts/knowledge/sources/distances.ts
+++ b/scripts/knowledge/sources/distances.ts
@@ -5,7 +5,7 @@
  * Usage:
  *   npx tsx scripts/knowledge/sources/distances.ts
  *
- * Input: data/knowledge/top-200-ports.json (200 LOCODE strings)
+ * Input: data/knowledge/top-200-ports.json (200 port objects with locode, name, country, lat, lon, rank, category)
  * Output: ~60K rows in port_distances (200×199/2 pairs × 3 routes)
  *
  * Progress: Logs percentage every 60s for ops visibility
@@ -142,7 +142,8 @@ export async function seedDistances(
       throw new Error(`Port list file not found: ${portListPath}`);
     }
     const content = fs.readFileSync(portListPath, 'utf-8');
-    locodes = JSON.parse(content);
+    const ports = JSON.parse(content) as Array<{ locode: string }>;
+    locodes = ports.map((p) => p.locode);
   }
 
   // Empty port list → log warning and exit


### PR DESCRIPTION
## Summary

Regression fix к PR #93 — \`scripts/knowledge/sources/distances.ts\` читал \`top-200-ports.json\` как массив строк, после PR #93 это массив объектов.

**Bug behavior:** \`isValidLocode\` получал \`"[object Object]"\` для каждой записи, silently filtered все 200 портов как invalid → \`generatePairs\` возвращал 0 pairs → \`seedDistances\` was a silent no-op (вместо ~60K rows).

**В проде не было visible bug**, потому что \`KNOWLEDGE_LAYER_DISTANCES_ENABLED\` default false. Но Block D activation падает на этом silently.

## Fix

Two-line change: \`JSON.parse(content)\` → \`JSON.parse(content).map(p => p.locode)\`.

## TDD evidence

Integration smoke tests добавлены **первыми** (RED → GREEN):
1. Shape assertion test — без mocks, с реальным ports.json
2. \`generatePairs\` call count — было 0, стало >100

## Test plan

- [x] Targeted: \`npx jest __tests__/scripts/knowledge/sources/distances.test.ts\` → 13/13 pass
- [x] Full knowledge suite: 274/274 pass (2 suites skipped — pre-existing @google-cloud/aiplatform missing)
- [x] tsc clean for changed files
- [ ] CI green

## Other callers

\`grep -rn top-200-ports\` показал 3 callers:
- \`scripts/knowledge/sources/distances.ts\` — broken (this PR fixes)
- \`scripts/knowledge/validate-data-files.ts\` — already uses object shape via PortSchema
- \`__tests__/data/knowledge/top-200-ports.test.ts\` — test file, no fix needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)