### PR TITLE
fix(sanctions): retry EU adapter with exponential backoff on 5xx/429

### DIFF
--- a/__tests__/lib/knowledge/sanctions/eu-adapter.test.ts
+++ b/__tests__/lib/knowledge/sanctions/eu-adapter.test.ts
@@ -1,7 +1,7 @@
 import Database from "better-sqlite3";
 import migration013 from "@/lib/migrations/013-knowledge-sources";
 import migration014 from "@/lib/migrations/014-sanctions-entities";
-import { refreshEu } from "@/lib/knowledge/sanctions/eu-adapter";
+import { refreshEu, withRetry, HttpFetchError } from "@/lib/knowledge/sanctions/eu-adapter";
 import type { Fetcher } from "@/lib/knowledge/sanctions/eu-adapter";
 import { registerSource } from "@/lib/knowledge/governance";
 
@@ -330,6 +330,134 @@ describe("eu-adapter", () => {
         .prepare("SELECT * FROM knowledge_sources WHERE slug = 'eu-sanctions'")
         .get() as any;
       expect(source.status).toBe("fresh");
+    });
+  });
+
+  describe("withRetry", () => {
+    const noSleep = async () => {};
+
+    it("returns value on first attempt when fn succeeds", async () => {
+      let calls = 0;
+      const result = await withRetry(async () => {
+        calls++;
+        return "ok";
+      }, { sleep: noSleep });
+      expect(result).toBe("ok");
+      expect(calls).toBe(1);
+    });
+
+    it("retries on HTTP 500 and succeeds on 2nd attempt", async () => {
+      let calls = 0;
+      const result = await withRetry(async () => {
+        calls++;
+        if (calls === 1) throw new HttpFetchError(500, "upstream");
+        return "ok";
+      }, { sleep: noSleep });
+      expect(result).toBe("ok");
+      expect(calls).toBe(2);
+    });
+
+    it("retries on HTTP 429 (rate limit)", async () => {
+      let calls = 0;
+      const result = await withRetry(async () => {
+        calls++;
+        if (calls < 3) throw new HttpFetchError(429, "rate limited");
+        return "ok";
+      }, { sleep: noSleep });
+      expect(result).toBe("ok");
+      expect(calls).toBe(3);
+    });
+
+    it("retries on network error (no status)", async () => {
+      let calls = 0;
+      const result = await withRetry(async () => {
+        calls++;
+        if (calls === 1) throw new Error("ECONNRESET");
+        return "ok";
+      }, { sleep: noSleep });
+      expect(result).toBe("ok");
+      expect(calls).toBe(2);
+    });
+
+    it("does NOT retry on HTTP 401 (auth)", async () => {
+      let calls = 0;
+      await expect(
+        withRetry(async () => {
+          calls++;
+          throw new HttpFetchError(401, "unauthorized");
+        }, { sleep: noSleep })
+      ).rejects.toThrow("unauthorized");
+      expect(calls).toBe(1);
+    });
+
+    it("does NOT retry on HTTP 403 (forbidden — token issue)", async () => {
+      let calls = 0;
+      await expect(
+        withRetry(async () => {
+          calls++;
+          throw new HttpFetchError(403, "forbidden");
+        }, { sleep: noSleep })
+      ).rejects.toThrow("forbidden");
+      expect(calls).toBe(1);
+    });
+
+    it("does NOT retry on HTTP 404 (client error)", async () => {
+      let calls = 0;
+      await expect(
+        withRetry(async () => {
+          calls++;
+          throw new HttpFetchError(404, "not found");
+        }, { sleep: noSleep })
+      ).rejects.toThrow("not found");
+      expect(calls).toBe(1);
+    });
+
+    it("gives up after maxAttempts and throws last error", async () => {
+      let calls = 0;
+      await expect(
+        withRetry(async () => {
+          calls++;
+          throw new HttpFetchError(503, `attempt ${calls}`);
+        }, { sleep: noSleep, maxAttempts: 3 })
+      ).rejects.toThrow("attempt 3");
+      expect(calls).toBe(3);
+    });
+
+    it("uses exponential backoff between attempts", async () => {
+      const delays: number[] = [];
+      let calls = 0;
+      await withRetry(async () => {
+        calls++;
+        if (calls < 3) throw new HttpFetchError(500, "x");
+        return "ok";
+      }, {
+        sleep: async (ms) => { delays.push(ms); },
+        baseDelayMs: 100,
+        maxAttempts: 3,
+      });
+      expect(delays).toEqual([100, 200]);
+    });
+
+    it("invokes onRetry callback for each retry", async () => {
+      const events: Array<{ attempt: number; status?: number }> = [];
+      let calls = 0;
+      await withRetry(async () => {
+        calls++;
+        if (calls < 3) throw new HttpFetchError(500, "boom");
+        return "ok";
+      }, {
+        sleep: noSleep,
+        onRetry: (attempt, err) => {
+          events.push({
+            attempt,
+            status: err instanceof HttpFetchError ? err.status : undefined,
+          });
+        },
+      });
+      expect(events).toEqual([
+        { attempt: 1, status: 500 },
+        { attempt: 2, status: 500 },
+      ]);
     });
   });
 });

