### PR TITLE
feat(charterers): add auth + dashboard tile (Task 2.B)

### DIFF
--- a/__tests__/api/charterers-id.test.ts
+++ b/__tests__/api/charterers-id.test.ts
@@ -1,7 +1,8 @@
 import Database from 'better-sqlite3';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import migration026 from '@/lib/migrations/026-charterers';
 import { upsertCharterer } from '@/lib/market/charterers-repository';
+import { requireSession } from '@/lib/session';
 
 let testDb: Database.Database;
 
@@ -10,6 +11,16 @@ jest.mock('@/lib/session-store', () => ({
     getDatabase: () => testDb,
   })),
 }));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+
+beforeEach(() => {
+  mockRequireSession.mockReturnValue({ session: { id: 'test' }, sessionId: 'test-sid' });
+});
 
 /**
  * Input Contract:
@@ -245,5 +256,60 @@ describe('DELETE /api/charterers/[id]', () => {
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toBeDefined();
+  });
+});
+
+describe('Auth: /api/charterers/[id]', () => {
+  const originalEnv = process.env.CHARTERER_CREDIT_ENABLED;
+
+  beforeEach(() => {
+    process.env.CHARTERER_CREDIT_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    process.env.CHARTERER_CREDIT_ENABLED = originalEnv;
+  });
+
+  // PI4 RC test — auth returns 401 when no session
+  it('GET returns 401 when session is missing', async () => {
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
+
+    const { GET } = await import('@/app/api/charterers/[id]/route');
+    const res = await GET(
+      new NextRequest('http://localhost/api/charterers/c1'),
+      { params: Promise.resolve({ id: 'c1' }) }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('PUT returns 401 when session is missing', async () => {
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
+
+    const { PUT } = await import('@/app/api/charterers/[id]/route');
+    const res = await PUT(
+      new NextRequest('http://localhost/api/charterers/c1', {
+        method: 'PUT',
+        body: JSON.stringify({ name: 'Test' }),
+      }),
+      { params: Promise.resolve({ id: 'c1' }) }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('DELETE returns 401 when session is missing', async () => {
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
+
+    const { DELETE } = await import('@/app/api/charterers/[id]/route');
+    const res = await DELETE(
+      new NextRequest('http://localhost/api/charterers/c1', { method: 'DELETE' }),
+      { params: Promise.resolve({ id: 'c1' }) }
+    );
+    expect(res.status).toBe(401);
   });
 });

--- a/__tests__/api/charterers.test.ts
+++ b/__tests__/api/charterers.test.ts
@@ -1,7 +1,8 @@
 import Database from 'better-sqlite3';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import migration026 from '@/lib/migrations/026-charterers';
 import { upsertCharterer } from '@/lib/market/charterers-repository';
+import { requireSession } from '@/lib/session';
 
 let testDb: Database.Database;
 
@@ -10,6 +11,16 @@ jest.mock('@/lib/session-store', () => ({
     getDatabase: () => testDb,
   })),
 }));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+
+beforeEach(() => {
+  mockRequireSession.mockReturnValue({ session: { id: 'test' }, sessionId: 'test-sid' });
+});
 
 /**
  * Input Contract:
@@ -41,7 +52,7 @@ describe('GET /api/charterers', () => {
     process.env.CHARTERER_CREDIT_ENABLED = 'false';
 
     const { GET } = await import('@/app/api/charterers/route');
-    const res = await GET();
+    const res = await GET(new NextRequest('http://localhost/api/charterers'));
 
     expect(res.status).toBe(503);
     const json = await res.json();
@@ -62,7 +73,7 @@ describe('GET /api/charterers', () => {
     });
 
     const { GET } = await import('@/app/api/charterers/route');
-    const res = await GET();
+    const res = await GET(new NextRequest('http://localhost/api/charterers'));
 
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -257,5 +268,42 @@ describe('POST /api/charterers', () => {
     expect(res.status).toBe(201);
     const json = await res.json();
     expect(json.require_lc).toBe(0);
+  });
+});
+
+describe('Auth: /api/charterers', () => {
+  const originalEnv = process.env.CHARTERER_CREDIT_ENABLED;
+
+  beforeEach(() => {
+    process.env.CHARTERER_CREDIT_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    process.env.CHARTERER_CREDIT_ENABLED = originalEnv;
+  });
+
+  // PI4 RC test — auth returns 401 when no session
+  it('GET returns 401 when session is missing', async () => {
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
+
+    const { GET } = await import('@/app/api/charterers/route');
+    const res = await GET(new NextRequest('http://localhost/api/charterers'));
+    expect(res.status).toBe(401);
+  });
+
+  it('POST returns 401 when session is missing', async () => {
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
+
+    const { POST } = await import('@/app/api/charterers/route');
+    const req = new NextRequest('http://localhost/api/charterers', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Test', tier: 'blue-chip' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
   });
 });

--- a/__tests__/pages/dashboard-charterers-link.test.ts
+++ b/__tests__/pages/dashboard-charterers-link.test.ts
@@ -1,0 +1,34 @@
+/**
+ * RC test (PI4) for Charterer Credit dashboard link.
+ *
+ * Verifies that app/dashboard/page.tsx:
+ * - Contains a link to /charterers
+ * - Guards it with NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED flag
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const dashboardPath = path.join(process.cwd(), 'app/dashboard/page.tsx');
+
+describe('Dashboard Charterer Credit link (RC test)', () => {
+  it('dashboard page file exists', () => {
+    expect(fs.existsSync(dashboardPath)).toBe(true);
+  });
+
+  it('dashboard contains a link to /charterers', () => {
+    const source = fs.readFileSync(dashboardPath, 'utf8');
+    expect(source).toMatch(/href="\/charterers"/);
+  });
+
+  it('charterers link is gated by NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED', () => {
+    const source = fs.readFileSync(dashboardPath, 'utf8');
+    expect(source).toMatch(/NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED/);
+    // Flag check and link must be within 400 chars of each other
+    const flagIdx = source.indexOf('NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED');
+    const linkIdx = source.indexOf('href="/charterers"');
+    expect(flagIdx).toBeGreaterThan(-1);
+    expect(linkIdx).toBeGreaterThan(-1);
+    expect(Math.abs(flagIdx - linkIdx)).toBeLessThan(400);
+  });
+});

--- a/app/api/charterers/[id]/route.ts
+++ b/app/api/charterers/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStore } from '@/lib/session-store';
+import { requireSession } from '@/lib/session';
 import {
   getCharterer,
   upsertCharterer,
@@ -22,9 +23,12 @@ function isFeatureEnabled(): boolean {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },
@@ -58,6 +62,9 @@ export async function PUT(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },
@@ -81,6 +88,17 @@ export async function PUT(
     const body = await request.json();
     const { name, tier, payment_history, require_lc, notes } = body;
 
+    // Validate tier if provided
+    if (tier !== undefined) {
+      const validTiers = ['blue-chip', 'second', 'weak'];
+      if (!validTiers.includes(tier)) {
+        return NextResponse.json(
+          { error: `Field "tier" must be one of: ${validTiers.join(', ')}` },
+          { status: 400 }
+        );
+      }
+    }
+
     // Update with new values or keep existing
     upsertCharterer(db, {
       id,
@@ -103,9 +121,12 @@ export async function PUT(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },

--- a/app/api/charterers/route.ts
+++ b/app/api/charterers/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStore } from '@/lib/session-store';
+import { requireSession } from '@/lib/session';
 import { listCharterers, upsertCharterer } from '@/lib/market/charterers-repository';
 import { randomBytes } from 'crypto';
 
@@ -19,7 +20,10 @@ function isFeatureEnabled(): boolean {
   return process.env.CHARTERER_CREDIT_ENABLED === 'true';
 }
 
-export async function GET(request?: NextRequest): Promise<NextResponse> {
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },
@@ -43,6 +47,9 @@ export async function GET(request?: NextRequest): Promise<NextResponse> {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -140,6 +140,20 @@ export default async function DashboardPage() {
         {/* ── γ-18: ROI Summary Tile (feature flag) ──────────────── */}
         {process.env.NEXT_PUBLIC_ROI_GUARANTEE_ENABLED === 'true' && <RoiSummaryTile />}
 
