### PR TITLE
feat(wave-gamma): retry+backoff in judge.ts + final bake-off (spec T3)

### DIFF
--- a/docs/waves/wave-gamma-quality-push-final.md
+++ b/docs/waves/wave-gamma-quality-push-final.md
@@ -1,0 +1,121 @@
+# Wave γ Quality Push — Final Bake-off Report
+
+**Run date:** 2026-05-06  
+**Run ID:** 2026-05-06T20-04-16-452Z  
+**Branch:** feat/wave-gamma-judge-retry  
+**Spec:** Spec 03 (T3) — retry+backoff in judge.ts + final bake-off
+
+---
+
+## Summary
+
+Финальный bake-off по трём endpoint'ам (parse-cargo, parse-vessel, parse-recap) был запущен с тремя моделями Gemini. Кандидатский вывод получен успешно для всех 213 пар (model × case × endpoint), однако судья (Bedrock Opus 4.7) недоступен в текущем AWS-аккаунте — все judge-вызовы вернули JUDGE_ERROR.
+
+**Причина JUDGE_ERROR:** модель `us.anthropic.claude-opus-4-7-20260415-v1:0` не активирована в AWS-аккаунте (ValidationException: "The provided model identifier is invalid"). Требует активации cross-region inference profile через AWS Console → Bedrock → Model Access.
+
+---
+
+## Bake-off results table
+
+| Endpoint     | Model                 | Cases   | Candidate OK | Parse Err | Model Err | Judge Status                        |
+| ------------ | --------------------- | ------- | ------------ | --------- | --------- | ----------------------------------- |
+| parse-cargo  | gemini-2.5-flash-lite | 24      | 24           | 0         | 0         | 100% JUDGE_ERROR                    |
+| parse-cargo  | gemini-2.5-flash      | 24      | 24           | 0         | 0         | 100% JUDGE_ERROR                    |
+| parse-cargo  | gemini-2.5-pro        | 24      | 15           | 1         | 8         | 63% JUDGE_ERROR, 37% model/no-judge |
+| parse-recap  | gemini-2.5-flash-lite | 22      | 22           | 0         | 0         | 100% JUDGE_ERROR                    |
+| parse-recap  | gemini-2.5-flash      | 22      | 21           | 1         | 0         | 95% JUDGE_ERROR                     |
+| parse-recap  | gemini-2.5-pro        | 22      | 21           | 1         | 0         | 95% JUDGE_ERROR                     |
+| parse-vessel | gemini-2.5-flash-lite | 25      | 25           | 0         | 0         | 100% JUDGE_ERROR                    |
+| parse-vessel | gemini-2.5-flash      | 25      | 25           | 0         | 0         | 100% JUDGE_ERROR                    |
+| parse-vessel | gemini-2.5-pro        | 25      | 25           | 0         | 0         | 100% JUDGE_ERROR                    |
+| **TOTAL**    | —                     | **213** | **202**      | **3**     | **8**     | **Judge: unavailable**              |
+
+---
+
+## Latency & cost profile (candidate generation only)
+
+| Model                 | N   | p50 latency | p95 latency | Total cost (run) | Cost/1k cases (est.) |
+| --------------------- | --- | ----------- | ----------- | ---------------- | -------------------- |
+| gemini-2.5-flash-lite | 71  | 2 235 ms    | 4 927 ms    | $0.062           | ~$0.87               |
+| gemini-2.5-flash      | 71  | 13 888 ms   | 33 286 ms   | $0.290           | ~$4.08               |
+| gemini-2.5-pro        | 71  | 27 408 ms   | 60 004 ms   | $1.049           | ~$14.77              |
+
+Notes:
+
+- gemini-2.5-pro имеет 33% model errors (timeout 60s) на parse-cargo — нестабилен на этом endpoint'е.
+- gemini-2.5-flash-lite: лучшая скорость, самая низкая цена, 0 model/parse ошибок.
+- gemini-2.5-flash: баланс между скоростью и качеством.
+
+---
+
+## Judge infrastructure status
+
+| Component                         | Status                                             |
+| --------------------------------- | -------------------------------------------------- | ------------------- | -------------------- |
+| Retry helper `callWithRetry`      | Реализован. Задержки [1000, 5000, 30000, 60000] мс |
+| Throttle detection (`isThrottle`) | Паттерн `/429                                      | ThrottlingException | Too Many Requests/i` |
+| Unit tests (3 retry scenarios)    | 14/14 PASS                                         |
+| Bedrock Opus 4.7 connectivity     | FAIL — model not activated in AWS account          |
+| Judge verdict coverage            | 0% (все записи JUDGE_ERROR)                        |
+
+---
+
+## Retry implementation (spec T3)
+
+Добавлено в `scripts/wave-gamma-bake-off/judge.ts`:
+
+```typescript
+export const RETRY_DELAYS_MS = [1000, 5000, 30000, 60000] as const;
+
+export function isThrottle(err: unknown): boolean {
+  const msg = String((err as Error)?.message ?? err);
+  return /429|ThrottlingException|Too Many Requests/i.test(msg);
+}
+
+export async function callWithRetry<T>(
+  fn: () => Promise<T>,
+  sleep: (ms: number) => Promise<void> = ...,
+): Promise<T> { ... }
+```
+
+Behaviour:
+
+- 429 / ThrottlingException / "Too Many Requests" → retry (до 4 попыток)
+- 500 / auth / validation errors → throw немедленно (no retry)
+- После 4 неудачных попыток → оригинальная ошибка
+
+---
+
+## Orchestrator: --max-concurrency
+
+Добавлен CLI-флаг в `scripts/wave-gamma-bake-off/cli.ts`:
+
+```bash
+npx tsx scripts/wave-gamma-bake-off/cli.ts --max-concurrency=4
+```
+
+Дефолт изменён с 5 → 4 (per spec). Переопределяет `BAKE_OFF_CONCURRENCY` env.
+
+---
+
+## Recommendation
+
+**DEFERRED** для всех трёх endpoint'ов.
+
+Причина: judge-вердикт недоступен из-за отсутствия активации Bedrock Opus 4.7 в AWS-аккаунте. Кандидатный вывод Gemini работает корректно.
+
+**Action items перед следующим прогоном:**
+
+1. Активировать model access в AWS Console → Bedrock → Model Access → `us.anthropic.claude-opus-4-7-20260415-v1:0`
+2. Или установить `JUDGE_BEDROCK_MODEL` на доступную модель (напр. `us.anthropic.claude-sonnet-4-6-20250514-v1:0`)
+3. Повторить `npx tsx scripts/wave-gamma-bake-off/cli.ts --max-concurrency=4`
+
+Когда judge заработает, рекомендуется **gemini-2.5-flash-lite** как кандидат для production (лучшая latency + нулевые ошибки), с **gemini-2.5-flash** как fallback для сложных endpoint'ов.
+
+---
+
+## Artifacts
+
+- Records JSONL: `.specs/wave-gamma-vertex/bake-off-results/2026-05-06T20-04-16-452Z/records.jsonl` (213 records)
+- Orchestrator report: `.specs/wave-gamma-vertex/bake-off-results/2026-05-06T20-04-16-452Z/report-2026-05-06T20-04-16-452Z.md`
+- Test log: `.specs/logs/spec-wgqp-03.log`

