### PR TITLE
fix(middleware): bypass auth for /api/admin/market/upload-csv

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -54,6 +54,7 @@ describe('middleware auth guard', () => {
       '/api/auth/logout',
       '/favicon.ico',
       '/api/admin/cron-heartbeat',
+      '/api/admin/market/upload-csv',
       '/_next/static/chunks/main.js',
       '/_next/image?url=x',
     ];

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,6 +13,8 @@ const AUTH_BYPASS_PATHS = new Set([
   '/api/health',
   // Cron heartbeat has its own X-Cron-Secret auth — must not be redirected to /login
   '/api/admin/cron-heartbeat',
+  // Market CSV upload has its own X-Admin-Token auth (requireAdmin) — must not be redirected to /login
+  '/api/admin/market/upload-csv',
 ]);
 
 const AUTH_BYPASS_PREFIXES = ['/_next/static', '/_next/image', '/_next/webpack'];


### PR DESCRIPTION
## Summary
- Adds `/api/admin/market/upload-csv` to `AUTH_BYPASS_PATHS` in [middleware.ts](middleware.ts) — mirrors the existing `/api/admin/cron-heartbeat` pattern.
- Endpoint added in #161 has its own `X-Admin-Token` auth (`requireAdmin`); without this fix, middleware redirects to `/login` (302) before the handler can run — making the documented weekly upload ritual non-functional.
- Test: extends `bypassPaths` array in `__tests__/middleware-auth.test.ts` (17/17 green).

## Why this slipped past #161
The new endpoint's auth was unit-tested in isolation, but the integration with `middleware.ts` was not — `__tests__/middleware-auth.test.ts` was not updated. Reproduced on prod: `curl -X POST … -H 'X-Admin-Token: …'` returned 302 → /login.

## Test plan
- [x] Existing tests pass (17/17)
- [x] New bypass entry exercises the regression
- [ ] After merge + deploy: `curl -X POST https://demo.quantika.org/api/admin/market/upload-csv -H "X-Admin-Token: \$ADMIN_TOKEN" -H 'Content-Type: application/json' -d '{"index_name":"bhsi","rows":[{"date":"2026-05-14","value":851}]}'` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)