+        {/* ── Charterer Credit (feature flag) ────────────────────── */}
+        {process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED === 'true' && (
+          <Link
+            href="/charterers"
+            className="flex items-center justify-between p-4 bg-white border border-gray-200 rounded-xl hover:bg-gray-50 transition-colors"
+          >
+            <div>
+              <p className="text-sm font-semibold text-gray-900">Charterer Credit</p>
+              <p className="text-xs text-gray-500">Credit profiles for blue-chip charterers</p>
+            </div>
+            <span className="text-gray-400 text-sm">→</span>
+          </Link>
+        )}
+
         {/* ── Morning Header ─────────────────────────────────────── */}
         <div>
           <MorningHeader userName="Broker" alertCount={urgentCount} />


### PR DESCRIPTION
## Summary

- `requireSession` добавлен на все 5 HTTP методов (`GET`/`POST` на `/api/charterers`, `GET`/`PUT`/`DELETE` на `/api/charterers/[id]`) — ранее эндпоинты были доступны без авторизации
- `PUT /api/charterers/[id]` — добавлена валидация `tier` enum (было только в POST)
- 5 новых тестов на 401 + RC-тест для dashboard tile (PI4 compliance)
- Dashboard: Charterer Credit tile за флагом `NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED`

Closes Task 2.B from `docs/plans/2026-05-13-acceleration-plan.md`

## Test plan

- [ ] All 58 charterers tests green (53 existing + 5 new auth tests)
- [ ] `tsc --noEmit` clean
- [ ] `/api/charterers` returns 401 without session cookie
- [ ] Dashboard shows Charterer Credit tile when flag ON, hidden when OFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)