### PR TITLE
feat(gamma-followup): Wave γ UX fixes — 6 specs

### DIFF
--- a/__tests__/regression/RC-bimco-seed.test.ts
+++ b/__tests__/regression/RC-bimco-seed.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression: RC-bimco-seed
+ *
+ * Verifies that seed-bimco-clauses.ts:
+ * 1. Exists at the expected path
+ * 2. syncBimcoRag inserts > 0 rows (calls embedAndStore with bimco_fts)
+ * 3. Is idempotent — adapter uses truncate:true, so re-run doesn't duplicate
+ *
+ * Spec: F-04
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// Factory mocks — governance imports @sentry/nextjs which blocks auto-mock
+jest.mock('@/lib/knowledge/governance', () => ({
+  reportSyncStarted: jest.fn(),
+  reportSyncSuccess: jest.fn(),
+  reportSyncFailure: jest.fn(),
+  registerSource: jest.fn(),
+}));
+jest.mock('@/lib/knowledge/embeddings/pipeline', () => ({
+  embedAndStore: jest.fn(),
+}));
+
+import * as governance from '@/lib/knowledge/governance';
+import * as pipeline from '@/lib/knowledge/embeddings/pipeline';
+import { syncBimcoRag } from '@/lib/knowledge/sources/bimco/adapter';
+import { BIMCO_FIXTURE_CLAUSES } from '@/lib/knowledge/sources/bimco/fixture';
+
+const SCRIPT_PATH = path.join(process.cwd(), 'scripts/seed-bimco-clauses.ts');
+
+describe('RC-bimco-seed — seed-bimco-clauses.ts', () => {
+  const mockDb = {} as import('better-sqlite3').Database;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (governance.reportSyncStarted as jest.Mock).mockReturnValue(1);
+    (governance.reportSyncSuccess as jest.Mock).mockReturnValue(undefined);
+    (governance.reportSyncFailure as jest.Mock).mockReturnValue(undefined);
+    (pipeline.embedAndStore as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('script file', () => {
+    it('exists at scripts/seed-bimco-clauses.ts', () => {
+      expect(fs.existsSync(SCRIPT_PATH)).toBe(true);
+    });
+
+    it('imports syncBimcoRag or refresh-bimco-rag', () => {
+      const content = fs.readFileSync(SCRIPT_PATH, 'utf-8');
+      expect(content).toMatch(/syncBimcoRag|refresh-bimco-rag/);
+    });
+  });
+
+  describe('syncBimcoRag adapter', () => {
+    it('calls embedAndStore with > 0 chunks (bimco_fts)', async () => {
+      await syncBimcoRag(mockDb, false);
+
+      expect(pipeline.embedAndStore).toHaveBeenCalledTimes(1);
+      const [chunks, opts] = (pipeline.embedAndStore as jest.Mock).mock.calls[0];
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(opts.ftsTable).toBe('bimco_fts');
+    });
+
+    it('stored count equals fixture clause count', async () => {
+      const result = await syncBimcoRag(mockDb, false);
+      expect(result.stored).toBe(BIMCO_FIXTURE_CLAUSES.length);
+      expect(result.stored).toBeGreaterThan(0);
+    });
+
+    it('idempotency: uses truncate:true so re-run overwrites', async () => {
+      await syncBimcoRag(mockDb, false);
+      const [, opts] = (pipeline.embedAndStore as jest.Mock).mock.calls[0];
+      expect(opts.truncate).toBe(true);
+    });
+
+    it('dry-run skips embedAndStore but returns correct count', async () => {
+      const result = await syncBimcoRag(mockDb, true);
+      expect(pipeline.embedAndStore).not.toHaveBeenCalled();
+      expect(result.stored).toBeGreaterThan(0);
+    });
+
+    it('each chunk has bimco source metadata', async () => {
+      let capturedChunks: Array<{ content: string; metadata: Record<string, unknown> }> = [];
+      (pipeline.embedAndStore as jest.Mock).mockImplementationOnce(
+        async (chunks: typeof capturedChunks) => {
+          capturedChunks = chunks;
+        }
+      );
+
+      await syncBimcoRag(mockDb, false);
+
+      expect(capturedChunks.length).toBeGreaterThan(0);
+      for (const chunk of capturedChunks) {
+        expect(chunk.content.length).toBeGreaterThan(10);
+        expect(chunk.metadata.source).toBe('bimco');
+        expect(chunk.metadata.charterParty).toBeTruthy();
+        expect(chunk.metadata.title).toBeTruthy();
+      }
+    });
+  });
+});

--- a/__tests__/regression/RC-fueleu-flag.test.tsx
+++ b/__tests__/regression/RC-fueleu-flag.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Regression: RC-fueleu-flag
+ * Guard: NEXT_PUBLIC_FUELEU_ENABLED controls client-side FuelEU tile visibility.
+ * When the flag is NOT 'true', the fueleu-tile must NOT appear in the DOM.
+ *
+ * EconomicsTab reads process.env.NEXT_PUBLIC_FUELEU_ENABLED inline (line 93),
+ * so mutating process.env before render() is sufficient — no resetModules needed.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EconomicsTab } from '@/components/match/EconomicsTab';
+
+// Mock heavy dependencies
+jest.mock('@/components/economics/RouteCompareModal', () => ({
+  RouteCompareModal: () => null,
+}));
+jest.mock('@/lib/economics/fueleu', () => ({
+  calculateFuelEu: jest.fn(() => ({
+    ghgIntensityActual: 91.0,
+    ghgIntensityTarget: 89.0,
+    complianceFactor: 1.02,
+    deficit: 1000,
+    penaltyEur: 2400000,
+    penaltyUsd: 2616000,
+    badge: 'non-compliant',
+  })),
+}));
+
+describe('RC-fueleu-flag — NEXT_PUBLIC_FUELEU_ENABLED gate', () => {
+  const originalValue = process.env.NEXT_PUBLIC_FUELEU_ENABLED;
+
+  afterEach(() => {
+    // restore original value
+    if (originalValue === undefined) {
+      delete process.env.NEXT_PUBLIC_FUELEU_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_FUELEU_ENABLED = originalValue;
+    }
+  });
+
+  it('fueleu-tile is absent when NEXT_PUBLIC_FUELEU_ENABLED is not set', () => {
+    delete process.env.NEXT_PUBLIC_FUELEU_ENABLED;
+    const { queryByTestId } = render(<EconomicsTab />);
+    expect(queryByTestId('fueleu-tile')).toBeNull();
+  });
+
+  it('fueleu-tile is absent when NEXT_PUBLIC_FUELEU_ENABLED=false', () => {
+    process.env.NEXT_PUBLIC_FUELEU_ENABLED = 'false';
+    const { queryByTestId } = render(<EconomicsTab />);
+    expect(queryByTestId('fueleu-tile')).toBeNull();
+  });
+
+  it('fueleu-tile is present when NEXT_PUBLIC_FUELEU_ENABLED=true', () => {
+    process.env.NEXT_PUBLIC_FUELEU_ENABLED = 'true';
+    const { queryByTestId } = render(<EconomicsTab />);
+    expect(queryByTestId('fueleu-tile')).not.toBeNull();
+  });
+});

