### PR TITLE
fix(auth): bypass middleware for /api/admin/cron-heartbeat

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -53,6 +53,7 @@ describe('middleware auth guard', () => {
       '/api/auth/login',
       '/api/auth/logout',
       '/favicon.ico',
+      '/api/admin/cron-heartbeat',
       '/_next/static/chunks/main.js',
       '/_next/image?url=x',
     ];

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,8 @@ const AUTH_BYPASS_PATHS = new Set([
   '/api/auth/logout',
   '/favicon.ico',
   '/api/health',
+  // Cron heartbeat has its own X-Cron-Secret auth — must not be redirected to /login
+  '/api/admin/cron-heartbeat',
 ]);
 
 const AUTH_BYPASS_PREFIXES = ['/_next/static', '/_next/image', '/_next/webpack'];


### PR DESCRIPTION
After demo-auth activation, sanctions cron passed EU refresh (#118) but failed final heartbeat — middleware redirected /api/admin/cron-heartbeat to /login. Endpoint has its own X-Cron-Secret auth.

Verified on VPS after #118 deploy:
- [EU] Done: rowsChanged=0 (fix works)
- [Heartbeat] Failed: HTML <!DOCTYPE> not JSON (this PR fixes)

Tests: 16/16 middleware-auth pass.