### PR TITLE
fix(security): auth guard for agent endpoints + roi ordering fix

### DIFF
--- a/__tests__/api/roi.test.ts
+++ b/__tests__/api/roi.test.ts
@@ -12,6 +12,11 @@ jest.mock('@/lib/session-store', () => ({
   })),
 }));
 
+// Bypass auth — these tests cover ROI logic, not auth (see test_roi_auth_regression.test.ts)
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(() => ({ session: { accessToken: 'test-token' }, sessionId: 'test-session-id' })),
+}));
+
 /**
  * Input Contract:
  * - Feature flag ROI_GUARANTEE_ENABLED !== 'true' → 503 with {error: "feature disabled"}

--- a/__tests__/regression/test_agent_auth_regression.test.ts
+++ b/__tests__/regression/test_agent_auth_regression.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression lock: /api/agent/plan and /api/agent/execute requireSession guards
+ *
+ * Both endpoints were unauthenticated prior to this fix. These tests lock:
+ * - Unauthenticated POST to /api/agent/plan → 401 (not 500 or 200)
+ * - Unauthenticated POST to /api/agent/execute → 401 (not 400 or 200)
+ *
+ * DO NOT mock lib/session — the whole point is to test real auth rejection.
+ */
+
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getSession: (_id: string) => null,
+    expireOldSessions: () => {},
+  })),
+}));
+
+jest.mock('@/lib/agent/plan-first', () => ({
+  buildPlan: jest.fn(),
+  executePlan: jest.fn(),
+}));
+
+describe('REGRESSION: /api/agent/plan — auth guard', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns 401 when no session cookie', async () => {
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const req = new NextRequest('http://localhost:3000/api/agent/plan', {
+      method: 'POST',
+      body: JSON.stringify({ goal: 'test' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  it('returns 401 when session_id cookie is invalid', async () => {
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const req = new NextRequest('http://localhost:3000/api/agent/plan', {
+      method: 'POST',
+      body: JSON.stringify({ goal: 'test' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'session_id=deadbeef00000000ffffffffffffffff',
+      },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+});
+
+describe('REGRESSION: /api/agent/execute — auth guard', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns 401 when no session cookie', async () => {
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const req = new NextRequest('http://localhost:3000/api/agent/execute', {
+      method: 'POST',
+      body: JSON.stringify({
+        planId: 'p1',
+        plan: {
+          planId: 'p1',
+          goal: 'test',
+          steps: [],
+          estimated_actions: 0,
+          createdAt: new Date().toISOString(),
+        },
+        approvedStepIds: [],
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  it('returns 401 when session_id cookie is invalid', async () => {
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const req = new NextRequest('http://localhost:3000/api/agent/execute', {
+      method: 'POST',
+      body: JSON.stringify({
+        planId: 'p1',
+        plan: {
+          planId: 'p1',
+          goal: 'test',
+          steps: [],
+          estimated_actions: 0,
+          createdAt: new Date().toISOString(),
+        },
+        approvedStepIds: [],
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'session_id=deadbeef00000000ffffffffffffffff',
+      },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+});

--- a/__tests__/regression/test_roi_auth_regression.test.ts
+++ b/__tests__/regression/test_roi_auth_regression.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression lock: /api/analytics/roi requireSession guard
+ *
+ * Finding F1 from test-skill adversarial QA (2026-05-12):
+ * The security fix (commit e2a433a) added requireSession() to /api/analytics/roi,
+ * but the original TDD tests mock session-store and never test the 401 path.
+ *
+ * This regression test locks: unauthenticated requests MUST return 401
+ * even when ROI_GUARANTEE_ENABLED=true.
+ *
+ * If requireSession is accidentally removed in a future wave, this test fails.
+ * DO NOT mock lib/session here — the whole point is to test real auth rejection.
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+    // getSession always returns null = no valid sessions in test DB
+    getSession: (_id: string) => null,
+    expireOldSessions: () => {},
+  })),
+}));
+
+// IMPORTANT: Do NOT mock lib/session — we want real requireSession to run.
+// The session store IS mocked for DB access, but getSession returns null
+// for any cookie value = simulates no valid sessions.
+
+describe('REGRESSION: /api/analytics/roi — auth guard (F1)', () => {
+  beforeEach(() => {
+    testDb = new Database(':memory:');
+    runMigrations(testDb, allMigrations);
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    testDb.close();
+    delete process.env.ROI_GUARANTEE_ENABLED;
+  });
+
+  it('returns 401 when no session cookie and feature flag is ON', async () => {
+    process.env.ROI_GUARANTEE_ENABLED = 'true';
+
+    const { GET } = await import('@/app/api/analytics/roi/route');
+
+    // Request with NO session_id cookie
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  it('returns 401 when session_id cookie has a fake/unknown value', async () => {
+    process.env.ROI_GUARANTEE_ENABLED = 'true';
+
+    const { GET } = await import('@/app/api/analytics/roi/route');
+
+    // Request with a random/tampered session_id not in the DB
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi', {
+      headers: {
+        Cookie: 'session_id=aaaabbbbccccdddd0000111122223333',
+      },
+    });
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  it('returns 401 (not 503) when unauthenticated and feature flag is OFF', async () => {
+    // Ordering regression: auth must run before feature-flag check.
+    // Before fix: unauthenticated users got 503 "Feature not enabled" leaking feature state.
+    process.env.ROI_GUARANTEE_ENABLED = 'false';
+
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/api/agent/execute/route.ts
+++ b/app/api/agent/execute/route.ts
@@ -7,8 +7,9 @@
  * Idempotent — re-POST с тем же planId возвращает cached ExecutionResult.
  */
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { requireSession } from '@/lib/session';
 import { executePlan } from '@/lib/agent/plan-first';
 import { PLAN_STEP_KINDS } from '@/lib/agent/plan-types';
 
@@ -37,7 +38,10 @@ const Body = z.object({
   approvedStepIds: z.array(z.string()),
 });
 
-export async function POST(req: Request): Promise<NextResponse> {
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const authResult = requireSession(req);
+  if (authResult instanceof NextResponse) return authResult;
+
   let payload: unknown;
   try {
     payload = await req.json();

--- a/app/api/agent/plan/route.ts
+++ b/app/api/agent/plan/route.ts
@@ -5,8 +5,9 @@
  * Returns: Plan JSON.
  */
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { requireSession } from '@/lib/session';
 import { buildPlan } from '@/lib/agent/plan-first';
 
 export const dynamic = 'force-dynamic';
@@ -16,7 +17,10 @@ const Body = z.object({
   context: z.record(z.unknown()).optional(),
 });
 
-export async function POST(req: Request): Promise<NextResponse> {
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const authResult = requireSession(req);
+  if (authResult instanceof NextResponse) return authResult;
+
   let payload: unknown;
   try {
     payload = await req.json();

--- a/app/api/analytics/roi/route.ts
+++ b/app/api/analytics/roi/route.ts
@@ -14,14 +14,14 @@ import { getRoiSummary } from "@/lib/analytics/roi-metrics";
  * Feature flag: ROI_GUARANTEE_ENABLED
  */
 export async function GET(request: NextRequest) {
+  // Require authentication first — unauthenticated users must not see feature state
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+
   // Check feature flag
   if (process.env.ROI_GUARANTEE_ENABLED !== "true") {
     return NextResponse.json({ error: "Feature not enabled" }, { status: 503 });
   }
-
-  // Require authentication
-  const authResult = requireSession(request);
-  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const store = getStore();

--- a/tests/agent/api-routes.test.ts
+++ b/tests/agent/api-routes.test.ts
@@ -7,13 +7,20 @@
  * Assert-budget: ≤ 30 expects.
  */
 
+import { NextRequest } from 'next/server';
 import { POST as planPOST } from '@/app/api/agent/plan/route';
 import { POST as execPOST } from '@/app/api/agent/execute/route';
 import { _resetIdempotencyCache } from '@/lib/agent/idempotency';
 import { resetStepHandlers, setStepHandler } from '@/lib/agent/plan-first';
 
-function jsonReq(body: unknown): Request {
-  return new Request('http://localhost/api/agent/test', {
+// Bypass auth — these tests cover plan/execute logic, not auth
+// (see __tests__/regression/test_agent_auth_regression.test.ts for 401 coverage)
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(() => ({ session: { accessToken: 'test-token' }, sessionId: 'test-session-id' })),
+}));
+
+function jsonReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/agent/test', {
     method: 'POST',
     body: JSON.stringify(body),
     headers: { 'content-type': 'application/json' },
@@ -49,7 +56,7 @@ describe('β-11 API: /api/agent/plan', () => {
   });
 
   it('rejects malformed JSON', async () => {
-    const req = new Request('http://localhost/api/agent/plan', {
+    const req = new NextRequest('http://localhost/api/agent/plan', {
       method: 'POST',
       body: 'not json',
       headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
## Summary

- **`POST /api/agent/plan`** — був повністю без auth. Будь-хто міг ініціювати необмежені LLM-дзвінки. Додано `requireSession()` першим чеком.
- **`POST /api/agent/execute`** — був повністю без auth. Будь-хто міг надсилати email та WhatsApp. Додано `requireSession()` першим чеком.
- **`GET /api/analytics/roi`** — перевірка feature flag стояла *перед* auth, тому неавтентифіковані запити отримували `503 "Feature not enabled"` замість `401` — витікав стан feature. Порядок поміняно: auth → feature flag.

## Зміни

| Файл | Що змінено |
|------|-----------|
| `app/api/agent/plan/route.ts` | `Request` → `NextRequest`, `requireSession` guard |
| `app/api/agent/execute/route.ts` | `Request` → `NextRequest`, `requireSession` guard |
| `app/api/analytics/roi/route.ts` | auth переміщено перед feature flag |
| `tests/agent/api-routes.test.ts` | `Request` → `NextRequest`, session mock |
| `__tests__/api/roi.test.ts` | session mock (функціональні тести) |
| `__tests__/regression/test_roi_auth_regression.test.ts` | +кейс ordering (401 коли flag=false) |
| `__tests__/regression/test_agent_auth_regression.test.ts` | новий — локує 401 на обох endpoints |

## Test plan

- [x] 19/19 тестів зелені (api/roi, regression/test_roi_auth_regression, regression/test_agent_auth_regression, tests/agent/api-routes)
- [x] TypeScript + ESLint чисті (pre-commit hook пройшов)
- [x] 1 коміт, без зайвих змін

🤖 Generated with [Claude Code](https://claude.com/claude-code)