### PR TITLE
fix(e2e): honest skips for manual/prod-only specs in CI

### DIFF
--- a/__tests__/e2e/rag-visual-verification.spec.ts
+++ b/__tests__/e2e/rag-visual-verification.spec.ts
@@ -31,6 +31,10 @@
 
 import { test, expect, chromium, type Page, type BrowserContext } from '@playwright/test';
 
+// CI skip: this spec requires a headed browser (X server) and is intended for
+// manual visual QA only. It is automatically skipped in CI environments.
+test.skip(!!process.env.CI, 'Manual visual QA spec — requires X server (headed browser); skipped in CI');
+
 // ─── Env ─────────────────────────────────────────────────────────────────────
 
 const BASE_URL   = process.env.E2E_BASE_URL   ?? 'http://localhost:3000';

--- a/__tests__/e2e/skeptical-forwarder.spec.ts
+++ b/__tests__/e2e/skeptical-forwarder.spec.ts
@@ -16,6 +16,12 @@ import { test, expect, type Page, type BrowserContext, chromium } from '@playwri
 import * as fs from 'fs';
 import * as path from 'path';
 
+// CI skip: this spec requires __tests__/fixtures/test-suite-50/expected.json (not committed)
+// and runs against the production URL https://demo.quantika.org.
+// It is intended for manual adversarial QA and is automatically skipped in CI.
+const _fixturePath = path.resolve(__dirname, '../fixtures/test-suite-50/expected.json');
+test.skip(!!process.env.CI || !fs.existsSync(_fixturePath), 'Requires test-suite-50/expected.json fixture (not committed) and prod baseURL; skipped in CI');
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 interface Finding {


### PR DESCRIPTION
## Summary

Two E2E specs were written as **manual / prod-only tools** and crash in CI. Both now skip honestly when `process.env.CI` is set, so CI E2E goes green without losing the specs themselves (they still work locally).

- `__tests__/e2e/rag-visual-verification.spec.ts` — `chromium.launch({ headless: false, slowMo: 1200 })` requires an X server. GitHub Actions runners don't have one, so all 8 tests crashed in `beforeAll`. Now: `test.skip(!!process.env.CI, …)`.
- `__tests__/e2e/skeptical-forwarder.spec.ts` — depends on `__tests__/fixtures/test-suite-50/expected.json` (not committed) and hardcodes prod baseURL. Now: `test.skip(!!process.env.CI || !fs.existsSync(fixturePath), …)`.

Both specs remain fully runnable locally for manual QA.

## Follow-up (next session, after 3 consecutive green push runs on main)

Remove ` continue-on-error: true` from the E2E job in [.github/workflows/ci.yml](.github/workflows/ci.yml). This is the final step of the CI health overhaul design ([docs/plans/2026-05-14-ci-health-overhaul-design.md](docs/plans/2026-05-14-ci-health-overhaul-design.md)).

## Test plan

- [x] lint + tsc green locally
- [ ] CI Test/Build/TypeCheck green on this PR
- [ ] After merge: first push run E2E goes green (with the two specs honestly skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)