### PR TITLE
ops(backup): daily cron backup of .env.local + GCP creds + SQLite DBs

### DIFF
--- a/scripts/ops/README-backup.md
+++ b/scripts/ops/README-backup.md
@@ -1,0 +1,125 @@
+# Quantika Backup
+
+Post-incident backup system. Created after **INCIDENT-2026-05-17**: `.env.local`
+was silently truncated to 35 bytes on 2026-05-16 10:55; production degraded for
+22 hours undetected.
+
+## What is backed up
+
+| Priority | Path | Why |
+|----------|------|-----|
+| 1 | `/root/work/quantika-demo/.env.local` | All secrets — irrecoverable if lost |
+| 2 | `/root/.config/gcp/quantika-vertex-ai.json` | GCP service-account creds |
+| 3 | `/root/work/quantika-demo/data/quantika.db` | RAG corpus + distances |
+| 4 | `/root/work/quantika-demo/data/sessions.db` | Session state |
+| 5 | `/root/work/quantika-demo/uploads/` | User uploads (if directory exists) |
+
+## Approach: local tar.gz with sha256
+
+**Option B (borgbackup)** was the original recommendation but requires installing
+an additional package (`apt install borgbackup`). The current implementation uses
+`tar + sha256sum` — zero external deps, already available on any Debian/Ubuntu
+system. Borgbackup can be layered on top later for deduplication if archive sizes
+grow.
+
+Storage: `/var/backups/quantika/`
+```
+/var/backups/quantika/
+  daily/
+    quantika-backup-YYYY-MM-DD.tar.gz
+    quantika-backup-YYYY-MM-DD.tar.gz.sha256
+  weekly/
+    quantika-backup-YYYY-WXX.tar.gz
+    quantika-backup-YYYY-WXX.tar.gz.sha256
+```
+
+Retention: **7 daily** + **4 weekly** (≈ 28 days total coverage)
+
+## Quick start
+
+```bash
+# 1. Dry-run: verify sources exist and dirs are writable
+./scripts/ops/backup.sh --dry-run
+
+# 2. First real backup
+./scripts/ops/backup.sh
+
+# 3. Verify the backup can be restored
+./scripts/ops/restore-test.sh
+
+# 4. Install cron (run as root on VPS)
+sudo cp scripts/ops/quantika-backup.cron /etc/cron.d/quantika-backup
+sudo chmod 644 /etc/cron.d/quantika-backup
+sudo chown root:root /etc/cron.d/quantika-backup
+```
+
+## Schedule
+
+| Time (UTC) | Time (BY) | Job |
+|------------|-----------|-----|
+| 00:00 | 03:00 | `backup.sh` — create daily archive |
+| 00:15 | 03:15 | `restore-test.sh` — verify latest archive |
+
+Runs after `nightly-ci-watch` (02:00 BY) to avoid I/O contention.
+
+## Monitoring / alerting
+
+On success, `backup.sh` POSTs to `/api/admin/cron-heartbeat` with
+`cron_name=quantika-backup`. If no heartbeat is seen for > 24 h, the monitoring
+dashboard will flag it.
+
+`backup.sh` reads `CRON_SECRET` and `NEXT_PUBLIC_APP_URL` automatically from
+`.env.local` — no separate configuration needed.
+
+The backup also pre-flight-checks `.env.local` size (aborts if < 100 bytes),
+preventing a repeat of the 2026-05-17 incident pattern where a truncated file
+was silently present.
+
+## Restore procedure
+
+```bash
+# List available backups
+ls -lh /var/backups/quantika/daily/
+
+# Automated verify
+BACKUP_DIR=/var/backups/quantika ./scripts/ops/restore-test.sh
+
+# Manual restore to /tmp (inspect before overwriting live)
+ARCHIVE=/var/backups/quantika/daily/quantika-backup-YYYY-MM-DD.tar.gz
+mkdir /tmp/quantika-restore
+tar -xzf "$ARCHIVE" -C /tmp/quantika-restore
+
+# Inspect
+ls /tmp/quantika-restore/root/work/quantika-demo/
+cat /tmp/quantika-restore/root/work/quantika-demo/.env.local | wc -c
+
+# If .env.local needs restoring (STOP APP FIRST)
+pm2 stop quantika-demo
+cp /tmp/quantika-restore/root/work/quantika-demo/.env.local \
+   /root/work/quantika-demo/.env.local
+pm2 restart quantika-demo --update-env
+```
+
+## Environment variables
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `APP_DIR` | `/root/work/quantika-demo` | App root |
+| `BACKUP_DIR` | `/var/backups/quantika` | Backup storage root |
+| `DAILY_KEEP` | `7` | Number of daily archives to retain |
+| `WEEKLY_KEEP` | `4` | Number of weekly archives to retain |
+| `CRON_SECRET` | from `.env.local` | For heartbeat POST auth |
+| `APP_URL` | from `NEXT_PUBLIC_APP_URL` | Heartbeat target base URL |
+
+## Logs
+
+```bash
+# Real-time
+tail -f /var/log/quantika-backup.log
+
+# Via systemd journal
+journalctl -t quantika-backup -f
+
+# Last run summary
+grep -E "PASS|FAIL|complete|ERROR" /var/log/quantika-backup.log | tail -20
+```

