### PR TITLE
fix(prompts): parse-cargo R3 — stowage/HRCTD (from parallel wave-deep session)

### DIFF
--- a/.pipeline/phase_1_scope.md
+++ b/.pipeline/phase_1_scope.md
@@ -1,100 +1,70 @@
-# Phase 1 Scope — parse-cargo Stage 2 targeted prompt fix
+# Phase 1 Scope -- parse-cargo R3
 
 ## Assumptions (Karpathy #1)
 
-Понимаю задачу как: добавить 2 правила в production prompt
-`lib/prompts/parse-cargo.ts` для устранения двух чистых failure-кластеров
-из Phase 3a analysis — laycan/Spot-inference и cargo/stowage-noise.
-Альтернатива: переезд parse-cargo на Sonnet 4.6 через AI provider shim
-(Stage 2 option 2) — стоит дороже и инвазивнее, оставляем как fallback.
-Иду по targeted-prompt, потому что: failure pattern узкий (17/26 laycan +
-5/23 cargo), config-леверы Gemini исчерпаны (responseSchema регрессирует),
-1 файл, низкий риск регрессии остальных полей.
+Понимаю задачу как: точечная правка CARGO DESCRIPTION RULES секции в одном файле.
+Альтернатива: переписать всю секцию или добавить few-shot примеры.
+Иду по точечной правке, потому что: fewer changes = less risk of side effects; targeted fixes for identified root causes.
+
+## Affected Files
+
+| File                       | Change                                              | Risk |
+| -------------------------- | --------------------------------------------------- | ---- |
+| lib/prompts/parse-cargo.ts | 6 targeted edits in CARGO DESCRIPTION RULES section | LOW  |
+
+No other files touched.
 
 ## Boundaries
 
-### Can Change
+- Can Change: lines 130-160 (CARGO DESCRIPTION RULES section)
+- Cannot Change: stowage_factor field rules (lines 161-175), LAYCAN RULES, test files
+- Must Not Break: laycan match (currently 86.4% post-R1), commission/weight/ports fields
 
-- `lib/prompts/parse-cargo.ts`:
-  - Секция `=== LAYCAN RULES ===` (строки 199–209) — переписать с inversion:
-    null по умолчанию, Spot/Prompt только при literal substring.
-  - Секция `=== CARGO DESCRIPTION RULES ===` (строки 130–160) — снять
-    требования inline stowage / dimensions / weight; оставить только
-    cargo name + grade + physical form (bulk/bagged/coils/HRC etc.).
+## Changes Detail
 
-### Cannot Change
+### Change 1: HRCTD abbreviation fix (line ~137)
 
