### PR TITLE
feat(ux): cleanup bundle — /upgrade + /matches + FuelEU days

### DIFF
--- a/__tests__/economics/fueleu-voyage-days.test.ts
+++ b/__tests__/economics/fueleu-voyage-days.test.ts
@@ -1,0 +1,43 @@
+/**
+ * UX cleanup bundle: FuelEU voyageDays derivation.
+ * Audit 2026-05-13 — components/match/EconomicsTab.tsx hardcoded
+ * `estimatedVoyageDays = 15`. Now computed from route distance + vessel speed.
+ *
+ * Formula: voyageDays = max(1, round(distanceNm / (speedKnots * 24)))
+ * Fallback speed: 12 kn when vessel speed is missing/invalid.
+ * Missing distance → 0 (FuelEU calc skipped / "n/a" in UI).
+ */
+import { estimateVoyageDays } from '@/lib/economics/voyage-days';
+
+describe('estimateVoyageDays', () => {
+  test('5000 nm at 12 kn → ~17 days', () => {
+    expect(estimateVoyageDays(5000, 12)).toBe(17);
+  });
+
+  test('1500 nm at 10 kn → ~6 days', () => {
+    expect(estimateVoyageDays(1500, 10)).toBe(6);
+  });
+
+  test('missing distance returns 0', () => {
+    expect(estimateVoyageDays(null, 14)).toBe(0);
+    expect(estimateVoyageDays(undefined, 14)).toBe(0);
+  });
+
+  test('missing or zero speed falls back to 12 kn', () => {
+    // 5000 / (12*24) ≈ 17.36 → 17
+    expect(estimateVoyageDays(5000, null)).toBe(17);
+    expect(estimateVoyageDays(5000, 0)).toBe(17);
+    expect(estimateVoyageDays(5000, undefined)).toBe(17);
+  });
+
+  test('very short distance clamps to minimum 1 day', () => {
+    // 50 / (14*24) ≈ 0.15 → max(1, round(0.15)) = 1
+    expect(estimateVoyageDays(50, 14)).toBe(1);
+  });
+
+  test('negative or NaN inputs return 0', () => {
+    expect(estimateVoyageDays(-100, 12)).toBe(0);
+    expect(estimateVoyageDays(NaN, 12)).toBe(0);
+    expect(estimateVoyageDays(5000, NaN)).toBe(17); // fallback applies
+  });
+});

--- a/__tests__/pages/matches-page.test.tsx
+++ b/__tests__/pages/matches-page.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ *
+ * UX cleanup bundle: /matches "Coming soon" placeholder.
+ * Audit 2026-05-13 (F3) — /matches redirected to /dashboard with no listing.
+ * Since /api/matches doesn't exist, we replace the redirect with a placeholder
+ * + link back to /dashboard. No new endpoint is created.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+import MatchesPage from '@/app/matches/page';
+
+describe('/matches placeholder page', () => {
+  test('renders "Coming soon" heading instead of redirecting', () => {
+    render(<MatchesPage />);
+    expect(screen.getByRole('heading', { name: /coming soon|скоро/i })).toBeInTheDocument();
+  });
+
+  test('exposes link back to /dashboard', () => {
+    render(<MatchesPage />);
+    const link = screen.getByRole('link', { name: /dashboard|дашборд/i });
+    expect(link).toHaveAttribute('href', '/dashboard');
+  });
+});

--- a/__tests__/pages/upgrade-page.test.tsx
+++ b/__tests__/pages/upgrade-page.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ *
+ * UX cleanup bundle: /upgrade placeholder page.
+ * Audit 2026-05-13 (browser-walkthrough, F-?) — TrialBanner linked to /upgrade,
+ * route was 404. Minimal placeholder with mailto contact.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+import UpgradePage from '@/app/upgrade/page';
+
+describe('/upgrade placeholder page', () => {
+  test('renders heading', () => {
+    render(<UpgradePage />);
+    expect(screen.getByRole('heading', { name: /апгрейд|upgrade/i })).toBeInTheDocument();
+  });
+
+  test('exposes mailto link to hello@quantika.org', () => {
+    render(<UpgradePage />);
+    const link = screen.getByRole('link', { name: /hello@quantika\.org|связаться|contact/i });
+    expect(link).toHaveAttribute('href', 'mailto:hello@quantika.org');
+  });
+});

