### PR TITLE
fix(auth): redirect uses X-Forwarded-Host (login broken on demo.quantika.org)

### DIFF
--- a/__tests__/auth/redirect-url.test.ts
+++ b/__tests__/auth/redirect-url.test.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(url, { headers });
+}
+
+describe('getRequestBaseUrl', () => {
+  it('uses X-Forwarded-Host + X-Forwarded-Proto when present (Caddy reverse proxy)', () => {
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      'x-forwarded-host': 'demo.quantika.org',
+      'x-forwarded-proto': 'https',
+      host: 'localhost:3000',
+    });
+    expect(getRequestBaseUrl(req)).toBe('https://demo.quantika.org');
+  });
+
+  it('falls back to Host header with https when X-Forwarded-* missing (public host)', () => {
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      host: 'demo.quantika.org',
+    });
+    expect(getRequestBaseUrl(req)).toBe('https://demo.quantika.org');
+  });
+
+  it('falls back to Host with http for localhost (dev)', () => {
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      host: 'localhost:3000',
+    });
+    expect(getRequestBaseUrl(req)).toBe('http://localhost:3000');
+  });
+
+  it('uses 127.0.0.1 as localhost', () => {
+    const req = makeReq('http://127.0.0.1:3000/api/auth/login', {
+      host: '127.0.0.1:3000',
+    });
+    expect(getRequestBaseUrl(req)).toBe('http://127.0.0.1:3000');
+  });
+
+  it('respects explicit X-Forwarded-Proto even if Host looks like localhost', () => {
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      'x-forwarded-host': 'demo.quantika.org',
+      'x-forwarded-proto': 'http',
+      host: 'localhost:3000',
+    });
+    expect(getRequestBaseUrl(req)).toBe('http://demo.quantika.org');
+  });
+
+  it('falls back to request.url when all headers missing (NextRequest auto-fills host)', () => {
+    const req = makeReq('http://internal:9999/api/auth/login');
+    // NextRequest copies URL host into the host header automatically — accept either
+    const result = getRequestBaseUrl(req);
+    expect(['http://internal:9999', 'http://internal:9999/']).toContain(result + (result.endsWith('/') ? '' : ''));
+  });
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthConfig } from '@/lib/auth/config';
 import { signAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
 
 /**
  * Constant-time string comparison to prevent timing attacks.
@@ -48,8 +49,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const validUser = timingSafeStringEqual(user, config.user);
   const validPassword = timingSafeStringEqual(password, config.password ?? '');
 
+  const baseUrl = getRequestBaseUrl(request);
+
   if (!validUser || !validPassword || !password) {
-    return NextResponse.redirect(new URL('/login?error=1', request.url), { status: 303 });
+    return NextResponse.redirect(new URL('/login?error=1', baseUrl), { status: 303 });
   }
 
   // Credentials valid — sign and set cookie
@@ -58,7 +61,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const maxAge = config.cookieDays * 86_400;
   const isProduction = process.env.NODE_ENV === 'production';
 
-  const response = NextResponse.redirect(new URL('/', request.url), { status: 303 });
+  const response = NextResponse.redirect(new URL('/', baseUrl), { status: 303 });
   response.headers.set(
     'Set-Cookie',
     [

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
 
-export async function POST(_request: NextRequest): Promise<NextResponse> {
-  const response = NextResponse.redirect(new URL('/login', _request.url), { status: 303 });
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const response = NextResponse.redirect(new URL('/login', getRequestBaseUrl(request)), { status: 303 });
 
   // Clear the auth cookie by setting Max-Age=0
   response.headers.set(

--- a/lib/auth/redirect-url.ts
+++ b/lib/auth/redirect-url.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from 'next/server';
+
+/**
+ * Build the external base URL behind a reverse proxy (e.g. Caddy → localhost:3000).
+ * Prefers X-Forwarded-{Proto,Host} → Host header → request.url as last resort.
+ */
+export function getRequestBaseUrl(request: NextRequest): string {
+  const fwdHost = request.headers.get('x-forwarded-host');
+  const fwdProto = request.headers.get('x-forwarded-proto');
+  const host = fwdHost ?? request.headers.get('host');
+
+  if (host) {
+    const proto = fwdProto ?? (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
+    return `${proto}://${host}`;
+  }
+
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,7 @@ import { checkCsrfRequest } from '@/lib/csrf';
 import { aiRateLimiter } from '@/lib/rate-limit';
 import { getAuthConfig } from '@/lib/auth/config';
 import { verifyAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
 
 // Paths that bypass the auth guard entirely
 const AUTH_BYPASS_PATHS = new Set([
@@ -59,7 +60,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     if (!payload) {
       // Redirect to /login preserving the original URL as `next` param is intentionally omitted
       // (simple demo — no deep-link restoration needed)
-      const loginUrl = new URL('/login', request.url);
+      const loginUrl = new URL('/login', getRequestBaseUrl(request));
       return NextResponse.redirect(loginUrl, { status: 302 });
     }
   }


### PR DESCRIPTION
## Why this is URGENT

Browser login on https://demo.quantika.org was broken. POST `/api/auth/login` returned 303 with `Location: https://localhost:3000/...` — browsers cannot follow this.

**Repro before fix:**
```bash
$ curl -i -X POST https://demo.quantika.org/api/auth/login -d 'user=x&password=y'
HTTP/2 303
location: https://localhost:3000/login?error=1   ← unreachable from any external browser
```

**How long this was broken:** since commit `2729fa8` (auth perimeter added, weeks ago). Browser-login was never in CI until [#158](https://github.com/Vitali2011/quantika-demo/pull/158) Playwright suite. First prod-smoke run found it today.

## Root cause

`NextResponse.redirect(new URL(path, request.url))` takes `request.url` which behind Caddy is `http://localhost:3000/...` (upstream URL), not the external host the browser sent.

## Fix

New helper `lib/auth/redirect-url.ts::getRequestBaseUrl(request)`:
1. Prefer `X-Forwarded-Host` + `X-Forwarded-Proto` (Caddy default)
2. Fall back to `Host` header
3. Fall back to `request.url` (preserves dev/test behaviour)

Wired into **4** broken redirect sites:
- `app/api/auth/login/route.ts:52` (error redirect)
- `app/api/auth/login/route.ts:61` (success redirect)
- `app/api/auth/logout/route.ts:5` (logout)
- `middleware.ts:62` (unauth → /login)

## PI3 safety

Existing tests use `expect(location).toContain('/login')` — relative substring assertions survive without rewrite. 23/23 tests green (6 new + 17 existing). No test expectations modified.

## Test plan

- [x] `npx jest __tests__/auth/redirect-url.test.ts` — 6/6 (5 header combinations + fallback)
- [x] `npx jest __tests__/middleware-auth.test.ts` — 17/17 (PI3-safe)
- [x] `npx tsc --noEmit` — clean
- [ ] After deploy: `curl -i -X POST https://demo.quantika.org/api/auth/login -d '...'` returns `Location: https://demo.quantika.org/...`
- [ ] After deploy: re-run Playwright smoke (`npm run test:suite:prod`) — expect 10 → 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)