-- Schema / Zod-валидация cargo output (`lib/schemas/parse-cargo.ts`).
-- AI provider shim (`lib/ai-provider.ts`) — frozen config: gemini-2.5-pro,
-  us-central1, temp 0, seed 42, thinking off.
-- Eval harness `scripts/progonq/run-parse-cargo.ts` + judge — не трогать
-  (5-field scoring merged в PR #154).
-- Test fixtures под parse-cargo (`lib/__tests__/etms-corpus-fixtures.ts`).
+FROM: 'HRCTD' -> 'Hot Rolled Coils Trimmed & Dried (HRCTD)'
+TO: 'HRCTD' -> 'Hot Rolled Coils Trimmed & Descaled (HRCTD)'
+Why: factual error in prompt. Affects ~15 fails (Cluster B).
 
-### Must Not Break
+### Change 2: Add PNO abbreviation (after HRCPO line)
 
-- ports / weight / commission accuracy: каждое ≥ baseline R21-A − 1pp
-  (anti-regression gate).
-- Schema совместимость: cargo_description остаётся string, laycan
-  остаётся nullable string.
+ADD: '- PNO -> Plates Not Otherwise Specified (PNO)'
+Why: PNO undefined -> model guesses wrong expansion. Affects ~3 fails.
 
-## Affected files
+### Change 3: Fix rule 2 -- stowage factor duplication (lines 142-143)
 
-| Файл                       | Изменение           | Риск              |
-| -------------------------- | ------------------- | ----------------- |
-| lib/prompts/parse-cargo.ts | 2 секции переписаны | LOW (prompt-only) |
+REPLACE current rule 2 with clarified version:
+'2. Stowage factor: the numeric value (without units) MUST appear in cargo_description
+when stated in the email, e.g. stowage factor 51-52, without guarantee.
+The full 'X ft3/MT' notation also goes in the separate stowage_factor field.
+These are independent: both fields must be populated. Do not omit stowage from
+cargo_description because it is already in stowage_factor.'
+Why: rules 2 and 12 contradicted each other, causing model to omit stowage entirely.
 
-## Cross-cutting check
+### Change 4: BULK mandatory rule (after rule 10)
 
-Файлов <5, скейл cross-cutting grep не нужен. PI3 не активен — unit-тесты
-проверяют только schema/types, не assert'ят конкретные cargo_description
-строки или Spot-значения laycan (confirmed: grep по lib/**tests** показал
-только `stowageFactor: null` в fixtures).
+ADD: '10a. For BULK cargo: if stowage factor is stated, it is MANDATORY in cargo_description.'
+Example: corn with 'stw 51' -> 'Corn, stowage factor 51, without guarantee'
 
-## Acceptance gate (Phase 3 QI)
+### Change 5: BAGGED mandatory rule (after rule 10a)
 
-R22 baseline на VPS в tmux, 95 сценариев × 3 повтора, frozen config A
-(см. handover). Сравнение medians с R21-A baseline:
+ADD: '10b. For BAGGED cargo: if bag dimensions or unit weight are stated, they are MANDATORY.'
+Example: 'salt bb 1.1x1.1x1.1m uw 1.25mt' -> 'Salt in big bags, dimensions 1.1m x 1.1m x 1.1m, unit weight 1.25 MT'
 
-- laycan ≥ 88% (R21-A=82.4%, R1 expectation +5pp) → REQUIRED
-- cargo_description ≥ 85% (R21-A=83.0%, R2 expectation +2pp) → REQUIRED
-- ports / weight / commission: каждое ≥ R21-A − 1pp → REQUIRED
-- variance min-max ≤ 3pp по каждому полю → желательно
+### Change 6: Additional example showing stowage in cargo_description
 
-## Decision tree после gate
+ADD to examples block: shows bulk grain with stowage factor correctly included.
 
-- R1+R2 PASS → preview report, ⛔ wait merge command
-- Только R1 PASS → revert R2, оставить R1 (partial-merge)
-- Оба FAIL → revert обоих, эскалировать в Stage 2 option 2 (Sonnet)
+## PI3 Enforcement
 
-## Open questions
+Only lib/prompts/parse-cargo.ts changes. No test files touched. Tests do not assert prompt content directly.
+PI3 threshold: >5 test expectation rewrites = STOP. Expected here: 0.
 
-Нет.
+## Acceptance Gate
 
----
-
-## Result (Phase 3 eval, 2026-05-16)
-
-R22 baseline (3 × 95 sc, frozen config A) vs R21-A baseline:
-
-| Поле              | R21-A | R22 median | Δ    | Gate    |
-| ----------------- | ----- | ---------- | ---- | ------- |
-| ports             | 95.3  | 94.6       | -0.7 | ≥94.3 ✓ |
-| weight            | 93.9  | 96.6       | +2.7 | ≥92.9 ✓ |
-| cargo_description | 84.5  | 84.4       | -0.1 | ≥85 ✗   |
-| laycan            | 82.4  | 86.4       | +4.0 | ≥88 ✗   |
-| commission        | 98.0  | 98.6       | +0.6 | ≥97 ✓   |
-
-Variance: laycan 1.3pp, cargo 1.4pp (≤3pp ✓).
-
-**Decision: soft-merge R1, revert R2.**
-
-- R1 (laycan) даёт стабильный +4pp без регрессий. Gate в 88% не достигнут,
-  но direction-correct, prod-выигрыш реальный, цена нулевая.
-- R2 (cargo_description) — медиана в шуме (-0.1pp), правило не сработало.
-  Гипотеза «extra_detail = 5/23» не подтверждена, нужна другая failure
-  таксономия. Revert, оставить как negative result.
-- Stage 2 option 2 (Sonnet parser) **не активируем** — overreaction на 2pp
-  shortfall одного из двух экспериментов. Сначала исчерпать дешёвые опции.
-
-Anti-regression gate (ports/weight/commission ≥ baseline-1pp) пройден.
+- cargo_description >= 87.0% (R23-A median over 3 runs)
+- Soft-merge if 85.0-86.9% (direction-correct)
+- Revert if < 85.0%
+- Anti-regression: laycan >= 85.4%, all other fields >= R22 - 1pp

--- a/docs/plans/2026-05-16-parse-cargo-r3-cargo-rule.md
+++ b/docs/plans/2026-05-16-parse-cargo-r3-cargo-rule.md
@@ -1,0 +1,60 @@
+# Parse-Cargo R3: Cargo Description Rule Fix
+
+**Date:** 2026-05-16
+**Branch:** feat/parse-cargo-r3-cargo-rule
+**File:** lib/prompts/parse-cargo.ts (CARGO DESCRIPTION RULES section only)
+
+## Context
+
+Phase 3b shipped R1 (laycan literal-only, +4pp 82.4->86.4). R2 (canonical form, exclude stowage/dims) reverted at -0.1pp. This is R3.
+
+**Baseline:** R22-A median = 84.4% cargo_description match (373/442 item_matches passing)
+
+## Failure Analysis (Opus cluster from R22-A-1/2/3)
+
+**Total:** 69 fails / 442 assessments across 285 scenarios (3 runs x 95 scenarios)
+
+### Cluster A -- Stowage/dims omitted (approx 39 fails, ~13 unique items x 3 runs)
+
+Model outputs base commodity+form but omits technical details that the reference expects:
+
+- 'corn in bulk' -> reference: 'Corn, stowage factor 51-52, without guarantee'
+- 'Salt in big bags' -> reference: 'Salt in big bags, dimensions 1.1m x 1.1m x 1.1m, unit weight 1.25 MT'
+- 'PC Strand' -> reference: 'PC Strand, Diameter: 130-140 cm, H: 80 cm, Unit Weight: 3-3.5 MT, Tier limit: 2'
+
+Root cause: Rules 2 and 12 contradict each other.
+
+- Rule 2: Include stowage factor inline if given (with original units)
+- Rule 12: Do NOT include unit notations (ft3/MT, m3/MT) inside cargo_description
+  Model resolves contradiction by omitting stowage from cargo_description entirely.
+
+### Cluster B -- Wrong abbreviation expansion (approx 15 fails, ~5 unique items x 3 runs)
+
+1. HRCTD factual error in prompt: says 'Trimmed and Dried' but correct is 'Trimmed and Descaled'
+2. PNO not defined: model guesses 'Pickled and Oiled' instead of 'Plates Not Otherwise Specified'
+
+Coverage: Cluster A + B = 54/69 = 78% of all fails addressable.
+
+## Changes (ONE file: lib/prompts/parse-cargo.ts)
+
+1. Fix HRCTD abbreviation: 'Trimmed and Dried' -> 'Trimmed and Descaled'
+2. Add PNO abbreviation: 'Plates Not Otherwise Specified (PNO)'
+3. Fix rule 2: clarify stowage factor NUMBER (no units) goes in cargo_description,
+   full 'X ft3/MT' goes in stowage_factor field; both populated independently
+4. Strengthen BULK rule: stowage factor in cargo_description is MANDATORY when stated
+5. Strengthen BAGGED rule: dimensions + unit weight MANDATORY in cargo_description when stated
+6. Add clarifying examples
+
+## Expected Delta
+
+Conservative (50% LLM compliance for A, 90% for B): ~33/69 fails saved -> 91.9%
+Acceptance gate: >=87% (>=+2.6pp from 84.4 baseline)
+Soft-merge: 85-86.9% (direction-correct, like R1)
+
+## Anti-regression
+
+Ports / weight / laycan / commission >= R22 - 1pp each.
+
+## PI3 Status
+
+Only lib/prompts/parse-cargo.ts modified. No test expectations changed. PI3 not triggered.

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -35,7 +35,7 @@ PORT OPERATIONS:
 CARGO ABBREVIATIONS (always expand in cargo_description):
 - HRC = Hot Rolled Coils
 - HRCPO = Hot Rolled Coils Pickled & Oiled
-- HRCTD = Hot Rolled Coils Trimmed & Dried
+- HRCTD = Hot Rolled Coils Trimmed & Descaled
 - HRS = Hot Rolled Sheets / Hot Rolled Steel
 - CRC = Cold Rolled Coils
 - HMS = Heavy Melting Scrap
@@ -133,13 +133,18 @@ cargo_description MUST be human-readable English. Required contents:
 1. Expand ALL abbreviations (never leave bare abbreviations in the description):
    - "HRC" → "Hot Rolled Coils (HRC)"
    - "HRCPO" → "Hot Rolled Coils Pickled & Oiled (HRCPO)"
-   - "HRCTD" → "Hot Rolled Coils Trimmed & Dried (HRCTD)"
+   - "HRCTD" → "Hot Rolled Coils Trimmed & Descaled (HRCTD)"
    - "HRS" → "Hot Rolled Sheets (HRS)"
+   - "PNO" → "Plates Not Otherwise Specified (PNO)"
    - "bb" / "BB" → "big bags"
    - "uw" / "UW" → "unit weight"
    - "stw" → "stowage factor"
-   - Steel grade list example: "HRC + HRCPO + HRCTD + HRS" → "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Dried (HRCTD), and Hot Rolled Sheets (HRS)"
-2. Include stowage factor inline if given (with original units): "stowage factor approximately 47–49 ft³/MT"
+   - Steel grade list example: "HRC + HRCPO + HRCTD + HRS" → "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Descaled (HRCTD), and Hot Rolled Sheets (HRS)"
+2. Stowage factor MUST appear in cargo_description (as a bare number, no units) when stated in the email.
+   The full X ft³/MT notation also populates the separate stowage_factor field — these are independent, both must be filled.
+   Do NOT omit stowage from cargo_description just because it already appears in the stowage_factor field.
+   Example: email corn stw 51-52 ft³/MT wog → cargo_description: Corn, stowage factor 51–52, without guarantee
+            AND stowage_factor: 51–52 ft³/MT WOG
 3. Include per-piece / unit weight if given: "unit weight approximately 10–27 tonnes per coil"
 4. Include dimensions if given: "LxHxW 4.3m × 15.7m × 4.3m, 15,000 kg each"
 5. Include piece count if given
@@ -148,6 +153,12 @@ cargo_description MUST be human-readable English. Required contents:
 8. Do NOT copy-paste raw source text verbatim as cargo_description.
 9. For PROJECT cargo: dimensions and per-piece weights are MANDATORY.
 10. For BREAK_BULK: per-unit weight and packaging details are MANDATORY if given.
+10a. For BULK cargo: stowage factor is MANDATORY in cargo_description if stated in the email.
+   ✗ Corn in bulk  (email says stw 51-52)
+   ✓ Corn, stowage factor 51–52, without guarantee
+10b. For BAGGED cargo: bag dimensions and unit weight are MANDATORY in cargo_description if stated.
+   ✗ Salt in big bags  (email says bags 1.1×1.1×1.1m, uw 1.25mt)
+   ✓ Salt in big bags, dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT
 11. Use a concise noun phrase — NOT a full sentence.
     ✗ "The cargo consists of a fertilizer with a stowage factor of 51–52 ft³/MT"
     ✓ "Fertilizer, stowage factor 51–52"


### PR DESCRIPTION
## Context

This commit (b72673a) was made directly on the production VPS by a parallel wave-deep session working on parse-cargo Phase 1.7. It was committed on a feature branch (`feat/parse-cargo-r3-cargo-rule`) without going through CI.

I (orchestrator session) discovered the commit when deploying [#164](https://github.com/Vitali2011/quantika-demo/pull/164) — fast-forward failed because prod had diverged from origin/main. Saved as `parallel/parse-cargo-r3-prompt` branch to avoid losing the work, then opened this PR so it can be reviewed + merged through standard flow.

After merge, prod will be switched back to `main` branch (currently on the feature branch).

## Summary

Cluster A — stowage/dims omitted (~39/69 fails):
- Rule 2 rewritten: stowage factor MUST appear in cargo_description as bare number even when stowage_factor field is also populated.
- Rule 10a: BULK cargo stowage MANDATORY if stated.
- Rule 10b: BAGGED cargo dims+weight MANDATORY if stated.
- Root cause: rules 2 and 12 contradicted each other; model resolved by omitting stowage from cargo_description.

Cluster B — wrong abbreviation (~15/69 fails):
- HRCTD abbrev fix.

## Author note

PR opened by orchestrator on behalf of parallel session. **The parallel session author should review the diff** before merge — orchestrator did not write or verify these prompt changes, only preserved the commit and made it reviewable.

🤖 Opened by orchestrator on behalf of parallel session