### PR TITLE
test(import-gmail): align query test with sender-filter contract

### DIFF
--- a/scripts/__tests__/import-gmail-emails.test.ts
+++ b/scripts/__tests__/import-gmail-emails.test.ts
@@ -227,12 +227,12 @@ describe('run() — import-gmail-emails', () => {
   });
 
   describe('Gmail query format', () => {
-    it('uses quoted label name with spaces and underscores', async () => {
+    it('filters by sender email (from:management@etm-services.net)', async () => {
       const gmail = makeGmailMock({ threads: [] });
       await run(baseOpts({ gmailClient: gmail }));
 
       const allLogs = consoleSpy.mock.calls.flat().join(' ');
-      expect(allLogs).toContain('label:"_ ETMS - Management"');
+      expect(allLogs).toContain('from:management@etm-services.net');
     });
   });
 


### PR DESCRIPTION
## Summary
- Main has been red since 762c0aa changed the Gmail query from `label:"_ ETMS - Management"` to `from:management@etm-services.net`, but the matching assertion in `scripts/__tests__/import-gmail-emails.test.ts` wasn't updated.
- One test fails (`Gmail query format → uses quoted label name with spaces and underscores`), causing the CI Test job to red on main and all 5 open dependabot PRs (#112-#116).
- Fix: update the assertion to the deployed contract (`from:management@etm-services.net`). No production code touched.

## Root cause
The `TypeError: Cannot read properties of undefined (reading 'entries')` lines in CI logs are `logger.error` noise from `compare-routes-da.test.ts` — `callAiText` catches and returns fallback, so those tests pass. The only actual failure is the gmail query-format assertion.

## Test plan
- [x] `npx jest scripts/__tests__/import-gmail-emails.test.ts` → 18/18 pass
- [ ] CI Test job green
- [ ] After merge: rebase + merge dependabot PRs #112, #113, #114, #116 (safe deps). #115 (@google/genai 2.0.1 major) needs separate changelog review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)