### PR TITLE
feat(progonq): parse-vessel + classify eval runner + judge + baseline

### DIFF
--- a/docs/progonq/eval-baseline-2026-05-15.md
+++ b/docs/progonq/eval-baseline-2026-05-15.md
@@ -1,0 +1,93 @@
+# Eval Baseline — 2026-05-15
+
+Baseline runs for `parse-vessel` and `classify` endpoints using Gemini (AI_PROVIDER=gemini).
+
+## parse-vessel (etms-parse-vessel-baseline.json)
+
+**Corpus**: 56 scenarios  
+**Errors**: 4 (fetch failures — etms-parse-vessel-020/030/038/046)  
+**Evaluated**: 52 scenarios, 106 vessel items
+
+### Deterministic field accuracy (string / ±5% tolerance)
+
+| Field        | Match  | %     | Notes                          |
+|--------------|--------|-------|--------------------------------|
+| vessel_name  | 86/106 | 81.1% | case-insensitive, strips MV prefix |
+| imo          | 92/106 | 86.8% | digits-only comparison         |
+| flag         | 86/106 | 81.1% | case-insensitive               |
+| built        | 72/106 | 67.9% | exact year                     |
+| dwt_summer   | 69/106 | 65.1% | ±5% tolerance                  |
+| dwcc         | 55/106 | 51.9% | ±5% tolerance                  |
+| open_position| n/a    | —     | LLM judge not yet run          |
+| open_date    | n/a    | —     | LLM judge not yet run          |
+
+**Mean deterministic-field rate**: 76.0%  
+**Full deterministic match** (all 6 det fields = 1): 14/52 (26.9%)
+
+### Notable issues
+- 2 count mismatches (model returned 2× items vs ref): etms-parse-vessel-019 (ref=1, model=2), etms-parse-vessel-037 (ref=5, model=10)
+- `dwcc` is the weakest deterministic field (51.9%) — likely partial extraction or unit conversion gaps
+- `open_position` and `open_date` judge pending (0 LLM judge calls made)
+
+---
+
+## classify (etms-classify-baseline.json)
+
+**Corpus**: 154 scenarios  
+**Errors**: 0  
+
+### Overall accuracy
+
+| Field                  | Match   | %     |
+|------------------------|---------|-------|
+| category               | 147/154 | 95.5% |
+| urgency                | 113/154 | 73.4% |
+| is_unanswered          | 138/154 | 89.6% |
+| original_sender_company| —       | LLM judge not yet run |
+
+### Per-category breakdown
+
+| Category       | n  | category | urgency | is_unanswered |
+|----------------|----|----------|---------|---------------|
+| CARGO_INQUIRY  | 89 | 96.6%    | 82.0%   | 97.8%         |
+| CLIENT_REPLY   | 1  | 100%     | 0%      | 0%            |
+| FIXTURE_RECAP  | 2  | 100%     | 100%    | 100%          |
+| OTHER          | 2  | 50%      | 50%     | 50%           |
+| TCT_REQUEST    | 3  | 100%     | 33.3%   | 100%          |
+| VESSEL_POSITION| 57 | 94.7%    | 63.2%   | 78.9%         |
+
+### Stable category failures (7 scenarios)
+
+| Scenario             | Ref             | Got             |
+|----------------------|-----------------|-----------------|
+| etms-classify-005    | VESSEL_POSITION | FIXTURE_RECAP   |
+| etms-classify-026    | OTHER           | CARGO_INQUIRY   |
+| etms-classify-076    | VESSEL_POSITION | CARGO_INQUIRY   |
+| etms-classify-077    | VESSEL_POSITION | CARGO_INQUIRY   |
+| etms-classify-112    | CARGO_INQUIRY   | TCT_REQUEST     |
+| etms-classify-114    | CARGO_INQUIRY   | TCT_REQUEST     |
+| etms-classify-126    | CARGO_INQUIRY   | TCT_REQUEST     |
+
+### Urgency miss distribution (41 misses)
+
+| Direction      | Count |
+|----------------|-------|
+| medium → high  | 15    |
+| low → medium   | 8     |
+| medium → low   | 6     |
+| high → medium  | 5     |
+| low → high     | 3     |
+| high → null    | 2     |
+| high → low     | 1     |
+| low → null     | 1     |
+
+Primary urgency weakness: model over-escalates `medium` → `high` (15 cases). VESSEL_POSITION urgency notably low (63.2%).
+
+---
+
+## Next steps
+
+1. Run `judge-parse-vessel.ts` on baseline to fill in `open_position` and `open_date` semantic scores
+2. Run `judge-classify.ts` to fill in `original_sender_company` semantic scores
+3. Investigate VESSEL_POSITION urgency weakness (63.2%) — likely prompt ambiguity on urgency criteria for position lists
+4. Fix etms-parse-vessel-020/030/038/046 fetch errors (transient; re-run with `--round baseline-retry`)

--- a/scripts/progonq/__tests__/score-classify.test.ts
+++ b/scripts/progonq/__tests__/score-classify.test.ts
@@ -1,0 +1,48 @@
+import { scoreClassification } from '../run-classify';
+
+const REF = {
+  id: 'e1',
+  category: 'CARGO_INQUIRY',
+  urgency: 'high',
+  confidence: 0.9,
+  is_unanswered: true,
+  days_without_reply: 3,
+  original_sender: 'John Doe',
+  original_sender_company: 'Acme Shipping Ltd.',
+};
+
+describe('scoreClassification', () => {
+  it('all fields exact → all true', () => {
+    const r = scoreClassification(REF, { ...REF });
+    expect(r.category_match).toBe(true);
+    expect(r.urgency_match).toBe(true);
+    expect(r.is_unanswered_match).toBe(true);
+  });
+
+  it('category mismatch → false', () => {
+    const r = scoreClassification(REF, { ...REF, category: 'OTHER' });
+    expect(r.category_match).toBe(false);
+  });
+
+  it('urgency mismatch → false; case insensitive equal → true', () => {
+    expect(scoreClassification(REF, { ...REF, urgency: 'low' }).urgency_match).toBe(false);
+    expect(scoreClassification(REF, { ...REF, urgency: 'HIGH' }).urgency_match).toBe(true);
+  });
+
+  it('is_unanswered mismatch → false', () => {
+    const r = scoreClassification(REF, { ...REF, is_unanswered: false });
+    expect(r.is_unanswered_match).toBe(false);
+  });
+
+  it('preserves raw original_sender_company for judge', () => {
+    const r = scoreClassification(REF, { ...REF, original_sender_company: 'Acme Shipping' });
+    expect(r.ref_company).toBe('Acme Shipping Ltd.');
+    expect(r.model_company).toBe('Acme Shipping');
+  });
+
+  it('null model → category mismatch (parsing failed)', () => {
+    const r = scoreClassification(REF, null);
+    expect(r.category_match).toBe(false);
+    expect(r.urgency_match).toBe(false);
+  });
+});