--- a/scripts/wave-gamma-bake-off/__tests__/judge.test.ts
+++ b/scripts/wave-gamma-bake-off/__tests__/judge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 
-import { judge, JUDGE_SCOPE, type CallAiTextFn } from '../judge';
+import { judge, JUDGE_SCOPE, isThrottle, callWithRetry, RETRY_DELAYS_MS, type CallAiTextFn } from '../judge';
 
 /**
  * Tests inject a fake `callAiText` directly rather than mocking
@@ -165,5 +165,82 @@ describe('judge', () => {
         { callAiText: fakeCallAiText },
       ),
     ).rejects.toThrow(/no text block/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retry helper tests (callWithRetry + isThrottle)
+// ---------------------------------------------------------------------------
+
+describe('isThrottle', () => {
+  it('returns true for 429 in message', () => {
+    expect(isThrottle(new Error('HTTP 429: Too Many Requests'))).toBe(true);
+  });
+  it('returns true for ThrottlingException', () => {
+    expect(isThrottle(new Error('ThrottlingException: rate exceeded'))).toBe(true);
+  });
+  it('returns true for "Too Many Requests" prose', () => {
+    expect(isThrottle(new Error('Too Many Requests'))).toBe(true);
+  });
+  it('returns false for 500 errors', () => {
+    expect(isThrottle(new Error('Internal Server Error 500'))).toBe(false);
+  });
+  it('returns false for auth errors', () => {
+    expect(isThrottle(new Error('Unauthorized 401'))).toBe(false);
+  });
+});
+
+describe('callWithRetry', () => {
+  it('(a) resolves on attempt 2 after a 429 on attempt 1', async () => {
+    // Fake sleep — records calls but resolves immediately.
+    const sleepCalls: number[] = [];
+    const fakeSleep = async (ms: number) => { sleepCalls.push(ms); };
+
+    let callCount = 0;
+    const fn = async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('HTTP 429: Too Many Requests');
+      return 'success';
+    };
+
+    const result = await callWithRetry(fn, fakeSleep);
+
+    expect(result).toBe('success');
+    expect(callCount).toBe(2);
+    // One sleep between attempt 1 and attempt 2, matching RETRY_DELAYS_MS[0].
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBe(RETRY_DELAYS_MS[0]);
+  });
+
+  it('(b) throws after 4 consecutive 429 errors (all delays exhausted)', async () => {
+    const fakeSleep = async (_ms: number) => {};
+
+    let callCount = 0;
+    const throttleErr = new Error('ThrottlingException: capacity exceeded');
+    const fn = async () => {
+      callCount++;
+      throw throttleErr;
+    };
+
+    await expect(callWithRetry(fn, fakeSleep)).rejects.toThrow('ThrottlingException: capacity exceeded');
+    // RETRY_DELAYS_MS has 4 entries → 4 attempts total.
+    expect(callCount).toBe(RETRY_DELAYS_MS.length);
+  });
+
+  it('(c) throws immediately on a 500 error without retrying', async () => {
+    const sleepCalls: number[] = [];
+    const fakeSleep = async (ms: number) => { sleepCalls.push(ms); };
+
+    let callCount = 0;
+    const serverErr = new Error('Internal Server Error 500');
+    const fn = async () => {
+      callCount++;
+      throw serverErr;
+    };
+
+    await expect(callWithRetry(fn, fakeSleep)).rejects.toThrow('Internal Server Error 500');
+    // Non-throttle → exactly 1 attempt, no sleep.
+    expect(callCount).toBe(1);
+    expect(sleepCalls).toHaveLength(0);
   });
 });

--- a/scripts/wave-gamma-bake-off/cli.ts
+++ b/scripts/wave-gamma-bake-off/cli.ts
@@ -23,7 +23,11 @@ import type { Endpoint } from './corpus';
 import { ENDPOINTS } from './endpoint-specs';
 
 (async () => {
-  const concurrency = parseInt(process.env.BAKE_OFF_CONCURRENCY ?? '5', 10);
+  // --max-concurrency=N CLI flag (overrides BAKE_OFF_CONCURRENCY env, default 4).
+  const argMaxConc = process.argv.find((a) => a.startsWith('--max-concurrency='));
+  const concurrency = argMaxConc
+    ? Math.max(1, Number(argMaxConc.split('=')[1]))
+    : parseInt(process.env.BAKE_OFF_CONCURRENCY ?? '4', 10);
   // Comma-separated allowlist of model ids, e.g.
   //   BAKE_OFF_MODEL_FILTER=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite
   // Useful when some Gemini models 404 in the active Vertex project/region.

--- a/scripts/wave-gamma-bake-off/judge.ts
+++ b/scripts/wave-gamma-bake-off/judge.ts
@@ -196,10 +196,59 @@ export interface JudgeOptions {
    * shim routes to AWS Bedrock Opus 4.7.
    */
   callAiText?: CallAiTextFn;