--- a/lib/knowledge/sanctions/eu-adapter.ts
+++ b/lib/knowledge/sanctions/eu-adapter.ts
@@ -21,6 +21,63 @@ const EU_URL = EU_TOKEN ? `${EU_BASE_URL}?token=${EU_TOKEN}` : EU_BASE_URL;
 export type Fetcher = (url: string) => Promise<string>;
 
 /**
+ * HTTP error with a status code, distinguishable from generic network errors
+ * so withRetry can decide whether to retry (5xx, 429) or fail fast (4xx auth).
+ */
+export class HttpFetchError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpFetchError";
+    this.status = status;
+  }
+}
+
+export interface RetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  shouldRetry?: (err: unknown) => boolean;
+  onRetry?: (attempt: number, err: unknown, nextDelayMs: number) => void;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function defaultShouldRetry(err: unknown): boolean {
+  if (err instanceof HttpFetchError) {
+    return err.status >= 500 || err.status === 429;
+  }
+  // Non-HTTP errors (network failure, DNS, ECONNRESET, …) are transient.
+  return err instanceof Error;
+}
+
+/**
+ * Retries an async function with exponential backoff.
+ * Default: 3 attempts, 1s → 2s, retry on 5xx/429/network, fail fast on 4xx.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {}
+): Promise<T> {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? 3);
+  const baseDelayMs = opts.baseDelayMs ?? 1000;
+  const shouldRetry = opts.shouldRetry ?? defaultShouldRetry;
+  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt >= maxAttempts || !shouldRetry(err)) throw err;
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      opts.onRetry?.(attempt, err, delay);
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}
+
+/**
  * Refreshes EU Consolidated Sanctions entities from upstream source.
  *
  * Input contract:
@@ -184,14 +241,29 @@ function upsertEuEntities(
  * @returns Response text
  */
 async function defaultFetcher(url: string): Promise<string> {
-  const res = await fetch(url, {
-    headers: { "User-Agent": "Quantika-Demo/1.0" },
-  });
-  if (res.status === 401) {
-    throw new Error(
-      "EU fetch failed: 401 (check EU_SANCTIONS_TOKEN env var for token rotation)"
-    );
-  }
-  if (!res.ok) throw new Error(`EU fetch failed: ${res.status}`);
-  return res.text();
+  return withRetry(
+    async () => {
+      const res = await fetch(url, {
+        headers: { "User-Agent": "Quantika-Demo/1.0" },
+      });
+      if (res.status === 401) {
+        throw new HttpFetchError(
+          401,
+          "EU fetch failed: 401 (check EU_SANCTIONS_TOKEN env var for token rotation)"
+        );
+      }
+      if (!res.ok) {
+        throw new HttpFetchError(res.status, `EU fetch failed: ${res.status}`);
+      }
+      return res.text();
+    },
+    {
+      onRetry: (attempt, err, nextDelayMs) => {
+        const status = err instanceof HttpFetchError ? err.status : "network";
+        console.warn(
+          `[EU] attempt ${attempt} failed (${status}), retrying in ${nextDelayMs}ms`
+        );
+      },
+    }
+  );
 }


### PR DESCRIPTION
## Summary

- EU Commission endpoint returned transient 500s 10-11 May, failing daily `quantika-sanctions-refresh` cron 2 days in a row
- OFAC always succeeded, but heartbeat required both → cron exit 1, monitoring alerted
- Added `withRetry` wrapper around `defaultFetcher`: 3 attempts max, exponential backoff (1s → 2s), retries 5xx + 429 + network errors, fails fast on 401/403/404

## Behavior

- Transient upstream blips → automatically recovered, heartbeat sent
- Token expired (401/403) → fails immediately, no wasted retries
- Persistent 5xx (real outage) → still exits 1 so stale sanctions surface to ops

## Test plan

- [x] 22/22 eu-adapter tests pass (12 existing + 10 new behavioral)
- [x] 59/59 all sanctions tests pass (no regressions in ofac/parsers)
- [x] PI3: 0 existing test expectations rewritten
- [x] Manual: `curl` with current `EU_SANCTIONS_TOKEN` returns 200 OK + 24MB XML (endpoint healthy now)
- [ ] After merge: trigger `systemctl start quantika-sanctions-refresh.service` on VPS, verify EXIT=0 + heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)