--- a/scripts/progonq/__tests__/score-vessel.test.ts
+++ b/scripts/progonq/__tests__/score-vessel.test.ts
@@ -1,0 +1,78 @@
+import { scoreVesselItems, withinTolerance } from '../run-parse-vessel';
+
+function field<T>(value: T | null): { value: T; confidence: string } | null {
+  return value === null ? null : { value, confidence: 'confirmed' };
+}
+
+function makeRef(overrides: Record<string, unknown> = {}) {
+  return {
+    vessel_name: field('MV STAD'),
+    imo: null,
+    flag: field('Vanuatu'),
+    built: field(1989),
+    dwt_summer: field(3222),
+    dwcc: field(3050),
+    open_position: field('Teignmouth, UK'),
+    open_date: field({ open: '2017-07-25', close: '2017-07-28' }),
+    ...overrides,
+  };
+}
+
+describe('withinTolerance (numeric ±5%)', () => {
+  it('exact match → true', () => expect(withinTolerance(3000, 3000)).toBe(true));
+  it('within 5% → true', () => expect(withinTolerance(3000, 3140)).toBe(true));
+  it('outside 5% → false', () => expect(withinTolerance(3000, 3200)).toBe(false));
+  it('both null → true', () => expect(withinTolerance(null, null)).toBe(true));
+  it('one null → false', () => {
+    expect(withinTolerance(null, 100)).toBe(false);
+    expect(withinTolerance(100, null)).toBe(false);
+  });
+});
+
+describe('scoreVesselItems', () => {
+  it('exact match: all deterministic fields true', () => {
+    const ref = [makeRef()];
+    const model = [makeRef()];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.imo_match).toBe(true);
+    expect(r.flag_match).toBe(true);
+    expect(r.built_match).toBe(true);
+    expect(r.dwt_match).toBe(true);
+    expect(r.dwcc_match).toBe(true);
+  });
+
+  it('dwt within 5% tolerance → match', () => {
+    const ref = [makeRef({ dwt_summer: field(3000) })];
+    const model = [makeRef({ dwt_summer: field(3140) })];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.dwt_match).toBe(true);
+  });
+
+  it('built year mismatch → false', () => {
+    const ref = [makeRef({ built: field(1989) })];
+    const model = [makeRef({ built: field(1990) })];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.built_match).toBe(false);
+  });
+
+  it('preserves raw vessel_name / open_position / open_date for judge', () => {
+    const ref = [makeRef()];
+    const model = [makeRef({ vessel_name: field('M.V. STAD') })];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.ref_vessel_name).toBe('MV STAD');
+    expect(r.model_vessel_name).toBe('M.V. STAD');
+    expect(r.ref_open_position).toBe('Teignmouth, UK');
+  });
+
+  it('handles item count mismatch', () => {
+    const ref = [makeRef(), makeRef()];
+    const model = [makeRef()];
+    const results = scoreVesselItems(ref, model);
+    expect(results).toHaveLength(2);
+    expect(results[1].dwt_match).toBe(false);
+  });
+
+  it('both 0-items → empty list (caller handles)', () => {
+    expect(scoreVesselItems([], [])).toEqual([]);
+  });
+});

