### PR TITLE
fix(test): market.spec.ts assertions match table-fallback impl (no recharts)

### DIFF
--- a/__tests__/e2e/playwright/market.spec.ts
+++ b/__tests__/e2e/playwright/market.spec.ts
@@ -2,15 +2,16 @@ import { test, expect } from '@playwright/test';
 import { isFeatureGate } from './helpers/env';
 
 /**
- * Task 3.3e — Market benchmark page: BHSI / TMI / Drewry-BB charts.
+ * Task 3.3e — Market benchmark page: BHSI / TMI / Drewry-BB tables.
  *
  * Gated by NEXT_PUBLIC_MARKET_BENCHMARK_FULL_ENABLED. When off, page shows
  * "Feature Not Enabled" → we skip.
  *
- * The page renders <MarketBenchmarkChart> three times (one per index). We
- * don't introspect chart internals; we assert that 3 chart containers
- * exist and that the page heading + "No market data available" fallback
- * never both appear (sanity).
+ * The page renders <MarketBenchmarkChart> three times (one per index).
+ * MarketBenchmarkChart is a table-fallback implementation (no recharts/SVG
+ * dependency — intentional for B2B demo on low-bandwidth connections).
+ * We assert that 3 <table> elements exist (one per index) and that the page
+ * heading + "No market data available" fallback never both appear (sanity).
  */
 test.describe('Task 3.3e — Market benchmark dashboard', () => {
   test('page heading visible (or graceful empty state)', async ({ page }) => {
@@ -35,8 +36,9 @@ test.describe('Task 3.3e — Market benchmark dashboard', () => {
     }
 
     // The page issues async fetches in useEffect. Wait for the page to
-    // settle on one of three terminal states: charts, empty copy, or error.
-    const charts = page.locator('svg.recharts-surface, .recharts-responsive-container');
+    // settle on one of three terminal states: index tables, empty copy, or error.
+    // MarketBenchmarkChart renders a <table> per index (table-fallback, no recharts).
+    const charts = page.locator('table');
     const emptyCopy = page.locator('text=/No market data available/i');
     const errorCopy = page.locator('text=/Error:/i');
 
@@ -51,6 +53,7 @@ test.describe('Task 3.3e — Market benchmark dashboard', () => {
       return;
     }
 
+    // 3 market index tables rendered (bhsi / tmi / drewry-bb)
     expect(await charts.count()).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
## Summary

- `MarketBenchmarkChart` was intentionally built as a `<table>` fallback — no recharts/SVG (B2B demo for low-bandwidth connections). This was a gamma-04 wave design decision.
- The Playwright test in `market.spec.ts` was asserting `svg.recharts-surface, .recharts-responsive-container` — selectors that **never matched** the actual DOM.
- This PR fixes the selector to `table` (3 tables = BHSI / TMI / Drewry-BB) and updates the file comment to document the intentional table-only impl.

## What changed

- `__tests__/e2e/playwright/market.spec.ts` — 1 file, test-only change:
  - Selector: `svg.recharts-surface, .recharts-responsive-container` → `table`
  - Added inline comment: `// 3 market index tables rendered (bhsi / tmi / drewry-bb)`
  - Updated file-level JSDoc to explain table-fallback design decision

## No recharts

`recharts` is **not** in `package.json` and `MarketBenchmarkChart.tsx` has an explicit comment: *"Table fallback (no recharts dependency)"*. If we ever add SVG charts, that's a separate PR with its own test changes.

## Test plan

- [x] `npm test -- --testPathPatterns=market` → 155 passed ✅
- [x] `NODE_OPTIONS=--max-old-space-size=4096 npx tsc --noEmit` → 0 errors ✅
- [ ] Playwright smoke on prod after merge (expected: 3 tables visible → test PASS instead of skip)

Closes #168

🤖 Generated with [Claude Code](https://claude.ai/code)