### PR TITLE
feat(psc): fixture + seed + vessel-page link (Task 2.C)

### DIFF
--- a/__tests__/api/vessels-psc-history.test.ts
+++ b/__tests__/api/vessels-psc-history.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration: seed fixture into in-memory DB through the real psc-repository,
+ * then call GET /api/vessels/[imo]/psc-history and assert the response is
+ * filtered + shaped correctly. The route's network adapter is stubbed to
+ * keep the test hermetic.
+ */
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import migration028 from '@/lib/migrations/028-psc-history';
+import { upsertInspection } from '@/lib/market/psc-repository';
+import { PSC_FIXTURE } from '@/lib/knowledge/sources/psc/fixture';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/db/index', () => ({
+  getDb: jest.fn(() => testDb),
+}));
+
+jest.mock('@/lib/knowledge/sources/psc/psc-adapter', () => ({
+  fetchPscHistory: jest.fn(async () => []),
+}));
+
+function makeReq(path: string): NextRequest {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+describe('GET /api/vessels/[imo]/psc-history (fixture integration)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, PSC_DETENTION_ENABLED: 'true' };
+    testDb = new Database(':memory:');
+    migration028.up(testDb);
+    for (const rec of PSC_FIXTURE) {
+      upsertInspection(testDb, rec);
+    }
+  });
+
+  afterEach(() => {
+    testDb.close();
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('returns only records for the requested IMO', async () => {
+    const targetImo = '9322180';
+    const expectedCount = PSC_FIXTURE.filter((r) => r.imo === targetImo).length;
+    expect(expectedCount).toBeGreaterThan(0); // sanity on the fixture
+
+    const { GET } = await import('@/app/api/vessels/[imo]/psc-history/route');
+    const res = await GET(makeReq(`/api/vessels/${targetImo}/psc-history`), {
+      params: Promise.resolve({ imo: targetImo }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(expectedCount);
+    for (const row of body) {
+      expect(row.imo).toBe(targetImo);
+    }
+  });
+
+  it('returns rows sorted by inspection_date DESC', async () => {
+    const targetImo = '9478999';
+    const { GET } = await import('@/app/api/vessels/[imo]/psc-history/route');
+    const res = await GET(makeReq(`/api/vessels/${targetImo}/psc-history`), {
+      params: Promise.resolve({ imo: targetImo }),
+    });
+
+    expect(res.status).toBe(200);
+    const body: Array<{ inspection_date: string }> = await res.json();
+    expect(body.length).toBeGreaterThan(1);
+    for (let i = 1; i < body.length; i++) {
+      expect(body[i - 1].inspection_date >= body[i].inspection_date).toBe(true);
+    }
+  });
+
+  it('returns the canonical PscRecord shape per row', async () => {
+    const { GET } = await import('@/app/api/vessels/[imo]/psc-history/route');
+    const res = await GET(makeReq('/api/vessels/9322180/psc-history'), {
+      params: Promise.resolve({ imo: '9322180' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.length).toBeGreaterThan(0);
+    const row = body[0];
+    expect(row).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        imo: '9322180',
+        inspection_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        authority: expect.stringMatching(/^(paris-mou|tokyo-mou|uscg|other)$/),
+        deficiencies: expect.any(Number),
+        detained: expect.any(Boolean),
+      }),
+    );
+  });
+
+  it('returns an empty array for an IMO not in the fixture', async () => {
+    const { GET } = await import('@/app/api/vessels/[imo]/psc-history/route');
+    const res = await GET(makeReq('/api/vessels/9999999/psc-history'), {
+      params: Promise.resolve({ imo: '9999999' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+});

--- a/app/vessel/[id]/page.tsx
+++ b/app/vessel/[id]/page.tsx
@@ -13,6 +13,7 @@ import { formatDate } from '@/lib/utils';
 import { lookupCii } from '@/lib/imo/cii-lookup';
 import { CiiRatingBadge } from '@/components/vessel/CiiRatingBadge';
 import { SanctionsBadge } from '@/components/vessel/SanctionsBadge';
+import { PscHistoryLink } from '@/components/vessel/PscHistoryLink';
 
 // Only the three canonical string labels are valid. Guard against numeric
 // confidence scores from the parser reaching the ConfIcon branch — a truthy
@@ -134,6 +135,9 @@ export default async function VesselDetailPage({ params }: Props) {
                     size="medium"
                   />
                 )}
+                <span className="ml-auto">
+                  <PscHistoryLink imo={vessel.imo} />
+                </span>
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/components/vessel/PscHistoryLink.tsx
+++ b/components/vessel/PscHistoryLink.tsx
@@ -1,0 +1,29 @@
+/**
+ * PscHistoryLink — small navigation link to /vessels/[imo]/psc-history.
+ *
+ * Gated by NEXT_PUBLIC_PSC_DETENTION_ENABLED. Renders nothing when the
+ * flag is OFF or when no IMO is available, so the parent page can render
+ * it unconditionally without leaking the feature in non-prod builds.
+ */
+import Link from 'next/link';
+import { Anchor } from 'lucide-react';
+
+interface PscHistoryLinkProps {
+  /** Vessel IMO (7 digits). If empty/null, the link is hidden. */
+  imo: string | null | undefined;
+}
+
+export function PscHistoryLink({ imo }: PscHistoryLinkProps) {
+  if (process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED !== 'true') return null;
+  if (!imo) return null;
+
+  return (
+    <Link
+      href={`/vessels/${imo}/psc-history`}
+      className="inline-flex items-center gap-1 rounded border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+    >
+      <Anchor className="h-3.5 w-3.5" />
+      PSC History
+    </Link>
+  );
+}

--- a/components/vessel/__tests__/PscHistoryLink.test.tsx
+++ b/components/vessel/__tests__/PscHistoryLink.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PscHistoryLink } from '../PscHistoryLink';
+
+describe('PscHistoryLink', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('renders a link to /vessels/{imo}/psc-history when flag is enabled', () => {
+    process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED = 'true';
+    render(<PscHistoryLink imo="9322180" />);
+
+    const link = screen.getByRole('link', { name: /psc history/i });
+    expect(link).toHaveAttribute('href', '/vessels/9322180/psc-history');
+  });
+
+  it('renders nothing when the flag is unset', () => {
+    delete process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED;
+    const { container } = render(<PscHistoryLink imo="9322180" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the flag is explicitly "false"', () => {
+    process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED = 'false';
+    const { container } = render(<PscHistoryLink imo="9322180" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when imo is empty', () => {
+    process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED = 'true';
+    const { container } = render(<PscHistoryLink imo="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when imo is null', () => {
+    process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED = 'true';
+    const { container } = render(<PscHistoryLink imo={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/__tests__/psc-fixture.test.ts
+++ b/lib/__tests__/psc-fixture.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Validates structural invariants of the PSC fixture so the demo doesn't
+ * drift into impossible shapes (bad IMO format, unknown authority, runaway
+ * detention ratio, etc.). Schema fields must stay aligned with
+ * lib/migrations/028-psc-history.ts.
+ */
+import { PSC_FIXTURE, PSC_FIXTURE_IMOS } from '../knowledge/sources/psc/fixture';
+import ciiData from '../sample-data/imo/cii.json';
+
+const VALID_AUTHORITIES = new Set(['paris-mou', 'tokyo-mou', 'uscg', 'other']);
+const ALLOWED_IMOS = new Set<string>(ciiData.records.map((r) => r.imo));
+
+describe('PSC_FIXTURE', () => {
+  it('contains 15-20 records', () => {
+    expect(PSC_FIXTURE.length).toBeGreaterThanOrEqual(15);
+    expect(PSC_FIXTURE.length).toBeLessThanOrEqual(20);
+  });
+
+  it('spans 3-5 unique IMOs', () => {
+    const imos = new Set(PSC_FIXTURE.map((r) => r.imo));
+    expect(imos.size).toBeGreaterThanOrEqual(3);
+    expect(imos.size).toBeLessThanOrEqual(5);
+  });
+
+  it('declares the same IMO set in PSC_FIXTURE_IMOS', () => {
+    const inFixture = new Set(PSC_FIXTURE.map((r) => r.imo));
+    expect(new Set(PSC_FIXTURE_IMOS)).toEqual(inFixture);
+  });
+
+  it('uses IMOs that already appear in the demo CII dataset', () => {
+    for (const imo of PSC_FIXTURE_IMOS) {
+      expect(ALLOWED_IMOS.has(imo)).toBe(true);
+    }
+  });
+
+  it('uses 7-digit IMO numbers', () => {
+    for (const rec of PSC_FIXTURE) {
+      expect(rec.imo).toMatch(/^\d{7}$/);
+    }
+  });
+
+  it('uses only schema-valid authorities', () => {
+    for (const rec of PSC_FIXTURE) {
+      expect(VALID_AUTHORITIES.has(rec.authority)).toBe(true);
+    }
+  });
+
+  it('uses ISO-style YYYY-MM-DD inspection_date', () => {
+    for (const rec of PSC_FIXTURE) {
+      expect(rec.inspection_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      // Date constructor accepts the format and yields a real date
+      const parsed = new Date(rec.inspection_date);
+      expect(Number.isNaN(parsed.getTime())).toBe(false);
+    }
+  });
+
+  it('keeps inspection dates within a 24-month span', () => {
+    const times = PSC_FIXTURE.map((r) => new Date(r.inspection_date).getTime());
+    const min = Math.min(...times);
+    const max = Math.max(...times);
+    const spanMs = max - min;
+    const twentyFourMonthsMs = 24 * 31 * 24 * 60 * 60 * 1000;
+    expect(spanMs).toBeLessThanOrEqual(twentyFourMonthsMs);
+  });
+
+  it('keeps detained ratio ≤ 30%', () => {
+    const detainedCount = PSC_FIXTURE.filter((r) => r.detained).length;
+    const ratio = detainedCount / PSC_FIXTURE.length;
+    expect(ratio).toBeLessThanOrEqual(0.3);
+  });
+
+  it('uses non-negative finite deficiencies counts', () => {
+    for (const rec of PSC_FIXTURE) {
+      expect(Number.isFinite(rec.deficiencies)).toBe(true);
+      expect(rec.deficiencies).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('has unique ids per record (idempotency hinges on this)', () => {
+    const ids = PSC_FIXTURE.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('uses at least 3 distinct ports', () => {
+    const ports = new Set(PSC_FIXTURE.map((r) => r.port).filter(Boolean));
+    expect(ports.size).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/lib/knowledge/sources/psc/fixture.ts
+++ b/lib/knowledge/sources/psc/fixture.ts
@@ -1,0 +1,191 @@
+/**
+ * SYNTHETIC FIXTURE FOR DEMO — do not redistribute.
+ *
+ * 16 Port-State-Control inspection records spread across 5 IMOs that also
+ * appear in `lib/sample-data/imo/cii.json`, so the demo flow can correlate
+ * PSC history with CII ratings (poor-rated vessels have more deficiencies +
+ * detentions; well-rated vessels have a clean record).
+ *
+ * Schema matches `lib/migrations/028-psc-history.ts` (`psc_detention_history`):
+ * deficiencies is a count, not an array of codes; authority is constrained
+ * to {paris-mou, tokyo-mou, uscg, other}.
+ *
+ * Dates: spread across the last ~24 months from May 2026.
+ * Ports: 4 UN/LOCODEs (NLRTM, ESALG, JPYOK, USORF).
+ * Detained ratio: 4/16 = 25% (below the 30% cap used in fixture tests).
+ */
+import type { PscRecord } from '@/lib/market/psc-repository';
+
+export const PSC_FIXTURE: PscRecord[] = [
+  // 9322180 — CII rating D (poor) — repeat Paris-MoU activity, one detention
+  {
+    id: 'psc-9322180-2024-09-12',
+    imo: '9322180',
+    inspection_date: '2024-09-12',
+    port: 'NLRTM',
+    authority: 'paris-mou',
+    deficiencies: 4,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9322180-2025-03-04',
+    imo: '9322180',
+    inspection_date: '2025-03-04',
+    port: 'ESALG',
+    authority: 'paris-mou',
+    deficiencies: 7,
+    detained: true,
+    source_url: null,
+  },
+  {
+    id: 'psc-9322180-2025-08-21',
+    imo: '9322180',
+    inspection_date: '2025-08-21',
+    port: 'NLRTM',
+    authority: 'paris-mou',
+    deficiencies: 3,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9322180-2026-02-15',
+    imo: '9322180',
+    inspection_date: '2026-02-15',
+    port: 'ESALG',
+    authority: 'paris-mou',
+    deficiencies: 2,
+    detained: false,
+    source_url: null,
+  },
+
+  // 9478999 — CII rating E (very poor) — multiple detentions across MoUs
+  {
+    id: 'psc-9478999-2024-08-04',
+    imo: '9478999',
+    inspection_date: '2024-08-04',
+    port: 'USORF',
+    authority: 'uscg',
+    deficiencies: 5,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9478999-2025-01-19',
+    imo: '9478999',
+    inspection_date: '2025-01-19',
+    port: 'JPYOK',
+    authority: 'tokyo-mou',
+    deficiencies: 9,
+    detained: true,
+    source_url: null,
+  },
+  {
+    id: 'psc-9478999-2025-09-10',
+    imo: '9478999',
+    inspection_date: '2025-09-10',
+    port: 'NLRTM',
+    authority: 'paris-mou',
+    deficiencies: 6,
+    detained: true,
+    source_url: null,
+  },
+  {
+    id: 'psc-9478999-2026-03-22',
+    imo: '9478999',
+    inspection_date: '2026-03-22',
+    port: 'USORF',
+    authority: 'uscg',
+    deficiencies: 4,
+    detained: false,
+    source_url: null,
+  },
+
+  // 9512345 — CII rating B (good) — light history, no detentions
+  {
+    id: 'psc-9512345-2024-11-08',
+    imo: '9512345',
+    inspection_date: '2024-11-08',
+    port: 'NLRTM',
+    authority: 'paris-mou',
+    deficiencies: 1,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9512345-2025-05-14',
+    imo: '9512345',
+    inspection_date: '2025-05-14',
+    port: 'JPYOK',
+    authority: 'tokyo-mou',
+    deficiencies: 0,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9512345-2026-01-09',
+    imo: '9512345',
+    inspection_date: '2026-01-09',
+    port: 'ESALG',
+    authority: 'paris-mou',
+    deficiencies: 2,
+    detained: false,
+    source_url: null,
+  },
+
+  // 9156789 — CII rating A (excellent) — minimal, clean
+  {
+    id: 'psc-9156789-2024-12-02',
+    imo: '9156789',
+    inspection_date: '2024-12-02',
+    port: 'USORF',
+    authority: 'uscg',
+    deficiencies: 0,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9156789-2025-10-17',
+    imo: '9156789',
+    inspection_date: '2025-10-17',
+    port: 'NLRTM',
+    authority: 'paris-mou',
+    deficiencies: 1,
+    detained: false,
+    source_url: null,
+  },
+
+  // 9734567 — CII rating D (poor) — Tokyo-MoU detention
+  {
+    id: 'psc-9734567-2024-07-30',
+    imo: '9734567',
+    inspection_date: '2024-07-30',
+    port: 'JPYOK',
+    authority: 'tokyo-mou',
+    deficiencies: 3,
+    detained: false,
+    source_url: null,
+  },
+  {
+    id: 'psc-9734567-2025-04-25',
+    imo: '9734567',
+    inspection_date: '2025-04-25',
+    port: 'JPYOK',
+    authority: 'tokyo-mou',
+    deficiencies: 8,
+    detained: true,
+    source_url: null,
+  },
+  {
+    id: 'psc-9734567-2025-11-11',
+    imo: '9734567',
+    inspection_date: '2025-11-11',
+    port: 'ESALG',
+    authority: 'paris-mou',
+    deficiencies: 2,
+    detained: false,
+    source_url: null,
+  },
+];
+
+export const PSC_FIXTURE_IMOS = ['9322180', '9478999', '9512345', '9156789', '9734567'] as const;

--- a/scripts/knowledge/seeds/seed-psc-history.ts
+++ b/scripts/knowledge/seeds/seed-psc-history.ts
@@ -1,0 +1,75 @@
+/**
+ * seed-psc-history.ts
+ *
+ * Seeds the psc_detention_history table with synthetic PSC inspection records
+ * for ~5 demo IMOs (see lib/knowledge/sources/psc/fixture.ts).
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/seed-psc-history.ts
+ *   npx tsx --env-file=.env.local scripts/seed-psc-history.ts --dry-run
+ *
+ * Env:
+ *   SESSIONS_DB_PATH — path to sqlite db (default: data/sessions.db)
+ *
+ * Idempotent: clears all existing rows, then re-inserts the fixture, so
+ * repeated runs converge on the same state.
+ */
+
+import { getStore } from '../../../lib/session-store';
+import { upsertInspection } from '../../../lib/market/psc-repository';
+import { PSC_FIXTURE, PSC_FIXTURE_IMOS } from '../../../lib/knowledge/sources/psc/fixture';
+
+export function seedPscHistory(opts: { dryRun?: boolean } = {}): void {
+  const { dryRun = false } = opts;
+
+  console.log(
+    `Seeding PSC detention history${dryRun ? ' (DRY RUN — no DB writes)' : ''}...`,
+  );
+  console.log(`  Fixture: ${PSC_FIXTURE.length} records across ${PSC_FIXTURE_IMOS.length} IMOs`);
+
+  if (dryRun) {
+    console.log('\nFirst 5 records that would be inserted:');
+    for (const rec of PSC_FIXTURE.slice(0, 5)) {
+      console.log(
+        `  - ${rec.id} | ${rec.imo} | ${rec.inspection_date} | ${rec.port} | ${rec.authority} | def=${rec.deficiencies} | detained=${rec.detained}`,
+      );
+    }
+    console.log('\nDry run complete — no rows written.');
+    return;
+  }
+
+  const db = getStore().getDatabase();
+
+  const deleted = db
+    .prepare('DELETE FROM psc_detention_history')
+    .run().changes;
+  console.log(`  Cleared ${deleted} existing row(s).`);
+
+  for (const record of PSC_FIXTURE) {
+    upsertInspection(db, record);
+  }
+
+  const count = db
+    .prepare<[], { c: number }>('SELECT COUNT(*) as c FROM psc_detention_history')
+    .get()?.c ?? 0;
+  console.log(`  Inserted ${PSC_FIXTURE.length} record(s). Table now has ${count} row(s).`);
+
+  console.log('\nSample rows:');
+  const samples = db
+    .prepare<[], { id: string; imo: string; inspection_date: string; port: string; authority: string; deficiencies: number; detained: number }>(
+      'SELECT id, imo, inspection_date, port, authority, deficiencies, detained FROM psc_detention_history ORDER BY inspection_date DESC LIMIT 5',
+    )
+    .all();
+  for (const row of samples) {
+    console.log(
+      `  - ${row.id} | ${row.imo} | ${row.inspection_date} | ${row.port} | ${row.authority} | def=${row.deficiencies} | detained=${row.detained === 1}`,
+    );
+  }
+
+  console.log(`\nSeeded PSC history for IMOs: ${PSC_FIXTURE_IMOS.join(', ')}`);
+}
+
+if (require.main === module) {
+  const dryRun = process.argv.includes('--dry-run');
+  seedPscHistory({ dryRun });
+}

--- a/scripts/seed-psc-history.ts
+++ b/scripts/seed-psc-history.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env tsx
+/**
+ * Thin wrapper — delegates to scripts/knowledge/seeds/seed-psc-history.ts
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/seed-psc-history.ts
+ *   npx tsx --env-file=.env.local scripts/seed-psc-history.ts --dry-run
+ */
+import { seedPscHistory } from './knowledge/seeds/seed-psc-history';
+
+const dryRun = process.argv.includes('--dry-run');
+seedPscHistory({ dryRun });


### PR DESCRIPTION
## Summary

Enables the last hidden demo page — `/vessels/[imo]/psc-history` — with synthetic Port-State-Control data. Endpoint + migration + repository were already on `main`; this PR fills in the missing fixture, seed script, vessel-page entry point and tests.

- **Fixture** — `lib/knowledge/sources/psc/fixture.ts`: 16 records across 5 IMOs (`9322180`, `9478999`, `9512345`, `9156789`, `9734567`, all present in `lib/sample-data/imo/cii.json` so PSC and CII line up), 4 ports (`NLRTM`, `ESALG`, `JPYOK`, `USORF`), 3 authorities (`paris-mou`, `tokyo-mou`, `uscg`), 4/16 = 25 % detained.
- **Seed** — `scripts/seed-psc-history.ts` (thin wrapper) + `scripts/knowledge/seeds/seed-psc-history.ts`. Idempotent (delete + re-insert). Supports `--dry-run`.
- **Vessel-page link** — `components/vessel/PscHistoryLink.tsx`, rendered next to the vessel name in `app/vessel/[id]/page.tsx`. Hidden unless `NEXT_PUBLIC_PSC_DETENTION_ENABLED === 'true'` *and* `vessel.imo` is set, so non-prod builds are unchanged.
- **Tests** — 3 new files, 21 new tests:
  - `lib/__tests__/psc-fixture.test.ts` — shape / IMO whitelist / authority enum / date span / detained ratio / id uniqueness.
  - `__tests__/api/vessels-psc-history.test.ts` — seeds an in-memory DB with the real `upsertInspection`, then calls `GET /api/vessels/[imo]/psc-history` and asserts filtering by IMO, sort order, shape, and empty-array for unknown IMO.
  - `components/vessel/__tests__/PscHistoryLink.test.tsx` — flag on / off / unset, imo empty / null.
- Existing 32 PSC tests still pass; typecheck clean.

## Notes on schema reality vs. handover prompt

The handover prompt mentioned a deficiency-codes array and a Black Sea MoU authority. The migration on `main` (`lib/migrations/028-psc-history.ts`) actually stores **`deficiencies` as an INTEGER count** and **CHECK-constrains authority to `{paris-mou, tokyo-mou, uscg, other}`**. The PR follows the existing schema — no schema or repository changes.

## DEPLOY DEFERRED — wait for orchestrator after bake-off completes

This PR is **code only**. Production roll-out is intentionally deferred until the parse-cargo Phase 3a bake-off on outreach-vps finishes.

After merge, the orchestrator should, on the demo VPS:

1. Set both flags in `.env.local`:
   - `PSC_DETENTION_ENABLED=true`
   - `NEXT_PUBLIC_PSC_DETENTION_ENABLED=true`
2. Run the seed: `npx tsx --env-file=.env.local scripts/seed-psc-history.ts`
3. Rebuild + restart so the `NEXT_PUBLIC_*` flag is baked into the client bundle: `npm run build && pm2 restart quantika-demo --update-env`
4. Smoke: open `/vessel/{id}` for one of the parsed vessels with an IMO in `{9322180, 9478999, 9512345, 9156789, 9734567}`, click **PSC History**, confirm the table populates.

## Test plan

- [x] `npx jest lib/__tests__/psc-fixture.test.ts __tests__/api/vessels-psc-history.test.ts components/vessel/__tests__/PscHistoryLink.test.tsx` — 21/21 pass.
- [x] `npx jest lib/market/__tests__/psc-repository.test.ts lib/__tests__/psc-history-migration.test.ts app/api/vessels/[imo]/psc-history/__tests__/route.test.ts app/vessels/[imo]/psc-history/__tests__/page.test.tsx lib/knowledge/sources/psc/__tests__/psc-adapter.test.ts` — 32/32 pass (no regressions in existing PSC suite).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx tsx scripts/seed-psc-history.ts --dry-run` — prints fixture preview without DB writes.
- [x] `SESSIONS_DB_PATH=/tmp/psc-seed-test.db npx tsx scripts/seed-psc-history.ts` — seeds 16 rows; second run clears 16 and re-inserts 16 (idempotent).
- [ ] **After merge (orchestrator):** flags + seed + rebuild on VPS, then smoke-test `/vessel/{id}` → PSC History link → table populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)