### PR TITLE
feat(parse-cargo): Phase 1 — sampling foundation (temperature=0, seed=42, few-shot, model pin)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -60,6 +60,8 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/quantika-vertex-ai.json
 GOOGLE_CLOUD_PROJECT=quantika-demo-2026
 GOOGLE_CLOUD_LOCATION=us-central1
 AI_MODEL_GEMINI_DEFAULT=gemini-2.5-flash
+# Pinned Gemini version for parse-cargo (deterministic eval — prevents drift from auto-upgrades)
+# PARSE_CARGO_GEMINI_MODEL=gemini-2.5-pro-002
 
 # AWS Bedrock (for match endpoint, Anthropic Claude via Bedrock)
 AWS_REGION=us-east-1

--- a/.env.local.example
+++ b/.env.local.example
@@ -60,8 +60,8 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/quantika-vertex-ai.json
 GOOGLE_CLOUD_PROJECT=quantika-demo-2026
 GOOGLE_CLOUD_LOCATION=us-central1
 AI_MODEL_GEMINI_DEFAULT=gemini-2.5-flash
-# Pinned Gemini version for parse-cargo (deterministic eval — prevents drift from auto-upgrades)
-# PARSE_CARGO_GEMINI_MODEL=gemini-2.5-pro-002
+# Override Gemini model for parse-cargo scope (default: AI_MODEL_GEMINI_DEFAULT)
+# PARSE_CARGO_GEMINI_MODEL=gemini-2.5-pro
 
 # AWS Bedrock (for match endpoint, Anthropic Claude via Bedrock)
 AWS_REGION=us-east-1

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ next-env.d.ts
 
 # corpus-00: sample fixture removed from repo — keep gitignored to prevent accidental re-add
 lib/sample-data/etms-emails.json
+
+# local dev notes (ephemeral, not for review)
+/.notes/

--- a/__tests__/lib/ai-provider-sampling.test.ts
+++ b/__tests__/lib/ai-provider-sampling.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "@jest/globals";
+import type { AiOpts } from "@/lib/ai-provider";
+import { buildGeminiSamplingFields, buildBedrockSamplingFields } from "@/lib/ai-provider";
+
+describe("AiOpts sampling fields", () => {
+  it("accepts temperature option", () => {
+    const opts: AiOpts = { temperature: 0 };
+    expect(opts.temperature).toBe(0);
+  });
+
+  it("accepts seed option", () => {
+    const opts: AiOpts = { seed: 42 };
+    expect(opts.seed).toBe(42);
+  });
+
+  it("allows topP and topK options", () => {
+    const opts: AiOpts = { topP: 0.95, topK: 40 };
+    expect(opts.topP).toBe(0.95);
+    expect(opts.topK).toBe(40);
+  });
+});
+
+describe("buildGeminiSamplingFields", () => {
+  it("passes temperature into config", () => {
+    const cfg = buildGeminiSamplingFields({ temperature: 0, maxTokens: 4096 });
+    expect(cfg.temperature).toBe(0);
+  });
+
+  it("passes seed into config", () => {
+    const cfg = buildGeminiSamplingFields({ seed: 42 });
+    expect(cfg.seed).toBe(42);
+  });
+
+  it("omits undefined sampling options", () => {
+    const cfg = buildGeminiSamplingFields({});
+    expect(cfg.temperature).toBeUndefined();
+    expect(cfg.seed).toBeUndefined();
+    expect(cfg.topP).toBeUndefined();
+    expect(cfg.topK).toBeUndefined();
+  });
+
+  it("includes all provided sampling fields", () => {
+    const cfg = buildGeminiSamplingFields({ temperature: 0.3, topP: 0.95, topK: 40, seed: 1 });
+    expect(cfg.temperature).toBe(0.3);
+    expect(cfg.topP).toBe(0.95);
+    expect(cfg.topK).toBe(40);
+    expect(cfg.seed).toBe(1);
+  });
+});
+
+describe("buildBedrockSamplingFields", () => {
+  it("sets max_tokens from maxTokens", () => {
+    const cfg = buildBedrockSamplingFields({ maxTokens: 4096 });
+    expect(cfg.max_tokens).toBe(4096);
+  });
+
+  it("defaults max_tokens to 16000", () => {
+    const cfg = buildBedrockSamplingFields({});
+    expect(cfg.max_tokens).toBe(16000);
+  });
+
+  it("passes temperature", () => {
+    const cfg = buildBedrockSamplingFields({ temperature: 0 });
+    expect(cfg.temperature).toBe(0);
+  });
+
+  it("maps topP to top_p (Anthropic format)", () => {
+    const cfg = buildBedrockSamplingFields({ topP: 0.95 });
+    expect(cfg.top_p).toBe(0.95);
+  });
+
+  it("omits temperature and top_p when not provided", () => {
+    const cfg = buildBedrockSamplingFields({});
+    expect(cfg.temperature).toBeUndefined();
+    expect(cfg.top_p).toBeUndefined();
+  });
+});