--- a/scripts/progonq/judge-classify.ts
+++ b/scripts/progonq/judge-classify.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * LLM-judge scorer for classify results.
+ *
+ * Reads .progonq/results/etms-classify-<round>.json. Deterministic fields
+ * (category, urgency, is_unanswered) are taken from the runner. The single
+ * semantic field is original_sender_company — judged for legal-name equivalence
+ * ("Saudi Bulk Traders Co." vs "Saudi Bulk").
+ *
+ * Cache: .progonq/cache/judge-cache.json (shared).
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/judge-classify.ts \
+ *     --results .progonq/results/etms-classify-baseline.json
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { callAiText } from '@/lib/ai-provider';
+
+const CACHE_PATH = path.resolve(process.cwd(), '.progonq/cache/judge-cache.json');
+
+interface JudgeVerdict { equiv: boolean; reason: string; }
+
+interface ClassifyMatch {
+  category_match: boolean;
+  urgency_match: boolean;
+  is_unanswered_match: boolean;
+  ref_company: string | null;
+  model_company: string | null;
+  semantic_field_match?: Record<string, boolean>;
+}
+
+interface RunResult {
+  scenario_id: string;
+  match: ClassifyMatch;
+  [k: string]: unknown;
+}
+
+function loadCache(): Map<string, JudgeVerdict> {
+  if (!existsSync(CACHE_PATH)) return new Map();
+  try {
+    return new Map(Object.entries(JSON.parse(readFileSync(CACHE_PATH, 'utf-8'))));
+  } catch { return new Map(); }
+}
+function saveCache(cache: Map<string, JudgeVerdict>) {
+  mkdirSync(path.dirname(CACHE_PATH), { recursive: true });
+  writeFileSync(CACHE_PATH, JSON.stringify(Object.fromEntries(cache), null, 2));
+}
+function pairKey(prefix: string, ref: string | null, model: string | null): string {
+  return createHash('sha256').update(JSON.stringify({ prefix, ref, model })).digest('hex').slice(0, 16);
+}
+
+const COMPANY_JUDGE = `You decide whether two company-name strings refer to the same legal entity in a chartering email signature context.
+Equivalence rules:
+- Legal-suffix variants match: "Acme Co." = "Acme Co Ltd" = "Acme Company" only if the BASE name is the same.
+- Strict: a missing legal suffix ("Acme" vs "Acme Co. Ltd") = NOT equivalent — the reference is canonical.
+- Abbreviations match when the abbreviation is unambiguous: "ETMS" = "Egypt Trade Maritime Services" only when both visible.
+- Punctuation / case / extra whitespace — ignore.
+- Different brand names = NOT equivalent even if industry matches.
+- Null on both = equivalent. Null on one = NOT equivalent.
+Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
+
+async function judgePair(ref: string | null, model: string | null): Promise<JudgeVerdict> {
+  if (ref === model) return { equiv: true, reason: 'identical strings' };
+  const userMsg = `REF:   ${JSON.stringify(ref)}\nMODEL: ${JSON.stringify(model)}`;
+  let lastErr = 'unknown';
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      const raw = await callAiText('CLASSIFY_JUDGE', COMPANY_JUDGE, userMsg, { maxTokens: 200, timeoutMs: 30_000 });
+      const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+      const parsed = JSON.parse(cleaned) as JudgeVerdict;
+      if (typeof parsed.equiv !== 'boolean') throw new Error('equiv not boolean');
+      return parsed;
+    } catch (e) {
+      lastErr = (e as Error).message.slice(0, 80);
+      const isRate = /too many requests|throttl|rate.?limit|429/i.test(lastErr);
+      if (attempt < 4 && isRate) {
+        await new Promise((r) => setTimeout(r, 5_000 * attempt));
+        continue;
+      }
+      break;
+    }
+  }
+  console.error('[judge-cls] parse fail:', { ref, model, err: lastErr });
+  return { equiv: false, reason: 'judge parse error — conservative non-match' };
+}
+
+async function main() {
+  const idx = process.argv.indexOf('--results');
+  if (idx < 0) {
+    console.error('Usage: judge-classify.ts --results <path/to/results.json>');
+    process.exit(1);
+  }
+  const resultsPath = path.resolve(process.argv[idx + 1]);
+  const results: RunResult[] = JSON.parse(readFileSync(resultsPath, 'utf-8'));
+  const cache = loadCache();
+  let judged = 0, cached = 0;
+
+  for (const r of results) {
+    const m = r.match;
+    if (!m) continue;
+
+    let companyEquiv = false;
+    if (m.ref_company === null && m.model_company === null) {
+      companyEquiv = true;
+    } else if (m.ref_company !== null && m.model_company !== null && m.ref_company === m.model_company) {
+      companyEquiv = true;
+    } else {
+      const key = pairKey('company:', m.ref_company, m.model_company);
+      let v = cache.get(key);
+      if (!v) {
+        await new Promise((r) => setTimeout(r, 800));
+        v = await judgePair(m.ref_company, m.model_company);
+        if (!v.reason.startsWith('judge parse error')) {
+          cache.set(key, v);
+          saveCache(cache);
+        }
+        judged++;
+      } else cached++;
+      companyEquiv = v.equiv;
+    }
+
+    m.semantic_field_match = {
+      category: m.category_match,
+      urgency: m.urgency_match,
+      is_unanswered: m.is_unanswered_match,
+      original_sender_company: companyEquiv,
+    };
+  }
+
+  writeFileSync(resultsPath, JSON.stringify(results, null, 2));
+
+  const total = results.length;
+  const FIELDS = ['category', 'urgency', 'is_unanswered', 'original_sender_company'] as const;
+  console.error(`[judge-cls] judged=${judged} cached=${cached}`);
+  for (const f of FIELDS) {
+    const matches = results.filter((r) => r.match?.semantic_field_match?.[f]).length;
+    console.error(`  ${f.padEnd(28)} ${matches}/${total} (${(matches / total * 100).toFixed(1)}%)`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => { console.error('FATAL', e); process.exit(1); });
+}

--- a/scripts/progonq/judge-parse-vessel.ts
+++ b/scripts/progonq/judge-parse-vessel.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * LLM-judge scorer for parse-vessel results.
+ *
+ * Reads .progonq/results/etms-parse-vessel-<round>.json, semantically judges
+ * the fields that resist string equality: vessel_name (aliases, M.V. prefixes),
+ * open_position (UNLOCODE or free-text), open_date (window equivalence).
+ * Deterministic fields (imo, flag, built, dwt±5%, dwcc±5%) are taken from the
+ * runner's boolean flags.
+ *
+ * Cache: .progonq/cache/judge-cache.json — shared with parse-cargo (keyed by
+ *        prefixed sha256(ref||model)).
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/judge-parse-vessel.ts \
+ *     --results .progonq/results/etms-parse-vessel-baseline.json [--judge sonnet]
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { callAiText } from '@/lib/ai-provider';
+
+const CACHE_PATH = path.resolve(process.cwd(), '.progonq/cache/judge-cache.json');
+
+interface JudgeVerdict { equiv: boolean; reason: string; }
+
+interface VesselMatch {
+  ref_vessel_name: string | null; model_vessel_name: string | null;
+  ref_open_position: string | null; model_open_position: string | null;
+  ref_open_date: string | null; model_open_date: string | null;
+  vessel_name_match: boolean;
+  imo_match: boolean; flag_match: boolean; built_match: boolean;
+  dwt_match: boolean; dwcc_match: boolean;
+  semantic_field_match?: Record<string, boolean>;
+}
+
+interface RunResult {
+  scenario_id: string;
+  category: string;
+  item_matches: VesselMatch[];
+  match_rate: number;
+  semantic_match_rate?: number;
+  [k: string]: unknown;
+}
+
+function loadCache(): Map<string, JudgeVerdict> {
+  if (!existsSync(CACHE_PATH)) return new Map();
+  try {
+    const raw = JSON.parse(readFileSync(CACHE_PATH, 'utf-8')) as Record<string, JudgeVerdict>;
+    return new Map(Object.entries(raw));
+  } catch {
+    return new Map();
+  }
+}
+
+function saveCache(cache: Map<string, JudgeVerdict>): void {
+  mkdirSync(path.dirname(CACHE_PATH), { recursive: true });
+  writeFileSync(CACHE_PATH, JSON.stringify(Object.fromEntries(cache), null, 2));
+}
+
+function pairKey(prefix: string, ref: string | null, model: string | null): string {
+  return createHash('sha256').update(JSON.stringify({ prefix, ref, model })).digest('hex').slice(0, 16);
+}
+
+const VESSEL_NAME_JUDGE = `You decide whether two vessel names refer to the same ship.
+Equivalence rules:
+- "MV", "M.V.", "M/V", "MS", "M/S", "SS", "S.S.", "MT" prefixes are decorative — ignore.
+- Case, punctuation, extra spaces — ignore.
+- Common transliterations match (e.g. "ALEXANDRIA STAR" = "ALEXANDRIA-STAR").
+- Different names do NOT match even if similar.
+- Null on both = equivalent. Null on one = NOT equivalent.
+Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
+
+const OPEN_POSITION_JUDGE = `You decide whether two vessel "open position" descriptions refer to the same maritime location.
+Equivalence rules:
+- UNLOCODE matches free-text: "TRPMR" = "Iskenderun, Turkey".
+- Country suffix decorative: "Teignmouth" = "Teignmouth, UK".
+- Aliases match: "ARA" = "Amsterdam/Rotterdam/Antwerp range".
+- "Spot" / "promptly" / "available" qualifiers are decorative.
+- Different ports do NOT match.
+- Null on both = equivalent. Null on one = NOT equivalent.
+Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
+
+const OPEN_DATE_JUDGE = `You decide whether two vessel open-date / laycan values describe the same window.
+Equivalence rules:
+- Format variations same range: "25/28 July 2017" = "Jul 25-28, 2017" = "2017-07-25 to 2017-07-28".
+- "Spot prompt" = "promptly available" = "spot".
+- "Early July" = "1-10 July"; "mid-July" = "11-20 July"; "end July" = "21-31 July".
+- Different windows do NOT match.
+- Null on both = equivalent. Null on one = NOT equivalent.
+Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
+
+async function judgePair(ref: string | null, model: string | null, system: string): Promise<JudgeVerdict> {
+  if (ref === model) return { equiv: true, reason: 'identical strings' };
+  const userMsg = `REF:   ${JSON.stringify(ref)}\nMODEL: ${JSON.stringify(model)}`;
+  let lastErr = 'unknown';
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      const raw = await callAiText('PARSE_VESSEL_JUDGE', system, userMsg, { maxTokens: 200, timeoutMs: 30_000 });
+      const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+      const parsed = JSON.parse(cleaned) as JudgeVerdict;
+      if (typeof parsed.equiv !== 'boolean') throw new Error('equiv not boolean');
+      return parsed;
+    } catch (e) {
+      lastErr = (e as Error).message.slice(0, 80);
+      const isRate = /too many requests|throttl|rate.?limit|429/i.test(lastErr);
+      if (attempt < 4 && isRate) {
+        await new Promise((r) => setTimeout(r, 5_000 * attempt));
+        continue;
+      }
+      break;
+    }
+  }
+  console.error('[judge-pv] parse fail:', { ref, model, err: lastErr });
+  return { equiv: false, reason: 'judge parse error — conservative non-match' };
+}
+
+async function getCached(
+  cache: Map<string, JudgeVerdict>, prefix: string,
+  ref: string | null, model: string | null, system: string,
+  stats: { judged: number; cached: number },
+): Promise<JudgeVerdict> {
+  const key = pairKey(prefix, ref, model);
+  const hit = cache.get(key);
+  if (hit) { stats.cached++; return hit; }
+  await new Promise((r) => setTimeout(r, 800));
+  const verdict = await judgePair(ref, model, system);
+  if (!verdict.reason.startsWith('judge parse error')) {
+    cache.set(key, verdict);
+    saveCache(cache);
+  }
+  stats.judged++;
+  return verdict;
+}
+
+async function main() {
+  const idx = process.argv.indexOf('--results');
+  if (idx < 0) {
+    console.error('Usage: judge-parse-vessel.ts --results <path/to/results.json>');
+    process.exit(1);
+  }
+  const resultsPath = path.resolve(process.argv[idx + 1]);
+  const results: RunResult[] = JSON.parse(readFileSync(resultsPath, 'utf-8'));
+  const cache = loadCache();
+  const stats = { judged: 0, cached: 0 };
+
+  for (const r of results) {
+    let semanticMatches = 0;
+    const total = r.item_matches.length;
+
+    for (const m of r.item_matches) {
+      const nameV = m.vessel_name_match
+        ? { equiv: true, reason: 'deterministic match' }
+        : await getCached(cache, 'vessel_name:', m.ref_vessel_name, m.model_vessel_name, VESSEL_NAME_JUDGE, stats);
+      const posV = await getCached(cache, 'open_position:', m.ref_open_position, m.model_open_position, OPEN_POSITION_JUDGE, stats);
+      const dateV = await getCached(cache, 'open_date:', m.ref_open_date, m.model_open_date, OPEN_DATE_JUDGE, stats);
+
+      m.semantic_field_match = {
+        vessel_name: nameV.equiv,
+        imo: m.imo_match,
+        flag: m.flag_match,
+        built: m.built_match,
+        dwt_summer: m.dwt_match,
+        dwcc: m.dwcc_match,
+        open_position: posV.equiv,
+        open_date: dateV.equiv,
+      };
+
+      const allFields = Object.values(m.semantic_field_match);
+      const itemRate = allFields.filter(Boolean).length / allFields.length;
+      if (itemRate === 1) semanticMatches++;
+    }
+
+    r.semantic_match_rate = total === 0 ? 1 : semanticMatches / total;
+  }
+
+  writeFileSync(resultsPath, JSON.stringify(results, null, 2));
+
+  const total = results.length;
+  const fullSemantic = results.filter((r) => (r.semantic_match_rate ?? 0) === 1).length;
+  const fullString = results.filter((r) => r.match_rate === 1).length;
+  console.error(`[judge-pv] pairs_judged=${stats.judged} cached=${stats.cached}`);
+  console.error(`[judge-pv] string_full=${fullString}/${total} (${(fullString / total * 100).toFixed(1)}%)`);
+  console.error(`[judge-pv] semantic_full=${fullSemantic}/${total} (${(fullSemantic / total * 100).toFixed(1)}%)`);
+
+  // Per-field aggregation
+  const FIELDS = ['vessel_name', 'imo', 'flag', 'built', 'dwt_summer', 'dwcc', 'open_position', 'open_date'] as const;
+  const tot: Record<string, { m: number; t: number }> = {};
+  for (const f of FIELDS) tot[f] = { m: 0, t: 0 };
+  for (const r of results) {
+    for (const m of r.item_matches) {
+      const sfm = m.semantic_field_match;
+      if (!sfm) continue;
+      for (const f of FIELDS) { tot[f].t++; if (sfm[f]) tot[f].m++; }
+    }
+  }
+  console.error('[judge-pv] per-field accuracy:');
+  for (const f of FIELDS) {
+    const { m, t } = tot[f];
+    console.error(`  ${f.padEnd(20)} ${m}/${t} (${t === 0 ? 'n/a' : (m / t * 100).toFixed(1) + '%'})`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => { console.error('FATAL', e); process.exit(1); });
+}

--- a/scripts/progonq/run-classify.ts
+++ b/scripts/progonq/run-classify.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * progonq runner for classify endpoint.
+ *
+ * Runs CLASSIFICATION_SYSTEM_PROMPT against .progonq/corpus/etms-classify/
+ * scenarios and saves results to .progonq/results/etms-classify-<round>.json.
+ * Each scenario is classified individually (batch=1) to keep per-scenario
+ * accountability and remain compatible with the existing per-scenario cache.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/run-classify.ts [--round R0] [--limit N]
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { callAiJson } from '@/lib/ai-provider';
+import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts';
+import { CLASSIFY_SCHEMA } from '@/lib/schemas';
+
+const SCOPE = 'CLASSIFY';
+const MAX_BODY_CHARS = 3000;
+const REQUEST_DELAY_MS = 300;
+
+const CORPUS_DIR = path.resolve(process.cwd(), '.progonq/corpus/etms-classify');
+const RESULTS_DIR = path.resolve(process.cwd(), '.progonq/results');
+
+export interface AiClassification {
+  id: string;
+  category: string;
+  urgency: string;
+  confidence: number;
+  is_unanswered: boolean;
+  days_without_reply: number | null;
+  original_sender?: string | null;
+  original_sender_company?: string | null;
+}
+
+interface Scenario {
+  id: string;
+  source_email_id: string;
+  category: string;
+  input: { subject: string; from: string; date: string; body: string };
+  reference_output: AiClassification;
+}
+
+export interface ClassifyMatch {
+  category_match: boolean;
+  urgency_match: boolean;
+  is_unanswered_match: boolean;
+  ref_category: string;
+  model_category: string | null;
+  ref_urgency: string;
+  model_urgency: string | null;
+  ref_is_unanswered: boolean;
+  model_is_unanswered: boolean | null;
+  ref_company: string | null;
+  model_company: string | null;
+  ref_sender: string | null;
+  model_sender: string | null;
+}
+
+interface RunResult {
+  scenario_id: string;
+  category: string;
+  input: Scenario['input'];
+  reference_output: AiClassification;
+  model_output: AiClassification | null;
+  error?: string;
+  duration_ms: number;
+  match: ClassifyMatch;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max) + '\n[truncated]';
+}
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+function ciEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return String(a).trim().toLowerCase() === String(b).trim().toLowerCase();
+}
+
+export function scoreClassification(ref: AiClassification, model: AiClassification | null): ClassifyMatch {
+  return {
+    category_match: model !== null && ref.category === model.category,
+    urgency_match: model !== null && ciEqual(ref.urgency, model.urgency),
+    is_unanswered_match: model !== null && ref.is_unanswered === model.is_unanswered,
+    ref_category: ref.category,
+    model_category: model?.category ?? null,
+    ref_urgency: ref.urgency,
+    model_urgency: model?.urgency ?? null,
+    ref_is_unanswered: ref.is_unanswered,
+    model_is_unanswered: model?.is_unanswered ?? null,
+    ref_company: ref.original_sender_company ?? null,
+    model_company: model?.original_sender_company ?? null,
+    ref_sender: ref.original_sender ?? null,
+    model_sender: model?.original_sender ?? null,
+  };
+}
+
+async function classifyOne(scenario: Scenario): Promise<AiClassification | null> {
+  const body = truncate(scenario.input.body, MAX_BODY_CHARS);
+  const emailInput = [{
+    id: scenario.source_email_id,
+    subject: scenario.input.subject,
+    from: scenario.input.from,
+    date: scenario.input.date,
+    body_preview: body,
+  }];
+  const todayIso = new Date().toISOString().split('T')[0];
+  const userPrompt = `Today's date: ${todayIso}\n\n${JSON.stringify(emailInput)}`;
+
+  const result = await callAiJson<{ classifications: AiClassification[] }>(
+    SCOPE,
+    CLASSIFICATION_SYSTEM_PROMPT,
+    userPrompt,
+    {
+      maxTokens: 4000,
+      timeoutMs: 90_000,
+      temperature: 0,
+      seed: 42,
+      responseSchema: CLASSIFY_SCHEMA as Record<string, unknown>,
+    },
+  );
+  const list = result?.classifications;
+  if (!Array.isArray(list) || list.length === 0) return null;
+  return list[0];
+}
+
+async function runScenario(scenario: Scenario): Promise<RunResult> {
+  const t0 = Date.now();
+  let model: AiClassification | null = null;
+  let error: string | undefined;
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await sleep(REQUEST_DELAY_MS);
+      model = await classifyOne(scenario);
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (attempt >= 3) { error = msg; break; }
+      const delay = [2000, 10000][attempt - 1] ?? 30000;
+      console.error(`  [${scenario.id}] attempt ${attempt} ERR: ${msg.slice(0, 80)} — retry in ${delay / 1000}s`);
+      await sleep(delay);
+    }
+  }
+
+  return {
+    scenario_id: scenario.id,
+    category: scenario.category,
+    input: scenario.input,
+    reference_output: scenario.reference_output,
+    model_output: model,
+    error,
+    duration_ms: Date.now() - t0,
+    match: scoreClassification(scenario.reference_output, model),
+  };
+}
+
+async function main() {
+  const roundArg = process.argv.indexOf('--round');
+  const round = roundArg >= 0 ? process.argv[roundArg + 1] : 'R0';
+  const limitArg = process.argv.indexOf('--limit');
+  const limit = limitArg >= 0 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
+  const outArg = process.argv.indexOf('--output');
+
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const outPath = outArg >= 0
+    ? path.resolve(process.argv[outArg + 1])
+    : path.join(RESULTS_DIR, `etms-classify-${round}.json`);
+
+  const files = readdirSync(CORPUS_DIR).filter((f) => f.endsWith('.json')).sort();
+  const allScenarios: Scenario[] = files.map((f) =>
+    JSON.parse(readFileSync(path.join(CORPUS_DIR, f), 'utf-8')),
+  );
+  const scenarios = isFinite(limit) ? allScenarios.slice(0, limit) : allScenarios;
+
+  const existing: Map<string, RunResult> = new Map();
+  if (existsSync(outPath)) {
+    const prev: RunResult[] = JSON.parse(readFileSync(outPath, 'utf-8'));
+    for (const r of prev) existing.set(r.scenario_id, r);
+  }
+  const pending = scenarios.filter((s) => !existing.has(s.id) || existing.get(s.id)?.error);
+
+  console.error(`[run-classify] round=${round} total=${scenarios.length} pending=${pending.length}`);
+
+  let done = 0;
+  const results: RunResult[] = [...existing.values()].filter((r) => !r.error);
+
+  for (const scenario of pending) {
+    const result = await runScenario(scenario);
+    results.push(result);
+    done++;
+    if (done % 10 === 0 || done === pending.length) {
+      writeFileSync(outPath, JSON.stringify(results, null, 2));
+      const ok = results.filter((r) => !r.error).length;
+      const err = results.filter((r) => r.error).length;
+      const catOk = results.filter((r) => !r.error && r.match.category_match).length;
+      console.error(`[run-classify] ${done}/${pending.length} done (ok=${ok} err=${err} cat_ok=${catOk})`);
+    }
+  }
+
+  writeFileSync(outPath, JSON.stringify(results, null, 2));
+
+  const total = results.length;
+  const noErr = results.filter((r) => !r.error);
+  const catOk = noErr.filter((r) => r.match.category_match).length;
+  const urgOk = noErr.filter((r) => r.match.urgency_match).length;
+  const unsOk = noErr.filter((r) => r.match.is_unanswered_match).length;
+  const errors = total - noErr.length;
+
+  console.error(`\n[run-classify] DONE round=${round}`);
+  console.error(`Category accuracy:     ${catOk}/${total} (${((catOk / total) * 100).toFixed(1)}%)`);
+  console.error(`Urgency accuracy:      ${urgOk}/${total} (${((urgOk / total) * 100).toFixed(1)}%)`);
+  console.error(`is_unanswered match:   ${unsOk}/${total} (${((unsOk / total) * 100).toFixed(1)}%)`);
+  console.error(`Errors:                ${errors}`);
+  console.error(`Output: ${outPath}`);
+
+  // Confusion matrix for category
+  const confusion: Record<string, Record<string, number>> = {};
+  for (const r of noErr) {
+    const ref = r.match.ref_category;
+    const got = r.match.model_category ?? 'NULL';
+    confusion[ref] ??= {};
+    confusion[ref][got] = (confusion[ref][got] ?? 0) + 1;
+  }
+  console.error('\nConfusion matrix (ref → model):');
+  for (const ref of Object.keys(confusion).sort()) {
+    console.error(`  ${ref}:`, JSON.stringify(confusion[ref]));
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => { console.error('FATAL', e); process.exit(1); });
+}

