### PR TITLE
ci: add Claude security-review GitHub Action

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -1,0 +1,26 @@
+name: Claude Security Review
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  security-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Security Review
+        uses: anthropics/claude-code-security-review@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_model: claude-sonnet-4-6
+          comment-pr: true


### PR DESCRIPTION
## Что делает
Добавляет GitHub Action из anthropics/claude-code-security-review
для автоматического security-сканирования каждого PR в этот репо.

## Зачем
Защита от LLM-сгенерированных уязвимостей: substring auth, leaked tokens,
SQL injection, XSS, OWASP top 10.

Парный PR к [allegro-lister](https://github.com/Vitali2011/allegro-lister).

## Cost
~$0.05 на PR (Sonnet 4.6). При 20 PR/мес ~$1/мес.

## Test plan
- [ ] CI прошёл на этом PR
- [ ] После merge: создать тестовый PR с уязвимостью и проверить action

🤖 Generated with [Claude Code](https://claude.com/claude-code)