--- a/scripts/ops/backup.sh
+++ b/scripts/ops/backup.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# backup.sh — daily tar.gz backup of critical Quantika files
+#
+# Triggered by: /etc/cron.d/quantika-backup at 00:00 UTC (03:00 BY)
+# On success: POSTs heartbeat to /api/admin/cron-heartbeat
+# On failure: exits non-zero; absent heartbeat triggers monitoring alert
+#
+# Usage:
+#   ./backup.sh              — run backup
+#   ./backup.sh --dry-run    — check sources/dirs, print what would be backed up
+#
+# Env overrides (all optional, defaults shown):
+#   APP_DIR=/root/work/quantika-demo
+#   BACKUP_DIR=/var/backups/quantika
+#   DAILY_KEEP=7
+#   WEEKLY_KEEP=4
+
+set -euo pipefail
+
+# ── Config ───────────────────────────────────────────────────────────────────
+APP_DIR="${APP_DIR:-/root/work/quantika-demo}"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/quantika}"
+DAILY_KEEP="${DAILY_KEEP:-7}"
+WEEKLY_KEEP="${WEEKLY_KEEP:-4}"
+LOG_TAG="quantika-backup"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+log() {
+  local msg="[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"
+  echo "$msg" >&2
+  logger -t "$LOG_TAG" "$*" 2>/dev/null || true
+}
+die() { log "ERROR: $*"; exit 1; }
+
+# ── Resolve env from .env.local (CRON_SECRET, NEXT_PUBLIC_APP_URL) ───────────
+ENV_FILE="${APP_DIR}/.env.local"
+if [[ -f "$ENV_FILE" ]]; then
+  CRON_SECRET="${CRON_SECRET:-$(grep -E '^CRON_SECRET=' "$ENV_FILE" | head -1 | cut -d= -f2-)}"
+  APP_URL="${APP_URL:-$(grep -E '^NEXT_PUBLIC_APP_URL=' "$ENV_FILE" | head -1 | cut -d= -f2-)}"
+fi
+CRON_SECRET="${CRON_SECRET:-}"
+APP_URL="${APP_URL:-}"
+
+# ── Sources (priority order) ─────────────────────────────────────────────────
+declare -a SOURCES=(
+  "${APP_DIR}/.env.local"
+  "/root/.config/gcp/quantika-vertex-ai.json"
+  "${APP_DIR}/data/quantika.db"
+  "${APP_DIR}/data/sessions.db"
+)
+# Add uploads dir only if it exists (not present in all envs)
+[[ -d "${APP_DIR}/uploads" ]] && SOURCES+=("${APP_DIR}/uploads")
+
+# ── Dry-run mode ─────────────────────────────────────────────────────────────
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+if $DRY_RUN; then
+  log "DRY-RUN: checking sources..."
+  ALL_OK=true
+  for src in "${SOURCES[@]}"; do
+    if [[ -e "$src" ]]; then
+      SIZE=$(du -sh "$src" 2>/dev/null | cut -f1)
+      log "  FOUND  $src ($SIZE)"
+    else
+      log "  MISSING $src"
+      [[ "$src" == "${APP_DIR}/.env.local" || "$src" == "/root/.config/gcp/quantika-vertex-ai.json" ]] && ALL_OK=false
+    fi
+  done
+  log "DRY-RUN: backup dir: ${BACKUP_DIR} (retention: ${DAILY_KEEP} daily / ${WEEKLY_KEEP} weekly)"
+  log "DRY-RUN: heartbeat: ${APP_URL:-<APP_URL not set>}/api/admin/cron-heartbeat"
+  log "DRY-RUN: CRON_SECRET: ${CRON_SECRET:+set (${#CRON_SECRET} chars)}"
+  $ALL_OK || die "DRY-RUN: critical sources missing — backup would fail"
+  log "DRY-RUN: OK — all critical sources present"
+  exit 0
+fi
+
+# ── Pre-flight: critical files must exist ─────────────────────────────────────
+[[ -f "${APP_DIR}/.env.local" ]] || die ".env.local missing — aborting"
+SIZE=$(stat -c%s "${APP_DIR}/.env.local")
+[[ $SIZE -gt 100 ]] || die ".env.local suspiciously small (${SIZE} bytes) — possible incident, aborting backup"
+
+# ── Ensure backup dirs ────────────────────────────────────────────────────────
+mkdir -p "${BACKUP_DIR}/daily" "${BACKUP_DIR}/weekly"
+chmod 700 "${BACKUP_DIR}"
+
+# ── Create daily archive ─────────────────────────────────────────────────────
+TODAY=$(date +%Y-%m-%d)
+DAILY_FILE="${BACKUP_DIR}/daily/quantika-backup-${TODAY}.tar.gz"
+
+log "Creating: ${DAILY_FILE}"
+
+# Capture individual file sizes for manifest
+for src in "${SOURCES[@]}"; do
+  [[ -e "$src" ]] && log "  + $src ($(du -sh "$src" 2>/dev/null | cut -f1))"
+done
+
+# Build the archive. Use || true on the tar command since --ignore-failed-read
+# exits non-zero on vanished sparse inodes; the size check below catches real failures.
+tar -czf "${DAILY_FILE}" \
+  --ignore-failed-read \
+  "${SOURCES[@]}" 2>/dev/null || true
+
+ARCHIVE_SIZE=$(stat -c%s "${DAILY_FILE}" 2>/dev/null || echo 0)
+[[ $ARCHIVE_SIZE -gt 200 ]] || die "Archive too small (${ARCHIVE_SIZE} bytes) — tar likely failed"
+
+# Write sha256 checksum alongside archive
+sha256sum "${DAILY_FILE}" > "${DAILY_FILE}.sha256"
+log "Checksum: $(cat "${DAILY_FILE}.sha256")"
+
+# ── Weekly snapshot (first run of each ISO week) ─────────────────────────────
+WEEK=$(date +%Y-W%V)
+WEEKLY_FILE="${BACKUP_DIR}/weekly/quantika-backup-${WEEK}.tar.gz"
+if [[ ! -f "$WEEKLY_FILE" ]]; then
+  cp "${DAILY_FILE}" "${WEEKLY_FILE}"
+  sha256sum "${WEEKLY_FILE}" > "${WEEKLY_FILE}.sha256"
+  log "Weekly snapshot saved: ${WEEKLY_FILE}"
+fi
+
+# ── Retention: prune old archives ────────────────────────────────────────────
+prune_dir() {
+  local dir="$1" keep="$2"
+  # List by mtime descending; delete everything beyond $keep
+  mapfile -t old < <(ls -1t "${dir}/quantika-backup-"*.tar.gz 2>/dev/null | tail -n +$((keep + 1)))
+  for f in "${old[@]:-}"; do
+    [[ -n "$f" ]] || continue
+    rm -f "$f" "${f}.sha256"
+    log "Pruned: $f"
+  done
+}
+prune_dir "${BACKUP_DIR}/daily"  "$DAILY_KEEP"
+prune_dir "${BACKUP_DIR}/weekly" "$WEEKLY_KEEP"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+HUMAN_SIZE=$(du -sh "${DAILY_FILE}" | cut -f1)
+log "Backup complete: ${DAILY_FILE} (${HUMAN_SIZE})"
+log "Daily backups kept: $(ls "${BACKUP_DIR}/daily/"*.tar.gz 2>/dev/null | wc -l)/${DAILY_KEEP}"
+log "Weekly backups kept: $(ls "${BACKUP_DIR}/weekly/"*.tar.gz 2>/dev/null | wc -l)/${WEEKLY_KEEP}"
+
+# ── Heartbeat ─────────────────────────────────────────────────────────────────
+if [[ -n "$CRON_SECRET" && -n "$APP_URL" ]]; then
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    --max-time 10 \
+    -X POST "${APP_URL}/api/admin/cron-heartbeat" \
+    -H "Content-Type: application/json" \
+    -H "X-Cron-Secret: ${CRON_SECRET}" \
+    -d '{"cron_name":"quantika-backup"}' 2>/dev/null) || HTTP_CODE="000"
+  if [[ "$HTTP_CODE" == "200" ]]; then
+    log "Heartbeat: OK (HTTP 200)"
+  else
+    log "WARNING: heartbeat returned HTTP ${HTTP_CODE} — app may be down"
+    # Don't exit non-zero here: backup itself succeeded; heartbeat failure is a
+    # separate concern tracked by the monitoring dashboard.
+  fi
+else
+  log "WARNING: CRON_SECRET or APP_URL not set — heartbeat skipped"
+fi