+  /**
+   * Optional sleep function injected by tests to avoid real delays.
+   * Defaults to `(ms) => new Promise(r => setTimeout(r, ms))`.
+   */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Exponential-backoff delay schedule for throttle retries (ms). */
+export const RETRY_DELAYS_MS = [1000, 5000, 30000, 60000] as const;
+
+/**
+ * Returns true if the error looks like an API throttle / rate-limit signal
+ * (HTTP 429, AWS ThrottlingException, or "Too Many Requests" prose).
+ * Non-throttle errors (500, auth, malformed request, etc.) return false
+ * and should NOT be retried.
+ */
+export function isThrottle(err: unknown): boolean {
+  const msg = String((err as Error)?.message ?? err);
+  return /429|ThrottlingException|Too Many Requests/i.test(msg);
+}
+
+/**
+ * Calls `fn` with retry+backoff for throttle errors only.
+ *
+ * Retry schedule: RETRY_DELAYS_MS = [1000, 5000, 30000, 60000] ms.
+ * After 4 failed attempts (= all delays exhausted) the original error is
+ * re-thrown. Non-throttle errors are re-thrown immediately without retry.
+ *
+ * @param fn   Async operation to execute.
+ * @param sleep  Injected sleep (for tests). Defaults to real setTimeout.
+ */
+export async function callWithRetry<T>(
+  fn: () => Promise<T>,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (!isThrottle(err)) throw err;
+      // Last attempt — don't sleep, just break and re-throw below.
+      if (attempt === RETRY_DELAYS_MS.length - 1) break;
+      await sleep(RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastErr;
 }
 
 export async function judge(input: JudgeInput, options: JudgeOptions = {}): Promise<JudgeOutput> {
   const callFn: CallAiTextFn = options.callAiText ?? defaultCallAiText;
+  const sleepFn = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
   // User message: structured payload. We do NOT include the candidate's actual
   // model id — only the anonymous label.
@@ -219,30 +268,16 @@ export async function judge(input: JudgeInput, options: JudgeOptions = {}): Prom
   // Pin the judge model explicitly — independent of any per-scope BEDROCK_MODEL_ID
   // override the project may use elsewhere.
   // Bedrock Opus 4.7 has tight per-account TPM throttles. Retry on
-  // "Too many tokens"/ThrottlingException-style errors with exponential
-  // backoff + jitter. Up to 5 attempts (~31s worst-case wait).
-  const maxAttempts = 5;
-  let rawText = '';
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    try {
-      rawText = await callFn(JUDGE_SCOPE, JUDGE_PROMPT, userMessage, {
+  // ThrottlingException / 429 / "Too Many Requests" only. Other errors
+  // (auth, malformed request, 500) are thrown immediately.
+  const rawText = await callWithRetry(
+    () =>
+      callFn(JUDGE_SCOPE, JUDGE_PROMPT, userMessage, {
         model: resolveJudgeModel(),
         maxTokens: JUDGE_MAX_TOKENS,
-      });
-      lastErr = undefined;
-      break;
-    } catch (e) {
-      lastErr = e;
-      const msg = e instanceof Error ? e.message : String(e);
-      const isThrottle = /too many tokens|throttl|rate.?limit|429|ServiceUnavailable|503/i.test(msg);
-      if (!isThrottle || attempt === maxAttempts - 1) throw e;
-      const baseMs = 1000 * Math.pow(2, attempt); // 1s, 2s, 4s, 8s, 16s
-      const jitter = Math.floor(Math.random() * 500);
-      await new Promise((r) => setTimeout(r, baseMs + jitter));
-    }
-  }
-  if (lastErr) throw lastErr;
+      }),
+    sleepFn,
+  );
 
   if (!rawText || rawText.trim().length === 0) {
     throw new Error('Judge returned no text block in response content');


### PR DESCRIPTION
## Summary

- **judge.ts**: заменён ad-hoc retry-loop на `callWithRetry()` с задержками `[1000, 5000, 30000, 60000]` мс. Ретрай только для throttle-ошибок (`429 / ThrottlingException / Too Many Requests`), остальные — немедленно throw. DI-seam `sleep()` позволяет тестам избежать реальных задержек.
- **cli.ts**: добавлен флаг `--max-concurrency=N` (default 4, overrides `BAKE_OFF_CONCURRENCY` env).
- **judge.test.ts**: 3 новых unit-теста на retry (a) 429→success attempt 2, (b) 4×throttle→throw, (c) 500→immediate. Итого 14/14 PASS.
- **docs/waves/wave-gamma-quality-push-final.md**: финальный отчёт bake-off (213 records, 3 endpoints × 3 Gemini models).

## Bake-off status

Кандидатский вывод Gemini получен успешно (202/213 OK). Judge (Bedrock Opus 4.7) вернул JUDGE_ERROR для всех записей — модель `us.anthropic.claude-opus-4-7-20260415-v1:0` не активирована в AWS-аккаунте. Требует активации через AWS Console → Bedrock → Model Access.

Предварительная рекомендация по latency/cost: **gemini-2.5-flash-lite** (p50=2.2s, $0.87/1k cases, 0 ошибок).

## Test plan

- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `npx jest "scripts/wave-gamma-bake-off/__tests__/judge.test.ts"` — 14/14 PASS
- [ ] Активировать Bedrock Opus 4.7 и повторить bake-off для получения judge-вердиктов

🤖 Generated with [Claude Code](https://claude.com/claude-code)