### PR TITLE
fix(test-harness): pass DEMO_AUTH_* env to Playwright suite (re-enables prod smoke)

### DIFF
--- a/__tests__/e2e/playwright/auth.setup.ts
+++ b/__tests__/e2e/playwright/auth.setup.ts
@@ -19,7 +19,7 @@ const STORAGE_STATE = path.join('playwright', '.auth', 'user.json');
  * Either way we write a storageState file so the chromium project can mount
  * it unconditionally without an `if` in every spec.
  */
-setup('authenticate and seed demo session', async ({ request, page }) => {
+setup('authenticate and seed demo session', async ({ page }) => {
   setup.setTimeout(120_000); // first request can hit a cold Next.js dev compile
   fs.mkdirSync(path.dirname(STORAGE_STATE), { recursive: true });
 
@@ -29,7 +29,7 @@ setup('authenticate and seed demo session', async ({ request, page }) => {
   // is false (default local dev), the middleware bypasses the cookie check
   // and a POST would just waste a slow first-request budget.
   if (authEnabled && SUITE_ENV.demoAuthPassword) {
-    const res = await request.post('/api/auth/login', {
+    const res = await page.request.post('/api/auth/login', {
       form: { user: SUITE_ENV.demoAuthUser, password: SUITE_ENV.demoAuthPassword },
       maxRedirects: 0,
       failOnStatusCode: false,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:regression:prod": "jest --testPathPattern='tests/regression/test-tc' --silent",
     "test:smoke": "playwright test --config=__tests__/e2e/playwright.config.smoke.ts",
     "test:suite": "playwright test --config=__tests__/e2e/playwright.config.suite.ts",
-    "test:suite:prod": "SUITE_BASE_URL=https://demo.quantika.org playwright test --config=__tests__/e2e/playwright.config.suite.ts",
+    "test:suite:prod": "SUITE_BASE_URL=https://demo.quantika.org DEMO_AUTH_ENABLED=true playwright test --config=__tests__/e2e/playwright.config.suite.ts",
     "test:smoke:prod": "SMOKE_BASE_URL=https://demo.quantika.org playwright test --config=__tests__/e2e/playwright.config.smoke.ts smoke/tier1-health.spec.ts",
     "test:smoke:tier1": "playwright test --config=__tests__/e2e/playwright.config.smoke.ts smoke/tier1-health.spec.ts",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary

Re-smoke against `demo.quantika.org` after PR #164 was reporting 8 failures all caused by `/login` redirects despite the login-flow fix being verified. Root cause: **test-infrastructure regression**, not prod code.

Two bugs in the Playwright harness silently disabled auth bootstrap:

1. **Env var not propagated to test process.** `playwright.config.suite.ts` loads `.env.local` via dotenv. Local `.env.local` has `DEMO_AUTH_ENABLED=false` (correct for local dev where middleware bypasses auth). The `test:suite:prod` npm script didn't override it, so `auth.setup.ts:31` skipped the login POST entirely → empty storage state → all protected specs redirected to `/login`.

2. **Cookie isolation between fixtures.** `auth.setup.ts` used the top-level `request` fixture (separate APIRequestContext with its own cookie jar) to POST `/api/auth/login`. The `Set-Cookie: demo_auth=...` landed in that jar; the subsequent `page.goto('/')` used `page.context()` (a different jar) so the cookie never reached `storageState()`. Switching to `page.request.post(...)` shares the jar.

## Re-smoke against demo.quantika.org

| | Pass | Fail | Skip |
|---|---|---|---|
| Before (a3d1950) | 4 | 8 | 6 |
| After (4ca5837)  | 9 | ~4 | 4 |

- **0 `/login` redirect failures remaining** — cascade fully resolved.
- Remaining failures are downstream prod-side issues out of scope for this harness fix:
  - 500 Internal Server Error on `/clauses` (2 tests)
  - 500 Internal Server Error on `/charterers` (1 test)
  - Missing UI elements on `/laytime` and `/market` (likely feature-flag / data issue)

## PI3 stat

0 changes to existing test expectations.

## Test plan

- [x] Re-smoke against demo.quantika.org with `SUITE_BASE_URL=https://demo.quantika.org DEMO_AUTH_ENABLED=true npx playwright test --config=__tests__/e2e/playwright.config.suite.ts` → 9 pass, 0 login-redirect failures
- [x] Trace verified: `POST /api/auth/login → 303 + set-cookie` → `GET /charterers → 200` (no redirect)
- [ ] CI runs the new `test:suite:prod` script (if wired into a workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)