### PR TITLE
fix(ai-provider): strip Bedrock CoT preamble [CRITICAL]

### DIFF
--- a/lib/__tests__/ai-provider-bedrock-json.test.ts
+++ b/lib/__tests__/ai-provider-bedrock-json.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for extractJson — Bedrock JSON extraction.
+ *
+ * Context: Bedrock Claude Sonnet 4.6 returns chain-of-thought preamble
+ * ("I'll systematically work through this...") before JSON, breaking
+ * naive JSON.parse on raw response. This helper strips preamble,
+ * markdown fences, trailing junk and balances braces to find clean JSON.
+ *
+ * Refs: Task 3.2-FIX-1 Phase B1 (acceleration plan), ai_audit MATCH 9/10 fails 24h.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { extractJson } from '@/lib/ai-provider';
+
+describe('extractJson — Bedrock JSON extraction', () => {
+  it('extracts JSON from CoT preamble', () => {
+    const raw = "I'll systematically analyze this match.\n\n{\"matches\":[]}";
+    expect(extractJson(raw)).toBe('{"matches":[]}');
+  });
+
+  it('extracts array JSON from preamble', () => {
+    const raw = "I'll work through these:\n\n[{\"id\":1}]";
+    expect(extractJson(raw)).toBe('[{"id":1}]');
+  });
+
+  it('handles markdown fence (json)', () => {
+    const raw = '```json\n{"matches":[]}\n```';
+    expect(extractJson(raw)).toBe('{"matches":[]}');
+  });
+
+  it('handles markdown fence (plain)', () => {
+    const raw = '```\n{"x":1}\n```';
+    expect(extractJson(raw)).toBe('{"x":1}');
+  });
+
+  it('returns JSON unchanged if no preamble', () => {
+    const raw = '{"matches":[{"id":1}]}';
+    expect(extractJson(raw)).toBe('{"matches":[{"id":1}]}');
+  });
+
+  it('strips trailing junk after JSON', () => {
+    const raw = '{"x":1}\n\nThat\'s my analysis.';
+    expect(extractJson(raw)).toBe('{"x":1}');
+  });
+
+  it('throws if no JSON found at all', () => {
+    expect(() => extractJson('just text, no json here')).toThrow();
+  });
+
+  it('handles nested objects/arrays correctly', () => {
+    const raw = "Preamble.\n\n{\"a\":{\"b\":[1,2,{\"c\":3}]}}";
+    expect(JSON.parse(extractJson(raw))).toEqual({ a: { b: [1, 2, { c: 3 }] } });
+  });
+
+  it('handles strings containing braces inside JSON', () => {
+    const raw = 'Analysis:\n\n{"note":"contains } closing brace","ok":true}';
+    expect(JSON.parse(extractJson(raw))).toEqual({
+      note: 'contains } closing brace',
+      ok: true,
+    });
+  });
+
+  it('handles escaped quotes in strings', () => {
+    const raw = '{"msg":"he said \\"hi\\""}';
+    expect(JSON.parse(extractJson(raw))).toEqual({ msg: 'he said "hi"' });
+  });
+
+  it('handles markdown fence with preamble inside', () => {
+    // Edge case: model wraps CoT inside the fence
+    const raw = "Sure, here you go:\n```json\n{\"x\":1}\n```\nDone!";
+    expect(extractJson(raw)).toBe('{"x":1}');
+  });
+
+  it('throws on empty input', () => {
+    expect(() => extractJson('')).toThrow();
+  });
+
+  it('throws on non-string input', () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => extractJson(null)).toThrow();
+  });
+
+  it('picks earliest of { or [ as start', () => {
+    const raw = 'before [1,2,3] then {"x":1} done';
+    // First JSON token is [, balanced array ends at ]
+    expect(extractJson(raw)).toBe('[1,2,3]');
+  });
+});

