### PR TITLE
fix: post-PR#108 QA bugs — SQL date guard + 422 format + mode type

### DIFF
--- a/__tests__/api/voyage/tce-auto-bunker.test.ts
+++ b/__tests__/api/voyage/tce-auto-bunker.test.ts
@@ -127,9 +127,9 @@ describe('TCE auto-bunker lookup (bp-03)', () => {
     const res = await POST(req);
     expect(res.status).toBe(422);
     const body = await res.json();
-    expect(body.error).toBe('bunker_price_unavailable');
-    expect(body.port).toBe('ZZZZZ');
-    expect(body.grade).toBe('VLSFO');
+    expect(body.error.code).toBe('bunker_price_unavailable');
+    expect(body.error.details.port).toBe('ZZZZZ');
+    expect(body.error.details.grade).toBe('VLSFO');
   });
 
   it('manual bunkerPriceUsdPerMt bypasses DB, source.mode=manual', async () => {

--- a/__tests__/lib/market/bunker-repository.test.ts
+++ b/__tests__/lib/market/bunker-repository.test.ts
@@ -53,6 +53,16 @@ describe('bunker-repository', () => {
     expect(row!.price_usd_per_mt).toBe(750);
   });
 
+  it('getLatestBunkerPrice ignores future-dated rows (date guard)', () => {
+    db.prepare(
+      "INSERT INTO bunker_prices (port_unlocode, fuel_grade, price_usd_per_mt, price_date, source, fetched_at) VALUES ('SGSIN', 'VLSFO', 9999, '2099-01-01', 'future-source', datetime('now'))"
+    ).run();
+    const row = getLatestBunkerPrice(db, 'SGSIN', 'VLSFO');
+    expect(row).not.toBeNull();
+    expect(row!.price_date).toBe('2026-05-09');
+    expect(row!.price_usd_per_mt).toBe(801);
+  });
+
   it('upsertBunkerPrice updates existing row on conflict', () => {
     upsertBunkerPrice(db, {
       port_unlocode: 'SGSIN',

--- a/__tests__/lib/market/eua-repository.test.ts
+++ b/__tests__/lib/market/eua-repository.test.ts
@@ -44,6 +44,16 @@ describe('eua-repository', () => {
     expect(row!.price_eur_per_tco2).toBe(75.00);
   });
 
+  it('getLatestEuaPrice ignores future-dated rows (date guard)', () => {
+    db.prepare(
+      "INSERT INTO eua_prices (price_date, price_eur_per_tco2, contract_type, source, fetched_at) VALUES ('2099-01-01', 9999, 'spot', 'future-source', datetime('now'))"
+    ).run();
+    const row = getLatestEuaPrice(db, 'spot');
+    expect(row).not.toBeNull();
+    expect(row!.price_date).toBe('2026-05-04');
+    expect(row!.price_eur_per_tco2).toBe(72.65);
+  });
+
   it('upsertEuaPrice inserts a new row', () => {
     upsertEuaPrice(db, {
       price_date: '2026-05-11',

--- a/__tests__/lib/market/eua-repository.test.ts
+++ b/__tests__/lib/market/eua-repository.test.ts
@@ -56,7 +56,7 @@ describe('eua-repository', () => {
 
   it('upsertEuaPrice inserts a new row', () => {
     upsertEuaPrice(db, {
-      price_date: '2026-05-11',
+      price_date: '2026-05-10',
       price_eur_per_tco2: 73.5,
       contract_type: 'spot',
       source: 'test',
@@ -64,7 +64,7 @@ describe('eua-repository', () => {
     });
     const row = getLatestEuaPrice(db, 'spot');
     expect(row).not.toBeNull();
-    expect(row!.price_date).toBe('2026-05-11');
+    expect(row!.price_date).toBe('2026-05-10');
     expect(row!.price_eur_per_tco2).toBe(73.5);
   });
 

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -249,7 +249,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // ── EUA price resolution ──
   let euaPriceEur: number;
   let euaPriceSource: {
-    value: number; source: string; priceDate?: string; fetchedAt?: string; mode: string;
+    value: number; source: string; priceDate?: string; fetchedAt?: string; mode: 'manual' | 'auto' | 'auto-skip' | 'auto-fallback';
   };
   if (typeof data.euaPriceEur === 'number') {
     euaPriceEur = data.euaPriceEur;

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -222,6 +222,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // ── Bunker price resolution ──
   let bunkerPriceUsdPerMt: number;
+  // bunker always has a DB row or returns 422 — no auto-skip or auto-fallback path
   let bunkerPriceSource: {
     value: number; source: string; priceDate?: string; fetchedAt?: string; mode: 'manual' | 'auto';
   };

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -235,7 +235,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const row = getLatestBunkerPrice(db, port, grade);
     if (!row) {
       return NextResponse.json(
-        { error: 'bunker_price_unavailable', port, grade },
+        { error: { code: 'bunker_price_unavailable', details: { port, grade } } },
         { status: 422 },
       );
     }

--- a/lib/market/bunker-repository.ts
+++ b/lib/market/bunker-repository.ts
@@ -17,7 +17,7 @@ export function getLatestBunkerPrice(
   const row = db.prepare<[string, string], BunkerPriceRow>(`
     SELECT port_unlocode, fuel_grade, price_usd_per_mt, price_date, source, fetched_at
     FROM bunker_prices
-    WHERE port_unlocode = ? AND fuel_grade = ?
+    WHERE port_unlocode = ? AND fuel_grade = ? AND price_date <= date('now')
     ORDER BY price_date DESC
     LIMIT 1
   `).get(portUnlocode, fuelGrade);

--- a/lib/market/eua-repository.ts
+++ b/lib/market/eua-repository.ts
@@ -12,7 +12,7 @@ export function getLatestEuaPrice(db: Database.Database, contractType = 'spot'):
   const row = db.prepare<[string], EuaPriceRow>(`
     SELECT price_date, price_eur_per_tco2, contract_type, source, fetched_at
     FROM eua_prices
-    WHERE contract_type = ?
+    WHERE contract_type = ? AND price_date <= date('now')
     ORDER BY price_date DESC
     LIMIT 1
   `).get(contractType);


### PR DESCRIPTION
## Summary

Closes 3 bugs found by adversarial QA after PR #108 (bunker-eua-pipeline):

- **Bug 1 (MEDIUM):** `getLatestBunkerPrice` and `getLatestEuaPrice` had no upper bound on `price_date` — a future-dated row (e.g. from parser error inserting `2099-01-01`) would be returned as the current price. Fixed with `AND price_date <= date('now')` guard in both SQL queries. Added regression tests for each.
- **Bug 3 (LOW):** TCE endpoint returned flat `{ error: 'bunker_price_unavailable', port, grade }` on 422. Changed to nested `{ error: { code: 'bunker_price_unavailable', details: { port, grade } } }`. Test expectation updated.
- **Bug 4 (LOW):** `euaPriceSource.mode` typed as `string` — narrowed to `'manual' | 'auto' | 'auto-skip' | 'auto-fallback'` literal union.

> **Note:** Bug 2 (AbortSignal in EEX/ICAP adapters) was already fixed in PR #108 (commits `a2b7896`, `8da6452`) — removed from scope after Scope Freshness Check.

## Changes

| File | Change |
|------|--------|
| `lib/market/bunker-repository.ts` | `AND price_date <= date('now')` guard |
| `lib/market/eua-repository.ts` | `AND price_date <= date('now')` guard |
| `__tests__/lib/market/bunker-repository.test.ts` | +1 regression test (future date excluded) |
| `__tests__/lib/market/eua-repository.test.ts` | +1 regression test (future date excluded) |
| `app/api/voyage/tce/route.ts` | Nested 422 format + literal mode union |
| `__tests__/api/voyage/tce-auto-bunker.test.ts` | Updated 422 expectation |

## Test plan

- [x] `npx jest __tests__/lib/market/bunker-repository.test.ts __tests__/lib/market/eua-repository.test.ts __tests__/api/voyage/tce-auto-bunker.test.ts` → **17 passed** (was 15, +2 regression tests)
- [x] `npx tsc --noEmit` → no errors
- [x] QI Review: PASS (independent agent, no blocking issues)
- [ ] Smoke after deploy: `POST /api/voyage/tce` with `bunkerPort=SGSIN` + EU route → check `bunkerPriceSource.mode="auto"`, `euaPriceSource.mode="auto"` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)