--- a/scripts/ops/backup.sh
+++ b/scripts/ops/backup.sh
@@ -35,8 +35,8 @@ die() { log "ERROR: $*"; exit 1; }
 # ── Resolve env from .env.local (CRON_SECRET, NEXT_PUBLIC_APP_URL) ───────────
 ENV_FILE="${APP_DIR}/.env.local"
 if [[ -f "$ENV_FILE" ]]; then
-  CRON_SECRET="${CRON_SECRET:-$(grep -E '^CRON_SECRET=' "$ENV_FILE" | head -1 | cut -d= -f2-)}"
-  APP_URL="${APP_URL:-$(grep -E '^NEXT_PUBLIC_APP_URL=' "$ENV_FILE" | head -1 | cut -d= -f2-)}"
+  CRON_SECRET="${CRON_SECRET:-$(grep -E '^CRON_SECRET=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')}"
+  APP_URL="${APP_URL:-$(grep -E '^NEXT_PUBLIC_APP_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')}"
 fi
 CRON_SECRET="${CRON_SECRET:-}"
 APP_URL="${APP_URL:-}"

--- a/scripts/ops/backup.sh
+++ b/scripts/ops/backup.sh
@@ -95,11 +95,12 @@ for src in "${SOURCES[@]}"; do
   [[ -e "$src" ]] && log "  + $src ($(du -sh "$src" 2>/dev/null | cut -f1))"
 done
 