--- a/lib/__tests__/ai-provider-cot-integration.test.ts
+++ b/lib/__tests__/ai-provider-cot-integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration test: callAiJson handles Bedrock CoT preamble end-to-end.
+ *
+ * Validates the actual MATCH endpoint code path through callAiJson with
+ * provider=bedrock — uses the same Bedrock SDK mock pattern as ai-provider.test.ts,
+ * but configures the mocked response to include a CoT preamble like real
+ * Sonnet 4.6 emits in production.
+ *
+ * Pre-fix: this test would fail with `Unexpected token 'I', "I'll syste"...`.
+ * Post-fix: extractJson() strips preamble before JSON.parse.
+ */
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// We control the Bedrock response body per test via mockSend.mockResolvedValueOnce.
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn().mockImplementation(() => ({
+    send: mockSend,
+  })),
+  InvokeModelCommand: jest.fn().mockImplementation((opts: unknown) => opts),
+}), { virtual: true });
+
+// Stub openai/gemini so they don't get hit.
+jest.mock('@/lib/openai', () => ({
+  callAiJson: jest.fn(),
+  callAiText: jest.fn(),
+  LLMTimeoutError: class LLMTimeoutError extends Error {},
+}));
+
+jest.mock('@google/genai', () => ({
+  GoogleGenAI: jest.fn(),
+}), { virtual: true });
+
+// Route audit writes to in-memory DB so writeAuditRecord doesn't blow up.
+let testDb: Database.Database;
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: jest.fn(() => testDb),
+  })),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function setBedrockEnv(): void {
+  process.env.AI_PROVIDER = 'bedrock';
+  process.env.AWS_REGION = 'us-east-1';
+  process.env.AWS_ACCESS_KEY_ID = 'test-key';
+  process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
+  process.env.BEDROCK_MODEL_ID = 'us.anthropic.claude-sonnet-4-6';
+}
+
+function clearBedrockEnv(): void {
+  for (const k of [
+    'AI_PROVIDER', 'MATCH_PROVIDER', 'AWS_REGION', 'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY', 'BEDROCK_MODEL_ID',
+  ]) {
+    delete process.env[k];
+  }
+}
+
+function mockBedrockReply(text: string): void {
+  mockSend.mockResolvedValueOnce({
+    body: new TextEncoder().encode(
+      JSON.stringify({
+        content: [{ text }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }),
+    ),
+  });
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  testDb = new Database(':memory:');
+  runMigrations(testDb, allMigrations);
+  clearBedrockEnv();
+  setBedrockEnv();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  testDb.close();
+  clearBedrockEnv();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('callAiJson (bedrock) — CoT preamble handling', () => {
+  it('parses JSON when Bedrock prepends CoT preamble (MATCH-style)', async () => {
+    const { callAiJson } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
+
+    // This is the exact failure signature from production ai_audit (2026-05-13):
+    // 9/10 MATCH calls failed with "Unexpected token 'I', \"I'll syste\"..."
+    mockBedrockReply(
+      "I'll systematically work through this match request.\n\n" +
+        'Looking at the cargo and vessel data, here is my analysis:\n\n' +
+        '{"matches":[{"cargoId":"c1","vesselId":"v1","score":0.92}]}',
+    );
+
+    const result = await callAiJson<{ matches: Array<{ score: number }> }>(
+      'MATCH',
+      'system prompt',
+      'user prompt',
+    );
+
+    expect(result).toEqual({
+      matches: [{ cargoId: 'c1', vesselId: 'v1', score: 0.92 }],
+    });
+  });
+
+  it('parses JSON when response is wrapped in markdown fence', async () => {
+    const { callAiJson } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
+    mockBedrockReply('```json\n{"ok":true,"items":[1,2,3]}\n```');
+
+    const result = await callAiJson<{ ok: boolean; items: number[] }>(
+      'MATCH',
+      'sys',
+      'user',
+    );
+
+    expect(result).toEqual({ ok: true, items: [1, 2, 3] });
+  });
+
+  it('parses clean JSON unchanged (no regression for well-formed output)', async () => {
+    const { callAiJson } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
+    mockBedrockReply('{"matches":[]}');
+
+    const result = await callAiJson<{ matches: unknown[] }>('MATCH', 'sys', 'user');
+    expect(result).toEqual({ matches: [] });
+  });
+
+  it('audits ok=true when CoT preamble is stripped successfully', async () => {
+    const { callAiJson } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
+    mockBedrockReply("Let me think.\n\n{\"x\":1}");
+
+    await callAiJson<{ x: number }>('MATCH', 'sys', 'user');
+
+    const row = testDb
+      .prepare('SELECT ok, err, scope FROM ai_audit ORDER BY id DESC LIMIT 1')
+      .get() as { ok: number; err: string | null; scope: string } | undefined;
+    expect(row?.ok).toBe(1);
+    expect(row?.err).toBeNull();
+    expect(row?.scope).toBe('MATCH');
+  });
+});

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -153,6 +153,102 @@ export function computeCostUsd(
   return Math.round(cost * 1_000_000) / 1_000_000;
 }
 
+// ─── JSON extraction helper ───────────────────────────────────────────────────
+
+/**
+ * Strip chain-of-thought preamble, markdown fences, and trailing junk from
+ * an LLM response to yield clean JSON suitable for `JSON.parse()`.
+ *
+ * Why: Bedrock Claude Sonnet 4.6 routinely emits CoT-style preamble before
+ * JSON ("I'll systematically work through this..."), which breaks naive
+ * `JSON.parse(raw)`. ai_audit (2026-05-13) shows 9/10 MATCH failures in 24h
+ * with signature `Unexpected token 'I', "I'll syste"...`. This helper is the
+ * defensive parser applied before `JSON.parse` in `callAiJson` for the
+ * Bedrock provider (and Gemini fallback when no responseSchema is used).
+ *
+ * Algorithm:
+ *   1. Trim whitespace.
+ *   2. If wrapped in ```...``` fence (with optional `json` tag), unwrap.
+ *   3. Locate first `{` or `[`, slice from there.
+ *   4. Walk characters, respecting string literals + escape sequences,
+ *      tracking brace/bracket depth; cut at matching close.
+ *
+ * @throws if input is empty, non-string, or contains no JSON-looking start char.
+ */
+export function extractJson(raw: string): string {
+  if (!raw || typeof raw !== 'string') {
+    throw new Error('extractJson: empty or non-string input');
+  }
+
+  let s = raw.trim();
+  if (s.length === 0) {
+    throw new Error('extractJson: empty input after trim');
+  }
+
+  // Strip a wrapping markdown fence if the whole thing is fenced.
+  // We do not handle nested fences — only outermost.
+  const fenceMatch = s.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (fenceMatch) {
+    s = fenceMatch[1].trim();
+  }
+
+  // Find first `{` or `[` (whichever appears earliest).
+  const firstBrace = s.indexOf('{');
+  const firstBracket = s.indexOf('[');
+  const candidates = [firstBrace, firstBracket].filter((i) => i >= 0);
+  if (candidates.length === 0) {
+    throw new Error(
+      `extractJson: no JSON-looking start char ({ or [) found in: ${raw.slice(0, 100)}`,
+    );
+  }
+  const start = Math.min(...candidates);
+  s = s.slice(start);
+
+  // Balance braces/brackets to find the matching closing token.
+  // Respect string boundaries and escape characters so that `}` inside a
+  // JSON string literal doesn't cut us off early.
+  const openChar = s[0];
+  const closeChar = openChar === '{' ? '}' : ']';
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let endIdx = -1;
+
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (c === '\\') {
+      escape = true;
+      continue;
+    }
+    if (c === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (c === openChar) {
+      depth++;
+    } else if (c === closeChar) {
+      depth--;
+      if (depth === 0) {
+        endIdx = i;
+        break;
+      }
+    }
+  }
+
+  if (endIdx === -1) {
+    // Unbalanced — return what we have; JSON.parse downstream will surface a
+    // clearer "Unexpected end of JSON input" error with the real reason.
+    return s;
+  }
+
+  return s.slice(0, endIdx + 1);
+}
+
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
 function toScopeEnv(scope: string): string {
@@ -544,18 +640,18 @@ export async function callAiJson<T>(
       case 'gemini': {
         const r = await callGeminiText(system, user, model, opts);
         usage = r.usage;
-        // When responseSchema is provided, Gemini returns clean JSON — no fences.
-        const raw = opts?.responseSchema
-          ? r.text.trim()
-          : r.text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+        // When responseSchema is provided, Gemini returns clean JSON — parse directly.
+        // Otherwise apply extractJson to strip any CoT preamble / fences.
+        const raw = opts?.responseSchema ? r.text.trim() : extractJson(r.text);
         result = JSON.parse(raw) as T;
         break;
       }
       case 'bedrock': {
         const r = await callBedrockText(system, user, model, opts);
         usage = r.usage;
-        const cleaned = r.text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
-        result = JSON.parse(cleaned) as T;
+        // Bedrock Claude (esp. Sonnet 4.6) often emits CoT preamble before JSON.
+        // extractJson strips preamble + fences + trailing junk before parse.
+        result = JSON.parse(extractJson(r.text)) as T;
         break;
       }
       case 'openai':


### PR DESCRIPTION
## Critical hotfix for /processing 502

Production /processing pipeline падает на шаге MATCH с 502 (Caddy), root cause:
Bedrock Sonnet 4.6 возвращает chain-of-thought preamble перед JSON, `JSON.parse(rawText)` падает на первой букве, route бросает 500 → Caddy 502.

**Что починил человеческим языком:** модель Claude (Sonnet 4.6 на AWS Bedrock) перед ответом любит «подумать вслух»: пишет фразу «I'll systematically work through this…», а уже потом JSON. Старый код ожидал чистый JSON и падал на букве `I`. Новый helper `extractJson()` находит начало JSON (`{` или `[`), считает скобки с учётом строк и эскейпов, и возвращает только JSON-кусок. Markdown-обёртку ` ```json ... ``` ` тоже снимает. Применил в `callAiJson` для Bedrock и для Gemini (когда responseSchema не задан).

### ai_audit за 24h (до фикса)

```
MATCH (bedrock): 1 success / 9 fails
All failures: "Unexpected token 'I', \"I'll syste\"... is not valid JSON"
```

## Changes

- `lib/ai-provider.ts` — new exported `extractJson(raw)` helper; applied in `callAiJson` bedrock branch (line ~558) и gemini branch без responseSchema (line ~551).
- `lib/__tests__/ai-provider-bedrock-json.test.ts` — 14 unit tests
- `lib/__tests__/ai-provider-cot-integration.test.ts` — 4 integration tests через mocked Bedrock SDK

Что НЕ трогал (намеренно, surgical):
- OpenAI branch (использует `lib/openai.ts` собственный JSON cleaner)
- Gemini branch с `responseSchema` (Vertex AI гарантирует чистый JSON через `responseMimeType=application/json`)
- `lib/parsing/parse-vessel-helpers.ts` line 106, `lib/parsing/parse-recap-helpers.ts` line 72, `app/api/ai/parse-cargo/route.ts` line 103 — у них собственные fence-strip обёртки, не идут через `callAiJson`. Если будут CoT-проблемы — отдельный PR.
- Assistant-prefill подход (Anthropic best-practice `messages: [..., {role:'assistant', content:'{'}]`) — отложен, scope растёт; центральный strip покрывает все варианты сюрпризов модели.

## Tests

- 14 unit tests на `extractJson`: CoT preamble, markdown fence (json/plain), нет preamble (no-op), trailing junk, nested objects/arrays, escaped quotes, строки содержащие `}`, empty input, non-string input, earliest of `{`/`[`
- 4 integration tests: exact production failure signature reproduced + audit row check
- Полный прогон `npx jest --testPathPatterns="match|bedrock|ai-provider"` — **35 suites, 644 tests, all green**
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (24 pre-existing warnings в unrelated файлах)

## Test plan

- [x] Unit tests pass (14 cases на extractJson edge cases)
- [x] Integration tests pass (4 cases reproducing prod signature через mocked SDK)
- [x] No existing tests modified (PI3 — 0 test-expectation rewrites)
- [x] tsc clean
- [x] lint clean
- [ ] **After merge:** VPS deploy + smoke `/processing` end-to-end на demo.quantika.org
- [ ] **Post-deploy:** проверить `ai_audit` — MATCH success rate должен подняться с ~10% до ~100% (либо до базовой ошибки модели если есть другие)
- [ ] **Post-deploy:** Sentry/logs на любые новые `extractJson: no JSON-looking start char` warnings — это будет означать модель отвечает чистым текстом (не JSON) и стоит ловить отдельно

Refs: Task 3.2-FIX-1 Phase B1, docs/plans/2026-05-13-acceleration-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)