### PR TITLE
fix(ai-provider): Bedrock judge retry + backoff + Anthropic fallback (20% → <5% target)

### DIFF
--- a/__tests__/scripts/progonq/judge-parse-cargo-retry.test.ts
+++ b/__tests__/scripts/progonq/judge-parse-cargo-retry.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for judge-parse-cargo resilience layer.
+ *
+ * Covers 9-class boundary applied to the judge retry/fallback policy:
+ *   Class 1 (empty)        — empty Bedrock response → retry
+ *   Class 4 (range)        — exhausted attempts → conservative non-match
+ *   Class 5 (switch)       — error classification per error kind
+ *   Class 6 (substring)    — regex matches "unable to process" but not unrelated tokens
+ *   Class 7 (config)       — ANTHROPIC_API_KEY missing vs present switches fallback
+ *   Class 9 (E2E property) — returned object is a valid {equiv, reason} verdict
+ *
+ * PI3: these are NEW tests for NEW behavior — no existing test expectations
+ * are rewritten.
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+import {
+  classifyJudgeError,
+  computeBackoffMs,
+  executeJudgeWithResilience,
+  type JudgePrimaryCall,
+  type JudgeFallbackCall,
+  type JudgeResilienceOpts,
+} from '@/scripts/progonq/judge-parse-cargo';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classifyJudgeError — Class 5 (switch/dispatch) + Class 6 (substring leak)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('classifyJudgeError', () => {
+  it('classifies rate-limit phrases as rate_limit', () => {
+    expect(classifyJudgeError('Too many requests, please wait before trying again')).toBe('rate_limit');
+    expect(classifyJudgeError('ThrottlingException: rate exceeded')).toBe('rate_limit');
+    expect(classifyJudgeError('HTTP 429 Too Many Requests')).toBe('rate_limit');
+  });
+
+  it('classifies "Bedrock unable to process your request" as transient', () => {
+    expect(classifyJudgeError('Bedrock unable to process your request')).toBe('transient');
+    expect(classifyJudgeError('The model is unable to process your request at this time')).toBe('transient');
+  });
+
+  it('classifies 5xx and service-unavailable as service_unavailable', () => {
+    expect(classifyJudgeError('HTTP 503 Service Unavailable')).toBe('service_unavailable');
+    expect(classifyJudgeError('500 Internal Server Error')).toBe('service_unavailable');
+    expect(classifyJudgeError('Service is temporarily unavailable')).toBe('service_unavailable');
+  });
+
+  it('classifies network timeouts as transient', () => {
+    expect(classifyJudgeError('Request aborted: timeout after 30000ms')).toBe('transient');
+    expect(classifyJudgeError('ETIMEDOUT')).toBe('transient');
+    expect(classifyJudgeError('socket hang up')).toBe('transient');
+  });
+
+  it('classifies empty/malformed parse errors', () => {
+    expect(classifyJudgeError('extractJson: empty input after trim')).toBe('empty');
+    expect(classifyJudgeError('Unexpected token \'I\', "I\'ll syste"...')).toBe('malformed');
+    expect(classifyJudgeError('equiv not boolean')).toBe('malformed');
+  });
+
+  it('classifies auth and validation errors as non_retryable', () => {
+    expect(classifyJudgeError('AccessDeniedException: not authorized')).toBe('non_retryable');
+    expect(classifyJudgeError('InvalidSignatureException')).toBe('non_retryable');
+    expect(classifyJudgeError('ValidationException: model not supported')).toBe('non_retryable');
+  });
+
+  it('does NOT misclassify benign substrings (Class 6 substring leak)', () => {
+    expect(classifyJudgeError('Capability assessment failed')).toBe('non_retryable');
+    expect(classifyJudgeError('Unable to deserialize foo')).toBe('non_retryable');
+  });
+
+  it('defaults unknown errors to non_retryable', () => {
+    expect(classifyJudgeError('Some weird new failure mode')).toBe('non_retryable');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeBackoffMs — exponential 1s → 2s → 4s → 8s, cap 30s
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('computeBackoffMs', () => {
+  it('returns exponential delays starting at base 1000ms', () => {
+    expect(computeBackoffMs(1, { baseMs: 1000, capMs: 30_000 })).toBe(1000);
+    expect(computeBackoffMs(2, { baseMs: 1000, capMs: 30_000 })).toBe(2000);
+    expect(computeBackoffMs(3, { baseMs: 1000, capMs: 30_000 })).toBe(4000);
+    expect(computeBackoffMs(4, { baseMs: 1000, capMs: 30_000 })).toBe(8000);
+  });
+
+  it('caps at capMs', () => {
+    expect(computeBackoffMs(10, { baseMs: 1000, capMs: 30_000 })).toBe(30_000);
+    expect(computeBackoffMs(20, { baseMs: 1000, capMs: 30_000 })).toBe(30_000);
+  });
+
+  it('rate-limit kind doubles base (slower retry on throttle)', () => {
+    expect(computeBackoffMs(1, { baseMs: 1000, capMs: 30_000, kind: 'rate_limit' })).toBe(2000);
+    expect(computeBackoffMs(2, { baseMs: 1000, capMs: 30_000, kind: 'rate_limit' })).toBe(4000);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// executeJudgeWithResilience — retry + backoff + fallback policy
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeOpts(overrides: Partial<JudgeResilienceOpts> = {}): JudgeResilienceOpts {
+  return {
+    maxAttempts: 4,
+    backoff: { baseMs: 1, capMs: 10 }, // tiny — keep tests fast
+    ...overrides,
+  };
+}
+
+describe('executeJudgeWithResilience', () => {
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it('returns parsed verdict on first success', async () => {
+    const primary = jest.fn(async () => '{"equiv": true, "reason": "ok"}') as JudgePrimaryCall;
+
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts());
+
+    expect(r).toEqual({ equiv: true, reason: 'ok' });
+    expect(primary).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips ```json fences before parsing', async () => {
+    const primary = jest.fn(async () => '```json\n{"equiv": false, "reason": "diff"}\n```') as JudgePrimaryCall;
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts());
+    expect(r.equiv).toBe(false);
+    expect(r.reason).toBe('diff');
+  });
+
+  it('retries on "unable to process" (transient) — was previously not retried', async () => {
+    let n = 0;
+    const primary = jest.fn(async () => {
+      n++;
+      if (n < 3) throw new Error('Bedrock unable to process your request');
+      return '{"equiv": true, "reason": "retry-recovered"}';
+    }) as JudgePrimaryCall;
+
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts());
+
+    expect(primary).toHaveBeenCalledTimes(3);
+    expect(r.equiv).toBe(true);
+    expect(r.reason).toBe('retry-recovered');
+  });
+
+  it('retries on rate-limit', async () => {
+    let n = 0;
+    const primary = jest.fn(async () => {
+      n++;
+      if (n < 2) throw new Error('Too many requests, please wait before trying again');
+      return '{"equiv": false, "reason": "ok"}';
+    }) as JudgePrimaryCall;
+
+    await executeJudgeWithResilience(primary, undefined, makeOpts());
+    expect(primary).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on empty Bedrock response (Class 1)', async () => {
+    let n = 0;
+    const primary = jest.fn(async () => {
+      n++;
+      if (n < 2) return ''; // empty body
+      return '{"equiv": true, "reason": "ok"}';
+    }) as JudgePrimaryCall;
+
+    await executeJudgeWithResilience(primary, undefined, makeOpts());
+    expect(primary).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry on non_retryable errors (fast-fail)', async () => {
+    const primary = jest.fn(async () => {
+      throw new Error('AccessDeniedException: not authorized');
+    }) as JudgePrimaryCall;
+
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts());
+
+    expect(primary).toHaveBeenCalledTimes(1);
+    expect(r.equiv).toBe(false);
+    expect(r.reason).toMatch(/conservative non-match/i);
+  });
+
+  it('exhausts attempts and returns conservative non-match (Class 4)', async () => {
+    const primary = jest.fn(async () => {
+      throw new Error('Bedrock unable to process your request');
+    }) as JudgePrimaryCall;
+
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts({ maxAttempts: 3 }));
+
+    expect(primary).toHaveBeenCalledTimes(3);
+    expect(r.equiv).toBe(false);
+    expect(r.reason).toMatch(/conservative non-match/i);
+  });
+
+  it('uses Anthropic fallback after primary exhausts retries (Class 7: config)', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+
+    const primary = jest.fn(async () => {
+      throw new Error('Bedrock unable to process your request');
+    }) as JudgePrimaryCall;
+    const fallback = jest.fn(async () => '{"equiv": true, "reason": "via-anthropic"}') as JudgeFallbackCall;
+
+    const r = await executeJudgeWithResilience(primary, fallback, makeOpts({ maxAttempts: 3 }));
+
+    expect(primary).toHaveBeenCalledTimes(3);
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(r.equiv).toBe(true);
+    expect(r.reason).toBe('via-anthropic');
+  });
+
+  it('does NOT call fallback when ANTHROPIC_API_KEY missing (Class 7: config)', async () => {
+    // env was cleared in beforeEach
+    const primary = jest.fn(async () => {
+      throw new Error('Bedrock unable to process your request');
+    }) as JudgePrimaryCall;
+    const fallback = jest.fn(async () => '{"equiv": true, "reason": "should-not-fire"}') as JudgeFallbackCall;
+
+    const r = await executeJudgeWithResilience(primary, fallback, makeOpts({ maxAttempts: 3 }));
+
+    expect(fallback).not.toHaveBeenCalled();
+    expect(r.reason).toMatch(/conservative non-match/i);
+  });
+
+  it('falls back to conservative when fallback itself fails', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+
+    const primary = jest.fn(async () => {
+      throw new Error('Bedrock unable to process your request');
+    }) as JudgePrimaryCall;
+    const fallback = jest.fn(async () => {
+      throw new Error('Anthropic API: 503 service unavailable');
+    }) as JudgeFallbackCall;
+
+    const r = await executeJudgeWithResilience(primary, fallback, makeOpts({ maxAttempts: 2 }));
+
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(r.equiv).toBe(false);
+    expect(r.reason).toMatch(/conservative non-match/i);
+  });
+
+  it('returned object is always a valid JudgeVerdict (Class 9: E2E property)', async () => {
+    const primary = jest.fn(async () => 'garbage not json') as JudgePrimaryCall;
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts({ maxAttempts: 2 }));
+
+    expect(typeof r.equiv).toBe('boolean');
+    expect(typeof r.reason).toBe('string');
+    expect(r.reason.length).toBeGreaterThan(0);
+  });
+
+  it('treats malformed JSON as retryable and recovers on next attempt', async () => {
+    let n = 0;
+    const primary = jest.fn(async () => {
+      n++;
+      if (n === 1) return 'I will analyse this carefully...';
+      return '{"equiv": true, "reason": "recovered"}';
+    }) as JudgePrimaryCall;
+
+    const r = await executeJudgeWithResilience(primary, undefined, makeOpts());
+
+    expect(primary).toHaveBeenCalledTimes(2);
+    expect(r.equiv).toBe(true);
+  });
+});

--- a/scripts/progonq/judge-parse-cargo.ts
+++ b/scripts/progonq/judge-parse-cargo.ts
@@ -85,6 +85,136 @@ function pairKey(ref: string | null, model: string | null): string {
   return createHash('sha256').update(JSON.stringify({ ref, model })).digest('hex').slice(0, 16);
 }
 
+// ─── Resilience layer (exported for tests) ────────────────────────────────────
+//
+// 2026-05-15 incident: ai_audit shows ~20% fail rate on PARSE_CARGO_JUDGE Bedrock
+// calls. Two error families dominate: "Bedrock unable to process your request"
+// (transient model-side) and "Too many requests" (rate limit). The previous
+// retry loop only matched the rate-limit family, so transient errors flowed
+// straight to "conservative non-match". This module exports a small, testable
+// resilience helper that classifies errors, applies exponential backoff, and
+// optionally falls back to the Anthropic API SDK when AWS Bedrock keeps
+// refusing the call.
+
+export type JudgeErrorKind =
+  | 'rate_limit'
+  | 'service_unavailable'
+  | 'transient'
+  | 'empty'
+  | 'malformed'
+  | 'non_retryable';
+
+const RATE_LIMIT_RE = /too many requests|throttl|rate.?limit|\b429\b|quota.?exceeded/i;
+const SERVICE_UNAVAILABLE_RE = /\b50[023]\b|service\s+(?:is\s+)?(?:temporarily\s+)?unavailable|internal\s+server\s+error|bad\s+gateway|gateway\s+timeout/i;
+// Strict word-anchored phrases — avoids substring leak (Class 6) into unrelated
+// words like "capability" or "unable to deserialize".
+const TRANSIENT_RE = /unable to process your request|model is unable to process|\bETIMEDOUT\b|socket\s+hang\s+up|\bECONNRESET\b|\bEAI_AGAIN\b|request\s+aborted|\btimeout\b/i;
+const EMPTY_RE = /empty\s+input|empty\s+(?:after\s+)?trim|no\s+JSON-looking\s+start/i;
+const MALFORMED_RE = /unexpected\s+token|equiv\s+not\s+boolean|unexpected\s+end\s+of\s+JSON/i;
+
+const RETRYABLE_KINDS: ReadonlySet<JudgeErrorKind> = new Set([
+  'rate_limit',
+  'service_unavailable',
+  'transient',
+  'empty',
+  'malformed',
+]);
+
+export function classifyJudgeError(msg: string): JudgeErrorKind {
+  if (!msg) return 'non_retryable';
+  // Order matters: rate_limit before service_unavailable (some 429 also carry 5xx text);
+  // empty + malformed are inspected before transient timeouts so the more specific
+  // parse-side cause wins.
+  if (RATE_LIMIT_RE.test(msg)) return 'rate_limit';
+  if (EMPTY_RE.test(msg)) return 'empty';
+  if (MALFORMED_RE.test(msg)) return 'malformed';
+  if (SERVICE_UNAVAILABLE_RE.test(msg)) return 'service_unavailable';
+  if (TRANSIENT_RE.test(msg)) return 'transient';
+  return 'non_retryable';
+}
+
+export interface BackoffOpts {
+  baseMs: number;
+  capMs: number;
+  kind?: JudgeErrorKind;
+}
+
+export function computeBackoffMs(attempt: number, opts: BackoffOpts): number {
+  const multiplier = opts.kind === 'rate_limit' ? 2 : 1;
+  const raw = opts.baseMs * multiplier * Math.pow(2, Math.max(0, attempt - 1));
+  return Math.min(raw, opts.capMs);
+}
+
+export type JudgePrimaryCall = () => Promise<string>;
+export type JudgeFallbackCall = () => Promise<string>;
+
+export interface JudgeResilienceOpts {
+  maxAttempts: number;
+  backoff: { baseMs: number; capMs: number };
+  /** Injected for tests; defaults to real setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((res) => setTimeout(res, ms));
+
+function parseVerdict(raw: string): JudgeVerdict {
+  if (!raw || raw.trim().length === 0) {
+    throw new Error('extractJson: empty input after trim');
+  }
+  const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+  const parsed = JSON.parse(cleaned) as JudgeVerdict;
+  if (typeof parsed.equiv !== 'boolean') throw new Error('equiv not boolean');
+  return parsed;
+}
+
+const CONSERVATIVE: JudgeVerdict = {
+  equiv: false,
+  reason: 'judge parse error — conservative non-match',
+};
+
+export async function executeJudgeWithResilience(
+  primary: JudgePrimaryCall,
+  fallback: JudgeFallbackCall | undefined,
+  opts: JudgeResilienceOpts,
+): Promise<JudgeVerdict> {
+  const sleep = opts.sleep ?? defaultSleep;
+  let lastErr = 'unknown';
+
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      const raw = await primary();
+      return parseVerdict(raw);
+    } catch (e) {
+      lastErr = (e as Error).message ?? 'unknown';
+      const kind = classifyJudgeError(lastErr);
+      if (!RETRYABLE_KINDS.has(kind)) {
+        console.error(`[judge] non-retryable (${kind}): ${lastErr.slice(0, 120)}`);
+        return CONSERVATIVE;
+      }
+      if (attempt >= opts.maxAttempts) break;
+      const delayMs = computeBackoffMs(attempt, { ...opts.backoff, kind });
+      console.error(`[judge] ${kind} (attempt ${attempt}/${opts.maxAttempts}), backoff ${delayMs}ms`);
+      await sleep(delayMs);
+    }
+  }
+
+  if (fallback && process.env.ANTHROPIC_API_KEY) {
+    try {
+      console.error('[judge] primary exhausted — falling back to Anthropic API direct');
+      const raw = await fallback();
+      return parseVerdict(raw);
+    } catch (e) {
+      const msg = (e as Error).message ?? 'unknown';
+      console.error(`[judge] Anthropic fallback failed: ${msg.slice(0, 120)}`);
+    }
+  }
+
+  console.error(`[judge] all attempts failed, last err: ${lastErr.slice(0, 120)}`);
+  return CONSERVATIVE;
+}
+
+// ─── End resilience layer ─────────────────────────────────────────────────────
+
 const JUDGE_SYSTEM = `You are a Senior Chartering Broker (dry-bulk + break-bulk, 20+ years).
 Decide whether two port descriptions refer to the same maritime location
 in a cargo inquiry context.
@@ -128,35 +258,43 @@ NOT equivalent: different date ranges; one side specific, the other a different 
 Null on both sides = equivalent. Null on one side, a date on the other = NOT equivalent.
 Reply ONLY with JSON: {"equiv": true | false, "reason": "one short sentence"}`;
 
+async function callAnthropicDirect(system: string, userMsg: string): Promise<string> {
+  // Lazy require — only loaded when fallback fires AND ANTHROPIC_API_KEY is set.
+  // @anthropic-ai/sdk is already in package.json dependencies.
+  const Anthropic = require('@anthropic-ai/sdk').default as new (opts: { apiKey: string }) => {
+    messages: {
+      create: (params: {
+        model: string;
+        max_tokens: number;
+        system: string;
+        messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+      }) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+    };
+  };
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+  const model = process.env.ANTHROPIC_FALLBACK_MODEL ?? 'claude-opus-4-7';
+  const resp = await client.messages.create({
+    model,
+    max_tokens: 200,
+    system,
+    messages: [{ role: 'user', content: userMsg }],
+  });
+  const block = resp.content.find((c) => c.type === 'text');
+  return block?.text ?? '';
+}
+
 async function judgePair(ref: string | null, model: string | null, system: string): Promise<JudgeVerdict> {
   if (ref === model) return { equiv: true, reason: 'identical strings' };
   const userMsg = `REF:   ${JSON.stringify(ref)}\nMODEL: ${JSON.stringify(model)}`;
-  const maxAttempts = 4;
-  let lastErr: string = 'unknown';
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const raw = await callAiText('PARSE_CARGO_JUDGE', system, userMsg, {
-        maxTokens: 200,
-        timeoutMs: 30_000,
-      });
-      const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
-      const parsed = JSON.parse(cleaned) as JudgeVerdict;
-      if (typeof parsed.equiv !== 'boolean') throw new Error('equiv not boolean');
-      return parsed;
-    } catch (e) {
-      lastErr = (e as Error).message.slice(0, 80);
-      const isRateLimit = /too many requests|throttl|rate.?limit|429/i.test(lastErr);
-      if (attempt < maxAttempts && isRateLimit) {
-        const delayMs = 5_000 * attempt; // 5s, 10s, 15s
-        console.error(`[judge] rate-limited (attempt ${attempt}/${maxAttempts}), backoff ${delayMs}ms`);
-        await new Promise((res) => setTimeout(res, delayMs));
-        continue;
-      }
-      break;
-    }
-  }
-  console.error('[judge] parse fail for pair:', { ref, model, err: lastErr });
-  return { equiv: false, reason: 'judge parse error — conservative non-match' };
+
+  const primary: JudgePrimaryCall = () =>
+    callAiText('PARSE_CARGO_JUDGE', system, userMsg, { maxTokens: 200, timeoutMs: 30_000 });
+  const fallback: JudgeFallbackCall = () => callAnthropicDirect(system, userMsg);
+
+  return executeJudgeWithResilience(primary, fallback, {
+    maxAttempts: 4,
+    backoff: { baseMs: 1_000, capMs: 30_000 },
+  });
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

Eval-only resilience для `scripts/progonq/judge-parse-cargo.ts` — снижает fail rate Bedrock-судьи с 20% до целевых <5%.

**Контекст:** ai_audit за 24h показал 131/635 fail на `PARSE_CARGO_JUDGE`. Две ошибочные семьи: "Too many requests" (rate limit) и "Bedrock unable to process your request" (transient). PR #139 (strip CoT preamble, 13 мая) не лечил эти ~20% — старый retry-loop ловил **только** rate-limit regex; "unable to process" падал в conservative non-match без попыток.

**Что изменилось:**
- `classifyJudgeError` — 6 классов ошибок (rate_limit / service_unavailable / transient / empty / malformed / non_retryable).
- `computeBackoffMs` — экспоненциальный backoff 1s→2s→4s→8s, cap 30s. Rate-limit удваивает base.
- `executeJudgeWithResilience` — generic retry loop, non-retryable (AccessDenied/Validation) fail-fast.
- Anthropic API direct fallback (`@anthropic-ai/sdk`, уже в `package.json`) при `ANTHROPIC_API_KEY` присутствующем. Модель `claude-opus-4-7`.

**Безопасность:** `lib/ai-provider.ts` НЕ тронут. Прод `parse_cargo` runtime неизменен — fix влияет только на progonq eval.

## Test plan

- [x] 23 новых юнит-теста, 9-class boundary coverage (empty / range exhaustion / switch / substring leak / config / E2E property)
- [x] PI3-чистые: 0 переписанных existing expectations
- [x] PI2: behavioral mocks (call counts, parsed verdicts), не string-match на логи
- [x] `npx tsc --noEmit` — clean
- [x] Adjacent tests (`__tests__/lib/ai-provider-sampling.test.ts`, `__tests__/scripts/progonq/`) — 35/35 green
- [ ] Прогнать judge на свежем `.progonq/results/etms-parse-cargo-R*.json` и сверить ai_audit fail rate с baseline 20%

## Ожидаемое улучшение

- 20% → <5% fail rate на eval'е. 80% prev-fails имели сигнатуру "unable to process" — теперь ретраятся 4× с exp backoff.

## Что retry не лечит

- Genuine auth ошибки (AccessDenied / InvalidSignature) — fast-fail by design.
- Семантически неверные verdicts (валидный JSON, неверное решение) — out of scope.
- Если `ANTHROPIC_API_KEY` отсутствует, fallback skip; Bedrock retry-only покрывает ~70-80% transient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)