-# Build the archive. Use || true on the tar command since --ignore-failed-read
-# exits non-zero on vanished sparse inodes; the size check below catches real failures.
+# --ignore-failed-read tolerates vanished/unreadable inodes; real failures (disk
+# full, I/O error) still exit non-zero and are caught here.
 tar -czf "${DAILY_FILE}" \
   --ignore-failed-read \
-  "${SOURCES[@]}" 2>/dev/null || true
+  "${SOURCES[@]}" 2>/dev/null \
+  || { rm -f "${DAILY_FILE}"; die "tar failed — disk full or I/O error"; }
 
 ARCHIVE_SIZE=$(stat -c%s "${DAILY_FILE}" 2>/dev/null || echo 0)
 [[ $ARCHIVE_SIZE -gt 200 ]] || die "Archive too small (${ARCHIVE_SIZE} bytes) — tar likely failed"

--- a/scripts/ops/quantika-backup.cron
+++ b/scripts/ops/quantika-backup.cron
@@ -1,0 +1,22 @@
+# /etc/cron.d/quantika-backup
+#
+# Daily backup of critical Quantika files.
+# 03:00 BY (Europe/Minsk, UTC+3) = 00:00 UTC
+#
+# INSTALLATION:
+#   sudo cp scripts/ops/quantika-backup.cron /etc/cron.d/quantika-backup
+#   sudo chmod 644 /etc/cron.d/quantika-backup
+#   sudo chown root:root /etc/cron.d/quantika-backup
+#
+# LOG:
+#   tail -f /var/log/quantika-backup.log
+#   # or via journald: journalctl -t quantika-backup
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# daily at 00:00 UTC (03:00 BY)
+0 0 * * * root APP_DIR=/root/work/quantika-demo BACKUP_DIR=/var/backups/quantika /root/work/quantika-demo/scripts/ops/backup.sh >> /var/log/quantika-backup.log 2>&1
+
+# restore-test: runs 15 min after backup to verify last archive is valid
+15 0 * * * root APP_DIR=/root/work/quantika-demo BACKUP_DIR=/var/backups/quantika /root/work/quantika-demo/scripts/ops/restore-test.sh >> /var/log/quantika-backup.log 2>&1