--- a/__tests__/routing/matches-redirect.test.tsx
+++ b/__tests__/routing/matches-redirect.test.tsx
@@ -1,11 +1,14 @@
-describe('/matches redirect (γ-cleanup-4 F3)', () => {
-  it('app/matches/page.tsx exists and uses next/navigation redirect', () => {
+describe('/matches Coming Soon page (γ-cleanup-4 F3)', () => {
+  it('app/matches/page.tsx exists as a Coming Soon server component', () => {
     const fs = require('fs');
     const path = require('path');
     const filePath = path.join(__dirname, '../../app/matches/page.tsx');
     expect(fs.existsSync(filePath)).toBe(true);
     const src = fs.readFileSync(filePath, 'utf8');
-    expect(src).toMatch(/from\s+['"]next\/navigation['"]/);
-    expect(src).toMatch(/redirect\s*\(\s*['"]\/dashboard['"]\s*\)/);
+    expect(src).toMatch(/export\s+default\s+function/);
+    expect(src).toMatch(/[Cc]oming\s+[Ss]oon/);
+    expect(src).toMatch(/href=['"]\/dashboard['"]/);
+    expect(src).not.toMatch(/from\s+['"]next\/navigation['"]/);
+    expect(src).not.toMatch(/redirect\s*\(/);
   });
 });

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,10 +1,26 @@
-import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import Link from 'next/link';
 
-/**
- * γ-cleanup-4 F3: /matches list page is not implemented (only /match/[id]).
- * Users hitting /matches directly are redirected to /dashboard where
- * they can find Top Priorities → matches via the action panel.
- */
-export default function MatchesRedirect(): never {
-  redirect('/dashboard');
+export const metadata: Metadata = {
+  title: 'Matches — Quantika',
+};
+
+export default function MatchesPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-12">
+      <div className="max-w-md w-full bg-white rounded-lg border p-6 space-y-4 text-center">
+        <h1 className="text-xl font-bold">Matches — coming soon</h1>
+        <p className="text-sm text-gray-600">
+          Список матчей появится в одном из следующих обновлений. Пока актуальные
+          подсветки доступны на дашборде в блоке Top Priorities.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-block px-4 py-2 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+        >
+          К дашборду
+        </Link>
+      </div>
+    </main>
+  );
 }

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Запросить апгрейд — Quantika',
+};
+
+export default function UpgradePage() {
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4 py-12">
+      <div className="max-w-md w-full bg-white rounded-lg border p-6 space-y-4 text-center">
+        <h1 className="text-xl font-bold">Запросить апгрейд</h1>
+        <p className="text-sm text-gray-600">
+          Свяжитесь с нами, чтобы перейти на полный тариф. Мы ответим в течение рабочего дня.
+        </p>
+        <a
+          href="mailto:hello@quantika.org"
+          className="inline-block px-4 py-2 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+        >
+          hello@quantika.org
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -4,11 +4,18 @@ import { useState, useMemo } from 'react';
 import type { ParsedVessel, ParsedCargo } from '@/lib/types';
 import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
 import { calculateFuelEu } from '@/lib/economics/fueleu';
+import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 
 interface EconomicsTabProps {
   commissionPercent?: number | null;
   vessel?: ParsedVessel;
   cargo?: ParsedCargo;
+  /**
+   * Route distance in nautical miles, e.g. from `match.readiness.distanceNm`.
+   * When omitted/null the FuelEU tile renders without a penalty estimate
+   * (shows "Voyage distance n/a") instead of using a hardcoded constant.
+   */
+  routeDistanceNm?: number | null;
 }
 
 function parseLeadingNumber(s: string | null | undefined): number {
@@ -41,7 +48,7 @@ const DISPLAY_RATES: Record<DisplayCurrency, number> = {
   USD: 1, EUR: 0.926, GBP: 0.787, NOK: 10.87, AED: 3.67,
 };
 
-export function EconomicsTab({ commissionPercent, vessel, cargo }: EconomicsTabProps) {
+export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm }: EconomicsTabProps) {
   const [open, setOpen] = useState(false);
   const [bunkerPriceUsdPerMt, setBunkerPriceUsdPerMt] = useState('');
   const [bunkerPort, setBunkerPort] = useState<BunkerPort>('SGSIN');
@@ -96,24 +103,26 @@ export function EconomicsTab({ commissionPercent, vessel, cargo }: EconomicsTabP
     if (!fuelEuEnabled) return null;
 
     const consumption = parseLeadingNumber(vessel?.consumption);
-    const origin = cargo?.originPort?.value ?? '';
-    const destination = cargo?.destinationPort?.value ?? '';
-
-    // Estimate voyage days (simple calculation: assume 5000 nm average, 14 kts)
-    // This is a placeholder — real implementation would calculate from route distance
-    const estimatedVoyageDays = origin && destination ? 15 : 0;
+    const speedKnots = parseLeadingNumber(vessel?.speedLaden);
+    const voyageDays = estimateVoyageDays(routeDistanceNm, speedKnots);
 
     try {
       return calculateFuelEu({
         fuelType,
         consumptionMtPerDay: consumption,
-        voyageDays: estimatedVoyageDays,
+        voyageDays,
         year: 2025,
       });
     } catch {
       return null;
     }
-  }, [fuelType, vessel, cargo, fuelEuEnabled]);
+  }, [fuelType, vessel, routeDistanceNm, fuelEuEnabled]);
+
+  const fuelEuVoyageDays = useMemo(() => {
+    if (!fuelEuEnabled) return 0;
+    const speedKnots = parseLeadingNumber(vessel?.speedLaden);
+    return estimateVoyageDays(routeDistanceNm, speedKnots);
+  }, [vessel, routeDistanceNm, fuelEuEnabled]);
 
   return (
     <div data-testid="tab-economics" className="space-y-4 text-sm">
@@ -221,6 +230,12 @@ export function EconomicsTab({ commissionPercent, vessel, cargo }: EconomicsTabP
               <option value="biodiesel-b100">Biodiesel B100</option>
             </select>
           </div>
+
+          {fuelEuResult && fuelEuVoyageDays === 0 && (
+            <p className="text-xs text-gray-500" data-testid="fueleu-distance-missing">
+              Voyage distance n/a — provide origin/destination + vessel speed for a penalty estimate.
+            </p>
+          )}
 
           {fuelEuResult && (
             <div className="space-y-1 text-xs">

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -66,7 +66,12 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId }: MatchTabsProps
           <VesselsTab vessel={vessel} newCargo={cargo?.cargoDescription?.value ?? undefined} />
         )}
         {activeTab === 'economics' && (
-          <EconomicsTab commissionPercent={cargo?.commissionPercent} vessel={vessel} cargo={cargo} />
+          <EconomicsTab
+            commissionPercent={cargo?.commissionPercent}
+            vessel={vessel}
+            cargo={cargo}
+            routeDistanceNm={match.readiness?.distanceNm ?? null}
+          />
         )}
         {activeTab === 'passport' && (
           <PassportTab vessel={vessel} />

--- a/lib/economics/voyage-days.ts
+++ b/lib/economics/voyage-days.ts
@@ -1,0 +1,21 @@
+/**
+ * Estimate voyage duration from route distance and vessel speed.
+ *
+ * voyageDays = max(1, round(distanceNm / (speedKnots * 24)))
+ *
+ * Returns 0 when distance is missing/invalid (UI should treat as "n/a"
+ * and skip downstream calc rather than substitute a fake constant).
+ * Falls back to 12 kn when speed is missing/invalid.
+ */
+export function estimateVoyageDays(
+  distanceNm: number | null | undefined,
+  speedKnots: number | null | undefined,
+): number {
+  if (distanceNm == null || !Number.isFinite(distanceNm) || distanceNm <= 0) {
+    return 0;
+  }
+  const speed =
+    speedKnots != null && Number.isFinite(speedKnots) && speedKnots > 0 ? speedKnots : 12;
+  const days = distanceNm / (speed * 24);
+  return Math.max(1, Math.round(days));
+}


### PR DESCRIPTION
## Summary

UX cleanup bundle from `docs/audits/browser-walkthrough-2026-05-13.md` (Group D / Task 2.D in acceleration-plan):

- **`/upgrade`** — was 404; `TrialBanner.tsx` linked there. Added minimal placeholder page (`app/upgrade/page.tsx`) with `mailto:hello@quantika.org`.
- **`/matches`** — was a silent `redirect('/dashboard')`. Replaced with an explicit "Coming soon" placeholder + link back to `/dashboard`. **No new `/api/matches` endpoint introduced** (it doesn't exist; per scope decision we don't create one in this PR).
- **FuelEU `estimatedVoyageDays = 15` hardcode** — replaced with `estimateVoyageDays(distanceNm, speedKnots)` helper. Distance comes from `match.readiness.distanceNm` via `MatchTabs`, speed from `vessel.speedLaden` (fallback 12 kn). Missing distance → shows "Voyage distance n/a" instead of substituting a fake constant.

## Excluded from this PR — already correct on `main`

- **`/recap/[id]`** — the 05-13 audit reported a 404, but on current `main` (HEAD `5b9bf52`) `app/recap/[id]/page.tsx` already exists and renders recap data from session. The audit's 404 was likely from visiting with a stale id (`notFound()` from missing session record), not a missing route. Real `/recap/<threadId>` links from `app/dashboard/page.tsx:383` work. No change needed.

## Manual VPS env step required (NOT in this PR)

The 05-13 walkthrough flagged a flag-name mismatch — backend uses `ROI_GUARANTEE_ENABLED`, UI uses `NEXT_PUBLIC_ROI_GUARANTEE_ENABLED`:

```bash
# To enable RoiSummaryTile on /dashboard, on outreach-vps:
echo 'NEXT_PUBLIC_ROI_GUARANTEE_ENABLED=true' >> /root/quantika-demo/.env.local
# then rebuild + restart next-server
```

This PR does **not** change env files; please apply manually when deploying.

## DEPLOY DEFERRED

🚦 **Do not auto-deploy.** A parallel session (`parse-cargo Phase 3a bakeoff`) is currently running on `outreach-vps` in `tmux:bakeoff` against `/root/quantika-demo` (branch `feat/parse-cargo-phase3a-config-bakeoff`). Wait for orchestrator confirmation that bakeoff is done before merging + deploying. This session did **not** touch `outreach-vps`.

## Test plan

- [x] `npx jest __tests__/economics/fueleu-voyage-days __tests__/pages __tests__/components/match __tests__/economics` → 63/63 ✅
- [x] `npx jest __tests__/regression/RC-fueleu-flag __tests__/regression/RC-sample-match __tests__/sample/sample-demo-match` → 15/15 ✅
- [x] `npx tsc --noEmit` → clean
- [ ] Post-deploy smoke (after merge + VPS update): `/upgrade` 200, `/matches` 200, `/recap/<existing-thread-id>` 200, `/match/<id>` → Economics tab → FuelEU tile shows non-15 voyage days when distance is set
- [ ] Apply `NEXT_PUBLIC_ROI_GUARANTEE_ENABLED=true` on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)