### PR TITLE
fix(rag): post-QA follow-up — F-3/F-4/F-5 citation and ID bugs

### DIFF
--- a/__tests__/regression/test_adapter_truncation_and_id.test.ts
+++ b/__tests__/regression/test_adapter_truncation_and_id.test.ts
@@ -368,3 +368,52 @@ describe('H2 regression: JWC fallback ID collision', () => {
     }
   });
 });
+
+// ─── Q3: JWC ID uniqueness after full-URL hash fix ────────────────────────────
+
+describe('Q3 regression: JWC ID uniqueness after full-URL hash fix', () => {
+  const JWLA_FREE_HTML = `
+    <html>
+      <body>
+        <h1>Bulletin</h1>
+        <time>2026-01-15</time>
+        <p>Content without JWLA identifier.</p>
+      </body>
+    </html>
+  `;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Q3-a: two URLs with same basename but different paths get different IDs', async () => {
+    const URL_A = 'https://jwc.example.com/2024/bulletin.html';
+    const URL_B = 'https://jwc.example.com/2025/bulletin.html';
+
+    const LISTING_HTML = `
+      <html><body>
+        <a href="${URL_A}">Bulletin 2024</a>
+        <a href="${URL_B}">Bulletin 2025</a>
+      </body></html>
+    `;
+
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation(
+      (url: any): Promise<Response> => {
+        const urlStr = String(url);
+        const body = (urlStr === URL_A || urlStr === URL_B) ? JWLA_FREE_HTML : LISTING_HTML;
+        return Promise.resolve(
+          new Response(body, { status: 200, headers: { 'Content-Type': 'text/html' } })
+        );
+      }
+    );
+
+    const { scrapeJwc } = await import('@/lib/knowledge/sources/jwc/scraper');
+    const bulletins = await scrapeJwc('https://jwc.example.com/listing');
+
+    fetchMock.mockRestore();
+
+    expect(bulletins.length).toBe(2);
+    const ids = bulletins.map((b) => b.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+});

--- a/__tests__/regression/test_citation_validator.test.ts
+++ b/__tests__/regression/test_citation_validator.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression tests: F-4 (dot-anchored section match) + F-5 (case-insensitive regex)
+ * Discovery: adversarial QA cold-start, 2026-05-07
+ * Branch: fix/rag-phase2-post-qa-fixes
+ *
+ * DO NOT DELETE — these tests lock in two citation validator bug fixes.
+ *
+ * ── F-4: substring section match allows hallucinations ─────────────────────
+ * section.includes(sectionRef) is true for sectionRef='1', section='21.5'
+ * because '21.5'.includes('1') === true. §1 validates against a §21.5 chunk
+ * → hallucinated citation passes through the filter.
+ * Fix: dot-anchored prefix match — §1 matches §1.x but not §21.x.
+ *
+ * ── F-5: case-sensitive CITATION_PATTERN misses mixed-case tags ────────────
+ * [Source: imsbc §1.1] does not match /IMSBC|IGC/ without the `i` flag.
+ * The tag is preserved as-is rather than being checked against retrieved chunks
+ * → a hallucinated lowercase citation is never stripped.
+ * Fix: add `i` flag to CITATION_PATTERN.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { validateCitations } from '@/lib/knowledge/citations/validator';
+import type { RetrievedChunk } from '@/lib/knowledge/embeddings/chunks';
+
+function makeChunk(source: string, section: string): RetrievedChunk {
+  return {
+    content: 'chunk content',
+    metadata: { source, section },
+    distance: 0.1,
+    chunkId: 'test-id',
+  };
+}
+
+// ─── F-4: dot-anchored section match ────────────────────────────────────────
+
+describe('F-4 regression: citation validator dot-anchored section match', () => {
+  it('F-4-a: §1 against chunk section=21.5 → citation REMOVED (was false positive)', () => {
+    // Old code: '21.5'.includes('1') === true → citation kept (BUG)
+    // Fixed:    '21.5' !== '1' and !startsWith('1.') and !('1'.startsWith('21.5.')) → removed
+    const chunk = makeChunk('imsbc', '21.5');
+    const result = validateCitations('[Source: IMSBC §1] some text', [chunk]);
+    expect(result).toBe(' some text');
+  });
+
+  it('F-4-b: §2 against chunk section=2.1 → citation KEPT (legitimate sub-section)', () => {
+    // §2 is a valid parent of §2.1 — citation should survive
+    const chunk = makeChunk('imsbc', '2.1');
+    const result = validateCitations('[Source: IMSBC §2] some text', [chunk]);
+    expect(result).toBe('[Source: IMSBC §2] some text');
+  });
+
+  it('F-4-c: §21 against chunk section=21.5 → citation KEPT (prefix match)', () => {
+    // §21.5 starts with '21.' → §21 is the parent section
+    const chunk = makeChunk('imsbc', '21.5');
+    const result = validateCitations('[Source: IMSBC §21] some text', [chunk]);
+    expect(result).toBe('[Source: IMSBC §21] some text');
+  });
+
+  it('F-4-d: exact section match → citation KEPT', () => {
+    const chunk = makeChunk('imsbc', '3.1');
+    const result = validateCitations('[Source: IMSBC §3.1] text', [chunk]);
+    expect(result).toBe('[Source: IMSBC §3.1] text');
+  });
+
+  it('F-4-e: §3 against chunk section=13.1 → citation REMOVED', () => {
+    // '13.1'.startsWith('3.') === false, '3'.startsWith('13.1.') === false → removed
+    const chunk = makeChunk('imsbc', '13.1');
+    const result = validateCitations('[Source: IMSBC §3] text', [chunk]);
+    expect(result).toBe(' text');
+  });
+});
+
+// ─── F-5: case-insensitive CITATION_PATTERN ──────────────────────────────────
+
+describe('F-5 regression: citation validator case-insensitive pattern', () => {
+  it('F-5-a: lowercase [Source: imsbc §1.1] against empty chunks → citation REMOVED', () => {
+    // Without `i` flag the pattern never matches 'imsbc' → tag preserved (BUG)
+    const result = validateCitations('[Source: imsbc §1.1] text', []);
+    expect(result).toBe(' text');
+  });
+
+  it('F-5-b: uppercase [Source: IMSBC §1.1] against empty chunks → citation REMOVED', () => {
+    // Baseline: already worked before the fix
+    const result = validateCitations('[Source: IMSBC §1.1] text', []);
+    expect(result).toBe(' text');
+  });
+
+  it('F-5-c: mixed case [Source: Imsbc §1.1] against empty chunks → citation REMOVED', () => {
+    // Without `i` flag 'Imsbc' doesn't match → tag preserved (BUG)
+    const result = validateCitations('[Source: Imsbc §1.1] text', []);
+    expect(result).toBe(' text');
+  });
+});

--- a/lib/knowledge/citations/validator.ts
+++ b/lib/knowledge/citations/validator.ts
@@ -37,7 +37,11 @@ export function validateCitations(
       const found = retrievedChunks.some((c) => {
         if (c.metadata?.source !== sourceLower) return false;
         const section = String(c.metadata?.section ?? '');
-        return section.includes(sectionRef) || sectionRef.includes(section);
+        return (
+          section === sectionRef ||
+          section.startsWith(sectionRef + '.') ||
+          sectionRef.startsWith(section + '.')
+        );
       });
       return found ? fullMatch : '';
     }

--- a/lib/knowledge/citations/validator.ts
+++ b/lib/knowledge/citations/validator.ts
@@ -15,7 +15,7 @@ export function validateCitations(
 ): string {
   // Regex to match citation tags in 3 formats:
   // [Source: IMSBC §X.Y]   or   [Source: IGC X.Y]   or   [JWC-bulletinId]
-  const CITATION_PATTERN = /\[(?:Source:\s*(IMSBC|IGC)\s*§?([\w.]+)|JWC-([\w-]+))\]/g;
+  const CITATION_PATTERN = /\[(?:Source:\s*(IMSBC|IGC)\s*§?([\w.]+)|JWC-([\w-]+))\]/gi;
 
   return llmResponse.replace(CITATION_PATTERN, (fullMatch, sourceType, sectionRef, bulletinId) => {
     if (bulletinId) {

--- a/lib/knowledge/sources/jwc/scraper.ts
+++ b/lib/knowledge/sources/jwc/scraper.ts
@@ -226,17 +226,19 @@ function normalizeDate(dateStr: string): string {
 }
 
 function extractId(html: string, sourceUrl: string): string | null {
-  const idMatch = /JWLA-(\d+)/i.exec(html);
-  if (idMatch) {
-    return `JWLA-${idMatch[1]}`;
+  const htmlMatch = /JWLA-(\d+)/i.exec(html);
+  if (htmlMatch) {
+    return `JWLA-${htmlMatch[1]}`;
   }
 
-  const GENERIC_SEGMENTS = new Set(['index.html', 'index.htm', 'index.php', 'default.html']);
-  const urlMatch = /\/([^\/]+)$/.exec(sourceUrl);
-  if (urlMatch && !GENERIC_SEGMENTS.has(urlMatch[1])) {
-    return urlMatch[1];
+  // Also check the URL itself (e.g. /bulletins/JWLA-2025-001)
+  const urlMatch = /JWLA-([\w-]+)/i.exec(sourceUrl);
+  if (urlMatch) {
+    return `JWLA-${urlMatch[1]}`;
   }
-  return null;
+
+  // Hash the full URL so two bulletins at different paths are always unique
+  return createHash('sha256').update(sourceUrl).digest('hex').slice(0, 16);
 }
 
 function htmlToPlainText(html: string): string {


### PR DESCRIPTION
## Summary

Post-QA adversarial follow-up for RAG phase 2. Three bugs found after merge of #99/#100:

- **F-3 (HIGH):** JWC scraper returned raw URL basename as bulletin ID → `/2024/foo.html` and `/2025/foo.html` both got id `"foo.html"` → silent last-write-wins data loss in vec table. Fixed: check URL for JWLA-pattern first, then `sha256(sourceUrl)` as fallback — always unique per URL. Adds Q3-a regression test; H2-c/H2-d (previously RED) also turn GREEN.
- **F-4 (MEDIUM):** Citation validator used `section.includes(sectionRef)` — `§1` matched chunk `section='21.5'` because `'21.5'.includes('1') === true`. LLM hallucination passed through unchecked. Fixed: dot-anchored prefix match (`=== || startsWith(ref+'.') || ref.startsWith(section+'.')`).
- **F-5 (LOW-MED):** `CITATION_PATTERN` regex had no `i` flag → `[Source: imsbc §1.1]` (lowercase) was not matched, tag preserved as-is, hallucination never stripped. Fixed: added `gi` flags; existing `.toLowerCase()` on sourceType already handles normalisation.

## Test plan

- [x] Q3-a GREEN: two URLs with same basename get different IDs
- [x] H2-c GREEN (was RED): index.html collision fixed
- [x] F-4-a GREEN: `§1` vs `section=21.5` → citation removed
- [x] F-4-b GREEN: `§2` vs `section=2.1` → citation kept (sub-section)
- [x] F-4-c GREEN: `§21` vs `section=21.5` → citation kept (prefix match)
- [x] F-5-a/b/c GREEN: lowercase/mixed case → citation removed on empty chunks
- [x] Full `npm test` — 345 suites, 3626 tests green, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)