--- a/__tests__/regression/RC-market-tmi.test.ts
+++ b/__tests__/regression/RC-market-tmi.test.ts
@@ -1,0 +1,90 @@
+/**
+ * RC-market-tmi.test.ts
+ *
+ * Regression test for F-03: GET /api/market/tmi alias route.
+ *
+ * Covers:
+ * - 404 when market_indices table has no tmi rows
+ * - 200 with { value: number, date: string, unit: string } when data present
+ */
+
+import Database from 'better-sqlite3';
+import migration027 from '@/lib/migrations/027-market-indices';
+import { upsertIndex } from '@/lib/market/market-indices-repository';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+describe('GET /api/market/tmi', () => {
+  beforeEach(() => {
+    testDb = new Database(':memory:');
+    migration027.up(testDb);
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  it('returns 404 when table is empty', async () => {
+    const { GET } = await import('@/app/api/market/tmi/route');
+    const req = new Request('http://localhost/api/market/tmi');
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json).toHaveProperty('error');
+  });
+
+  it('returns 200 with value as number when data present', async () => {
+    upsertIndex(testDb, {
+      id: 'tmi-2026-05-13',
+      index_name: 'tmi',
+      index_date: '2026-05-13',
+      value: 5200,
+      unit: 'USD/day',
+      source: 'seed-synthetic',
+      fetched_at: new Date().toISOString(),
+    });
+
+    const { GET } = await import('@/app/api/market/tmi/route');
+    const req = new Request('http://localhost/api/market/tmi');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.value).toBe('number');
+    expect(json).toHaveProperty('date');
+    expect(json).toHaveProperty('unit');
+  });
+
+  it('returns the most recent tmi row (boundary: multiple rows)', async () => {
+    const rows = [
+      { id: 'tmi-2026-05-11', date: '2026-05-11', value: 4800 },
+      { id: 'tmi-2026-05-13', date: '2026-05-13', value: 5200 },
+      { id: 'tmi-2026-05-12', date: '2026-05-12', value: 5000 },
+    ];
+    for (const r of rows) {
+      upsertIndex(testDb, {
+        id: r.id,
+        index_name: 'tmi',
+        index_date: r.date,
+        value: r.value,
+        unit: 'USD/day',
+        source: 'seed-synthetic',
+        fetched_at: new Date().toISOString(),
+      });
+    }
+
+    const { GET } = await import('@/app/api/market/tmi/route');
+    const req = new Request('http://localhost/api/market/tmi');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.value).toBe(5200);
+    expect(json.date).toBe('2026-05-13');
+  });
+});

