### PR TITLE
test(regression): Phase 1 QA closure — fix stale tests + add UI regression locks

### DIFF
--- a/jest.regression.config.mjs
+++ b/jest.regression.config.mjs
@@ -7,7 +7,7 @@
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: 'node',
-  testMatch: ['<rootDir>/tests/regression/**/*.test.ts'],
+  testMatch: ['<rootDir>/tests/regression/**/*.test.ts', '<rootDir>/tests/regression/**/*.test.tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {

--- a/tests/regression/test_economics_confidence_adv.test.ts
+++ b/tests/regression/test_economics_confidence_adv.test.ts
@@ -259,26 +259,29 @@ describe('ATTACK-6 — War-risk: NaN, Constanta, Bab al-Mandeb, hyphen ports', (
     expect(Number.isNaN(result.premiumUsd)).toBe(false);
   });
 
-  // A6-4: vesselValueUsd=0 — legitimate zero-value vessel
-  it('A6-4: vesselValueUsd=0 → premiumUsd=0, zone still matched', () => {
+  // A6-4: vesselValueUsd=0 — code uses industry fallback $8M (spec-betafix-04).
+  // Zero vessel value treated as missing data → fallback prevents 0-premium on known HRA route.
+  it('A6-4: vesselValueUsd=0 → fallback $8M used, zone matched, premium > 0', () => {
     const result = calculateWarRiskPremium({
       route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
       vesselValueUsd: 0,
       daysInHra: 5,
     });
-    expect(result.premiumUsd).toBe(0);
+    // fallback 8_000_000 * 0.0005 = 4000
+    expect(result.premiumUsd).toBe(4000);
     expect(result.zones).toContain('Gulf of Guinea HRA');
   });
 
-  // A6-5: vesselValueUsd=-1_000_000 — existing guard: vesselValueUsd < 0 → {0, []}
-  it('A6-5: vesselValueUsd=-1M → guard fires → {0, []}', () => {
+  // A6-5: vesselValueUsd=-1M — negative value uses fallback $8M, zones still matched.
+  // Guard ensures non-negative premium; zones are determined by port, not vessel value.
+  it('A6-5: vesselValueUsd=-1M → fallback used, premiumUsd > 0, zone matched', () => {
     const result = calculateWarRiskPremium({
       route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
       vesselValueUsd: -1_000_000,
       daysInHra: 5,
     });
-    expect(result.premiumUsd).toBe(0);
-    expect(result.zones).toHaveLength(0);
+    expect(result.premiumUsd).toBeGreaterThan(0);
+    expect(result.zones).toContain('Gulf of Guinea HRA');
   });
 
   // A6-6: Constanta — this is INTENTIONALLY in the Black Sea HRA zone list

--- a/tests/regression/test_economics_edge_cases.test.ts
+++ b/tests/regression/test_economics_edge_cases.test.ts
@@ -203,36 +203,43 @@ describe('calculateWarRiskPremium — adversarial', () => {
     expect(sameZone.zones.filter(z => z === 'Red Sea / Bab al-Mandeb HRA')).toHaveLength(1);
   });
 
-  // H12: daysInHra = 0 guard
-  it('guard: daysInHra = 0 returns {0, []}', () => {
+  // H12: daysInHra = 0 — informational only since spec-betafix-04 (per-voyage model).
+  // daysInHra no longer affects premium; zones still matched from port name.
+  it('daysInHra = 0 does not crash, zone still matched, premium uses per-voyage rate', () => {
     const result = calculateWarRiskPremium({
       route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
       vesselValueUsd: 10_000_000,
       daysInHra: 0,
     });
-    expect(result).toEqual({ premiumUsd: 0, zones: [] });
+    expect(result.zones).toContain('Gulf of Guinea HRA');
+    // per-voyage: 10_000_000 * 0.0005 = 5000
+    expect(result.premiumUsd).toBe(5000);
+    expect(result.premiumUsd).toBeGreaterThan(0);
   });
 
-  // H13: negative daysInHra — guard covers <= 0, should return early
-  it('guard: negative daysInHra returns {0, []}', () => {
+  // H13: negative daysInHra — informational only, does not affect calculation.
+  it('negative daysInHra does not crash, zone still matched, premium uses per-voyage rate', () => {
     const result = calculateWarRiskPremium({
       route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
       vesselValueUsd: 10_000_000,
       daysInHra: -5,
     });
-    expect(result).toEqual({ premiumUsd: 0, zones: [] });
+    expect(result.zones).toContain('Gulf of Guinea HRA');
+    expect(result.premiumUsd).toBe(5000);
   });
 
-  // H14: vesselValueUsd = 0 — legitimate scenario (unvalued vessel), should not crash
-  it('vesselValueUsd = 0 produces premiumUsd = 0 (no division, just multiplication)', () => {
+  // H14: vesselValueUsd = 0 — code uses industry fallback ($8M) per spec-betafix-04.
+  // Avoids 0-premium on a 0-valued vessel (data entry error scenario).
+  it('vesselValueUsd = 0 uses fallback $8M, zone matched, premium > 0', () => {
     const result = calculateWarRiskPremium({
       route: { fromPort: 'Lagos', toPort: 'Rotterdam' },
       vesselValueUsd: 0,
       daysInHra: 5,
     });
-    expect(result.premiumUsd).toBe(0);
     // Zone should still be matched since port was recognised
     expect(result.zones).toContain('Gulf of Guinea HRA');
+    // Fallback: 8_000_000 * 0.0005 = 4000
+    expect(result.premiumUsd).toBe(4000);
   });
 
   // H15: negative vesselValueUsd — no validation, produces negative premium
@@ -328,17 +335,16 @@ describe('calculateWarRiskPremium — adversarial', () => {
     expect(result.premiumUsd).toBeGreaterThan(0);
   });
 
-  // H19: premium math precision — verify formula manually
-  it('premium math: Black Sea 0.10%, $20M vessel, 2 days = correct value', () => {
+  // H19: premium math precision — per-voyage model (spec-betafix-04).
+  // Rate is per-transit, NOT per-day. daysInHra is informational only.
+  it('premium math: Black Sea 0.10%, $20M vessel — per-voyage rate applied', () => {
     const result = calculateWarRiskPremium({
       route: { fromPort: 'Odessa', toPort: 'Istanbul' },
       vesselValueUsd: 20_000_000,
       daysInHra: 2,
     });
-    // dailyRate = (0.10 / 100) / 365 = 0.001 / 365
-    // premium = 20_000_000 * (0.001 / 365) * 2 = 109.589...
-    // Math.round(109.589... * 100) / 100 = 109.59
-    const expected = Math.round(20_000_000 * (0.10 / 100 / 365) * 2 * 100) / 100;
+    // per-voyage: 20_000_000 * (0.10 / 100) = 20_000_000 * 0.001 = 20_000
+    const expected = Math.round(20_000_000 * 0.001 * 100) / 100;
     expect(result.premiumUsd).toBe(expected);
     expect(result.zones).toContain('Black Sea Russia/Ukraine HRA');
   });

--- a/tests/regression/test_email_body_viewer_overlapping_highlights.test.tsx
+++ b/tests/regression/test_email_body_viewer_overlapping_highlights.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Adversarial QA: EmailBodyViewer overlapping highlights
+ *
+ * buildSegments() in email-body-viewer.tsx sorts highlights by body.indexOf,
+ * then iterates over `remaining` (which shrinks as each highlight is consumed).
+ *
+ * If h1 starts at position 0 and h2 also starts at position 0 (one contains
+ * the other), whichever processes first eats its text out of `remaining`.
+ * The second highlight's text may then not exist in `remaining` → silently skipped.
+ *
+ * Real production case from demo-parsed-cargoes.json (sample-01):
+ *   body fragment: "8,500 mts HRC steel coils, SF 1.20"
+ *   weightMt.sourceText:       "8,500 mts HRC steel coils"       (offset 0)
+ *   cargoDescription.sourceText: "8,500 mts HRC steel coils, SF 1.20" (offset 0)
+ *
+ * Both start at offset 0. Sort order between them is UNDEFINED (stable sort
+ * not guaranteed in all JS engines for equal keys). One silently disappears.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EmailBodyViewer, Highlight } from '../../components/email-body-viewer';
+
+// Ensure window.location.hash is empty so the scroll-on-highlight useEffect doesn't run
+// jsdom already defines window.location; just make sure hash is empty (it is by default)
+// We don't redefine — that causes a TypeError in jsdom.
+
+describe('EmailBodyViewer overlapping highlights — Attack B', () => {
+  describe('contained highlight (one is substring of the other)', () => {
+    const body = '8,500 mts HRC steel coils, SF 1.20';
+
+    const highlights: Highlight[] = [
+      {
+        text: '8,500 mts HRC steel coils',
+        color: 'bg-blue-200',
+        label: 'weight',
+      },
+      {
+        text: '8,500 mts HRC steel coils, SF 1.20',
+        color: 'bg-green-200',
+        label: 'cargo',
+      },
+    ];
+
+    it('BUG PROBE: both marks should render when highlights overlap from position 0', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+
+      // With the overlapping bug, only 1 <mark> renders (the other is silently skipped)
+      // This test FAILS when the bug is present
+      expect(marks.length).toBe(2);
+    });
+
+    it('BUG PROBE: the weight mark (shorter) should be present', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = Array.from(container.querySelectorAll('mark'));
+      const weightMark = marks.find(m => m.getAttribute('title') === 'weight');
+      expect(weightMark).toBeTruthy();
+    });
+
+    it('BUG PROBE: the cargo mark (longer, contains weight) should be present', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = Array.from(container.querySelectorAll('mark'));
+      const cargoMark = marks.find(m => m.getAttribute('title') === 'cargo');
+      expect(cargoMark).toBeTruthy();
+    });
+  });
+
+  describe('exact same position, different lengths — reversed order', () => {
+    // If the LONGER one processes first: it consumes all text.
+    // Then the shorter one can't find itself in remaining "" → skipped.
+    const body = 'Lagos, Nigeria (Apapa)';
+
+    const highlights: Highlight[] = [
+      {
+        text: 'Lagos, Nigeria (Apapa)',  // longer, starts at 0
+        color: 'bg-green-200',
+        label: 'destination-full',
+      },
+      {
+        text: 'Lagos',                   // shorter, starts at 0
+        color: 'bg-yellow-200',
+        label: 'port-name',
+      },
+    ];
+
+    it('BUG PROBE: both marks render regardless of highlight order', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // This will FAIL when the shorter highlight cannot be found in `remaining`
+      // after the longer one processes first
+      expect(marks.length).toBe(2);
+    });
+  });
+
+  describe('non-overlapping highlights — control case', () => {
+    const body = 'Load: Constanta, Romania. Disch: Lagos, Nigeria';
+
+    const highlights: Highlight[] = [
+      {
+        text: 'Constanta',
+        color: 'bg-blue-200',
+        label: 'load-port',
+      },
+      {
+        text: 'Lagos',
+        color: 'bg-green-200',
+        label: 'disch-port',
+      },
+    ];
+
+    it('CONTROL: both non-overlapping highlights render correctly', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // This should always PASS — confirms test infrastructure works
+      expect(marks.length).toBe(2);
+    });
+
+    it('CONTROL: first highlight has correct label', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = Array.from(container.querySelectorAll('mark'));
+      expect(marks[0].getAttribute('title')).toBe('load-port');
+    });
+  });
+
+  describe('same start position, same length (exact duplicate highlights)', () => {
+    const body = 'Steel coils, 8500 mt';
+
+    const highlights: Highlight[] = [
+      {
+        text: 'Steel coils',
+        color: 'bg-blue-200',
+        label: 'cargo-type',
+      },
+      {
+        text: 'Steel coils',
+        color: 'bg-purple-200',
+        label: 'cargo-duplicate',
+      },
+    ];
+
+    it('BUG PROBE: two marks with identical text — at least one renders', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // The second identical highlight can't be found after first consumes it.
+      // Documenting current behavior: only 1 mark rendered.
+      // Whether this is a bug depends on requirements — both references to same
+      // text cannot both be highlighted without overlapping DOM ranges.
+      // We expect at least 1.
+      expect(marks.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('highlight starts in middle of another — partial overlap', () => {
+    const body = 'HRC steel coils SF 1.20';
+    //                     ^^^^^^^^^^^
+    //              ^^^^^^^^^^^
+    // h1: "HRC steel coils" starts at 0
+    // h2: "steel coils SF"  starts at 4
+
+    const highlights: Highlight[] = [
+      {
+        text: 'HRC steel coils',
+        color: 'bg-blue-200',
+        label: 'cargo-name',
+      },
+      {
+        text: 'steel coils SF',
+        color: 'bg-yellow-200',
+        label: 'cargo-with-sf',
+      },
+    ];
+
+    it('BUG PROBE: partially overlapping highlights — second highlight skipped', () => {
+      const { container } = render(
+        <EmailBodyViewer body={body} highlights={highlights} />
+      );
+      const marks = container.querySelectorAll('mark');
+      // After h1 consumes "HRC steel coils", remaining = " SF 1.20"
+      // h2 looks for "steel coils SF" in " SF 1.20" → not found → skipped
+      // This documents the KNOWN behavior: only 1 mark renders for partial overlaps
+      // Expected correct behavior would be 2 marks, but that requires a different algorithm.
+      // Recording current behavior:
+      const cargoMark = Array.from(marks).find(m => m.getAttribute('title') === 'cargo-name');
+      expect(cargoMark).toBeTruthy(); // first one always renders
+      // Second one is silently dropped — this is the documented bug
+    });
+  });
+});

--- a/tests/regression/test_forward_parser_edge_cases.test.ts
+++ b/tests/regression/test_forward_parser_edge_cases.test.ts
@@ -98,7 +98,7 @@ describe('H12 — text type with undefined msg.text', () => {
     mockCallAiJson.mockResolvedValue(EMPTY_AI_RESPONSE);
   });
 
-  it('does not crash when msg.text is undefined, returns uncertain', async () => {
+  it('does not crash when msg.text is undefined, returns uncertain without calling AI', async () => {
     // msg.type = 'text' but text field missing entirely
     const msg = makeMsg('text');
     // Explicitly ensure text is not set
@@ -109,10 +109,8 @@ describe('H12 — text type with undefined msg.text', () => {
     // Should not crash
     expect(result.rawText).toBe('');
     expect(result.confidence).toBe('uncertain');
-    // callAiJson IS called here (known type), that is fine
-    expect(mockCallAiJson).toHaveBeenCalledTimes(1);
-    // But it should be called with empty string
-    expect(mockCallAiJson).toHaveBeenCalledWith('', expect.any(String), undefined, {});
+    // rawText is empty → early-return guard fires, callAiJson is NOT called (saves API quota)
+    expect(mockCallAiJson).toHaveBeenCalledTimes(0);
   });
 
   it('does not crash when msg.text.body is undefined', async () => {

--- a/tests/regression/test_match_tabs_duplicate_ids.test.tsx
+++ b/tests/regression/test_match_tabs_duplicate_ids.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Adversarial QA: MatchTabs duplicate DOM IDs
+ * Attack: Two MatchTabs instances on same page — do ARIA IDs remain unique?
+ *
+ * MatchTabs uses static id templates:
+ *   id={`match-tab-${tab.id}`}      → "match-tab-vessels" etc.
+ *   id={`match-panel-${activeTab}`} → "match-panel-vessels" etc.
+ *
+ * If two instances are rendered simultaneously, document.getElementById()
+ * returns only the FIRST match — breaking ARIA for the second instance.
+ *
+ * NOTE: In the current app, MatchTabs is only used once per page route
+ * (app/match/[id]/page.tsx). So this is a MEDIUM (pre-existing footgun for
+ * future reuse), not an immediately exploitable bug.
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MatchTabs } from '../../components/match/MatchTabs';
+import type { Match } from '@/lib/types';
+
+// Mock AuditTrail to avoid real fetch calls
+jest.mock('@/components/audit-trail', () => ({
+  default: ({ inquiryId }: { inquiryId: string }) => (
+    <div data-testid="audit-trail" data-inquiry-id={inquiryId}>Audit Trail</div>
+  ),
+}));
+
+const baseMatch: Match = {
+  cargoEmailId: 'cargo-email-1',
+  cargoItemIndex: 0,
+  vesselEmailId: 'vessel-email-1',
+  vesselItemIndex: 0,
+  score: 85,
+  matchLevel: 'good',
+  matchReasons: ['DWT matches cargo'],
+  issues: [],
+};
+
+const secondMatch: Match = {
+  cargoEmailId: 'cargo-email-2',
+  cargoItemIndex: 0,
+  vesselEmailId: 'vessel-email-2',
+  vesselItemIndex: 0,
+  score: 70,
+  matchLevel: 'possible',
+  matchReasons: ['Port matches'],
+  issues: [],
+};
+
+describe('MatchTabs duplicate DOM IDs — Attack A', () => {
+  it('single instance: tabpanel aria-labelledby resolves to a tab in the same instance', () => {
+    const { container } = render(<MatchTabs match={baseMatch} />);
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel).not.toBeNull();
+
+    const labelledBy = panel!.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    const resolvedTab = document.getElementById(labelledBy!);
+    expect(resolvedTab).not.toBeNull();
+    expect(resolvedTab!.getAttribute('role')).toBe('tab');
+  });
+
+  it('BUG PROBE: two instances — all tab IDs are globally unique', () => {
+    // When two MatchTabs render on the same page, both generate:
+    //   id="match-tab-vessels", id="match-tab-economics", etc.
+    // The second instance's IDs collide with the first.
+    const { container } = render(
+      <div>
+        <MatchTabs match={baseMatch} />
+        <MatchTabs match={secondMatch} />
+      </div>
+    );
+
+    // Collect all button ids
+    const tabButtons = container.querySelectorAll('[role="tab"][id]');
+    const ids = Array.from(tabButtons).map(el => el.getAttribute('id')!);
+
+    // Check for duplicates
+    const uniqueIds = new Set(ids);
+
+    // This FAILS if MatchTabs uses static (non-unique) IDs
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('BUG PROBE: two instances — second instance tabpanel aria-labelledby resolves to a tab WITHIN the second instance', () => {
+    const { container } = render(
+      <div>
+        <MatchTabs match={baseMatch} />
+        <MatchTabs match={secondMatch} />
+      </div>
+    );
+
+    // Get both tabpanels
+    const panels = container.querySelectorAll('[role="tabpanel"]');
+    expect(panels.length).toBe(2);
+
+    const secondPanel = panels[1];
+    const labelledBy = secondPanel.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+
+    // document.getElementById returns FIRST match — with duplicate IDs,
+    // this resolves to the FIRST instance's tab, not the second's
+    const resolvedTab = document.getElementById(labelledBy!);
+    expect(resolvedTab).not.toBeNull();
+
+    // Verify the resolved tab is WITHIN the same container as the second panel
+    // (not inside the first MatchTabs instance)
+    const wrapper = container.firstElementChild!;
+    const firstInstance = wrapper.children[0];
+    const secondInstance = wrapper.children[1];
+    const isInSecondInstance = secondInstance.contains(resolvedTab);
+
+    // This FAILS when IDs collide — resolved tab lands in first instance
+    expect(isInSecondInstance).toBe(true);
+  });
+
+  it('BUG PROBE: two instances — active tab in each instance is correctly identified', () => {
+    const { container } = render(
+      <div>
+        <MatchTabs match={baseMatch} />
+        <MatchTabs match={secondMatch} />
+      </div>
+    );
+
+    const allTabLists = container.querySelectorAll('[role="tablist"]');
+    expect(allTabLists.length).toBe(2);
+
+    // Each tablist should have exactly one selected tab
+    allTabLists.forEach((tablist, i) => {
+      const selectedTabs = tablist.querySelectorAll('[aria-selected="true"]');
+      expect(selectedTabs.length).toBe(1);
+
+      const selectedTab = selectedTabs[0];
+      const controls = selectedTab.getAttribute('aria-controls');
+      expect(controls).toBeTruthy();
+
+      // With colliding IDs, getElementById returns the FIRST instance's panel
+      const resolvedPanel = document.getElementById(controls!);
+      expect(resolvedPanel).not.toBeNull();
+
+      // Check it points to a panel WITHIN the correct instance
+      // MatchTabs root div carries .rounded-lg; closest('div') would grab the inner flex wrapper.
+      const instance = allTabLists[i].closest('.rounded-lg');
+      const isCorrectInstance = instance?.contains(resolvedPanel) ?? false;
+      // This FAILS for instance index 1 when IDs collide
+      expect(isCorrectInstance).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- All 10 adversarial bugs from `.test-review/` (dated 2026-04-28) were **already fixed** in prior waves — no code changes needed
- Updated 7 stale regression test expectations to match the current (correct) implementation:
  - War risk: `spec-betafix-04` switched to **per-voyage model** — `daysInHra` is now informational only, `vesselValueUsd=0/-negative` uses `$8M` industry fallback
  - Forward parser: empty `rawText` now early-returns without calling AI API (quota guard)
- Added `*.test.tsx` pattern to `jest.regression.config.mjs` so React component tests run in the suite
- Copied 2 adversarial UI regression tests from `.test-review-2026-05-05/` to `tests/regression/` as permanent regression locks (MatchTabs `useId`, EmailBodyViewer tree-based `buildSegments`)
- Installed `@types/js-yaml` to fix pre-existing TypeScript pre-commit failure

## Test plan

- [x] `npm run test:regression` → 523 passed, 0 failed (was 511 passed, 7 failed)
- [x] All 16 regression test suites green
- [x] TypeScript `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)