### PR TITLE
ci: split coverage into separate weekly workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -71,15 +71,9 @@ jobs:
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      - run: npm test -- --coverage --coverageProvider=v8 --forceExit
+      - run: npm test -- --forceExit
         env:
           NODE_OPTIONS: --max-old-space-size=6144
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: coverage
-          path: coverage/
-          retention-days: 7
 
   e2e:
     name: E2E

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,36 @@
+name: Coverage
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+      - uses: actions/cache@v5
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      - run: npm test -- --coverage --coverageProvider=v8 --forceExit
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 7

--- a/docs/plans/2026-05-14-ci-coverage-split-design.md
+++ b/docs/plans/2026-05-14-ci-coverage-split-design.md
@@ -1,0 +1,64 @@
+# CI-таймаут: вынос coverage в отдельный weekly workflow
+
+**Дата:** 2026-05-14
+**Статус:** approved, реализуется в PR
+
+## Проблема
+
+CI workflow `.github/workflows/ci.yml`, job `Test`, падает по таймауту на каждом
+коммите в `main` (последние 5 коммитов — красный/cancelled CI, 20-25 мин). Job
+гонял `npm test -- --coverage --coverageProvider=v8 --forceExit` — весь jest-suite
+(~5000 тестовых файлов) **плюс** инструментацию всего кода для подсчёта покрытия.
+Сами тесты быстрые и зелёные; узкое место — именно `--coverage` (CPU + память).
+25-минутное окно не вмещало прогон → `The operation was canceled`.
+
+Следствие: `main` структурно не мог получить зелёный CI, мерджи блокировались всем
+(PR #141 пришлось мерджить через admin-bypass). Suite растёт каждую wave-волну,
+так что «поднять таймаут» проблему не решает.
+
+**Ключевая находка:** гейта «coverage ≥ N%» нигде нет — в `jest.config.mjs` нет
+`coverageThreshold`, в `.github/` нет ruleset/CODEOWNERS. Coverage был просто
+артефактом-отчётом (`coverage/`, retention 7 дней). Вынос coverage из блокирующего
+job ничего не ломает функционально.
+
+## Решение
+
+Разделить две задачи, которые были слиты в один job:
+
+1. **PR-гейт** (`ci.yml`, job `Test`) — гоняет тесты **без** `--coverage`. Быстро
+   (~10-12 мин вместо 25+), легче по памяти. Имя job осталось `Test` —
+   required-check в branch protection не ломается.
+2. **Periodic coverage** (новый `coverage.yml`) — полный прогон с `--coverage`
+   раз в неделю (cron `0 6 * * 1`, понедельник 06:00 UTC) плюс по кнопке
+   (`workflow_dispatch`). Его таймаут никого не блокирует.
+
+Расход GH Actions минут: было ~25 мин на каждый push/PR → стало ~10-12 мин на
+push/PR + ~25 мин раз в неделю.
+
+## Отвергнутые варианты
+
+- **Отдельный non-blocking job на каждый push** — coverage всё равно гоняется
+  каждый раз, суммарно минут больше.
+- **Шардинг jest (4 раннера)** — больше минут, сложнее конфиг, против $10-бюджета
+  на CI.
+- **Поднять таймаут** — рост suite не решает.
+
+## Изменения
+
+- `.github/workflows/ci.yml` — job `Test`: `npm test` без `--coverage`; удалён
+  шаг `upload-artifact` (артефакт переехал в coverage.yml); `timeout-minutes`
+  25 → 15.
+- `.github/workflows/coverage.yml` (новый) — зеркало старого Test job с триггерами
+  `schedule` + `workflow_dispatch`, `timeout-minutes: 30`.
+
+## Verification
+
+1. PR с этими изменениями: job `Test` зелёный и укладывается в ~10-15 мин.
+2. После мерджа: запустить `Coverage` вручную через `Run workflow` — job зелёный,
+   артефакт `coverage/` загрузился.
+3. `Coverage` не появляется как check на PR (нет `pull_request`/`push` триггеров).
+
+## Долгосрочно (вне этого PR)
+
+Если `Test` без coverage начнёт подбираться к 15-минутному лимиту — тогда
+возвращаться к шардингу или раздельным tier'ам (unit/integration). Сейчас YAGNI.


### PR DESCRIPTION
## Проблема

Job `Test` в `ci.yml` падал по таймауту на каждом коммите в `main` (последние 5 — красный/cancelled CI, 20-25 мин). Узкое место — флаг `--coverage`: инструментация ~5000-файлового suite не влезает в 25-минутное окно. Сами тесты зелёные. `main` структурно не мог получить зелёный CI — PR #141 пришлось мерджить через admin-bypass.

## Решение

- **`ci.yml` job `Test`** — гоняет тесты **без** `--coverage`. ~10-12 мин вместо 25+, влезает с запасом. Имя job `Test` сохранено → required-check в branch protection не ломается. `timeout-minutes` 25 → 15.
- **`coverage.yml` (новый)** — полный прогон с `--coverage` по расписанию (раз в неделю, пн 06:00 UTC) + кнопка `workflow_dispatch`. Его таймаут никого не блокирует, артефакт `coverage/` сохраняется.

Гейта «coverage ≥ N%» нигде нет (`jest.config.mjs` без `coverageThreshold`, нет ruleset) — вынос coverage из блокирующего job ничего не ломает функционально.

Расход GH Actions минут: было ~25 мин/push → стало ~10-12 мин/push + ~25 мин/неделю.

Дизайн: `docs/plans/2026-05-14-ci-coverage-split-design.md`

## Test plan

- [ ] Job `Test` в этом PR зелёный и укладывается в ~10-15 мин
- [ ] После мерджа — запустить `Coverage` вручную (Run workflow), убедиться что зелёный + артефакт `coverage/` загрузился
- [ ] `Coverage` не появляется как check на PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)