### PR TITLE
feat(market): add drewry-bb synthetic data to seed-market-indices

### DIFF
--- a/__tests__/sample/sample-demo-match.test.ts
+++ b/__tests__/sample/sample-demo-match.test.ts
@@ -161,7 +161,7 @@ describe('spec-03: demo seed-match for EconomicsTab', () => {
     expect(originalDemoMatch).toBeDefined();
 
     // Simulate AI returning zero matches (worst case)
-    const aiMatches: typeof session.matches = [];
+    const aiMatches: NonNullable<typeof session>['matches'] = [];
 
     // Guard logic (mirrors /api/ai/match/route.ts)
     const hasDemoMatch = aiMatches.some(

--- a/__tests__/scripts/seed-market-indices.test.ts
+++ b/__tests__/scripts/seed-market-indices.test.ts
@@ -1,0 +1,58 @@
+import Database from 'better-sqlite3';
+import migration027 from '@/lib/migrations/027-market-indices';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: () => testDb })),
+}));
+
+describe('seedMarketIndices', () => {
+  beforeEach(() => {
+    testDb = new Database(':memory:');
+    migration027.up(testDb);
+    jest.resetModules();
+  });
+  afterEach(() => {
+    testDb.close();
+  });
+
+  it('seeds rows for all 3 sources: bhsi, tmi, drewry-bb', async () => {
+    const { seedMarketIndices } = await import(
+      '@/scripts/knowledge/seeds/seed-market-indices'
+    );
+    seedMarketIndices();
+    const sources = (
+      testDb
+        .prepare('SELECT DISTINCT index_name FROM market_indices ORDER BY index_name')
+        .all() as { index_name: string }[]
+    ).map((r) => r.index_name);
+    expect(sources).toEqual(['bhsi', 'drewry-bb', 'tmi']);
+  });
+
+  it('seeds 30 rows for drewry-bb', async () => {
+    const { seedMarketIndices } = await import(
+      '@/scripts/knowledge/seeds/seed-market-indices'
+    );
+    seedMarketIndices();
+    const count = testDb
+      .prepare("SELECT COUNT(*) as cnt FROM market_indices WHERE index_name='drewry-bb'")
+      .get() as { cnt: number };
+    expect(count.cnt).toBe(30);
+  });
+
+  it('drewry-bb values are in range 1400-1800', async () => {
+    const { seedMarketIndices } = await import(
+      '@/scripts/knowledge/seeds/seed-market-indices'
+    );
+    seedMarketIndices();
+    const rows = testDb
+      .prepare("SELECT value FROM market_indices WHERE index_name='drewry-bb'")
+      .all() as { value: number }[];
+    expect(rows.length).toBe(30);
+    for (const row of rows) {
+      expect(row.value).toBeGreaterThanOrEqual(1400);
+      expect(row.value).toBeLessThanOrEqual(1800);
+    }
+  });
+});

--- a/scripts/knowledge/seeds/seed-market-indices.ts
+++ b/scripts/knowledge/seeds/seed-market-indices.ts
@@ -77,7 +77,24 @@ export function seedMarketIndices(): void {
   }
   console.log(`  ✓ Seeded ${tmiData.length} TMI rows`);
 
-  console.log(`\n✓ Seeded total ${bhsiData.length + tmiData.length} market index rows.`);
+  // Drewry Breakbulk: range ~$1500-1700 USD/TEU
+  const drewryData = generateSyntheticData('drewry-bb', 30, 1600, 200);
+  console.log('Seeding Drewry Breakbulk Index...');
+  for (const row of drewryData) {
+    const id = `drewry-bb-${row.date}`;
+    upsertIndex(db, {
+      id,
+      index_name: 'drewry-bb',
+      index_date: row.date,
+      value: row.value,
+      unit: 'USD/TEU',
+      source: 'seed-synthetic',
+      fetched_at: new Date().toISOString(),
+    });
+  }
+  console.log(`  ✓ Seeded ${drewryData.length} Drewry BB rows`);
+
+  console.log(`\n✓ Seeded total ${bhsiData.length + tmiData.length + drewryData.length} market index rows.`);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- Adds 30 days of synthetic Drewry Breakbulk Index (`drewry-bb`) data to `seed-market-indices.ts`
- Follows existing BHSI/TMI pattern; range ~1400-1800 USD/TEU, unit USD/TEU
- Fixes pre-existing TS18047 in `sample-demo-match.test.ts` (null-assertion on `session`)

## Test plan
- [x] 3 new tests in `__tests__/scripts/seed-market-indices.test.ts` (all sources seeded, 30 rows, range check)
- [x] Regression suite 697/697 green
- [x] tsc --noEmit clean
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)