### PR TITLE
feat(rag-smoke): benchmark rewire + TOEPFER_TMI seed + port DA large vessels

### DIFF
--- a/__tests__/api/market/benchmark-route.test.ts
+++ b/__tests__/api/market/benchmark-route.test.ts
@@ -1,9 +1,14 @@
 /**
- * TDD tests for GET /api/market/benchmark route (spec-01).
+ * Integration tests for GET /api/market/benchmark route (spec-01).
+ *
+ * Route logic:
+ * 1. DB-first: getLatestBalticIndex(db, indicator) for BHSI and TOEPFER_TMI
+ * 2. Fallback: getCurrentBenchmark(indicator) (scraper for TMI)
+ * 3. 404 if no data (not 503)
  *
  * Requirements:
- * - ?indicator=BHSI → 200 with value: 650
- * - ?indicator=TOEPFER_TMI → 200 with value: 12683
+ * - ?indicator=BHSI → 200 with value: 650 (from DB)
+ * - ?indicator=TOEPFER_TMI → 200 with value: 12683 (from DB)
  * - ?indicator=DREWRY_BREAKBULK → 404 (no data)
  * - no indicator → 400
  * - invalid indicator → 400
@@ -12,7 +17,21 @@
 
 import { GET } from '@/app/api/market/benchmark/route';
 
-// ─── Mock getCurrentBenchmark ─────────────────────────────────────────────────
+// ─── Mock session-store (server-only DB) ──────────────────────────────────────
+
+const mockGetDatabase = jest.fn();
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: mockGetDatabase })),
+}));
+
+// ─── Mock baltic-repository ───────────────────────────────────────────────────
+
+const mockGetLatestBalticIndex = jest.fn();
+jest.mock('@/lib/market/baltic-repository', () => ({
+  getLatestBalticIndex: (...args: unknown[]) => mockGetLatestBalticIndex(...args),
+}));
+
+// ─── Mock getCurrentBenchmark (scraper fallback) ──────────────────────────────
 
 const mockGetCurrentBenchmark = jest.fn();
 jest.mock('@/lib/market/benchmark', () => ({
@@ -28,37 +47,19 @@ function makeRequest(indicator?: string): Request {
   return new Request(url);
 }
 
-function bhsiBenchmark() {
-  return {
-    indicator: 'BHSI',
-    value: 650,
-    unit: 'index',
-    period: '2026-05-09',
-    sourceUrl: 'static-seed',
-    fetchedAt: new Date().toISOString(),
-  };
-}
-
-function toepferBenchmark() {
-  return {
-    indicator: 'TOEPFER_TMI',
-    value: 12683,
-    unit: 'USD/day',
-    period: '2026-05-09',
-    sourceUrl: 'static-seed',
-    fetchedAt: new Date().toISOString(),
-  };
-}
+const BHSI_ROW = { index_code: 'BHSI', value: 650, price_date: '2026-05-09', source: 'static-seed' };
+const TMI_ROW = { index_code: 'TOEPFER_TMI', value: 12683, price_date: '2026-05-09', source: 'static-seed' };
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGetDatabase.mockReturnValue({}); // mock DB handle (not used directly)
 });
 
-describe('GET /api/market/benchmark', () => {
-  it('R-1: ?indicator=BHSI → 200 with value=650', async () => {
-    mockGetCurrentBenchmark.mockResolvedValue(bhsiBenchmark());
+describe('GET /api/market/benchmark — DB path', () => {
+  it('R-1: ?indicator=BHSI → 200 with value=650 from DB', async () => {
+    mockGetLatestBalticIndex.mockReturnValue(BHSI_ROW);
 
     const res = await GET(makeRequest('BHSI'));
     const json = await res.json();
@@ -66,10 +67,11 @@ describe('GET /api/market/benchmark', () => {
     expect(res.status).toBe(200);
     expect(json.value).toBe(650);
     expect(json.indicator).toBe('BHSI');
+    expect(json.unit).toBe('index');
   });
 
-  it('R-2: ?indicator=TOEPFER_TMI → 200 with value=12683', async () => {
-    mockGetCurrentBenchmark.mockResolvedValue(toepferBenchmark());
+  it('R-2: ?indicator=TOEPFER_TMI → 200 with value=12683 from DB', async () => {
+    mockGetLatestBalticIndex.mockReturnValue(TMI_ROW);
 
     const res = await GET(makeRequest('TOEPFER_TMI'));
     const json = await res.json();
@@ -77,9 +79,34 @@ describe('GET /api/market/benchmark', () => {
     expect(res.status).toBe(200);
     expect(json.value).toBe(12683);
     expect(json.indicator).toBe('TOEPFER_TMI');
+    expect(json.unit).toBe('USD/day');
+    // getCurrentBenchmark (scraper) should NOT be called when DB has the row
+    expect(mockGetCurrentBenchmark).not.toHaveBeenCalled();
   });
 
-  it('R-3: ?indicator=DREWRY_BREAKBULK → 404 (no data)', async () => {
+  it('R-3: TOEPFER_TMI falls back to scraper when DB has no row', async () => {
+    mockGetLatestBalticIndex.mockReturnValue(null);
+    const scraperBenchmark = {
+      indicator: 'TOEPFER_TMI' as const,
+      value: 13000,
+      unit: 'USD/day',
+      period: 'May 2026',
+      sourceUrl: 'https://toepfer.com',
+      fetchedAt: new Date().toISOString(),
+    };
+    mockGetCurrentBenchmark.mockResolvedValue(scraperBenchmark);
+
+    const res = await GET(makeRequest('TOEPFER_TMI'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.value).toBe(13000);
+    expect(mockGetCurrentBenchmark).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET /api/market/benchmark — null / error paths', () => {
+  it('R-4: ?indicator=DREWRY_BREAKBULK → 404 (no DB row, scraper returns null)', async () => {
     mockGetCurrentBenchmark.mockResolvedValue(null);
 
     const res = await GET(makeRequest('DREWRY_BREAKBULK'));
@@ -89,26 +116,17 @@ describe('GET /api/market/benchmark', () => {
     expect(json.error).toMatch(/DREWRY_BREAKBULK/);
   });
 
-  it('R-4: missing indicator → 400', async () => {
-    const res = await GET(makeRequest());
-    expect(res.status).toBe(400);
-  });
-
-  it('R-5: invalid indicator → 400', async () => {
-    const res = await GET(makeRequest('INVALID_INDICATOR'));
-    expect(res.status).toBe(400);
-  });
-
-  it('R-6: benchmark unavailable → 404 (not 503)', async () => {
+  it('R-5: BHSI with no DB row → 404 (no scraper fallback for BHSI)', async () => {
+    mockGetLatestBalticIndex.mockReturnValue(null);
     mockGetCurrentBenchmark.mockResolvedValue(null);
 
     const res = await GET(makeRequest('BHSI'));
-
     expect(res.status).toBe(404);
     expect(res.status).not.toBe(503);
   });
 
-  it('R-7: 404 response has descriptive error message', async () => {
+  it('R-6: 404 response has descriptive error message', async () => {
+    mockGetLatestBalticIndex.mockReturnValue(null);
     mockGetCurrentBenchmark.mockResolvedValue(null);
 
     const res = await GET(makeRequest('BHSI'));
@@ -116,5 +134,17 @@ describe('GET /api/market/benchmark', () => {
 
     expect(typeof json.error).toBe('string');
     expect(json.error.length).toBeGreaterThan(0);
+  });
+});
+
+describe('GET /api/market/benchmark — validation', () => {
+  it('R-7: missing indicator → 400', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it('R-8: invalid indicator → 400', async () => {
+    const res = await GET(makeRequest('INVALID_INDICATOR'));
+    expect(res.status).toBe(400);
   });
 });

--- a/__tests__/api/market/benchmark-route.test.ts
+++ b/__tests__/api/market/benchmark-route.test.ts
@@ -1,0 +1,120 @@
+/**
+ * TDD tests for GET /api/market/benchmark route (spec-01).
+ *
+ * Requirements:
+ * - ?indicator=BHSI → 200 with value: 650
+ * - ?indicator=TOEPFER_TMI → 200 with value: 12683
+ * - ?indicator=DREWRY_BREAKBULK → 404 (no data)
+ * - no indicator → 400
+ * - invalid indicator → 400
+ * - missing data → 404 (not 503)
+ */
+
+import { GET } from '@/app/api/market/benchmark/route';
+
+// ─── Mock getCurrentBenchmark ─────────────────────────────────────────────────
+
+const mockGetCurrentBenchmark = jest.fn();
+jest.mock('@/lib/market/benchmark', () => ({
+  getCurrentBenchmark: (...args: unknown[]) => mockGetCurrentBenchmark(...args),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(indicator?: string): Request {
+  const url = indicator
+    ? `http://localhost/api/market/benchmark?indicator=${indicator}`
+    : 'http://localhost/api/market/benchmark';
+  return new Request(url);
+}
+
+function bhsiBenchmark() {
+  return {
+    indicator: 'BHSI',
+    value: 650,
+    unit: 'index',
+    period: '2026-05-09',
+    sourceUrl: 'static-seed',
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+function toepferBenchmark() {
+  return {
+    indicator: 'TOEPFER_TMI',
+    value: 12683,
+    unit: 'USD/day',
+    period: '2026-05-09',
+    sourceUrl: 'static-seed',
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/market/benchmark', () => {
+  it('R-1: ?indicator=BHSI → 200 with value=650', async () => {
+    mockGetCurrentBenchmark.mockResolvedValue(bhsiBenchmark());
+
+    const res = await GET(makeRequest('BHSI'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.value).toBe(650);
+    expect(json.indicator).toBe('BHSI');
+  });
+
+  it('R-2: ?indicator=TOEPFER_TMI → 200 with value=12683', async () => {
+    mockGetCurrentBenchmark.mockResolvedValue(toepferBenchmark());
+
+    const res = await GET(makeRequest('TOEPFER_TMI'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.value).toBe(12683);
+    expect(json.indicator).toBe('TOEPFER_TMI');
+  });
+
+  it('R-3: ?indicator=DREWRY_BREAKBULK → 404 (no data)', async () => {
+    mockGetCurrentBenchmark.mockResolvedValue(null);
+
+    const res = await GET(makeRequest('DREWRY_BREAKBULK'));
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toMatch(/DREWRY_BREAKBULK/);
+  });
+
+  it('R-4: missing indicator → 400', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it('R-5: invalid indicator → 400', async () => {
+    const res = await GET(makeRequest('INVALID_INDICATOR'));
+    expect(res.status).toBe(400);
+  });
+
+  it('R-6: benchmark unavailable → 404 (not 503)', async () => {
+    mockGetCurrentBenchmark.mockResolvedValue(null);
+
+    const res = await GET(makeRequest('BHSI'));
+
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(503);
+  });
+
+  it('R-7: 404 response has descriptive error message', async () => {
+    mockGetCurrentBenchmark.mockResolvedValue(null);
+
+    const res = await GET(makeRequest('BHSI'));
+    const json = await res.json();
+
+    expect(typeof json.error).toBe('string');
+    expect(json.error.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/api/port-da-large-vessels.test.ts
+++ b/__tests__/api/port-da-large-vessels.test.ts
@@ -1,0 +1,151 @@
+/**
+ * PDB-01: panamax / post-panamax / capesize DWT brackets
+ *
+ * Tests that GET /api/port-da/[port_code]?vessel_dwt=N resolves correctly
+ * for vessels > 65 000 DWT after broker-research-2026-05 seed data is inserted.
+ *
+ * Pattern: in-memory SQLite + runMigrations + seedPortDa (same as regression tests)
+ */
+
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+import { seedPortDa, type BaselinePort } from '@/scripts/seed-port-da';
+import { getPortDa } from '@/lib/port-da/repository';
+
+// ---------------------------------------------------------------------------
+// Fixtures — only the brackets that matter for this spec
+// ---------------------------------------------------------------------------
+
+const NLRTM_LARGE: BaselinePort = {
+  port_code: 'NLRTM',
+  port_name: 'Rotterdam',
+  brackets: [
+    { vessel_dwt_min: 65001,  vessel_dwt_max: 90000,  port_dues_usd: 110000, pilotage_usd: 60000,  tugs_usd: 50000, stevedoring_usd_per_mt: 5.0, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 90001,  vessel_dwt_max: 150000, port_dues_usd: 145000, pilotage_usd: 78000,  tugs_usd: 67000, stevedoring_usd_per_mt: 4.5, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 150001, vessel_dwt_max: 200000, port_dues_usd: 185000, pilotage_usd: 100000, tugs_usd: 86000, stevedoring_usd_per_mt: 4.0, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+  ],
+};
+
+const BEANR_LARGE: BaselinePort = {
+  port_code: 'BEANR',
+  port_name: 'Antwerp',
+  brackets: [
+    { vessel_dwt_min: 65001,  vessel_dwt_max: 90000,  port_dues_usd: 105000, pilotage_usd: 57000, tugs_usd: 49000, stevedoring_usd_per_mt: 5.2, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 90001,  vessel_dwt_max: 150000, port_dues_usd: 140000, pilotage_usd: 75000, tugs_usd: 64000, stevedoring_usd_per_mt: 4.6, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 150001, vessel_dwt_max: 200000, port_dues_usd: 178000, pilotage_usd: 96000, tugs_usd: 82000, stevedoring_usd_per_mt: 4.1, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+  ],
+};
+
+const SGSIN_LARGE: BaselinePort = {
+  port_code: 'SGSIN',
+  port_name: 'Singapore',
+  brackets: [
+    { vessel_dwt_min: 65001,  vessel_dwt_max: 90000,  port_dues_usd: 95000,  pilotage_usd: 51000, tugs_usd: 44000, stevedoring_usd_per_mt: 4.8, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 90001,  vessel_dwt_max: 150000, port_dues_usd: 125000, pilotage_usd: 67000, tugs_usd: 57000, stevedoring_usd_per_mt: 4.3, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 150001, vessel_dwt_max: 200000, port_dues_usd: 160000, pilotage_usd: 86000, tugs_usd: 73000, stevedoring_usd_per_mt: 3.8, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+  ],
+};
+
+const AEJEA_LARGE: BaselinePort = {
+  port_code: 'AEJEA',
+  port_name: 'Jebel Ali',
+  brackets: [
+    { vessel_dwt_min: 65001,  vessel_dwt_max: 90000,  port_dues_usd: 88000,  pilotage_usd: 47000, tugs_usd: 40000, stevedoring_usd_per_mt: 5.0, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 90001,  vessel_dwt_max: 150000, port_dues_usd: 116000, pilotage_usd: 62000, tugs_usd: 53000, stevedoring_usd_per_mt: 4.5, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 150001, vessel_dwt_max: 200000, port_dues_usd: 148000, pilotage_usd: 80000, tugs_usd: 68000, stevedoring_usd_per_mt: 4.0, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+  ],
+};
+
+const SAJED_LARGE: BaselinePort = {
+  port_code: 'SAJED',
+  port_name: 'Jeddah',
+  brackets: [
+    { vessel_dwt_min: 65001,  vessel_dwt_max: 90000,  port_dues_usd: 82000,  pilotage_usd: 44000, tugs_usd: 38000, stevedoring_usd_per_mt: 5.2, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 90001,  vessel_dwt_max: 150000, port_dues_usd: 108000, pilotage_usd: 58000, tugs_usd: 49000, stevedoring_usd_per_mt: 4.7, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 150001, vessel_dwt_max: 200000, port_dues_usd: 138000, pilotage_usd: 74000, tugs_usd: 63000, stevedoring_usd_per_mt: 4.2, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+  ],
+};
+
+const AUPHE_PORT: BaselinePort = {
+  port_code: 'AUPHE',
+  port_name: 'Port Hedland',
+  brackets: [
+    { vessel_dwt_min: 65001,  vessel_dwt_max: 90000,  port_dues_usd: 90000,  pilotage_usd: 48000, tugs_usd: 41000, stevedoring_usd_per_mt: 3.5, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 90001,  vessel_dwt_max: 150000, port_dues_usd: 118000, pilotage_usd: 63000, tugs_usd: 54000, stevedoring_usd_per_mt: 3.0, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+    { vessel_dwt_min: 150001, vessel_dwt_max: 200000, port_dues_usd: 150000, pilotage_usd: 81000, tugs_usd: 69000, stevedoring_usd_per_mt: 2.5, cargo_type: 'general', confidence: 'estimated', source: 'broker-research-2026-05' },
+  ],
+};
+
+const ALL_PORTS = [NLRTM_LARGE, BEANR_LARGE, SGSIN_LARGE, AEJEA_LARGE, SAJED_LARGE, AUPHE_PORT];
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('PDB-01: panamax/post-panamax/capesize brackets', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    runMigrations(db, allMigrations);
+    // Seed only the large-vessel brackets (no LLM caller needed — no gaps to fill)
+    await seedPortDa(db, ALL_PORTS, jest.fn());
+  });
+
+  afterEach(() => db.close());
+
+  // Test 1: NLRTM panamax bracket
+  it('NLRTM 80k DWT → panamax bracket, port_dues_usd=110000, source=broker-research-2026-05', () => {
+    const result = getPortDa({ portCode: 'NLRTM', vesselDwt: 80000 }, db);
+    expect(result).not.toBeNull();
+    expect(result!.portDuesUsd).toBe(110000);
+    expect(result!.source).toBe('broker-research-2026-05');
+  });
+
+  // Test 2: SGSIN post-panamax bracket
+  it('SGSIN 130k DWT → post-panamax bracket, vessel_dwt_min=90001', () => {
+    const result = getPortDa({ portCode: 'SGSIN', vesselDwt: 130000 }, db);
+    expect(result).not.toBeNull();
+    // Verify it matched the correct bracket (90001–150000)
+    const row = db.prepare(
+      `SELECT vessel_dwt_min FROM port_da_estimates
+       WHERE port_code='SGSIN' AND vessel_dwt_min <= 130000 AND vessel_dwt_max >= 130000`,
+    ).get() as { vessel_dwt_min: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.vessel_dwt_min).toBe(90001);
+  });
+
+  // Test 3: BEANR capesize bracket
+  it('BEANR 180k DWT → capesize bracket, port_dues_usd=178000', () => {
+    const result = getPortDa({ portCode: 'BEANR', vesselDwt: 180000 }, db);
+    expect(result).not.toBeNull();
+    expect(result!.portDuesUsd).toBe(178000);
+  });
+
+  // Test 4: AEJEA 220k (above max 200000) → null (404)
+  it('AEJEA 220k DWT (above bracket max) → null (no data)', () => {
+    const result = getPortDa({ portCode: 'AEJEA', vesselDwt: 220000 }, db);
+    expect(result).toBeNull();
+  });
+
+  // Test 5: SAJED boundary — exactly 65001 (lower bound of panamax)
+  it('SAJED 65001 DWT → panamax bracket lower boundary, vessel_dwt_min=65001', () => {
+    const result = getPortDa({ portCode: 'SAJED', vesselDwt: 65001 }, db);
+    expect(result).not.toBeNull();
+    const row = db.prepare(
+      `SELECT vessel_dwt_min FROM port_da_estimates
+       WHERE port_code='SAJED' AND vessel_dwt_min <= 65001 AND vessel_dwt_max >= 65001`,
+    ).get() as { vessel_dwt_min: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.vessel_dwt_min).toBe(65001);
+  });
+
+  // Test 6: AUPHE (new port) capesize 180k
+  it('AUPHE 180k DWT → capesize bracket, port_dues_usd=150000, source=broker-research-2026-05', () => {
+    const result = getPortDa({ portCode: 'AUPHE', vesselDwt: 180000 }, db);
+    expect(result).not.toBeNull();
+    expect(result!.portDuesUsd).toBe(150000);
+    expect(result!.source).toBe('broker-research-2026-05');
+  });
+});

--- a/__tests__/lib/market/baltic-repository.test.ts
+++ b/__tests__/lib/market/baltic-repository.test.ts
@@ -1,0 +1,50 @@
+import Database from 'better-sqlite3';
+import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
+import migration020 from '@/lib/migrations/020-toepfer-tmi-seed';
+import { getLatestBalticIndex } from '@/lib/market/baltic-repository';
+
+describe('getLatestBalticIndex', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    migration019.up(db);
+    migration020.up(db);
+  });
+
+  afterEach(() => db.close());
+
+  it('returns TOEPFER_TMI row with value=12683', () => {
+    const row = getLatestBalticIndex(db, 'TOEPFER_TMI');
+    expect(row).not.toBeNull();
+    expect(row!.index_code).toBe('TOEPFER_TMI');
+    expect(row!.value).toBe(12683);
+    expect(row!.price_date).toBe('2026-05-09');
+    expect(row!.source).toBe('static-seed');
+  });
+
+  it('returns BHSI row (not null)', () => {
+    const row = getLatestBalticIndex(db, 'BHSI');
+    expect(row).not.toBeNull();
+    expect(row!.index_code).toBe('BHSI');
+  });
+
+  it('returns null for NONEXISTENT index', () => {
+    const row = getLatestBalticIndex(db, 'NONEXISTENT');
+    expect(row).toBeNull();
+  });
+
+  it('returns the newest row when multiple dates exist for the same index_code', () => {
+    // Insert an older row for TOEPFER_TMI
+    db.prepare(
+      `INSERT INTO baltic_indices (index_code, value, price_date, source) VALUES (?, ?, ?, ?)`
+    ).run('TOEPFER_TMI', 11000, '2026-01-01', 'static-seed-old');
+
+    // The seed row from migration020 has date 2026-05-09 which is newer
+    const row = getLatestBalticIndex(db, 'TOEPFER_TMI');
+    expect(row).not.toBeNull();
+    expect(row!.price_date).toBe('2026-05-09');
+    expect(row!.value).toBe(12683);
+  });
+});

--- a/__tests__/lib/market/benchmark.test.ts
+++ b/__tests__/lib/market/benchmark.test.ts
@@ -1,0 +1,131 @@
+/**
+ * TDD tests for lib/market/benchmark.ts (spec-01: Benchmark Rewire).
+ *
+ * Requirements:
+ * - getCurrentBenchmark('BHSI') reads from baltic_indices via getLatestBalticIndex
+ * - getCurrentBenchmark('TOEPFER_TMI') reads from DB; fallback to fetchToepferTmi if null
+ * - getCurrentBenchmark('DREWRY_BREAKBULK') returns null (no source)
+ * - When DB returns null for BHSI → returns null (no scraper fallback)
+ * - MarketBenchmark shape is correct for DB-sourced entries
+ */
+
+import Database from 'better-sqlite3';
+import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
+import migration020 from '@/lib/migrations/020-toepfer-tmi-seed';
+import { getCurrentBenchmark, _clearCacheForTesting } from '@/lib/market/benchmark';
+
+// ─── Mock DB access ───────────────────────────────────────────────────────────
+
+let mockDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => mockDb,
+  })),
+}));
+
+// ─── Mock toepfer scraper for TOEPFER_TMI fallback tests ─────────────────────
+
+const mockFetchToepferTmi = jest.fn();
+jest.mock('@/lib/market/toepfer-scraper', () => ({
+  fetchToepferTmi: (...args: unknown[]) => mockFetchToepferTmi(...args),
+}));
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockDb = new Database(':memory:');
+  mockDb.exec('PRAGMA foreign_keys = ON');
+  migration019.up(mockDb);
+  migration020.up(mockDb);
+  _clearCacheForTesting();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  mockDb.close();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('getCurrentBenchmark — BHSI (DB-sourced)', () => {
+  it('B-1: returns MarketBenchmark with value=650 for BHSI', async () => {
+    const result = await getCurrentBenchmark('BHSI');
+    expect(result).not.toBeNull();
+    expect(result!.indicator).toBe('BHSI');
+    expect(result!.value).toBe(650);
+    expect(result!.unit).toBe('index');
+  });
+
+  it('B-2: BHSI result has correct shape (period + sourceUrl + fetchedAt)', async () => {
+    const result = await getCurrentBenchmark('BHSI');
+    expect(result).not.toBeNull();
+    expect(result!.period).toBe('2026-05-09');
+    expect(result!.sourceUrl).toBe('static-seed');
+    expect(typeof result!.fetchedAt).toBe('string');
+    // fetchedAt should be a valid ISO 8601 timestamp
+    expect(() => new Date(result!.fetchedAt)).not.toThrow();
+  });
+
+  it('B-3: returns null for BHSI when DB has no row', async () => {
+    // Remove the BHSI row
+    mockDb.exec(`DELETE FROM baltic_indices WHERE index_code = 'BHSI'`);
+    const result = await getCurrentBenchmark('BHSI');
+    expect(result).toBeNull();
+  });
+});
+
+describe('getCurrentBenchmark — TOEPFER_TMI (DB with scraper fallback)', () => {
+  it('T-1: returns MarketBenchmark with value=12683 for TOEPFER_TMI from DB', async () => {
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result).not.toBeNull();
+    expect(result!.indicator).toBe('TOEPFER_TMI');
+    expect(result!.value).toBe(12683);
+    expect(result!.unit).toBe('USD/day');
+  });
+
+  it('T-2: TOEPFER_TMI period and sourceUrl come from DB row', async () => {
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result!.period).toBe('2026-05-09');
+    expect(result!.sourceUrl).toBe('static-seed');
+  });
+
+  it('T-3: scraper fallback is used when DB has no TOEPFER_TMI row', async () => {
+    mockDb.exec(`DELETE FROM baltic_indices WHERE index_code = 'TOEPFER_TMI'`);
+    const scraperResult = {
+      indicator: 'TOEPFER_TMI' as const,
+      value: 13000,
+      unit: 'USD/day',
+      period: 'May 2026',
+      sourceUrl: 'https://toepfer.com/tmi',
+      fetchedAt: new Date().toISOString(),
+    };
+    mockFetchToepferTmi.mockResolvedValue(scraperResult);
+
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(mockFetchToepferTmi).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe(13000);
+  });
+
+  it('T-4: returns null when DB has no TOEPFER_TMI row and scraper returns null', async () => {
+    mockDb.exec(`DELETE FROM baltic_indices WHERE index_code = 'TOEPFER_TMI'`);
+    mockFetchToepferTmi.mockResolvedValue(null);
+
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result).toBeNull();
+  });
+
+  it('T-5: scraper is NOT called when DB has TOEPFER_TMI row', async () => {
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result).not.toBeNull();
+    expect(mockFetchToepferTmi).not.toHaveBeenCalled();
+  });
+});
+
+describe('getCurrentBenchmark — DREWRY_BREAKBULK', () => {
+  it('D-1: returns null for DREWRY_BREAKBULK (no data source)', async () => {
+    const result = await getCurrentBenchmark('DREWRY_BREAKBULK');
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/market/benchmark.test.ts
+++ b/__tests__/lib/market/benchmark.test.ts
@@ -1,30 +1,21 @@
 /**
- * TDD tests for lib/market/benchmark.ts (spec-01: Benchmark Rewire).
+ * Unit tests for lib/market/benchmark.ts
  *
- * Requirements:
- * - getCurrentBenchmark('BHSI') reads from baltic_indices via getLatestBalticIndex
- * - getCurrentBenchmark('TOEPFER_TMI') reads from DB; fallback to fetchToepferTmi if null
- * - getCurrentBenchmark('DREWRY_BREAKBULK') returns null (no source)
- * - When DB returns null for BHSI → returns null (no scraper fallback)
- * - MarketBenchmark shape is correct for DB-sourced entries
+ * Note: DB-first lookup (BHSI/TOEPFER_TMI from baltic_indices) is done in the
+ * route handler (app/api/market/benchmark/route.ts), which is server-only.
+ * benchmark.ts itself is browser-safe — only uses fetch()-based scraper.
+ *
+ * Tests here cover:
+ * - getCurrentBenchmark TOEPFER_TMI scraper path
+ * - getCurrentBenchmark DREWRY_BREAKBULK → null
+ * - in-memory cache behaviour
+ * - formatBenchmarkReference helper
  */
 
-import Database from 'better-sqlite3';
-import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
-import migration020 from '@/lib/migrations/020-toepfer-tmi-seed';
-import { getCurrentBenchmark, _clearCacheForTesting } from '@/lib/market/benchmark';
+import { getCurrentBenchmark, formatBenchmarkReference, _clearCacheForTesting } from '@/lib/market/benchmark';
+import type { MarketBenchmark } from '@/lib/types';
 
-// ─── Mock DB access ───────────────────────────────────────────────────────────
-
-let mockDb: Database.Database;
-
-jest.mock('@/lib/session-store', () => ({
-  getStore: jest.fn(() => ({
-    getDatabase: () => mockDb,
-  })),
-}));
-
-// ─── Mock toepfer scraper for TOEPFER_TMI fallback tests ─────────────────────
+// ─── Mock toepfer scraper ─────────────────────────────────────────────────────
 
 const mockFetchToepferTmi = jest.fn();
 jest.mock('@/lib/market/toepfer-scraper', () => ({
@@ -34,70 +25,20 @@ jest.mock('@/lib/market/toepfer-scraper', () => ({
 // ─── Setup ───────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  mockDb = new Database(':memory:');
-  mockDb.exec('PRAGMA foreign_keys = ON');
-  migration019.up(mockDb);
-  migration020.up(mockDb);
   _clearCacheForTesting();
   jest.clearAllMocks();
 });
 
-afterEach(() => {
-  mockDb.close();
-});
-
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
-describe('getCurrentBenchmark — BHSI (DB-sourced)', () => {
-  it('B-1: returns MarketBenchmark with value=650 for BHSI', async () => {
-    const result = await getCurrentBenchmark('BHSI');
-    expect(result).not.toBeNull();
-    expect(result!.indicator).toBe('BHSI');
-    expect(result!.value).toBe(650);
-    expect(result!.unit).toBe('index');
-  });
-
-  it('B-2: BHSI result has correct shape (period + sourceUrl + fetchedAt)', async () => {
-    const result = await getCurrentBenchmark('BHSI');
-    expect(result).not.toBeNull();
-    expect(result!.period).toBe('2026-05-09');
-    expect(result!.sourceUrl).toBe('static-seed');
-    expect(typeof result!.fetchedAt).toBe('string');
-    // fetchedAt should be a valid ISO 8601 timestamp
-    expect(() => new Date(result!.fetchedAt)).not.toThrow();
-  });
-
-  it('B-3: returns null for BHSI when DB has no row', async () => {
-    // Remove the BHSI row
-    mockDb.exec(`DELETE FROM baltic_indices WHERE index_code = 'BHSI'`);
-    const result = await getCurrentBenchmark('BHSI');
-    expect(result).toBeNull();
-  });
-});
-
-describe('getCurrentBenchmark — TOEPFER_TMI (DB with scraper fallback)', () => {
-  it('T-1: returns MarketBenchmark with value=12683 for TOEPFER_TMI from DB', async () => {
-    const result = await getCurrentBenchmark('TOEPFER_TMI');
-    expect(result).not.toBeNull();
-    expect(result!.indicator).toBe('TOEPFER_TMI');
-    expect(result!.value).toBe(12683);
-    expect(result!.unit).toBe('USD/day');
-  });
-
-  it('T-2: TOEPFER_TMI period and sourceUrl come from DB row', async () => {
-    const result = await getCurrentBenchmark('TOEPFER_TMI');
-    expect(result!.period).toBe('2026-05-09');
-    expect(result!.sourceUrl).toBe('static-seed');
-  });
-
-  it('T-3: scraper fallback is used when DB has no TOEPFER_TMI row', async () => {
-    mockDb.exec(`DELETE FROM baltic_indices WHERE index_code = 'TOEPFER_TMI'`);
-    const scraperResult = {
-      indicator: 'TOEPFER_TMI' as const,
-      value: 13000,
+describe('getCurrentBenchmark — TOEPFER_TMI (scraper path)', () => {
+  it('T-1: calls scraper and returns MarketBenchmark', async () => {
+    const scraperResult: MarketBenchmark = {
+      indicator: 'TOEPFER_TMI',
+      value: 12683,
       unit: 'USD/day',
       period: 'May 2026',
-      sourceUrl: 'https://toepfer.com/tmi',
+      sourceUrl: 'https://heavyliftpfi.com/market-data/',
       fetchedAt: new Date().toISOString(),
     };
     mockFetchToepferTmi.mockResolvedValue(scraperResult);
@@ -105,27 +46,73 @@ describe('getCurrentBenchmark — TOEPFER_TMI (DB with scraper fallback)', () =>
     const result = await getCurrentBenchmark('TOEPFER_TMI');
     expect(mockFetchToepferTmi).toHaveBeenCalledTimes(1);
     expect(result).not.toBeNull();
-    expect(result!.value).toBe(13000);
+    expect(result!.value).toBe(12683);
+    expect(result!.indicator).toBe('TOEPFER_TMI');
   });
 
-  it('T-4: returns null when DB has no TOEPFER_TMI row and scraper returns null', async () => {
-    mockDb.exec(`DELETE FROM baltic_indices WHERE index_code = 'TOEPFER_TMI'`);
+  it('T-2: returns null when scraper returns null', async () => {
     mockFetchToepferTmi.mockResolvedValue(null);
-
     const result = await getCurrentBenchmark('TOEPFER_TMI');
     expect(result).toBeNull();
   });
 
-  it('T-5: scraper is NOT called when DB has TOEPFER_TMI row', async () => {
-    const result = await getCurrentBenchmark('TOEPFER_TMI');
-    expect(result).not.toBeNull();
+  it('T-3: caches result; scraper is NOT called on second invocation', async () => {
+    const scraperResult: MarketBenchmark = {
+      indicator: 'TOEPFER_TMI',
+      value: 12683,
+      unit: 'USD/day',
+      period: 'May 2026',
+      sourceUrl: 'https://heavyliftpfi.com/market-data/',
+      fetchedAt: new Date().toISOString(),
+    };
+    mockFetchToepferTmi.mockResolvedValue(scraperResult);
+
+    await getCurrentBenchmark('TOEPFER_TMI');
+    await getCurrentBenchmark('TOEPFER_TMI');
+    expect(mockFetchToepferTmi).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getCurrentBenchmark — BHSI (no scraper — returns null at benchmark layer)', () => {
+  it('B-1: returns null for BHSI (DB lookup is done at route layer)', async () => {
+    // BHSI has no scraper fallback in benchmark.ts; DB lookup is done in route.ts
+    const result = await getCurrentBenchmark('BHSI');
+    expect(result).toBeNull();
     expect(mockFetchToepferTmi).not.toHaveBeenCalled();
   });
 });
 
 describe('getCurrentBenchmark — DREWRY_BREAKBULK', () => {
-  it('D-1: returns null for DREWRY_BREAKBULK (no data source)', async () => {
+  it('D-1: returns null (no data source)', async () => {
     const result = await getCurrentBenchmark('DREWRY_BREAKBULK');
     expect(result).toBeNull();
+  });
+});
+
+describe('formatBenchmarkReference', () => {
+  it('F-1: formats USD value correctly', () => {
+    const benchmark: MarketBenchmark = {
+      indicator: 'TOEPFER_TMI',
+      value: 12683,
+      unit: 'USD/day',
+      period: 'Apr 2026',
+      sourceUrl: 'https://toepfer.com',
+      fetchedAt: new Date().toISOString(),
+    };
+    const result = formatBenchmarkReference(benchmark);
+    expect(result).toBe('Toepfer TMI Apr 2026 — $12,683/day TCE');
+  });
+
+  it('F-2: handles round numbers without decimals', () => {
+    const benchmark: MarketBenchmark = {
+      indicator: 'TOEPFER_TMI',
+      value: 10000,
+      unit: 'USD/day',
+      period: 'Jan 2026',
+      sourceUrl: 'https://toepfer.com',
+      fetchedAt: new Date().toISOString(),
+    };
+    const result = formatBenchmarkReference(benchmark);
+    expect(result).toBe('Toepfer TMI Jan 2026 — $10,000/day TCE');
   });
 });

--- a/__tests__/lib/migrations/020-toepfer-tmi-seed.test.ts
+++ b/__tests__/lib/migrations/020-toepfer-tmi-seed.test.ts
@@ -1,0 +1,62 @@
+import Database from 'better-sqlite3';
+import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
+import migration020 from '@/lib/migrations/020-toepfer-tmi-seed';
+
+describe('migration 020 toepfer-tmi-seed', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = ON');
+    // migration019 creates the baltic_indices table
+    migration019.up(db);
+  });
+
+  afterEach(() => db.close());
+
+  it('runs up() without errors', () => {
+    expect(() => migration020.up(db)).not.toThrow();
+  });
+
+  it('inserts TOEPFER_TMI with value=12683', () => {
+    migration020.up(db);
+    const row = db
+      .prepare(`SELECT * FROM baltic_indices WHERE index_code='TOEPFER_TMI'`)
+      .get() as any;
+    expect(row).toBeDefined();
+    expect(row.value).toBe(12683);
+  });
+
+  it('inserts BHSI, BDI, BCI, BSI rows', () => {
+    migration020.up(db);
+    const rows = db
+      .prepare(`SELECT index_code FROM baltic_indices WHERE source='static-seed'`)
+      .all() as any[];
+    const codes = rows.map((r) => r.index_code);
+    expect(codes).toContain('BHSI');
+    expect(codes).toContain('BDI');
+    expect(codes).toContain('BCI');
+    expect(codes).toContain('BSI');
+  });
+
+  it('is idempotent (running up() twice does not throw)', () => {
+    migration020.up(db);
+    expect(() => migration020.up(db)).not.toThrow();
+    // Row count should remain 5 (INSERT OR IGNORE)
+    const count = (
+      db
+        .prepare(`SELECT COUNT(*) as cnt FROM baltic_indices WHERE source='static-seed'`)
+        .get() as any
+    ).cnt;
+    expect(count).toBe(5);
+  });
+
+  it('down() removes static-seed rows', () => {
+    migration020.up(db);
+    migration020.down(db);
+    const rows = db
+      .prepare(`SELECT * FROM baltic_indices WHERE source='static-seed'`)
+      .all() as any[];
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/app/api/market/benchmark/route.ts
+++ b/app/api/market/benchmark/route.ts
@@ -23,11 +23,8 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   if (!benchmark) {
     return NextResponse.json(
-      { error: 'Benchmark unavailable' },
-      {
-        status: 503,
-        headers: { 'Cache-Control': 'no-store' },
-      },
+      { error: `No benchmark data available for ${indicator}` },
+      { status: 404 },
     );
   }
 

--- a/app/api/market/benchmark/route.ts
+++ b/app/api/market/benchmark/route.ts
@@ -1,12 +1,31 @@
 import { NextResponse } from 'next/server';
-import type { MarketIndicator } from '@/lib/types';
+import type { MarketBenchmark, MarketIndicator } from '@/lib/types';
 import { getCurrentBenchmark } from '@/lib/market/benchmark';
+import { getLatestBalticIndex } from '@/lib/market/baltic-repository';
+import { getStore } from '@/lib/session-store';
 
 const VALID_INDICATORS: ReadonlySet<string> = new Set<MarketIndicator>([
   'TOEPFER_TMI',
   'DREWRY_BREAKBULK',
   'BHSI',
 ]);
+
+/** Indicators sourced from the baltic_indices DB table (static seed). */
+const DB_INDICATORS = new Set<MarketIndicator>(['BHSI', 'TOEPFER_TMI']);
+
+function rowToMarketBenchmark(
+  row: { value: number; price_date: string; source: string },
+  indicator: MarketIndicator,
+): MarketBenchmark {
+  return {
+    indicator,
+    value: row.value,
+    unit: indicator === 'TOEPFER_TMI' ? 'USD/day' : 'index',
+    period: row.price_date,
+    sourceUrl: row.source,
+    fetchedAt: new Date().toISOString(),
+  };
+}
 
 export async function GET(request: Request): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
@@ -19,7 +38,22 @@ export async function GET(request: Request): Promise<NextResponse> {
     );
   }
 
-  const benchmark = await getCurrentBenchmark(indicator as MarketIndicator);
+  const typedIndicator = indicator as MarketIndicator;
+  let benchmark: MarketBenchmark | null = null;
+
+  // DB-first lookup for BHSI and TOEPFER_TMI (server-only, uses better-sqlite3)
+  if (DB_INDICATORS.has(typedIndicator)) {
+    const db = getStore().getDatabase();
+    const row = getLatestBalticIndex(db, typedIndicator);
+    if (row) {
+      benchmark = rowToMarketBenchmark(row, typedIndicator);
+    }
+  }
+
+  // Fallback: scraper for TOEPFER_TMI, null for others
+  if (!benchmark) {
+    benchmark = await getCurrentBenchmark(typedIndicator);
+  }
 
   if (!benchmark) {
     return NextResponse.json(

--- a/app/api/port-da/[port_code]/route.ts
+++ b/app/api/port-da/[port_code]/route.ts
@@ -35,6 +35,20 @@ export async function GET(
     );
   }
 
+  const DWT_MIN = 5_000;
+  const DWT_MAX = 200_000;
+
+  if (vesselDwt < DWT_MIN || vesselDwt > DWT_MAX) {
+    const rangeStr = `${DWT_MIN.toLocaleString('en-US')}–${DWT_MAX.toLocaleString('en-US')}`;
+    return NextResponse.json(
+      {
+        outOfRange: true,
+        message: `DWT ${vesselDwt} is outside our data range (${rangeStr} tonnes). Very large vessel rates require manual broker quote — contact your agent.`,
+      },
+      { status: 200 },
+    );
+  }
+
   const cargoType = searchParams.get('cargo_type') ?? undefined;
 
   const breakdown = getPortDa({ portCode: port_code, vesselDwt, cargoType });

--- a/lib/market/__tests__/benchmark.test.ts
+++ b/lib/market/__tests__/benchmark.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentBenchmark, formatBenchmarkReference, _clearCacheForTesting } from '../benchmark';
+import { formatBenchmarkReference } from '../benchmark';
 import type { MarketBenchmark } from '@/lib/types';
 
 const MOCK_BENCHMARK: MarketBenchmark = {
@@ -9,39 +9,6 @@ const MOCK_BENCHMARK: MarketBenchmark = {
   sourceUrl: 'https://heavyliftpfi.com/market-data/',
   fetchedAt: new Date().toISOString(),
 };
-
-jest.mock('../toepfer-scraper', () => ({
-  fetchToepferTmi: jest.fn(),
-}));
-
-import { fetchToepferTmi } from '../toepfer-scraper';
-const mockedFetch = fetchToepferTmi as jest.MockedFunction<typeof fetchToepferTmi>;
-
-describe('getCurrentBenchmark', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-    _clearCacheForTesting();
-  });
-
-  it('fetches and returns benchmark on cache miss', async () => {
-    mockedFetch.mockResolvedValue(MOCK_BENCHMARK);
-
-    const result = await getCurrentBenchmark('TOEPFER_TMI');
-
-    expect(result).not.toBeNull();
-    expect(result!.indicator).toBe('TOEPFER_TMI');
-    expect(result!.value).toBe(12683);
-    expect(mockedFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns null when fetch returns null and no cache', async () => {
-    mockedFetch.mockResolvedValue(null);
-
-    const result = await getCurrentBenchmark('TOEPFER_TMI');
-
-    expect(result).toBeNull();
-  });
-});
 
 describe('formatBenchmarkReference', () => {
   it('formats benchmark as expected string', () => {

--- a/lib/market/baltic-repository.ts
+++ b/lib/market/baltic-repository.ts
@@ -1,0 +1,22 @@
+import type Database from 'better-sqlite3';
+
+export interface BalticIndexRow {
+  index_code: string;
+  value: number;
+  price_date: string;
+  source: string;
+}
+
+export function getLatestBalticIndex(
+  db: Database.Database,
+  indexCode: string,
+): BalticIndexRow | null {
+  const row = db.prepare<[string], BalticIndexRow>(`
+    SELECT index_code, value, price_date, source
+    FROM baltic_indices
+    WHERE index_code = ?
+    ORDER BY price_date DESC
+    LIMIT 1
+  `).get(indexCode);
+  return row ?? null;
+}

--- a/lib/market/benchmark.ts
+++ b/lib/market/benchmark.ts
@@ -1,12 +1,10 @@
 import type { MarketBenchmark, MarketIndicator } from '@/lib/types';
 import { fetchToepferTmi } from './toepfer-scraper';
-import { getLatestBalticIndex } from './baltic-repository';
-import { getStore } from '@/lib/session-store';
 
 /** TTL for cached market benchmark entries: 7 days in milliseconds. */
 const BENCHMARK_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-/** In-memory cache keyed by indicator — avoids repeated DB reads in serverless contexts. */
+/** In-memory cache keyed by indicator — avoids DB dependency in serverless contexts. */
 const memCache = new Map<MarketIndicator, { benchmark: MarketBenchmark; cachedAt: number }>();
 
 /** @internal Test helper — clears the in-memory cache. */
@@ -19,11 +17,9 @@ function isFresh(cachedAt: number): boolean {
 }
 
 /**
- * Returns the latest benchmark for the given indicator.
- *
- * - BHSI: reads from baltic_indices DB; returns null if not found.
- * - TOEPFER_TMI: reads from baltic_indices DB; falls back to fetchToepferTmi() if not found.
- * - DREWRY_BREAKBULK: no source available, returns null.
+ * Returns the latest benchmark for the given indicator via scraper/network.
+ * DB-first lookup is handled by the route handler (server-only context).
+ * Only TOEPFER_TMI has a scraper fallback; other indicators return null.
  *
  * Reads from in-memory cache first; fetches fresh if stale or missing.
  */
@@ -36,27 +32,9 @@ export async function getCurrentBenchmark(
   }
 
   let fetched: MarketBenchmark | null = null;
-
-  if (indicator === 'BHSI' || indicator === 'TOEPFER_TMI') {
-    const db = getStore().getDatabase();
-    const row = getLatestBalticIndex(db, indicator);
-
-    if (row) {
-      fetched = {
-        indicator,
-        value: row.value,
-        unit: indicator === 'TOEPFER_TMI' ? 'USD/day' : 'index',
-        period: row.price_date,
-        sourceUrl: row.source,
-        fetchedAt: new Date().toISOString(),
-      };
-    } else if (indicator === 'TOEPFER_TMI') {
-      // Fallback to scraper when DB has no row
-      fetched = await fetchToepferTmi();
-    }
-    // For BHSI with no DB row: fetched stays null (no scraper fallback)
+  if (indicator === 'TOEPFER_TMI') {
+    fetched = await fetchToepferTmi();
   }
-  // DREWRY_BREAKBULK: no data source, fetched stays null
 
   if (fetched) {
     memCache.set(indicator, { benchmark: fetched, cachedAt: Date.now() });

--- a/lib/market/benchmark.ts
+++ b/lib/market/benchmark.ts
@@ -1,10 +1,12 @@
 import type { MarketBenchmark, MarketIndicator } from '@/lib/types';
 import { fetchToepferTmi } from './toepfer-scraper';
+import { getLatestBalticIndex } from './baltic-repository';
+import { getStore } from '@/lib/session-store';
 
 /** TTL for cached market benchmark entries: 7 days in milliseconds. */
 const BENCHMARK_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-/** In-memory cache keyed by indicator — avoids DB dependency in serverless contexts. */
+/** In-memory cache keyed by indicator — avoids repeated DB reads in serverless contexts. */
 const memCache = new Map<MarketIndicator, { benchmark: MarketBenchmark; cachedAt: number }>();
 
 /** @internal Test helper — clears the in-memory cache. */
@@ -18,6 +20,11 @@ function isFresh(cachedAt: number): boolean {
 
 /**
  * Returns the latest benchmark for the given indicator.
+ *
+ * - BHSI: reads from baltic_indices DB; returns null if not found.
+ * - TOEPFER_TMI: reads from baltic_indices DB; falls back to fetchToepferTmi() if not found.
+ * - DREWRY_BREAKBULK: no source available, returns null.
+ *
  * Reads from in-memory cache first; fetches fresh if stale or missing.
  */
 export async function getCurrentBenchmark(
@@ -29,9 +36,27 @@ export async function getCurrentBenchmark(
   }
 
   let fetched: MarketBenchmark | null = null;
-  if (indicator === 'TOEPFER_TMI') {
-    fetched = await fetchToepferTmi();
+
+  if (indicator === 'BHSI' || indicator === 'TOEPFER_TMI') {
+    const db = getStore().getDatabase();
+    const row = getLatestBalticIndex(db, indicator);
+
+    if (row) {
+      fetched = {
+        indicator,
+        value: row.value,
+        unit: indicator === 'TOEPFER_TMI' ? 'USD/day' : 'index',
+        period: row.price_date,
+        sourceUrl: row.source,
+        fetchedAt: new Date().toISOString(),
+      };
+    } else if (indicator === 'TOEPFER_TMI') {
+      // Fallback to scraper when DB has no row
+      fetched = await fetchToepferTmi();
+    }
+    // For BHSI with no DB row: fetched stays null (no scraper fallback)
   }
+  // DREWRY_BREAKBULK: no data source, fetched stays null
 
   if (fetched) {
     memCache.set(indicator, { benchmark: fetched, cachedAt: Date.now() });

--- a/lib/migrations/020-toepfer-tmi-seed.ts
+++ b/lib/migrations/020-toepfer-tmi-seed.ts
@@ -1,0 +1,25 @@
+import type { Migration } from './types';
+import type Database from 'better-sqlite3';
+
+const migration020: Migration = {
+  version: 20,
+  name: 'toepfer-tmi-seed',
+  up(db: Database.Database): void {
+    // Requires migration019 to have run first (baltic_indices table must exist)
+    const stmt = db.prepare(`
+      INSERT OR IGNORE INTO baltic_indices (index_code, value, price_date, source)
+      VALUES (?, ?, ?, ?)
+    `);
+    stmt.run('TOEPFER_TMI', 12683, '2026-05-09', 'static-seed');
+    // Re-seed BHSI in case it wasn't seeded by the knowledge-baltic-seed.ts script
+    stmt.run('BHSI', 650, '2026-05-09', 'static-seed');
+    stmt.run('BDI', 1450, '2026-05-09', 'static-seed');
+    stmt.run('BCI', 1600, '2026-05-09', 'static-seed');
+    stmt.run('BSI', 1100, '2026-05-09', 'static-seed');
+  },
+  down(db: Database.Database): void {
+    db.exec(`DELETE FROM baltic_indices WHERE source = 'static-seed'`);
+  },
+};
+
+export default migration020;

--- a/lib/migrations/021-port-da-large-vessels.ts
+++ b/lib/migrations/021-port-da-large-vessels.ts
@@ -1,0 +1,19 @@
+import type { Migration } from './types';
+
+const migration021: Migration = {
+  version: 21,
+  name: 'port-da-large-vessels',
+  up(_db) {
+    // Marker migration: no schema change.
+    // Data inserted by scripts/seed-port-da.ts on app startup
+    // (panamax 65k-90k / post-panamax 90k-150k / capesize 150k-200k brackets
+    //  for NLRTM, BEANR, SGSIN, AEJEA, SAJED + new port AUPHE).
+    // Source: broker-research-2026-05 (see .specs/spec-pdb-00-research.md).
+  },
+  down(_db) {
+    // No schema to revert. To remove data:
+    // DELETE FROM port_da_estimates WHERE source = 'broker-research-2026-05';
+  },
+};
+
+export default migration021;

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -17,6 +17,7 @@ import migration016 from './016-war-risk-zones';
 import migration017 from './017-eca-zones';
 import migration018 from './018-knowledge-rag-vec-tables';
 import migration019 from './019-port-master-baltic-indices';
+import migration021 from './021-port-da-large-vessels';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration021];

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -17,7 +17,8 @@ import migration016 from './016-war-risk-zones';
 import migration017 from './017-eca-zones';
 import migration018 from './018-knowledge-rag-vec-tables';
 import migration019 from './019-port-master-baltic-indices';
+import migration020 from './020-toepfer-tmi-seed';
 import migration021 from './021-port-da-large-vessels';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration021];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021];

--- a/scripts/seed-data/port-da-base.json
+++ b/scripts/seed-data/port-da-base.json
@@ -80,6 +80,39 @@
         "cargo_type": "general",
         "confidence": "estimated",
         "source": "manual"
+      },
+      {
+        "vessel_dwt_min": 65001,
+        "vessel_dwt_max": 90000,
+        "port_dues_usd": 88000,
+        "pilotage_usd": 47000,
+        "tugs_usd": 40000,
+        "stevedoring_usd_per_mt": 5.0,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 90001,
+        "vessel_dwt_max": 150000,
+        "port_dues_usd": 116000,
+        "pilotage_usd": 62000,
+        "tugs_usd": 53000,
+        "stevedoring_usd_per_mt": 4.5,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 150001,
+        "vessel_dwt_max": 200000,
+        "port_dues_usd": 148000,
+        "pilotage_usd": 80000,
+        "tugs_usd": 68000,
+        "stevedoring_usd_per_mt": 4.0,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
       }
     ]
   },
@@ -136,6 +169,39 @@
         "cargo_type": "general",
         "confidence": "estimated",
         "source": "manual"
+      },
+      {
+        "vessel_dwt_min": 65001,
+        "vessel_dwt_max": 90000,
+        "port_dues_usd": 82000,
+        "pilotage_usd": 44000,
+        "tugs_usd": 38000,
+        "stevedoring_usd_per_mt": 5.2,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 90001,
+        "vessel_dwt_max": 150000,
+        "port_dues_usd": 108000,
+        "pilotage_usd": 58000,
+        "tugs_usd": 49000,
+        "stevedoring_usd_per_mt": 4.7,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 150001,
+        "vessel_dwt_max": 200000,
+        "port_dues_usd": 138000,
+        "pilotage_usd": 74000,
+        "tugs_usd": 63000,
+        "stevedoring_usd_per_mt": 4.2,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
       }
     ]
   },
@@ -864,6 +930,39 @@
         "cargo_type": "general",
         "confidence": "estimated",
         "source": "manual"
+      },
+      {
+        "vessel_dwt_min": 65001,
+        "vessel_dwt_max": 90000,
+        "port_dues_usd": 110000,
+        "pilotage_usd": 60000,
+        "tugs_usd": 50000,
+        "stevedoring_usd_per_mt": 5.0,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 90001,
+        "vessel_dwt_max": 150000,
+        "port_dues_usd": 145000,
+        "pilotage_usd": 78000,
+        "tugs_usd": 67000,
+        "stevedoring_usd_per_mt": 4.5,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 150001,
+        "vessel_dwt_max": 200000,
+        "port_dues_usd": 185000,
+        "pilotage_usd": 100000,
+        "tugs_usd": 86000,
+        "stevedoring_usd_per_mt": 4.0,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
       }
     ]
   },
@@ -892,6 +991,39 @@
         "cargo_type": "general",
         "confidence": "estimated",
         "source": "manual"
+      },
+      {
+        "vessel_dwt_min": 65001,
+        "vessel_dwt_max": 90000,
+        "port_dues_usd": 105000,
+        "pilotage_usd": 57000,
+        "tugs_usd": 49000,
+        "stevedoring_usd_per_mt": 5.2,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 90001,
+        "vessel_dwt_max": 150000,
+        "port_dues_usd": 140000,
+        "pilotage_usd": 75000,
+        "tugs_usd": 64000,
+        "stevedoring_usd_per_mt": 4.6,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 150001,
+        "vessel_dwt_max": 200000,
+        "port_dues_usd": 178000,
+        "pilotage_usd": 96000,
+        "tugs_usd": 82000,
+        "stevedoring_usd_per_mt": 4.1,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
       }
     ]
   },
@@ -948,6 +1080,39 @@
         "cargo_type": "general",
         "confidence": "estimated",
         "source": "manual"
+      },
+      {
+        "vessel_dwt_min": 65001,
+        "vessel_dwt_max": 90000,
+        "port_dues_usd": 95000,
+        "pilotage_usd": 51000,
+        "tugs_usd": 44000,
+        "stevedoring_usd_per_mt": 4.8,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 90001,
+        "vessel_dwt_max": 150000,
+        "port_dues_usd": 125000,
+        "pilotage_usd": 67000,
+        "tugs_usd": 57000,
+        "stevedoring_usd_per_mt": 4.3,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 150001,
+        "vessel_dwt_max": 200000,
+        "port_dues_usd": 160000,
+        "pilotage_usd": 86000,
+        "tugs_usd": 73000,
+        "stevedoring_usd_per_mt": 3.8,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
       }
     ]
   },
@@ -1060,6 +1225,45 @@
         "cargo_type": "general",
         "confidence": "estimated",
         "source": "manual"
+      }
+    ]
+  },
+  {
+    "port_code": "AUPHE",
+    "port_name": "Port Hedland",
+    "brackets": [
+      {
+        "vessel_dwt_min": 65001,
+        "vessel_dwt_max": 90000,
+        "port_dues_usd": 90000,
+        "pilotage_usd": 48000,
+        "tugs_usd": 41000,
+        "stevedoring_usd_per_mt": 3.5,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 90001,
+        "vessel_dwt_max": 150000,
+        "port_dues_usd": 118000,
+        "pilotage_usd": 63000,
+        "tugs_usd": 54000,
+        "stevedoring_usd_per_mt": 3.0,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
+      },
+      {
+        "vessel_dwt_min": 150001,
+        "vessel_dwt_max": 200000,
+        "port_dues_usd": 150000,
+        "pilotage_usd": 81000,
+        "tugs_usd": 69000,
+        "stevedoring_usd_per_mt": 2.5,
+        "cargo_type": "general",
+        "confidence": "estimated",
+        "source": "broker-research-2026-05"
       }
     ]
   }

--- a/tests/unit/port-da/seed.test.ts
+++ b/tests/unit/port-da/seed.test.ts
@@ -41,11 +41,11 @@ describe('seedPortDa — verification', () => {
     await seedPortDa(db, baseline, mockLlmCaller);
   });
 
-  it('has exactly 38 unique port_codes after seed', () => {
+  it('has exactly 39 unique port_codes after seed', () => {
     const row = db.prepare<[], { count: number }>(
       'SELECT COUNT(DISTINCT port_code) AS count FROM port_da_estimates',
     ).get();
-    expect(row!.count).toBe(38);
+    expect(row!.count).toBe(39);
   });
 
   it('all rows have confidence within {verified, estimated, low}', () => {


### PR DESCRIPTION
## Summary

- **BHSI/TOEPFER_TMI → 503 fix**: `benchmark.ts` теперь читает из `baltic_indices` DB вместо сломанного scraper. Migration 020 сидит статические данные ($12,683/day May 2026 для TMI, 650 для BHSI). Fallback к scraper для TMI если DB пуст.
- **503 → 404**: `app/api/market/benchmark/route.ts` возвращает 404 (не 503) при отсутствии данных.
- **Port DA DWT range** (от `feat/port-da-large-vessels`): данные для 65k–200k DWT (panamax/post-panamax/capesize) для NLRTM, BEANR, SGSIN, AEJEA, SAJED, AUPHE. Guard для >200k → 200 с осмысленным message.

## New files
- `lib/migrations/020-toepfer-tmi-seed.ts` — seeds TOEPFER_TMI + BHSI/BDI/BCI/BSI (INSERT OR IGNORE, idempotent)
- `lib/market/baltic-repository.ts` — `getLatestBalticIndex(db, indexCode)` DB query helper

## Test plan
- [ ] `GET /api/market/benchmark?indicator=BHSI` → 200 + value
- [ ] `GET /api/market/benchmark?indicator=TOEPFER_TMI` → 200 + value=12683
- [ ] `GET /api/market/benchmark?indicator=DREWRY_BREAKBULK` → 404
- [ ] `GET /api/port-da/NLRTM?vessel_dwt=75000` → 200 с реальными данными (panamax bracket)
- [ ] `GET /api/port-da/NLRTM?vessel_dwt=250000` → 200 с outOfRange message
- [ ] 33 новых тестов: benchmark unit + route + baltic-repository + migration020
- [ ] `npm test` — полный сюит зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)