### PR TITLE
test(ai-provider): smoke-check @google/genai v2 response surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "setup:gmail-oauth": "tsx scripts/setup-gmail-oauth.ts",
     "import:emails": "tsx scripts/import-gmail-emails.ts",
     "build:corpus": "tsx scripts/build-corpus.ts",
+    "smoke:genai-v2": "npx tsx scripts/smoke/genai-v2.ts",
     "sync:corpus:vps": "bash scripts/sync-corpus-vps.sh",
     "corpus:extract": "tsx scripts/extract-corpus-cases.ts",
     "prepare": "husky",

--- a/scripts/smoke/genai-v2.ts
+++ b/scripts/smoke/genai-v2.ts
@@ -1,0 +1,134 @@
+/**
+ * genai-v2.ts — smoke-check for @google/genai v2 GenerateContent surface.
+ *
+ * Why: @google/genai was bumped 1.52.0 → 2.3.0 in commit 0898a87 (2026-05-15).
+ * v2.0 release notes state breaking changes are isolated to `interactions`,
+ * and `GenerateContent` usage is unaffected — but v2.0.1 did rename
+ * `response_format` field names to snake_case. lib/ai-provider.ts reads
+ * `response.text` and `response.usageMetadata` (see ai-provider.ts:418-462,
+ * 479-503, 882-904); this script asserts those fields are still present and
+ * well-typed against the live Vertex AI endpoint before the next prod deploy.
+ *
+ * Usage:
+ *   npm run smoke:genai-v2
+ *
+ * Exit codes:
+ *   0 — pass, OR skipped because GOOGLE_CLOUD_PROJECT is not configured
+ *   1 — response surface broken (assertion failure or call error)
+ *
+ * The script intentionally skips (exit 0) when creds are missing so it can
+ * be wired into CI before the GOOGLE_CLOUD_PROJECT secret is provisioned.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ─── Bootstrap env (mirrors scripts/eval/ pattern) ────────────────────────────
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const envLocalPath = path.join(repoRoot, '.env.local');
+if (fs.existsSync(envLocalPath)) {
+  for (const line of fs.readFileSync(envLocalPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 0) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim();
+    if (key && !(key in process.env)) process.env[key] = val;
+  }
+}
+
+const GCP_KEY_PATH = path.join(process.env.HOME ?? '', '.config', 'gcp', 'quantika-vertex-ai.json');
+if (!process.env.GOOGLE_APPLICATION_CREDENTIALS && fs.existsSync(GCP_KEY_PATH)) {
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = GCP_KEY_PATH;
+}
+if (!process.env.GOOGLE_CLOUD_PROJECT && fs.existsSync(GCP_KEY_PATH)) {
+  try {
+    const gcpKey = JSON.parse(fs.readFileSync(GCP_KEY_PATH, 'utf8')) as { project_id?: string };
+    if (gcpKey.project_id) process.env.GOOGLE_CLOUD_PROJECT = gcpKey.project_id;
+  } catch {
+    /* ignore */
+  }
+}
+
+// ─── Skip when creds not available ────────────────────────────────────────────
+if (!process.env.GOOGLE_CLOUD_PROJECT) {
+  console.log('[smoke:genai-v2] SKIPPED — GOOGLE_CLOUD_PROJECT not set.');
+  process.exit(0);
+}
+
+// ─── Smoke check ──────────────────────────────────────────────────────────────
+interface GenerateContentResponse {
+  text?: string;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
+}
+
+async function main(): Promise<void> {
+  const { GoogleGenAI } = (await import('@google/genai')) as unknown as {
+    GoogleGenAI: new (opts: { vertexai: boolean; project: string; location: string }) => {
+      models: {
+        generateContent: (params: {
+          model: string;
+          contents: Array<{ role: string; parts: Array<{ text: string }> }>;
+        }) => Promise<GenerateContentResponse>;
+      };
+    };
+  };
+
+  const model = process.env.AI_MODEL_GEMINI_DEFAULT ?? 'gemini-2.5-flash';
+  const project = process.env.GOOGLE_CLOUD_PROJECT!;
+  const location = process.env.GOOGLE_CLOUD_LOCATION ?? 'us-central1';
+
+  console.log(`[smoke:genai-v2] calling Vertex AI: model=${model} project=${project} location=${location}`);
+
+  const ai = new GoogleGenAI({ vertexai: true, project, location });
+  const t0 = Date.now();
+  const response = await ai.models.generateContent({
+    model,
+    contents: [{ role: 'user', parts: [{ text: 'Reply with the single word: OK' }] }],
+  });
+  const elapsedMs = Date.now() - t0;
+
+  const failures: string[] = [];
+
+  if (typeof response.text !== 'string' || response.text.length === 0) {
+    failures.push(`response.text must be a non-empty string, got: ${JSON.stringify(response.text)}`);
+  }
+
+  const usage = response.usageMetadata;
+  if (!usage || typeof usage !== 'object') {
+    failures.push(`response.usageMetadata must be an object, got: ${JSON.stringify(usage)}`);
+  } else {
+    for (const field of ['promptTokenCount', 'candidatesTokenCount', 'totalTokenCount'] as const) {
+      const v = usage[field];
+      if (typeof v !== 'number' || !(v > 0)) {
+        failures.push(`response.usageMetadata.${field} must be a positive number, got: ${JSON.stringify(v)}`);
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('[smoke:genai-v2] FAILED');
+    for (const f of failures) console.error('  - ' + f);
+    console.error('[smoke:genai-v2] raw response:', JSON.stringify(response, null, 2));
+    process.exit(1);
+  }
+
+  console.log(
+    `[smoke:genai-v2] OK — text=${JSON.stringify(response.text)} ` +
+      `prompt=${usage!.promptTokenCount} candidates=${usage!.candidatesTokenCount} ` +
+      `total=${usage!.totalTokenCount} elapsedMs=${elapsedMs}`,
+  );
+  process.exit(0);
+}
+
+main().catch((err: unknown) => {
+  console.error('[smoke:genai-v2] FAILED — call threw:');
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

`@google/genai` was bumped **1.52.0 → 2.3.0** in commit `0898a87` (2026-05-15 07:14 UTC, dependabot PR #115). Prod `demo.quantika.org` is still on the 2026-05-14 21:10 build, so the v2 SDK has **not shipped yet** — the next deploy from `main` will carry it.

v2 release-notes summary (from `gh api repos/googleapis/js-genai/releases`):
- **v2.0.0** (05-07): breaking changes are **isolated to `interactions`**; `GenerateContent` usage is unaffected.
- **v2.0.1** (05-09): renamed `response_format` field names to snake_case.
- v2.1.0/2.2.0/2.3.0: feature additions only.

`lib/ai-provider.ts` reads `response.text` and `response.usageMetadata.{promptTokenCount,candidatesTokenCount,totalTokenCount}` in `callGeminiText` / `callGeminiVision` / the audio path (lines 418-462, 479-503, 882-904). We want to catch silent breakage of *that surface* before redeploy.

## What

- New `scripts/smoke/genai-v2.ts` — calls Vertex AI on `gemini-2.5-flash` with the prompt `"Reply with the single word: OK"`, asserts:
  - `response.text` is a non-empty string
  - `response.usageMetadata.promptTokenCount` is a positive number
  - `response.usageMetadata.candidatesTokenCount` is a positive number
  - `response.usageMetadata.totalTokenCount` is a positive number
- `npm run smoke:genai-v2` script in `package.json`.
- Designed as a **manual pre-deploy gate** (run locally before `deploy-vps.sh`).
- Skips with exit 0 when `GOOGLE_CLOUD_PROJECT` is not set, so it's safe to invoke in any environment.
- Env bootstrap mirrors `scripts/eval/run-match-providers-comparison.ts` (`.env.local` + `~/.config/gcp/quantika-vertex-ai.json` fallback).

## What this PR explicitly does NOT do

- **Does not pin model IDs.** Investigation showed the hardcoded `gemini-2.5-flash` alias literal in `lib/ai-provider.ts:338` has been **bit-identical since the initial Vertex AI migration on 2026-05-05** (commit `8e99bfb`). No evidence of alias drift.
- **Does not add `model_version` drift detection to `ai_audit`.** No documented incident; current `ai_audit` schema (`lib/migrations/012-ai-audit.ts`) has no `model_version` column. Adding both column + capture path is out of scope without a real signal.
- **Does not touch existing tests or `lib/ai-provider.ts`.**

## Investigation background

Three findings that motivated narrowing the original "pin Gemini model versions" ask down to this single smoke PR:

1. **Model alias literal unchanged** across all 9 commits to `lib/ai-provider.ts` since 2026-05-05.
2. **No `.progonq/results/` directory exists** in the repo — the "94→82 parse-cargo regression" couldn't be verified from on-disk eval artifacts.
3. **The real risk vector is the SDK major bump merged today** — not a Vertex AI model-id drift. That's what this smoke covers.

## Follow-up (does not block merge)

- **CI auto-run is not wired up in this PR** due to a `workflow` scope limitation on the gh CLI token used to push. By design the smoke is a **manual pre-deploy gate**, so CI wiring isn't critical; the npm script is reachable via `npm run smoke:genai-v2` on any machine with creds. If/when we want to automate, add a step to `.github/workflows/ci.yml` (with `GOOGLE_CLOUD_PROJECT` + `GOOGLE_APPLICATION_CREDENTIALS` repo secrets) via the GitHub web UI or a follow-up PR pushed with a token that has `workflow` scope.
- **No `docs/ops/gemini-v2-smoke-check.md` runbook** in this PR — kept surgical. A short runbook describing the pre-deploy ritual would be a natural follow-up.

## Test plan

- [x] `npm run smoke:genai-v2` locally on dev-vps → `SKIPPED — GOOGLE_CLOUD_PROJECT not set` (expected; no creds on this VPS)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint scripts/smoke/genai-v2.ts --max-warnings 0` clean
- [x] husky pre-commit hooks green (eslint --fix, prettier, tsc --noEmit)
- [ ] Reviewer runs `npm run smoke:genai-v2` on a machine with Vertex AI creds and confirms exit 0 with usage counts printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)