### PR TITLE
feat(phase0): ground truth construction scripts for progonq ETMS corpus

### DIFF
--- a/scripts/progonq/build-ground-truth.ts
+++ b/scripts/progonq/build-ground-truth.ts
@@ -29,7 +29,7 @@ import type { ClassifiedEmail } from './classify-corpus';
 
 const MODEL = 'us.anthropic.claude-sonnet-4-6';
 const MAX_BODY_CHARS = 3000;
-const CONCURRENCY = 4;
+const CONCURRENCY = 2;
 const CLASSIFY_BATCH = 20;
 
 const CLASSIFIED_PATH = path.resolve(process.cwd(), '.private/etms-corpus-classified.json');
@@ -77,7 +77,20 @@ function extractJson(text: string): unknown {
   let s = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
   const start = s.search(/[{[]/);
   if (start > 0) s = s.slice(start);
-  return JSON.parse(s);
+  const opener = s[0];
+  if (opener !== '{' && opener !== '[') return JSON.parse(s);
+  const closer = opener === '{' ? '}' : ']';
+  let depth = 0, inStr = false, esc = false, end = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (esc) { esc = false; continue; }
+    if (c === '\\' && inStr) { esc = true; continue; }
+    if (c === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (c === opener) depth++;
+    else if (c === closer && --depth === 0) { end = i; break; }
+  }
+  return JSON.parse(end > 0 ? s.slice(0, end + 1) : s);
 }
 
 const SCOPE_MAP: Record<Endpoint, string> = {

--- a/scripts/progonq/build-ground-truth.ts
+++ b/scripts/progonq/build-ground-truth.ts
@@ -18,7 +18,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
-import { callAiJson, callAiText } from '@/lib/ai-provider';
+import { callAiText } from '@/lib/ai-provider';
 import {
   CLASSIFICATION_SYSTEM_PROMPT,
   CARGO_INQUIRY_PARSER_PROMPT,
@@ -73,34 +73,44 @@ function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+function extractJson(text: string): unknown {
+  let s = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  const start = s.search(/[{[]/);
+  if (start > 0) s = s.slice(start);
+  return JSON.parse(s);
+}
+
+const SCOPE_MAP: Record<Endpoint, string> = {
+  classify: 'CLASSIFY',
+  'parse-cargo': 'PARSE_CARGO',
+  'parse-vessel': 'PARSE_VESSEL',
+  'parse-recap': 'RECAP',
+};
+
 async function extractOne(endpoint: Endpoint, email: ClassifiedEmail): Promise<unknown> {
   const system = getSystemPrompt(endpoint);
   const user = buildUserPrompt(endpoint, email);
+  const scope = SCOPE_MAP[endpoint];
 
   let attempt = 0;
   while (attempt < 4) {
     attempt++;
     try {
+      const text = await callAiText(
+        scope,
+        system,
+        endpoint === 'classify'
+          ? `Today's date: ${new Date().toISOString().split('T')[0]}\n\n[${user}]`
+          : user,
+        { model: MODEL, maxTokens: 4096, timeoutMs: 90_000 },
+      );
+      const parsed = extractJson(text);
+      // For classify, unwrap classifications[0]
       if (endpoint === 'classify') {
-        // classify returns structured JSON
-        const today = new Date().toISOString().split('T')[0];
-        const batchInput = [{ id: email.id, subject: email.subject, from: email.from, date: email.date, body_preview: truncate(email.body || email.snippet, MAX_BODY_CHARS) }];
-        const result = await callAiJson<{ classifications: unknown[] }>(
-          'CLASSIFY',
-          system,
-          `Today's date: ${today}\n\n${JSON.stringify(batchInput)}`,
-          { model: MODEL, maxTokens: 2048, timeoutMs: 90_000 },
-        );
-        return result.classifications?.[0] ?? null;
-      } else {
-        const text = await callAiText(
-          endpoint === 'parse-cargo' ? 'PARSE_CARGO' : endpoint === 'parse-vessel' ? 'PARSE_VESSEL' : 'RECAP',
-          system,
-          user,
-          { model: MODEL, maxTokens: 4096, timeoutMs: 90_000 },
-        );
-        return JSON.parse(stripFences(text));
+        const cl = parsed as { classifications?: unknown[] };
+        return cl.classifications?.[0] ?? parsed;
       }
+      return parsed;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       const delay = [1000, 5000, 30000][attempt - 1] ?? 60000;

--- a/scripts/progonq/build-ground-truth.ts
+++ b/scripts/progonq/build-ground-truth.ts
@@ -29,7 +29,8 @@ import type { ClassifiedEmail } from './classify-corpus';
 
 const MODEL = 'us.anthropic.claude-sonnet-4-6';
 const MAX_BODY_CHARS = 3000;
-const CONCURRENCY = 2;
+const CONCURRENCY = 1;
+const REQUEST_DELAY_MS = 500; // spacing between sequential Bedrock calls
 const CLASSIFY_BATCH = 20;
 
 const CLASSIFIED_PATH = path.resolve(process.cwd(), '.private/etms-corpus-classified.json');
@@ -109,6 +110,7 @@ async function extractOne(endpoint: Endpoint, email: ClassifiedEmail): Promise<u
   while (attempt < 4) {
     attempt++;
     try {
+      await sleep(REQUEST_DELAY_MS);
       const text = await callAiText(
         scope,
         system,
@@ -126,7 +128,7 @@ async function extractOne(endpoint: Endpoint, email: ClassifiedEmail): Promise<u
       return parsed;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      const delay = [1000, 5000, 30000][attempt - 1] ?? 60000;
+      const delay = [5000, 15000, 60000][attempt - 1] ?? 60000;
       if (attempt >= 4) throw err;
       console.error(`  [${endpoint}/${email.id}] attempt ${attempt} ERR: ${msg.slice(0, 100)} — retry in ${delay / 1000}s`);
       await sleep(delay);

--- a/scripts/progonq/build-ground-truth.ts
+++ b/scripts/progonq/build-ground-truth.ts
@@ -175,7 +175,8 @@ async function main() {
   for (const email of corpus) {
     for (const endpoint of endpointFilter) {
       if (!email.applicable_endpoints.includes(endpoint)) continue;
-      if (gt[email.id]?.[endpoint] !== undefined) continue; // already done
+      const existing = gt[email.id]?.[endpoint];
+      if (existing !== undefined && !(existing as Record<string, unknown>)?.__error) continue;
       workItems.push({ email, endpoint });
     }
   }

--- a/scripts/progonq/build-ground-truth.ts
+++ b/scripts/progonq/build-ground-truth.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Phase 0 Step 2: Build ground truth by running production parsers on
+ * applicable emails from the classified corpus.
+ *
+ * Uses Bedrock Sonnet 4.6 as extractor for each (email, endpoint) pair.
+ * Resumable: skips pairs already present in output file.
+ *
+ * Output: .private/etms-corpus-ground-truth.json
+ *   Shape: { [emailId]: { [endpoint]: <parsed output> } }
+ *
+ * Usage:
+ *   AI_PROVIDER=bedrock npx tsx --env-file=.env.local scripts/progonq/build-ground-truth.ts [--endpoint classify] [--limit N]
+ *
+ * Env (from .env.local):
+ *   AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY  (required)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { callAiJson, callAiText } from '@/lib/ai-provider';
+import {
+  CLASSIFICATION_SYSTEM_PROMPT,
+  CARGO_INQUIRY_PARSER_PROMPT,
+  VESSEL_POSITION_PARSER_PROMPT,
+  FIXTURE_RECAP_PARSER_PROMPT,
+} from '@/lib/prompts';
+import type { ClassifiedEmail } from './classify-corpus';
+
+const MODEL = 'us.anthropic.claude-sonnet-4-6';
+const MAX_BODY_CHARS = 3000;
+const CONCURRENCY = 4;
+const CLASSIFY_BATCH = 20;
+
+const CLASSIFIED_PATH = path.resolve(process.cwd(), '.private/etms-corpus-classified.json');
+const OUT_PATH = path.resolve(process.cwd(), '.private/etms-corpus-ground-truth.json');
+
+type Endpoint = 'classify' | 'parse-cargo' | 'parse-vessel' | 'parse-recap';
+type GroundTruth = Record<string, Partial<Record<Endpoint, unknown>>>;
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max) + '\n[truncated]';
+}
+
+function buildUserPrompt(endpoint: Endpoint, email: ClassifiedEmail): string {
+  const header = `From: ${email.from}\nSubject: ${email.subject}\nDate: ${email.date}`;
+  switch (endpoint) {
+    case 'parse-cargo':
+      return `${header}\n\n${truncate(email.body || email.snippet, MAX_BODY_CHARS)}`;
+    case 'parse-vessel':
+    case 'parse-recap':
+      return `${header}\n\n${email.body || email.snippet}`;
+    case 'classify':
+      // Handled separately via batched classify
+      return JSON.stringify({ id: email.id, subject: email.subject, from: email.from, date: email.date, body_preview: truncate(email.body || email.snippet, MAX_BODY_CHARS) });
+  }
+}
+
+function getSystemPrompt(endpoint: Endpoint): string {
+  switch (endpoint) {
+    case 'classify':    return CLASSIFICATION_SYSTEM_PROMPT;
+    case 'parse-cargo': return CARGO_INQUIRY_PARSER_PROMPT;
+    case 'parse-vessel': return VESSEL_POSITION_PARSER_PROMPT;
+    case 'parse-recap': return FIXTURE_RECAP_PARSER_PROMPT;
+  }
+}
+
+function stripFences(text: string): string {
+  return text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function extractOne(endpoint: Endpoint, email: ClassifiedEmail): Promise<unknown> {
+  const system = getSystemPrompt(endpoint);
+  const user = buildUserPrompt(endpoint, email);
+
+  let attempt = 0;
+  while (attempt < 4) {
+    attempt++;
+    try {
+      if (endpoint === 'classify') {
+        // classify returns structured JSON
+        const today = new Date().toISOString().split('T')[0];
+        const batchInput = [{ id: email.id, subject: email.subject, from: email.from, date: email.date, body_preview: truncate(email.body || email.snippet, MAX_BODY_CHARS) }];
+        const result = await callAiJson<{ classifications: unknown[] }>(
+          'CLASSIFY',
+          system,
+          `Today's date: ${today}\n\n${JSON.stringify(batchInput)}`,
+          { model: MODEL, maxTokens: 2048, timeoutMs: 90_000 },
+        );
+        return result.classifications?.[0] ?? null;
+      } else {
+        const text = await callAiText(
+          endpoint === 'parse-cargo' ? 'PARSE_CARGO' : endpoint === 'parse-vessel' ? 'PARSE_VESSEL' : 'RECAP',
+          system,
+          user,
+          { model: MODEL, maxTokens: 4096, timeoutMs: 90_000 },
+        );
+        return JSON.parse(stripFences(text));
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const delay = [1000, 5000, 30000][attempt - 1] ?? 60000;
+      if (attempt >= 4) throw err;
+      console.error(`  [${endpoint}/${email.id}] attempt ${attempt} ERR: ${msg.slice(0, 100)} — retry in ${delay / 1000}s`);
+      await sleep(delay);
+    }
+  }
+  throw new Error('unreachable');
+}
+
+async function pLimit<T>(tasks: (() => Promise<T>)[], concurrency: number): Promise<T[]> {
+  const results: T[] = [];
+  let idx = 0;
+  async function worker() {
+    while (idx < tasks.length) {
+      const i = idx++;
+      results[i] = await tasks[i]();
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return results;
+}
+
+async function main() {
+  const endpointFilter = process.argv.includes('--endpoint')
+    ? [process.argv[process.argv.indexOf('--endpoint') + 1] as Endpoint]
+    : (['classify', 'parse-cargo', 'parse-vessel', 'parse-recap'] as Endpoint[]);
+  const limitArg = process.argv.indexOf('--limit');
+  const limit = limitArg >= 0 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
+
+  if (!existsSync(CLASSIFIED_PATH)) {
+    console.error(`ERROR: ${CLASSIFIED_PATH} not found — run classify-corpus.ts first`);
+    process.exit(1);
+  }
+
+  const classified: ClassifiedEmail[] = JSON.parse(readFileSync(CLASSIFIED_PATH, 'utf-8'));
+  const corpus = isFinite(limit) ? classified.slice(0, limit) : classified;
+
+  // Load existing ground truth
+  const gt: GroundTruth = existsSync(OUT_PATH)
+    ? JSON.parse(readFileSync(OUT_PATH, 'utf-8'))
+    : {};
+
+  // Build work items
+  const workItems: Array<{ email: ClassifiedEmail; endpoint: Endpoint }> = [];
+  for (const email of corpus) {
+    for (const endpoint of endpointFilter) {
+      if (!email.applicable_endpoints.includes(endpoint)) continue;
+      if (gt[email.id]?.[endpoint] !== undefined) continue; // already done
+      workItems.push({ email, endpoint });
+    }
+  }
+
+  console.error(`[build-ground-truth] ${workItems.length} pairs to process (${corpus.length} emails × up to ${endpointFilter.length} endpoints)`);
+  let done = 0;
+  let errors = 0;
+
+  const tasks = workItems.map(({ email, endpoint }) => async () => {
+    try {
+      const output = await extractOne(endpoint, email);
+      if (!gt[email.id]) gt[email.id] = {};
+      gt[email.id][endpoint] = output;
+      done++;
+      if (done % 10 === 0 || done === workItems.length) {
+        writeFileSync(OUT_PATH, JSON.stringify(gt, null, 2));
+        console.error(`[build-ground-truth] ${done}/${workItems.length} done (${errors} errors)`);
+      }
+    } catch (err) {
+      errors++;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[build-ground-truth] ERROR ${endpoint}/${email.id}: ${msg.slice(0, 120)}`);
+      if (!gt[email.id]) gt[email.id] = {};
+      gt[email.id][endpoint] = { __error: msg.slice(0, 200) };
+    }
+  });
+
+  await pLimit(tasks, CONCURRENCY);
+  writeFileSync(OUT_PATH, JSON.stringify(gt, null, 2));
+
+  // Summary
+  const counts: Partial<Record<Endpoint, { ok: number; error: number }>> = {};
+  for (const [, endpointMap] of Object.entries(gt)) {
+    for (const [ep, val] of Object.entries(endpointMap) as [Endpoint, unknown][]) {
+      if (!counts[ep]) counts[ep] = { ok: 0, error: 0 };
+      if (val && typeof val === 'object' && '__error' in (val as object)) {
+        counts[ep]!.error++;
+      } else {
+        counts[ep]!.ok++;
+      }
+    }
+  }
+  console.error(`\n[build-ground-truth] DONE`);
+  console.error('Per-endpoint stats:', JSON.stringify(counts, null, 2));
+  console.error(`Output: ${OUT_PATH}`);
+}
+
+main().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/scripts/progonq/build-progonq-corpus.ts
+++ b/scripts/progonq/build-progonq-corpus.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Phase 0 Step 3: Convert ground truth to progonq corpus format.
+ *
+ * Creates .progonq/corpus/etms-{endpoint}/scenario-NNN.json for each
+ * (email, endpoint) pair. Auto-detects category from email body signals.
+ *
+ * Output structure per scenario:
+ *   {
+ *     id: "etms-classify-001",
+ *     source_email_id: "<gmail-id>",
+ *     category: "forwarded_chain",   // auto-detected
+ *     input: { subject, from, date, body },
+ *     reference_output: { ... }      // from ground truth
+ *   }
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/build-progonq-corpus.ts [--endpoint classify]
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import type { ClassifiedEmail } from './classify-corpus';
+
+type Endpoint = 'classify' | 'parse-cargo' | 'parse-vessel' | 'parse-recap';
+type GroundTruth = Record<string, Partial<Record<Endpoint, unknown>>>;
+
+const CLASSIFIED_PATH = path.resolve(process.cwd(), '.private/etms-corpus-classified.json');
+const GT_PATH = path.resolve(process.cwd(), '.private/etms-corpus-ground-truth.json');
+const CORPUS_ROOT = path.resolve(process.cwd(), '.progonq/corpus');
+
+const ENDPOINT_CATEGORIES: Record<Endpoint, string[]> = {
+  classify: ['simple_clean', 'forwarded_chain', 'mixed_languages', 'ambiguous_intent', 'multi_intent'],
+  'parse-cargo': ['single_cargo', 'multi_cargo', 'incomplete_data', 'hedged_language', 'numeric_edge', 'forwarded'],
+  'parse-vessel': ['single_vessel', 'multi_vessel', 'position_only', 'full_specs', 'dwcc_edge'],
+  'parse-recap': ['bulk_recap', 'project_recap', 'partial_recap', 'multi_clause'],
+};
+
+function detectCategory(endpoint: Endpoint, email: ClassifiedEmail): string {
+  const body = (email.body || email.snippet || '').toLowerCase();
+  const subject = (email.subject || '').toLowerCase();
+
+  if (endpoint === 'classify') {
+    if (body.includes('forwarded message') || body.includes('fw:') || subject.includes('fw:') || body.includes('-----original message-----')) return 'forwarded_chain';
+    if (/[Ѐ-ӿ]/.test(body) || /[؀-ۿ]/.test(body)) return 'mixed_languages'; // Cyrillic or Arabic
+    if (email.classification.confidence < 0.85) return 'ambiguous_intent';
+    const cats = ['cargo_inquiry', 'vessel_position', 'fixture_recap', 'client_reply', 'document', 'tct_request'];
+    const matched = cats.filter((c) => body.includes(c.replace('_', ' ')) || subject.includes(c.replace('_', ' ')));
+    if (matched.length > 1) return 'multi_intent';
+    return 'simple_clean';
+  }
+
+  if (endpoint === 'parse-cargo') {
+    if (body.includes('forwarded') || body.includes('-----original message-----')) return 'forwarded';
+    if (body.match(/cargo\s*[12]|lot\s*[12]|item\s*[12]/i) || body.match(/\band\b.*\band\b.*port/i)) return 'multi_cargo';
+    if (body.includes('abt') || body.includes('about') || body.includes('approx') || body.includes('tbc') || body.includes('tbd')) return 'hedged_language';
+    if (body.includes('10%') || body.includes('moloo') || body.includes('molco') || body.match(/\d+[\/,]\d+\s*mt/i)) return 'numeric_edge';
+    if (!body.match(/\d+\s*(?:mt|mts|tons?)/i) || body.match(/tba|tbd|tbc/i)) return 'incomplete_data';
+    return 'single_cargo';
+  }
+
+  if (endpoint === 'parse-vessel') {
+    if (body.includes('fleet') || body.match(/vessel\s+[12]/i) || body.match(/mv\s+\w+.*mv\s+\w+/i)) return 'multi_vessel';
+    if (body.includes('dwcc') || body.includes('deadweight') || body.match(/\d{4,6}\s*dwt/i)) return 'dwcc_edge';
+    if (body.includes('dwtcc') || body.includes('dwat') || body.includes('nrt') || body.includes('grt') || body.includes('built') || body.includes('imo')) return 'full_specs';
+    if (body.match(/open\s+\w+|available\s+\w+|eta\s+\w+/i) && !body.match(/imo\s*\d{7}/i)) return 'position_only';
+    return 'single_vessel';
+  }
+
+  if (endpoint === 'parse-recap') {
+    if (body.includes('additional clause') || body.includes('clause') || body.match(/\d+\.\s+[A-Z]/)) return 'multi_clause';
+    if (body.includes('project') || body.includes('heavy lift') || body.includes('break bulk')) return 'project_recap';
+    if (!body.match(/freight|hire|rate/i) || !body.match(/load|discharge/i)) return 'partial_recap';
+    return 'bulk_recap';
+  }
+
+  return 'simple_clean';
+}
+
+function padNum(n: number, len: number): string {
+  return String(n).padStart(len, '0');
+}
+
+async function main() {
+  const endpointFilter = process.argv.includes('--endpoint')
+    ? [process.argv[process.argv.indexOf('--endpoint') + 1] as Endpoint]
+    : (['classify', 'parse-cargo', 'parse-vessel', 'parse-recap'] as Endpoint[]);
+
+  if (!existsSync(CLASSIFIED_PATH)) {
+    console.error(`ERROR: ${CLASSIFIED_PATH} not found — run classify-corpus.ts first`);
+    process.exit(1);
+  }
+  if (!existsSync(GT_PATH)) {
+    console.error(`ERROR: ${GT_PATH} not found — run build-ground-truth.ts first`);
+    process.exit(1);
+  }
+
+  const classified: ClassifiedEmail[] = JSON.parse(readFileSync(CLASSIFIED_PATH, 'utf-8'));
+  const gt: GroundTruth = JSON.parse(readFileSync(GT_PATH, 'utf-8'));
+
+  const stats: Partial<Record<Endpoint, { written: number; skipped: number }>> = {};
+
+  for (const endpoint of endpointFilter) {
+    const applicable = classified.filter((e) => e.applicable_endpoints.includes(endpoint));
+    const dir = path.join(CORPUS_ROOT, `etms-${endpoint}`);
+    mkdirSync(dir, { recursive: true });
+
+    let written = 0;
+    let skipped = 0;
+
+    for (let i = 0; i < applicable.length; i++) {
+      const email = applicable[i];
+      const ref = gt[email.id]?.[endpoint];
+
+      if (ref === undefined || (typeof ref === 'object' && ref !== null && '__error' in ref)) {
+        skipped++;
+        continue;
+      }
+
+      const category = detectCategory(endpoint, email);
+      const scenario = {
+        id: `etms-${endpoint}-${padNum(i + 1, 3)}`,
+        source_email_id: email.id,
+        category,
+        input: {
+          subject: email.subject,
+          from: email.from,
+          date: email.date,
+          body: email.body || email.snippet,
+        },
+        reference_output: ref,
+      };
+
+      const outFile = path.join(dir, `scenario-${padNum(i + 1, 3)}.json`);
+      writeFileSync(outFile, JSON.stringify(scenario, null, 2));
+      written++;
+    }
+
+    stats[endpoint] = { written, skipped };
+    console.error(`[${endpoint}] ${written} scenarios written, ${skipped} skipped (no GT or error)`);
+  }
+
+  // Write manifest
+  const manifest = {
+    generated_at: new Date().toISOString(),
+    extractor_model: 'us.anthropic.claude-sonnet-4-6',
+    endpoints: endpointFilter.map((ep) => ({
+      endpoint: ep,
+      dir: `etms-${ep}`,
+      categories: ENDPOINT_CATEGORIES[ep],
+      ...stats[ep],
+    })),
+  };
+  writeFileSync(path.join(CORPUS_ROOT, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+  console.error('\n[build-progonq-corpus] DONE');
+  console.error('Stats:', JSON.stringify(stats, null, 2));
+  console.error(`Corpus root: ${CORPUS_ROOT}`);
+}
+
+main().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/scripts/progonq/classify-corpus.ts
+++ b/scripts/progonq/classify-corpus.ts
@@ -17,7 +17,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
-import { callAiJson } from '@/lib/ai-provider';
+import { callAiText } from '@/lib/ai-provider';
 import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts';
 
 const BATCH_SIZE = 20;
@@ -76,6 +76,15 @@ function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+function extractJson(text: string): unknown {
+  // Strip markdown fences
+  let s = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  // Find first { or [ — strip any preamble the model may have added
+  const start = s.search(/[{[]/);
+  if (start > 0) s = s.slice(start);
+  return JSON.parse(s);
+}
+
 async function classifyBatch(emails: RawEmail[]): Promise<AiClassification[]> {
   const input = emails.map((e) => ({
     id: e.id,
@@ -85,12 +94,13 @@ async function classifyBatch(emails: RawEmail[]): Promise<AiClassification[]> {
     body_preview: truncate(e.body || e.snippet, MAX_BODY_CHARS),
   }));
   const today = new Date().toISOString().split('T')[0];
-  const result = await callAiJson<{ classifications: AiClassification[] }>(
+  const text = await callAiText(
     SCOPE,
     CLASSIFICATION_SYSTEM_PROMPT,
     `Today's date: ${today}\n\n${JSON.stringify(input)}`,
     { model: MODEL, maxTokens: 4096, timeoutMs: 120_000 },
   );
+  const result = extractJson(text) as { classifications: AiClassification[] };
   return result.classifications ?? [];
 }
 

--- a/scripts/progonq/classify-corpus.ts
+++ b/scripts/progonq/classify-corpus.ts
@@ -77,12 +77,24 @@ function sleep(ms: number) {
 }
 
 function extractJson(text: string): unknown {
-  // Strip markdown fences
   let s = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
-  // Find first { or [ — strip any preamble the model may have added
   const start = s.search(/[{[]/);
   if (start > 0) s = s.slice(start);
-  return JSON.parse(s);
+  // Find matching closing bracket, ignoring trailing garbage after the JSON
+  const opener = s[0];
+  if (opener !== '{' && opener !== '[') return JSON.parse(s);
+  const closer = opener === '{' ? '}' : ']';
+  let depth = 0, inStr = false, esc = false, end = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (esc) { esc = false; continue; }
+    if (c === '\\' && inStr) { esc = true; continue; }
+    if (c === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (c === opener) depth++;
+    else if (c === closer && --depth === 0) { end = i; break; }
+  }
+  return JSON.parse(end > 0 ? s.slice(0, end + 1) : s);
 }
 
 async function classifyBatch(emails: RawEmail[]): Promise<AiClassification[]> {

--- a/scripts/progonq/classify-corpus.ts
+++ b/scripts/progonq/classify-corpus.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Phase 0 Step 1: Classify 154 ETMS emails via production classify prompt.
+ *
+ * Uses Bedrock Sonnet 4.6 (Opus 4.7 not activated on this account).
+ * Batches 20 emails per call (same as production).
+ * Determines applicable_endpoints per email based on classification category.
+ *
+ * Output: .private/etms-corpus-classified.json
+ *
+ * Usage:
+ *   AI_PROVIDER=bedrock npx tsx --env-file=.env.local scripts/progonq/classify-corpus.ts [--limit N]
+ *
+ * Env (from .env.local):
+ *   AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY  (required)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { callAiJson } from '@/lib/ai-provider';
+import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts';
+
+const BATCH_SIZE = 20;
+const SCOPE = 'CLASSIFY';
+const MODEL = 'us.anthropic.claude-sonnet-4-6';
+const MAX_BODY_CHARS = 3000;
+const CONCURRENCY = 3;
+
+const CORPUS_PATH = path.resolve(process.cwd(), '.private/etms-corpus.json');
+const OUT_PATH = path.resolve(process.cwd(), '.private/etms-corpus-classified.json');
+
+interface RawEmail {
+  id: string;
+  from: string;
+  subject: string;
+  date: string;
+  body: string;
+  snippet: string;
+}
+
+interface AiClassification {
+  id: string;
+  category: string;
+  urgency: string;
+  confidence: number;
+  is_unanswered: boolean;
+  days_without_reply: number | null;
+  original_sender: string | null;
+  original_sender_company: string | null;
+}
+
+export interface ClassifiedEmail extends RawEmail {
+  classification: AiClassification;
+  applicable_endpoints: string[];
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max) + '\n[truncated]';
+}
+
+function applicableEndpoints(category: string): string[] {
+  const eps = ['classify'];
+  if (category === 'CARGO_INQUIRY' || category === 'TCT_REQUEST') eps.push('parse-cargo');
+  if (category === 'VESSEL_POSITION' || category === 'FIXTURE_RECAP') eps.push('parse-vessel');
+  if (category === 'FIXTURE_RECAP') eps.push('parse-recap');
+  return eps;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function classifyBatch(emails: RawEmail[]): Promise<AiClassification[]> {
+  const input = emails.map((e) => ({
+    id: e.id,
+    subject: e.subject,
+    from: e.from,
+    date: e.date,
+    body_preview: truncate(e.body || e.snippet, MAX_BODY_CHARS),
+  }));
+  const today = new Date().toISOString().split('T')[0];
+  const result = await callAiJson<{ classifications: AiClassification[] }>(
+    SCOPE,
+    CLASSIFICATION_SYSTEM_PROMPT,
+    `Today's date: ${today}\n\n${JSON.stringify(input)}`,
+    { model: MODEL, maxTokens: 4096, timeoutMs: 120_000 },
+  );
+  return result.classifications ?? [];
+}
+
+async function main() {
+  const limitArg = process.argv.indexOf('--limit');
+  const limit = limitArg >= 0 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
+
+  const corpus: RawEmail[] = JSON.parse(readFileSync(CORPUS_PATH, 'utf-8'));
+  const emails = isFinite(limit) ? corpus.slice(0, limit) : corpus;
+  console.error(`[classify-corpus] ${emails.length} emails to classify`);
+
+  // Resume from existing output if partial
+  const existing: Map<string, ClassifiedEmail> = new Map();
+  if (existsSync(OUT_PATH)) {
+    const prev: ClassifiedEmail[] = JSON.parse(readFileSync(OUT_PATH, 'utf-8'));
+    for (const e of prev) existing.set(e.id, e);
+    console.error(`[classify-corpus] resuming — ${existing.size} already classified`);
+  }
+
+  const pending = emails.filter((e) => !existing.has(e.id));
+  const batches = chunk(pending, BATCH_SIZE);
+
+  let batchIdx = 0;
+  for (let i = 0; i < batches.length; i += CONCURRENCY) {
+    const group = batches.slice(i, i + CONCURRENCY);
+    await Promise.all(
+      group.map(async (batch) => {
+        const n = ++batchIdx;
+        let attempt = 0;
+        while (attempt < 4) {
+          attempt++;
+          try {
+            const classifications = await classifyBatch(batch);
+            const byId = new Map(classifications.map((c) => [c.id, c]));
+            for (const email of batch) {
+              const cl = byId.get(email.id);
+              if (!cl) {
+                console.error(`[batch ${n}] WARN: no classification for ${email.id}`);
+                continue;
+              }
+              existing.set(email.id, {
+                ...email,
+                classification: cl,
+                applicable_endpoints: applicableEndpoints(cl.category),
+              });
+            }
+            console.error(`[batch ${n}] ok — ${batch.length} emails (total done: ${existing.size}/${emails.length})`);
+            break;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            const delay = [1000, 5000, 30000][attempt - 1] ?? 60000;
+            console.error(`[batch ${n}] attempt ${attempt} ERR: ${msg.slice(0, 120)} — retry in ${delay / 1000}s`);
+            if (attempt >= 4) throw err;
+            await sleep(delay);
+          }
+        }
+        // Persist after every batch
+        const result = emails
+          .map((e) => existing.get(e.id))
+          .filter((e): e is ClassifiedEmail => !!e);
+        writeFileSync(OUT_PATH, JSON.stringify(result, null, 2));
+      }),
+    );
+  }
+
+  const result = emails
+    .map((e) => existing.get(e.id))
+    .filter((e): e is ClassifiedEmail => !!e);
+  writeFileSync(OUT_PATH, JSON.stringify(result, null, 2));
+
+  // Summary
+  const counts: Record<string, number> = {};
+  const epCounts: Record<string, number> = {};
+  for (const e of result) {
+    counts[e.classification.category] = (counts[e.classification.category] ?? 0) + 1;
+    for (const ep of e.applicable_endpoints) {
+      epCounts[ep] = (epCounts[ep] ?? 0) + 1;
+    }
+  }
+  console.error(`\n[classify-corpus] DONE — ${result.length}/${emails.length} classified`);
+  console.error('Categories:', JSON.stringify(counts, null, 2));
+  console.error('Endpoint coverage:', JSON.stringify(epCounts, null, 2));
+  console.error(`Output: ${OUT_PATH}`);
+}
+
+main().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Three new scripts in `scripts/progonq/` for Phase 0 ground truth construction
- `classify-corpus.ts`: classifies 154 ETMS emails via Bedrock Sonnet 4.6 → determines applicable endpoints per email
- `build-ground-truth.ts`: runs production parsers on applicable emails → saves reference JSON per (email, endpoint)
- `build-progonq-corpus.ts`: converts ground truth to `.progonq/corpus/etms-{endpoint}/scenario-NNN.json`

**Phase 0 results (VPS-side artifacts, gitignored):**
- classify: 154/154 ✅
- parse-cargo: 95/95 ✅
- parse-vessel: 56/56 ✅
- parse-recap: 3/3 ✅
- Total: 308 (email, endpoint) pairs of ground truth

**Notes:**
- Bedrock Opus 4.7 not activated → using Sonnet 4.6 (lower cost, comparable quality)
- Scripts are resumable (skip successful pairs on re-run, retry errors)
- Scope-specific provider overrides required: `CLASSIFY_PROVIDER=bedrock PARSE_CARGO_PROVIDER=bedrock PARSE_VESSEL_PROVIDER=bedrock RECAP_PROVIDER=bedrock`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Phase 0 artifacts generated on VPS: 308/308 pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)