--- a/scripts/ops/restore-test.sh
+++ b/scripts/ops/restore-test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# restore-test.sh — verifies that the latest backup can be fully restored
+#
+# Extracts the most recent daily backup into a temp dir and checks:
+#   1. sha256 checksum matches
+#   2. .env.local exists and is non-trivially sized (> 100 bytes)
+#   3. GCP JSON creds parse as valid JSON
+#   4. SQLite .db files are present
+#
+# Usage:
+#   ./restore-test.sh                      — test latest daily backup
+#   ./restore-test.sh /path/to/backup.tar.gz  — test a specific archive
+#
+# Exits 0 on PASS, 1 on FAIL.
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/quantika}"
+TARGET="${1:-}"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+log()  { echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"; }
+pass() { log "PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { log "FAIL: $*"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+die()  { log "ERROR: $*"; exit 1; }
+
+# ── Find archive ──────────────────────────────────────────────────────────────
+if [[ -n "$TARGET" ]]; then
+  ARCHIVE="$TARGET"
+else
+  ARCHIVE=$(ls -1t "${BACKUP_DIR}/daily/quantika-backup-"*.tar.gz 2>/dev/null | head -1)
+fi
+[[ -n "$ARCHIVE" && -f "$ARCHIVE" ]] || die "No backup archive found (checked: ${BACKUP_DIR}/daily/)"
+
+log "Testing: $ARCHIVE"
+log "Archive size: $(du -sh "$ARCHIVE" | cut -f1)"
+
+# ── Checksum verification ─────────────────────────────────────────────────────
+CHECKSUM_FILE="${ARCHIVE}.sha256"
+if [[ -f "$CHECKSUM_FILE" ]]; then
+  if (cd "$(dirname "$ARCHIVE")" && sha256sum -c "$(basename "$CHECKSUM_FILE")" >/dev/null 2>&1); then
+    pass "sha256 checksum verified"
+  else
+    fail "sha256 checksum MISMATCH — archive may be corrupted"
+  fi
+else
+  fail "Checksum file missing: $CHECKSUM_FILE"
+fi
+
+# ── Extract to temp dir ───────────────────────────────────────────────────────
+TEST_DIR=$(mktemp -d /tmp/quantika-restore-test.XXXXXX)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+if tar -xzf "$ARCHIVE" -C "$TEST_DIR" 2>/dev/null; then
+  pass "Extraction successful"
+else
+  die "tar extraction failed — aborting further checks"
+fi
+
+# ── .env.local ────────────────────────────────────────────────────────────────
+ENV_FILE=$(find "$TEST_DIR" -name ".env.local" 2>/dev/null | head -1)
+if [[ -n "$ENV_FILE" ]]; then
+  ENV_SIZE=$(stat -c%s "$ENV_FILE")
+  if [[ $ENV_SIZE -gt 100 ]]; then
+    pass ".env.local present (${ENV_SIZE} bytes)"
+  else
+    fail ".env.local too small (${ENV_SIZE} bytes) — likely truncated/corrupted"
+  fi
+  # Cross-check with live file if available
+  LIVE_ENV="/root/work/quantika-demo/.env.local"
+  if [[ -f "$LIVE_ENV" ]]; then
+    BACKUP_CKSUM=$(sha256sum "$ENV_FILE" | cut -d' ' -f1)
+    LIVE_CKSUM=$(sha256sum "$LIVE_ENV" | cut -d' ' -f1)
+    if [[ "$BACKUP_CKSUM" == "$LIVE_CKSUM" ]]; then
+      pass ".env.local matches live file (checksums identical)"
+    else
+      log "NOTE: .env.local differs from live — expected if file changed since backup"
+    fi
+  fi
+else
+  fail ".env.local NOT found in backup — critical file missing"
+fi
+
+# ── GCP JSON creds ────────────────────────────────────────────────────────────
+GCP_FILE=$(find "$TEST_DIR" -name "quantika-vertex-ai.json" 2>/dev/null | head -1)
+if [[ -n "$GCP_FILE" ]]; then
+  if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$GCP_FILE" 2>/dev/null; then
+    GCP_SIZE=$(stat -c%s "$GCP_FILE")
+    pass "GCP creds valid JSON (${GCP_SIZE} bytes)"
+  else
+    fail "GCP creds not valid JSON — file corrupted"
+  fi
+else
+  fail "quantika-vertex-ai.json NOT found in backup"
+fi
+
+# ── SQLite databases ──────────────────────────────────────────────────────────
+mapfile -t DB_FILES < <(find "$TEST_DIR" -name "*.db" 2>/dev/null)
+if [[ ${#DB_FILES[@]} -gt 0 ]]; then
+  for db in "${DB_FILES[@]}"; do
+    DB_SIZE=$(stat -c%s "$db")
+    pass "$(basename "$db") present (${DB_SIZE} bytes)"
+    # SQLite magic bytes check: first 16 bytes must start with "SQLite format 3"
+    MAGIC=$(head -c 15 "$db" 2>/dev/null || true)
+    if [[ "$MAGIC" == "SQLite format 3" ]]; then
+      pass "$(basename "$db") SQLite magic bytes OK"
+    else
+      fail "$(basename "$db") missing SQLite magic bytes — may be corrupted"
+    fi
+  done
+else
+  fail "No .db files found in backup"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "Restore test result: ${PASS_COUNT} PASS / ${FAIL_COUNT} FAIL"
+log "Archive: $ARCHIVE"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  log "RESULT: FAILED — backup is not reliably restorable"
+  exit 1
+else
+  log "RESULT: PASSED — backup verified OK"
+  exit 0
+fi

--- a/scripts/ops/tests/backup-unit.sh
+++ b/scripts/ops/tests/backup-unit.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression tests for backup.sh HIGH findings:
+#   HIGH-1: tar || true allowed partial archives to exit 0
+#   HIGH-2: quoted .env.local values broke CRON_SECRET/APP_URL extraction
+#
+# Run: bash scripts/ops/tests/backup-unit.sh
+# Exits 0 on all pass, 1 if any fail.
+
+set -euo pipefail
+
+PASS=0; FAIL=0
+
+pass() { echo "PASS: $*"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Strip quotes and inline comments from an env-file value — mirrors backup.sh logic
+parse_env_value() {
+  echo "$1" | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' '
+}
+
+# ── HIGH-2: env-file value parsing ───────────────────────────────────────────
+
+got=$(parse_env_value '"my-secret-token-abc123"')
+[[ "$got" == "my-secret-token-abc123" ]] \
+  && pass "HIGH-2: double-quoted value stripped correctly" \
+  || fail "HIGH-2: double-quoted → got '$got', want 'my-secret-token-abc123'"
+
+got=$(parse_env_value "'my-secret-token-abc123'")
+[[ "$got" == "my-secret-token-abc123" ]] \
+  && pass "HIGH-2: single-quoted value stripped correctly" \
+  || fail "HIGH-2: single-quoted → got '$got', want 'my-secret-token-abc123'"
+
+got=$(parse_env_value 'my-secret-token-abc123')
+[[ "$got" == "my-secret-token-abc123" ]] \
+  && pass "HIGH-2: unquoted value unchanged" \
+  || fail "HIGH-2: unquoted → got '$got', want 'my-secret-token-abc123'"
+
+got=$(parse_env_value 'abc123 # prod key')
+[[ "$got" == "abc123" ]] \
+  && pass "HIGH-2: inline comment stripped" \
+  || fail "HIGH-2: inline comment → got '$got', want 'abc123'"
+
+# cut -d= -f2- already handles = in value; verify quote-strip preserves it
+got=$(parse_env_value '"abc=def=="')
+[[ "$got" == "abc=def==" ]] \
+  && pass "HIGH-2: value containing = preserved after quote-strip" \
+  || fail "HIGH-2: = in value → got '$got', want 'abc=def=='"
+
+# Full env-file extraction via grep+cut+sed (mirrors exact backup.sh pipeline)
+TMP_ENV=$(mktemp)
+trap 'rm -f "$TMP_ENV"' EXIT
+cat > "$TMP_ENV" <<'EOF'
+# Next.js .env.local
+CRON_SECRET="my-real-secret"
+NEXT_PUBLIC_APP_URL="https://example.com"
+OTHER_VAR=irrelevant
+EOF
+
+got_secret=$(grep -E '^CRON_SECRET=' "$TMP_ENV" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')
+[[ "$got_secret" == "my-real-secret" ]] \
+  && pass "HIGH-2: CRON_SECRET extracted from quoted .env.local" \
+  || fail "HIGH-2: CRON_SECRET extraction → got '$got_secret', want 'my-real-secret'"
+
+got_url=$(grep -E '^NEXT_PUBLIC_APP_URL=' "$TMP_ENV" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')
+[[ "$got_url" == "https://example.com" ]] \
+  && pass "HIGH-2: NEXT_PUBLIC_APP_URL extracted from quoted .env.local" \
+  || fail "HIGH-2: APP_URL extraction → got '$got_url', want 'https://example.com'"
+
+# ── HIGH-1: tar failure removes partial archive and exits non-zero ────────────
+
+TMP_BACKUP=$(mktemp -d)
+trap 'rm -rf "$TMP_BACKUP" "$TMP_ENV"' EXIT
+
+# Build a minimal mock backup.sh that exercises only the tar error-handling path.
+# We use a fake tar that fails immediately so we don't need root or a full disk.
+MOCK_SCRIPT=$(mktemp --suffix=.sh)
+trap 'rm -f "$MOCK_SCRIPT"; rm -rf "$TMP_BACKUP" "$TMP_ENV"' EXIT
+
+cat > "$MOCK_SCRIPT" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+DAILY_FILE="${TMP_BACKUP}/test-backup.tar.gz"
+die() { echo "ERROR: \$*" >&2; exit 1; }
+# simulate tar failure by calling false
+tar() { touch "\${DAILY_FILE}"; return 1; }
+export -f tar
+tar -czf "\${DAILY_FILE}" /dev/null 2>/dev/null \
+  || { rm -f "\${DAILY_FILE}"; die "tar failed — disk full or I/O error"; }
+echo "SHOULD NOT REACH HERE"
+EOF
+chmod +x "$MOCK_SCRIPT"
+
+if bash "$MOCK_SCRIPT" 2>/dev/null; then
+  fail "HIGH-1: script should exit non-zero on tar failure but exited 0"
+else
+  pass "HIGH-1: script exits non-zero on tar failure"
+fi
+
+if [[ -f "${TMP_BACKUP}/test-backup.tar.gz" ]]; then
+  fail "HIGH-1: partial archive still exists after tar failure"
+else
+  pass "HIGH-1: partial archive removed after tar failure"
+fi
+
+# ── Results ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: ${PASS} PASS / ${FAIL} FAIL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Post-incident insurance after **INCIDENT-2026-05-17**: `.env.local` was silently truncated to 35 bytes on 2026-05-16 10:55; production degraded for 22 hours undetected.

- **`scripts/ops/backup.sh`** — daily `tar.gz` to `/var/backups/quantika`, retains 7 daily + 4 weekly archives. Pre-flight checks `.env.local` size (aborts if < 100 bytes to catch truncation). POSTs to `/api/admin/cron-heartbeat` on success; absent heartbeat = monitoring alert.
- **`scripts/ops/restore-test.sh`** — extracts latest archive to `/tmp`, verifies sha256 checksum, `.env.local` size, GCP JSON validity, SQLite magic bytes.
- **`scripts/ops/quantika-backup.cron`** — `/etc/cron.d` template, 00:00 UTC (03:00 BY). Not auto-installed — manual step required (see README).
- **`scripts/ops/README-backup.md`** — install guide, restore procedure, env vars, log paths.

## Smoke test results

```
Archive: quantika-backup-2026-05-17.tar.gz (2.0 MB)
PASS: sha256 checksum verified
PASS: Extraction successful
PASS: .env.local present (2412 bytes)
PASS: .env.local matches live file (checksums identical)
PASS: GCP creds valid JSON (2390 bytes)
PASS: quantika.db present (16384 bytes) — SQLite magic bytes OK
PASS: sessions.db present (6823936 bytes) — SQLite magic bytes OK
Restore test result: 9 PASS / 0 FAIL
```

## Installation on VPS

```bash
sudo cp scripts/ops/quantika-backup.cron /etc/cron.d/quantika-backup
sudo chmod 644 /etc/cron.d/quantika-backup
sudo chown root:root /etc/cron.d/quantika-backup
```

First backup runs at 03:00 BY; restore-test auto-runs at 03:15 BY.

## Test plan

- [ ] Merge and deploy
- [ ] Run `scripts/ops/backup.sh --dry-run` on VPS — confirm all 4 sources FOUND
- [ ] Run `scripts/ops/backup.sh` manually — confirm archive created in `/var/backups/quantika/daily/`
- [ ] Run `scripts/ops/restore-test.sh` — confirm 9/9 PASS
- [ ] Install cron file, verify first scheduled run at next 03:00 BY
- [ ] Check heartbeat in monitoring dashboard at `/api/admin/cron-heartbeat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)