--- a/app/api/ai/parse-cargo/route.ts
+++ b/app/api/ai/parse-cargo/route.ts
@@ -268,6 +268,8 @@ export async function POST(request: NextRequest) {
                 maxTokens: 16000,
                 model: process.env.PARSE_CARGO_GEMINI_MODEL,
                 responseSchema: PARSE_CARGO_SCHEMA,
+                temperature: 0,
+                seed: 42,
               },
             ),
           ),

--- a/docs/plans/2026-05-13-parse-cargo-phase1-retro.md
+++ b/docs/plans/2026-05-13-parse-cargo-phase1-retro.md
@@ -1,0 +1,46 @@
+# Phase 1 — Sampling Foundation Retro
+
+## Results
+
+| Round  | String | Semantic |
+| ------ | ------ | -------- |
+| R18a   | 78/95  | 83/95    |
+| R18b   | 75/95  | 81/95    |
+| R18c   | 78/95  | 84/95    |
+| Median | **78** | **83**   |
+
+## Delta vs R17 baseline (string 74, semantic 81)
+
+- String: +4 (74 → 78)
+- Semantic: +2 (81 → 83)
+- Variance string: ±1.5 (was ±8) — **dramatic improvement**
+
+## Phase 1 Gate Verdict
+
+| Gate              | Target | Actual | Status  |
+| ----------------- | ------ | ------ | ------- |
+| String median ≥84 | 84     | 78     | ❌ MISS |
+| Variance ≤4       | ≤4     | ±1.5   | ✅ PASS |
+
+**Overall: PARTIAL** — median target missed, but variance goal exceeded expectations.
+
+## What Worked
+
+- **temperature=0 + seed=42**: variance dropped from ±8 to ±1.5. This is the main win of Phase 1.
+- **few-shot examples**: likely contributed to the +4 string improvement (hard to isolate).
+- **gemini-2.5-pro model pin**: gemini-2.5-pro-002 unavailable in us-central1; using unversioned gemini-2.5-pro.
+
+## Why median didn't reach 84
+
+Phase 1 was designed to kill variance (success) and hoped few-shot examples would boost accuracy.
+The +4 improvement on string is real but below the 84-86 target. The remaining gap is likely:
+
+- Hedged language scenarios (still the largest failure category)
+- Multi-port rotation edge cases
+- These require either RAG (Phase 2) or model switch (Phase 3) to improve
+
+## Decision: Proceed to Phase 2
+
+- String delta +4 ≥ +3 threshold → proceed gate MET
+- Phase 2 RAG is the main bet (+5-15 expected)
+- Phase 2 will be measured vs **R18 median (78 string / 83 semantic)** as new baseline

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -41,6 +41,40 @@ export interface AiOpts {
    * without markdown fences. Ignored for other providers.
    */
   responseSchema?: Record<string, unknown>;
+  /** Sampling temperature 0..1. 0 = greedy/deterministic. Default: provider default. */
+  temperature?: number;
+  /** Top-p nucleus sampling. Default: provider default. */
+  topP?: number;
+  /** Top-k sampling (Gemini only). Default: provider default. */
+  topK?: number;
+  /** Random seed for reproducibility (Gemini Vertex AI supports). */
+  seed?: number;
+}
+
+/**
+ * Returns sampling-related fields for Gemini `generateContent` config.
+ * Only includes fields that are explicitly provided (no defaults).
+ */
+export function buildGeminiSamplingFields(opts: AiOpts): Record<string, unknown> {
+  const cfg: Record<string, unknown> = {};
+  if (opts.temperature !== undefined) cfg.temperature = opts.temperature;
+  if (opts.topP !== undefined) cfg.topP = opts.topP;
+  if (opts.topK !== undefined) cfg.topK = opts.topK;
+  if (opts.seed !== undefined) cfg.seed = opts.seed;
+  return cfg;
+}
+
+/**
+ * Returns sampling-related fields for Bedrock Anthropic payload.
+ * Maps camelCase AiOpts → Anthropic API snake_case names.
+ */
+export function buildBedrockSamplingFields(opts: AiOpts): Record<string, unknown> {
+  const cfg: Record<string, unknown> = {
+    max_tokens: opts.maxTokens ?? 16000,
+  };
+  if (opts.temperature !== undefined) cfg.temperature = opts.temperature;
+  if (opts.topP !== undefined) cfg.top_p = opts.topP;
+  return cfg;
 }
 
 export interface ImageInput {

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -424,6 +424,7 @@ async function callBedrockText(
   system: string,
   user: string,
   model: string,
+  opts?: AiOpts,
 ): Promise<{ text: string; usage?: Usage }> {
   assertBedrockEnv();
   const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
@@ -443,7 +444,7 @@ async function callBedrockText(
 
   const payload = {
     anthropic_version: 'bedrock-2023-05-31',
-    max_tokens: 16000,
+    ...buildBedrockSamplingFields(opts ?? {}),
     system,
     messages: [{ role: 'user', content: user }],
   };
@@ -551,7 +552,7 @@ export async function callAiJson<T>(
         break;
       }
       case 'bedrock': {
-        const r = await callBedrockText(system, user, model);
+        const r = await callBedrockText(system, user, model, opts);
         usage = r.usage;
         const cleaned = r.text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
         result = JSON.parse(cleaned) as T;
@@ -608,7 +609,7 @@ export async function callAiText(
         break;
       }
       case 'bedrock': {
-        const r = await callBedrockText(system, user, model);
+        const r = await callBedrockText(system, user, model, opts);
         usage = r.usage;
         result = r.text;
         break;

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -314,6 +314,10 @@ async function callGeminiText(
             thinkingConfig?: { thinkingBudget: number; includeThoughts: boolean };
             responseMimeType?: string;
             responseSchema?: Record<string, unknown>;
+            temperature?: number;
+            topP?: number;
+            topK?: number;
+            seed?: number;
           };
         }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
       };
@@ -333,6 +337,10 @@ async function callGeminiText(
     thinkingConfig?: { thinkingBudget: number; includeThoughts: boolean };
     responseMimeType?: string;
     responseSchema?: Record<string, unknown>;
+    temperature?: number;
+    topP?: number;
+    topK?: number;
+    seed?: number;
   } = { systemInstruction: system };
 
   if (opts?.thinkingBudget !== undefined) {
@@ -346,6 +354,8 @@ async function callGeminiText(
     config.responseMimeType = 'application/json';
     config.responseSchema = opts.responseSchema;
   }
+
+  Object.assign(config, buildGeminiSamplingFields(opts ?? {}));
 
   const response = await ai.models.generateContent({
     model,

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -329,6 +329,40 @@ IMPORTANT: Do NOT confuse "loading rate" or "discharge rate" (which are cargo ha
 
 IMPORTANT: "dwcc" (deadweight cargo capacity) when used in a cargo inquiry context (e.g., "2k dwcc spot marmara") means the sender is looking for a vessel with at least that DWCC. Treat this as CARGO_INQUIRY, not VESSEL_POSITION.
 
+=== EXAMPLES ===
+
+Example 1 — Vessel position circular (return empty items):
+
+Email: "OPEN VESSEL 8500 DWCC GLESS open ALEXANDRIA 12-15 May/onw => MED EUROPE. Rgds"
+
+Output: {"items": [], "missing_info": ["Vessel availability circular, not a cargo inquiry"]}
+
+---
+
+Example 2 — Port alternatives (vessel chooses one):
+
+Email: "PLS PROPOSE FOR: 25000 mt clinker in bulk, El Arish OR El Dekheila / POC, 7-15/Jun, 12000x/8000x, 2.5 pct ttl"
+
+Output: {"items": [{"origin_port": {"value": "El Arish", "confidence": "confirmed", "source_text": "El Arish OR El Dekheila"}, "origin_port_alternatives": ["El Dekheila"], "destination_port": {"value": "Port of Call", "confidence": "interpreted", "source_text": "POC"}, "weight_mt": {"value": 25000, "confidence": "confirmed", "source_text": "25000 mt clinker"}, "cargo_type": "BULK"}]}
+
+---
+
+Example 3 — Port rotation (vessel calls both in sequence):
+
+Email: "40000 mt rice in bb, Kandla to Banjul 10000 + Dakar 30000, laycan 5-12 Jul"
+
+Output: {"items": [{"origin_port": {"value": "Kandla", "confidence": "confirmed", "source_text": "Kandla"}, "destination_port": {"value": "Banjul", "confidence": "confirmed", "source_text": "Banjul 10000"}, "destination_port_rotation": ["Banjul", "Dakar"], "weight_per_port": [10000, 30000], "weight_mt": {"value": 40000, "confidence": "confirmed", "source_text": "40000 mt rice"}, "cargo_type": "BREAK_BULK"}]}
+
+---
+
+Example 4 — Destination unspecified (POC):
+
+Email: "6000mt urea in big-bags, Alexandria to POC, mid Jul, 3000/3000 shinc"
+
+Output: {"items": [{"origin_port": {"value": "Alexandria", "confidence": "confirmed", "source_text": "Alexandria"}, "destination_port": {"value": "Port of Call (unspecified)", "confidence": "interpreted", "source_text": "POC"}, "weight_mt": {"value": 6000, "confidence": "confirmed", "source_text": "6000mt urea"}, "cargo_type": "BREAK_BULK"}]}
+
+=== END EXAMPLES ===
+
 Output: { "items": [ ...one object per cargo inquiry... ] }`;
 
 /**

--- a/scripts/progonq/run-parse-cargo.ts
+++ b/scripts/progonq/run-parse-cargo.ts
@@ -320,6 +320,8 @@ async function runScenario(scenario: Scenario): Promise<RunResult> {
       const text = await callAiText(SCOPE, CARGO_INQUIRY_PARSER_PROMPT, userPrompt, {
         maxTokens: 4096,
         timeoutMs: 180_000,
+        temperature: 0,
+        seed: 42,
       });
       const parsed = extractJson(text) as ParsedOutput;
       model_output = { items: Array.isArray(parsed.items) ? parsed.items : [] };

--- a/scripts/progonq/run-parse-cargo.ts
+++ b/scripts/progonq/run-parse-cargo.ts
@@ -322,6 +322,7 @@ async function runScenario(scenario: Scenario): Promise<RunResult> {
         timeoutMs: 180_000,
         temperature: 0,
         seed: 42,
+        model: process.env.PARSE_CARGO_GEMINI_MODEL,
       });
       const parsed = extractJson(text) as ParsedOutput;
       model_output = { items: Array.isArray(parsed.items) ? parsed.items : [] };


### PR DESCRIPTION
## Summary

Phase 1 of parse-cargo quality push. Цель: убить variance между прогонами через детерминированный sampling.

## Changes

- \`lib/ai-provider.ts\`: extend \`AiOpts\` with \`temperature\`, \`topP\`, \`topK\`, \`seed\` fields + exported helpers \`buildGeminiSamplingFields\` / \`buildBedrockSamplingFields\`
- \`lib/ai-provider.ts\`: wire sampling into Vertex AI Gemini config + Bedrock payload
- \`scripts/progonq/run-parse-cargo.ts\` + \`app/api/ai/parse-cargo/route.ts\`: set \`temperature=0, seed=42\` for deterministic extraction
- \`lib/prompts/parse-cargo.ts\`: 4 few-shot examples (vessel circular guard, port alternatives, rotation, POC)
- \`.env.local.example\`: \`PARSE_CARGO_GEMINI_MODEL\` override
- \`.gitignore\`: add \`/.notes/\`

## R18 verification (vs R17 baseline: string 74, semantic 81)

| Metric | R17 median | R18 median | Delta |
|--------|------------|------------|-------|
| String | 74/95 | **78/95** | +4 |
| Semantic | 81/95 | **83/95** | +2 |
| Variance | ±8 | **±1.5** | ↓ dramatically |

## Phase 1 Gate

- ✅ String delta +4 ≥ +3 → proceed to Phase 2
- ✅ Variance ≤4 (±1.5)
- ❌ String median 78 < target 84 — Phase 2 RAG is the main bet

Full retro: [docs/plans/2026-05-13-parse-cargo-phase1-retro.md](docs/plans/2026-05-13-parse-cargo-phase1-retro.md)

## Test plan

- [x] 12 unit tests for sampling fields (AiOpts, Gemini/Bedrock helpers)
- [x] R18a/b/c eval runs on VPS /root/qd-r17
- [x] Judge scores computed
- [x] Variance gate: ±1.5 (target ≤4) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)