--- a/__tests__/regression/RC-roi-tile-import.test.tsx
+++ b/__tests__/regression/RC-roi-tile-import.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Regression: RC-roi-tile-import (F-02)
+ * Guard: NEXT_PUBLIC_ROI_GUARANTEE_ENABLED controls RoiSummaryTile visibility.
+ * When the flag is NOT 'true', the component must return null.
+ * When flag IS 'true', the component must render (at least loading state).
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RoiSummaryTile } from '@/components/dashboard/RoiSummaryTile';
+
+// Mock global fetch — component calls /api/analytics/roi?days=90
+const mockFetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        totalVoyages: 5,
+        totalSavingsUsd: 12000,
+        avgSavingsPerVoyage: 2400,
+        roiMultiple: 3.2,
+        cohorts: [],
+      }),
+  })
+) as jest.Mock;
+
+beforeAll(() => {
+  global.fetch = mockFetch;
+});
+
+afterAll(() => {
+  // @ts-expect-error restore
+  delete global.fetch;
+});
+
+describe('RC-roi-tile-import — NEXT_PUBLIC_ROI_GUARANTEE_ENABLED gate', () => {
+  const originalValue = process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED = originalValue;
+    }
+  });
+
+  it('roi tile is absent when NEXT_PUBLIC_ROI_GUARANTEE_ENABLED is not set', () => {
+    delete process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED;
+    const { container } = render(<RoiSummaryTile />);
+    expect(container.firstChild).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('roi tile is absent when NEXT_PUBLIC_ROI_GUARANTEE_ENABLED=false', () => {
+    process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED = 'false';
+    const { container } = render(<RoiSummaryTile />);
+    expect(container.firstChild).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('roi tile is present when NEXT_PUBLIC_ROI_GUARANTEE_ENABLED=true', () => {
+    process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED = 'true';
+    const { getByText } = render(<RoiSummaryTile />);
+    // Component renders loading state immediately (before fetch resolves)
+    expect(getByText('90-Day ROI Summary')).toBeInTheDocument();
+  });
+});

--- a/__tests__/regression/RC-sample-match.test.ts
+++ b/__tests__/regression/RC-sample-match.test.ts
@@ -1,0 +1,18 @@
+import { getDemoVessel, getDemoCargo } from '../../scripts/seed-sample-data';
+
+describe('RC-sample-match: demo data для EconomicsTab', () => {
+  it('demo vessel имеет обязательные поля для EconomicsTab', () => {
+    const v = getDemoVessel();
+    expect(v.dwtSummer?.value).toBeDefined();
+    // speedLaden и consumption — строки, могут быть null, но поле должно существовать
+    expect('speedLaden' in v).toBe(true);
+    expect('consumption' in v).toBe(true);
+  });
+
+  it('demo cargo имеет обязательные поля для EconomicsTab', () => {
+    const c = getDemoCargo();
+    expect(c.weightMt?.value).toBeDefined();
+    expect(c.originPort?.value).toBeDefined();
+    expect(c.destinationPort?.value).toBeDefined();
+  });
+});

--- a/__tests__/regression/RC-subs-countdown-import.test.tsx
+++ b/__tests__/regression/RC-subs-countdown-import.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Regression: RC-subs-countdown-import (F-01)
+ * Guard: NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED controls SubsCountdownWidget visibility.
+ * When the flag is NOT 'true', the component must return null.
+ * When flag IS 'true', the component must render with demo data.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SubsCountdownWidget from '@/components/deals/SubsCountdownWidget';
+
+const DEMO_DEAL_ID = 'demo-deal-001';
+const DEMO_SUBS_DEADLINE = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
+
+describe('RC-subs-countdown-import — NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED gate', () => {
+  const originalValue = process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED;
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = originalValue;
+    }
+  });
+
+  it('widget is absent when NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED is not set', () => {
+    delete process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED;
+    const { container } = render(
+      <SubsCountdownWidget
+        dealId={DEMO_DEAL_ID}
+        subsDeadline={DEMO_SUBS_DEADLINE}
+        chartererTier="blue-chip"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('widget is absent when NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED=false', () => {
+    process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = 'false';
+    const { container } = render(
+      <SubsCountdownWidget
+        dealId={DEMO_DEAL_ID}
+        subsDeadline={DEMO_SUBS_DEADLINE}
+        chartererTier="blue-chip"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('widget is present when NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED=true', () => {
+    process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = 'true';
+    const { getByTestId } = render(
+      <SubsCountdownWidget
+        dealId={DEMO_DEAL_ID}
+        subsDeadline={DEMO_SUBS_DEADLINE}
+        chartererTier="blue-chip"
+      />,
+    );
+    expect(getByTestId(`subs-countdown-${DEMO_DEAL_ID}`)).toBeInTheDocument();
+  });
+});

--- a/app/api/market/tmi/route.ts
+++ b/app/api/market/tmi/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getStore } from '@/lib/session-store';
+import { getIndexHistory } from '@/lib/market/market-indices-repository';
+
+export async function GET(_req: Request): Promise<NextResponse> {
+  const db = getStore().getDatabase();
+  const rows = getIndexHistory(db, 'tmi', 7);
+  if (!rows.length) {
+    return NextResponse.json({ error: 'No TMI data' }, { status: 404 });
+  }
+  const latest = rows[0];
+  return NextResponse.json({
+    value: latest.value,
+    date: latest.index_date,
+    unit: latest.unit,
+  });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,12 +10,18 @@ import { countAwaitingApproval } from '@/lib/auto-prequote/queue';
 import { PriorityCard } from '@/components/dashboard/PriorityCard';
 import { InboxBreakdown } from '@/components/dashboard/InboxBreakdown';
 import { MarketIntelligence } from '@/components/dashboard/MarketIntelligence';
+import { RoiSummaryTile } from '@/components/dashboard/RoiSummaryTile';
+import SubsCountdownWidget from '@/components/deals/SubsCountdownWidget';
 import { classifyPriority } from '@/lib/sailing/priority-classifier';
 import type { PriorityLevel } from '@/lib/sailing/priority-classifier';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { formatNumber } from '@/lib/utils';
 
 const PRIORITY_ORDER: Record<PriorityLevel, number> = { urgent: 0, attention: 1, ok: 2 };
+
+// Demo data for SubsCountdownWidget (F-01) — static, server-safe
+const DEMO_DEAL_ID = 'demo-deal-001';
+const DEMO_SUBS_DEADLINE = '2099-01-01T12:00:00.000Z';
 
 export default async function DashboardPage() {
   const cookieStore = await cookies();
@@ -118,6 +124,7 @@ export default async function DashboardPage() {
   const urgentCount = priorityCards.filter((c) => c.priority === 'urgent').length;
   const noActiveDeals = goodMatches.length === 0;
 
+
   return (
     <main className="min-h-screen bg-gray-50 py-4 sm:py-8 px-3 sm:px-4">
       <AnalyticsTracker event="dashboard_viewed" />
@@ -130,6 +137,9 @@ export default async function DashboardPage() {
           errors={0}
         />
 
+        {/* ── γ-18: ROI Summary Tile (feature flag) ──────────────── */}
+        {process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED === 'true' && <RoiSummaryTile />}
+
         {/* ── Morning Header ─────────────────────────────────────── */}
         <div>
           <MorningHeader userName="Broker" alertCount={urgentCount} />
@@ -139,6 +149,15 @@ export default async function DashboardPage() {
             </span>
           )}
         </div>
+
+        {/* ── F-01: Subs Countdown Widget (feature flag) ─────────── */}
+        {process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED === 'true' && (
+          <SubsCountdownWidget
+            dealId={DEMO_DEAL_ID}
+            subsDeadline={DEMO_SUBS_DEADLINE}
+            chartererTier="blue-chip"
+          />
+        )}
 
         {/* ── Top Priorities ─────────────────────────────────────── */}
         <section>

--- a/scripts/seed-bimco-clauses.ts
+++ b/scripts/seed-bimco-clauses.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env tsx
+/**
+ * Seed script: populates bimco_fts + bimco_vec with BIMCO charter party clauses.
+ *
+ * Thin wrapper around syncBimcoRag — uses fixture data (no scraping).
+ * Idempotent: truncate=true in adapter means re-runs overwrite, not duplicate.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-bimco-clauses.ts [--dry-run]
+ *
+ * Spec: F-04
+ */
+
+import { getStore } from '@/lib/session-store';
+import { syncBimcoRag } from '@/lib/knowledge/sources/bimco/adapter';
+
+async function seed(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+  const db = getStore().getDb();
+  const result = await syncBimcoRag(db, dryRun);
+  const prefix = dryRun ? '[DRY RUN] ' : '';
+  console.log(`${prefix}BIMCO seed complete: ${result.stored} clauses stored`);
+}
+
+seed().catch((err) => {
+  console.error('BIMCO seed failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-market-indices.ts
+++ b/scripts/seed-market-indices.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env tsx
+/**
+ * Thin wrapper — delegates to scripts/knowledge/seeds/seed-market-indices.ts
+ * Usage: npx tsx scripts/seed-market-indices.ts
+ */
+import { seedMarketIndices } from './knowledge/seeds/seed-market-indices';
+
+seedMarketIndices();

--- a/scripts/seed-sample-data.ts
+++ b/scripts/seed-sample-data.ts
@@ -1,0 +1,19 @@
+import vessels from '../lib/sample-data/demo-parsed-vessels.json';
+import cargoes from '../lib/sample-data/demo-parsed-cargoes.json';
+import type { ParsedVessel, ParsedCargo } from '../lib/types';
+
+export function getDemoVessel(): ParsedVessel {
+  return vessels[0] as unknown as ParsedVessel;
+}
+
+export function getDemoCargo(): ParsedCargo {
+  return cargoes[0] as unknown as ParsedCargo;
+}
+
+if (require.main === module) {
+  const vessel = getDemoVessel();
+  const cargo = getDemoCargo();
+  console.log('Demo vessel:', (vessel.vesselName as { value?: string } | null)?.value ?? 'unknown');
+  console.log('Demo cargo:', (cargo.cargoDescription as { value?: string } | null)?.value ?? 'unknown');
+  console.log('Sample match ready for EconomicsTab testing.');
+}


### PR DESCRIPTION
## Summary

Wave γ Scale deployed (v0.5.1-gamma-scale). UX walkthrough found 6 issues — components were built but not wired up, seed data missing, one endpoint broken.

- **F-01** `SubsCountdownWidget` wired into dashboard behind `NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED`
- **F-02** `RoiSummaryTile` wired into dashboard behind `NEXT_PUBLIC_ROI_GUARANTEE_ENABLED`
- **F-03** `/api/market/tmi` alias route added (was causing "Failed to fetch TMI"). Seed script `scripts/seed-market-indices.ts` added
- **F-04** `scripts/seed-bimco-clauses.ts` created — thin wrapper around existing `syncBimcoRag()` fixture adapter
- **F-05** `scripts/seed-sample-data.ts` created — `getDemoVessel()` / `getDemoCargo()` helpers for EconomicsTab testing
- **F-06** `.env.local.example` + `EconomicsTab.tsx` verified correct (`NEXT_PUBLIC_FUELEU_ENABLED` already properly wired)

## Test plan

- [ ] 697 regression tests pass (`npx jest __tests__/regression/`)
- [ ] 6 new RC tests added (RC-fueleu-flag, RC-market-tmi, RC-bimco-seed, RC-roi-tile-import, RC-subs-countdown-import, RC-sample-match)
- [ ] TypeScript + ESLint clean (pre-commit hooks passed)
- [ ] All feature flags default OFF — inert deploy
- [ ] VPS: run seed scripts after deploy (`seed-market-indices.ts`, `seed-bimco-clauses.ts`)
- [ ] Enable γ flags on VPS to verify 6 features visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)