--- a/scripts/progonq/run-parse-vessel.ts
+++ b/scripts/progonq/run-parse-vessel.ts
@@ -1,0 +1,386 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * progonq runner for parse-vessel endpoint.
+ *
+ * Runs VESSEL_POSITION_PARSER_PROMPT against .progonq/corpus/etms-parse-vessel/
+ * scenarios and saves results to .progonq/results/etms-parse-vessel-<round>.json.
+ * Resumable: skips scenarios already in results file.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/run-parse-vessel.ts [--round R0] [--limit N] [--scenario scenario-001]
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { callAiText } from '@/lib/ai-provider';
+import { VESSEL_POSITION_PARSER_PROMPT } from '@/lib/prompts';
+import { PARSE_VESSEL_SCHEMA } from '@/lib/schemas';
+
+const SCOPE = 'PARSE_VESSEL';
+const MAX_BODY_CHARS = 5000;
+const REQUEST_DELAY_MS = 400;
+
+const CORPUS_DIR = path.resolve(process.cwd(), '.progonq/corpus/etms-parse-vessel');
+const RESULTS_DIR = path.resolve(process.cwd(), '.progonq/results');
+
+interface ConfidenceField {
+  value: unknown;
+  confidence?: string;
+  source_text?: string;
+}
+
+interface VesselItem {
+  vessel_name?: ConfidenceField | null;
+  imo?: string | null;
+  flag?: ConfidenceField | string | null;
+  built?: ConfidenceField | number | null;
+  dwt_summer?: ConfidenceField | null;
+  dwcc?: ConfidenceField | null;
+  open_position?: ConfidenceField | null;
+  open_date?: ConfidenceField | null;
+  [key: string]: unknown;
+}
+
+interface ParsedOutput {
+  items: VesselItem[];
+}
+
+interface Scenario {
+  id: string;
+  source_email_id: string;
+  category: string;
+  input: { subject: string; from: string; date: string; body: string };
+  reference_output: ParsedOutput;
+}
+
+export interface VesselMatchResult {
+  ref_vessel_name: string | null;
+  model_vessel_name: string | null;
+  ref_imo: string | null;
+  model_imo: string | null;
+  ref_flag: string | null;
+  model_flag: string | null;
+  ref_built: number | null;
+  model_built: number | null;
+  ref_dwt: number | null;
+  model_dwt: number | null;
+  ref_dwcc: number | null;
+  model_dwcc: number | null;
+  ref_open_position: string | null;
+  model_open_position: string | null;
+  ref_open_date: string | null;
+  model_open_date: string | null;
+  vessel_name_match: boolean;          // deterministic (case-insensitive string match)
+  imo_match: boolean;
+  flag_match: boolean;
+  built_match: boolean;
+  dwt_match: boolean;
+  dwcc_match: boolean;
+  string_field_match_rate: number;     // deterministic-fields aggregate
+}
+
+interface RunResult {
+  scenario_id: string;
+  category: string;
+  input: Scenario['input'];
+  reference_output: ParsedOutput;
+  model_output: ParsedOutput | null;
+  error?: string;
+  duration_ms: number;
+  item_count_ref: number;
+  item_count_model: number;
+  item_matches: VesselMatchResult[];
+  match_rate: number;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max) + '\n[truncated]';
+}
+
+function extractJson(text: string): unknown {
+  let s = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  const start = s.search(/[{[]/);
+  if (start > 0) s = s.slice(start);
+  const opener = s[0];
+  if (opener !== '{' && opener !== '[') return JSON.parse(s);
+  const closer = opener === '{' ? '}' : ']';
+  let depth = 0, inStr = false, esc = false, end = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (esc) { esc = false; continue; }
+    if (c === '\\' && inStr) { esc = true; continue; }
+    if (c === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (c === opener) depth++;
+    else if (c === closer && --depth === 0) { end = i; break; }
+  }
+  return JSON.parse(end > 0 ? s.slice(0, end + 1) : s);
+}
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+function getFieldValue(field: unknown): unknown {
+  if (field == null) return null;
+  if (typeof field === 'object' && 'value' in (field as Record<string, unknown>)) {
+    return (field as { value: unknown }).value ?? null;
+  }
+  return field;
+}
+
+function asString(v: unknown): string | null {
+  if (v == null) return null;
+  if (typeof v === 'string') return v;
+  if (typeof v === 'object') {
+    // open_date appears as { open, close, display } — prefer display, else open
+    const obj = v as Record<string, unknown>;
+    if (typeof obj.display === 'string') return obj.display;
+    if (typeof obj.open === 'string') {
+      const close = typeof obj.close === 'string' ? obj.close : '';
+      return close ? `${obj.open} → ${close}` : obj.open;
+    }
+    return JSON.stringify(v);
+  }
+  return String(v);
+}
+
+function asNumber(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') {
+    const n = parseFloat(v.replace(/,/g, ''));
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+export function withinTolerance(ref: number | null, model: number | null, tolerance = 0.05): boolean {
+  if (ref === null && model === null) return true;
+  if (ref === null || model === null) return false;
+  if (ref === 0) return model === 0;
+  return Math.abs(ref - model) / Math.abs(ref) <= tolerance;
+}
+
+function ciEqual(a: string | null, b: string | null): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function normalizeVesselName(s: string | null): string | null {
+  if (!s) return s;
+  return s
+    .toUpperCase()
+    .replace(/^(M[\s.]*V[.\s]*|MS[.\s]*|SS[.\s]*|MT[.\s]*)/i, '')
+    .replace(/[^A-Z0-9 ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeImo(s: string | null): string | null {
+  if (!s) return s;
+  const m = s.match(/\d+/);
+  return m ? m[0] : null;
+}
+
+export function scoreVesselItems(refItems: VesselItem[], modelItems: VesselItem[]): VesselMatchResult[] {
+  const results: VesselMatchResult[] = [];
+  const maxLen = Math.max(refItems.length, modelItems.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    const ref = refItems[i] ?? null;
+    const model = modelItems[i] ?? null;
+
+    const refName = asString(getFieldValue(ref?.vessel_name));
+    const modelName = asString(getFieldValue(model?.vessel_name));
+    const refImo = asString(getFieldValue(ref?.imo));
+    const modelImo = asString(getFieldValue(model?.imo));
+    const refFlag = asString(getFieldValue(ref?.flag));
+    const modelFlag = asString(getFieldValue(model?.flag));
+    const refBuilt = asNumber(getFieldValue(ref?.built));
+    const modelBuilt = asNumber(getFieldValue(model?.built));
+    const refDwt = asNumber(getFieldValue(ref?.dwt_summer));
+    const modelDwt = asNumber(getFieldValue(model?.dwt_summer));
+    const refDwcc = asNumber(getFieldValue(ref?.dwcc));
+    const modelDwcc = asNumber(getFieldValue(model?.dwcc));
+    const refOpenPos = asString(getFieldValue(ref?.open_position));
+    const modelOpenPos = asString(getFieldValue(model?.open_position));
+    const refOpenDate = asString(getFieldValue(ref?.open_date));
+    const modelOpenDate = asString(getFieldValue(model?.open_date));
+
+    const vesselNameMatch = ciEqual(normalizeVesselName(refName), normalizeVesselName(modelName));
+    const imoMatch =
+      refImo === null && modelImo === null
+        ? true
+        : refImo === null || modelImo === null
+          ? false
+          : normalizeImo(refImo) === normalizeImo(modelImo);
+    const flagMatch = ciEqual(refFlag, modelFlag);
+    const builtMatch = refBuilt === modelBuilt;
+    const dwtMatch = withinTolerance(refDwt, modelDwt);
+    const dwccMatch = withinTolerance(refDwcc, modelDwcc);
+
+    const flags = [vesselNameMatch, imoMatch, flagMatch, builtMatch, dwtMatch, dwccMatch];
+    const stringRate = flags.filter(Boolean).length / flags.length;
+
+    results.push({
+      ref_vessel_name: refName,
+      model_vessel_name: modelName,
+      ref_imo: refImo,
+      model_imo: modelImo,
+      ref_flag: refFlag,
+      model_flag: modelFlag,
+      ref_built: refBuilt,
+      model_built: modelBuilt,
+      ref_dwt: refDwt,
+      model_dwt: modelDwt,
+      ref_dwcc: refDwcc,
+      model_dwcc: modelDwcc,
+      ref_open_position: refOpenPos,
+      model_open_position: modelOpenPos,
+      ref_open_date: refOpenDate,
+      model_open_date: modelOpenDate,
+      vessel_name_match: vesselNameMatch,
+      imo_match: imoMatch,
+      flag_match: flagMatch,
+      built_match: builtMatch,
+      dwt_match: dwtMatch,
+      dwcc_match: dwccMatch,
+      string_field_match_rate: stringRate,
+    });
+  }
+  return results;
+}
+
+function extractItems(raw: unknown): VesselItem[] {
+  if (Array.isArray(raw)) return raw as VesselItem[];
+  if (raw && typeof raw === 'object') {
+    const items = (raw as { items?: unknown }).items;
+    if (Array.isArray(items)) return items as VesselItem[];
+  }
+  return [];
+}
+
+async function runScenario(scenario: Scenario): Promise<RunResult> {
+  const body = truncate(scenario.input.body, MAX_BODY_CHARS);
+  const userPrompt = `From: ${scenario.input.from}\nSubject: ${scenario.input.subject}\nDate: ${scenario.input.date}\n\n${body}`;
+
+  const t0 = Date.now();
+  let model_output: ParsedOutput | null = null;
+  let error: string | undefined;
+
+  let attempt = 0;
+  while (attempt < 3) {
+    attempt++;
+    try {
+      await sleep(REQUEST_DELAY_MS);
+      const text = await callAiText(SCOPE, VESSEL_POSITION_PARSER_PROMPT, userPrompt, {
+        maxTokens: 16000,
+        timeoutMs: 180_000,
+        temperature: 0,
+        seed: 42,
+        responseSchema: PARSE_VESSEL_SCHEMA as Record<string, unknown>,
+      });
+      const raw = extractJson(text);
+      model_output = { items: extractItems(raw) };
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (attempt >= 3) { error = msg; break; }
+      const delay = [2000, 10000][attempt - 1] ?? 30000;
+      console.error(`  [${scenario.id}] attempt ${attempt} ERR: ${msg.slice(0, 80)} — retry in ${delay / 1000}s`);
+      await sleep(delay);
+    }
+  }
+
+  const refItems = scenario.reference_output?.items ?? [];
+  const modelItems = model_output?.items ?? [];
+  const itemMatches = error ? [] : scoreVesselItems(refItems, modelItems);
+  const matchRate = error
+    ? 0
+    : refItems.length === 0 && modelItems.length === 0
+      ? 1
+      : itemMatches.length === 0
+        ? 0
+        : itemMatches.reduce((s, m) => s + m.string_field_match_rate, 0) / itemMatches.length;
+
+  return {
+    scenario_id: scenario.id,
+    category: scenario.category,
+    input: scenario.input,
+    reference_output: scenario.reference_output,
+    model_output,
+    error,
+    duration_ms: Date.now() - t0,
+    item_count_ref: refItems.length,
+    item_count_model: modelItems.length,
+    item_matches: itemMatches,
+    match_rate: matchRate,
+  };
+}
+
+async function main() {
+  const roundArg = process.argv.indexOf('--round');
+  const round = roundArg >= 0 ? process.argv[roundArg + 1] : 'R0';
+  const limitArg = process.argv.indexOf('--limit');
+  const limit = limitArg >= 0 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
+  const scenarioFilter = process.argv.includes('--scenario')
+    ? process.argv[process.argv.indexOf('--scenario') + 1]
+    : null;
+  const outArg = process.argv.indexOf('--output');
+
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const outPath = outArg >= 0
+    ? path.resolve(process.argv[outArg + 1])
+    : path.join(RESULTS_DIR, `etms-parse-vessel-${round}.json`);
+
+  const files = readdirSync(CORPUS_DIR).filter((f) => f.endsWith('.json')).sort();
+  const allScenarios: Scenario[] = files.map((f) =>
+    JSON.parse(readFileSync(path.join(CORPUS_DIR, f), 'utf-8')),
+  );
+
+  let scenarios = isFinite(limit) ? allScenarios.slice(0, limit) : allScenarios;
+  if (scenarioFilter) scenarios = scenarios.filter((s) => s.id === scenarioFilter);
+
+  const existing: Map<string, RunResult> = new Map();
+  if (existsSync(outPath)) {
+    const prev: RunResult[] = JSON.parse(readFileSync(outPath, 'utf-8'));
+    for (const r of prev) existing.set(r.scenario_id, r);
+  }
+  const pending = scenarios.filter((s) => !existing.has(s.id) || existing.get(s.id)?.error);
+
+  console.error(`[run-parse-vessel] round=${round} total=${scenarios.length} pending=${pending.length}`);
+
+  let done = 0;
+  const results: RunResult[] = [...existing.values()].filter((r) => !r.error);
+
+  for (const scenario of pending) {
+    const result = await runScenario(scenario);
+    results.push(result);
+    done++;
+    if (done % 5 === 0 || done === pending.length) {
+      writeFileSync(outPath, JSON.stringify(results, null, 2));
+      const ok = results.filter((r) => !r.error).length;
+      const err = results.filter((r) => r.error).length;
+      console.error(`[run-parse-vessel] ${done}/${pending.length} done (ok=${ok} err=${err})`);
+    }
+  }
+
+  writeFileSync(outPath, JSON.stringify(results, null, 2));
+
+  const total = results.length;
+  const fullMatch = results.filter((r) => !r.error && r.match_rate === 1).length;
+  const errors = results.filter((r) => r.error).length;
+  const meanRate = results.filter((r) => !r.error).reduce((s, r) => s + r.match_rate, 0) / Math.max(1, total - errors);
+
+  console.error(`\n[run-parse-vessel] DONE round=${round}`);
+  console.error(`Full deterministic match: ${fullMatch}/${total} (${((fullMatch / total) * 100).toFixed(1)}%) errors=${errors}`);
+  console.error(`Mean deterministic-field match rate: ${(meanRate * 100).toFixed(1)}%`);
+  console.error(`Output: ${outPath}`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('FATAL', e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- **run-parse-vessel.ts** — runner scoring 6 deterministic fields (vessel_name CI+prefix-strip, IMO, flag, built, DWT±5%, DWCC±5%); resumable, supports `--round/--limit/--scenario/--output`
- **judge-parse-vessel.ts** — LLM judge for vessel_name aliases, UNLOCODE↔free-text open_position, open_date window equivalence; shared keyed cache
- **run-classify.ts** — per-scenario classify runner scoring category (exact), urgency (CI), is_unanswered (bool); confusion matrix output
- **judge-classify.ts** — LLM judge for `original_sender_company` legal-name equivalence; promotes deterministic fields into `semantic_field_match`
- **TDD tests** — `score-vessel.test.ts` + `score-classify.test.ts` covering withinTolerance, scoreVesselItems, scoreClassification

## Baseline results (Gemini, 2026-05-15)

| Endpoint | Scenarios | Errors | Key metric |
|---|---|---|---|
| parse-vessel | 56 | 4 | Mean det rate 76.0% (full match 26.9%) |
| classify | 154 | 0 | Category 95.5% / Urgency 73.4% / is_unanswered 89.6% |

Top weaknesses: `dwcc` 51.9%, VESSEL_POSITION urgency 63.2%, CARGO_INQUIRY→TCT_REQUEST confusions (3 cases). Full analysis in `docs/progonq/eval-baseline-2026-05-15.md`.

## Test plan

- [ ] `npx jest scripts/progonq/__tests__/score-vessel.test.ts` — green
- [ ] `npx jest scripts/progonq/__tests__/score-classify.test.ts` — green
- [ ] `npx tsc --noEmit -p tsconfig.json` — no type errors
- [ ] Re-run `judge-parse-vessel.ts` to populate open_position/open_date semantic scores
- [ ] Re-run `judge-classify.ts` to populate original_sender_company scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)