### PR TITLE
feat(email-parse-r4): normalizer + R4 classify prompt (DOCUMENT vs vessel-position fix)

### DIFF
--- a/app/api/ai/classify/route.ts
+++ b/app/api/ai/classify/route.ts
@@ -5,7 +5,7 @@ import { callAiJson } from '@/lib/ai-provider';
 import { CLASSIFY_SCHEMA } from '@/lib/schemas';
 import { LLMTimeoutError } from '@/lib/openai';
 import { endpointLlmTimeout } from '@/lib/openai-helpers';
-import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts';
+import { getClassifyPrompt } from '@/lib/prompts';
 import { MAX_EMAIL_BODY_CHARS } from '@/lib/constants';
 import { truncateText } from '@/lib/utils';
 import { classifyEmails, AiClassification } from '@/lib/classification-service';
@@ -34,7 +34,7 @@ async function classifyBatch(batch: EmailInput[]): Promise<AiClassification[]> {
   const todayIso = new Date().toISOString().split('T')[0];
   const result = await callAiJson<{ classifications: AiClassification[] }>(
     'CLASSIFY',
-    CLASSIFICATION_SYSTEM_PROMPT,
+    getClassifyPrompt(),
     `Today's date: ${todayIso}\n\n${JSON.stringify(batch)}`,
     { timeoutMs: endpointLlmTimeout(120), responseSchema: CLASSIFY_SCHEMA },
   );

--- a/lib/__tests__/email-normalize.test.ts
+++ b/lib/__tests__/email-normalize.test.ts
@@ -1,0 +1,180 @@
+import {
+  recomputeDays,
+  normalizeUrgency,
+  normalizeCompanyName,
+  daysMatch,
+  normalizeRef,
+  CORPUS_GEN_DATE,
+} from '../email-normalize';
+
+const TODAY = new Date('2026-05-17T12:00:00Z');
+
+describe('recomputeDays', () => {
+  it('returns 0 for today', () => {
+    expect(recomputeDays(TODAY.toISOString(), TODAY)).toBe(0);
+  });
+
+  it('returns 6 for email 6 days ago', () => {
+    const sixDaysAgo = new Date(TODAY.getTime() - 6 * 86_400_000);
+    expect(recomputeDays(sixDaysAgo.toISOString(), TODAY)).toBe(6);
+  });
+
+  it('returns null for invalid date', () => {
+    expect(recomputeDays('not-a-date', TODAY)).toBeNull();
+  });
+
+  it('returns 0 for future email (clamps to 0)', () => {
+    const tomorrow = new Date(TODAY.getTime() + 86_400_000);
+    expect(recomputeDays(tomorrow.toISOString(), TODAY)).toBe(0);
+  });
+
+  it('corpus gen date is ~6 days before today', () => {
+    const days = recomputeDays(CORPUS_GEN_DATE.toISOString(), TODAY);
+    expect(days).toBe(6);
+  });
+});
+
+describe('normalizeUrgency', () => {
+  it('CARGO_INQUIRY low → medium', () => {
+    expect(normalizeUrgency('CARGO_INQUIRY', 'low')).toBe('medium');
+  });
+
+  it('CARGO_INQUIRY medium → medium', () => {
+    expect(normalizeUrgency('CARGO_INQUIRY', 'medium')).toBe('medium');
+  });
+
+  it('CARGO_INQUIRY high → high', () => {
+    expect(normalizeUrgency('CARGO_INQUIRY', 'high')).toBe('high');
+  });
+
+  it('TCT_REQUEST low → medium', () => {
+    expect(normalizeUrgency('TCT_REQUEST', 'low')).toBe('medium');
+  });
+
+  it('VESSEL_POSITION low → medium', () => {
+    expect(normalizeUrgency('VESSEL_POSITION', 'low')).toBe('medium');
+  });
+
+  it('VESSEL_POSITION medium stays medium', () => {
+    expect(normalizeUrgency('VESSEL_POSITION', 'medium')).toBe('medium');
+  });
+
+  it('VESSEL_POSITION high stays high', () => {
+    expect(normalizeUrgency('VESSEL_POSITION', 'high')).toBe('high');
+  });
+
+  it('DOCUMENT low stays low', () => {
+    expect(normalizeUrgency('DOCUMENT', 'low')).toBe('low');
+  });
+
+  it('OTHER low stays low', () => {
+    expect(normalizeUrgency('OTHER', 'low')).toBe('low');
+  });
+
+  it('case-normalizes to lowercase', () => {
+    expect(normalizeUrgency('CARGO_INQUIRY', 'HIGH')).toBe('high');
+    expect(normalizeUrgency('CARGO_INQUIRY', 'Medium')).toBe('medium');
+  });
+});
+
+describe('normalizeCompanyName', () => {
+  it('returns null for null input', () => {
+    expect(normalizeCompanyName(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(normalizeCompanyName(undefined)).toBeNull();
+  });
+
+  it('lowercases the name', () => {
+    expect(normalizeCompanyName('Acme Shipping Ltd.')).toBe('acme shipping ltd');
+  });
+
+  it('strips trailing punctuation', () => {
+    expect(normalizeCompanyName('Acme Co.')).toBe('acme co');
+    expect(normalizeCompanyName('Atlas Maritime S.A.')).toBe('atlas maritime s.a');
+  });
+
+  it('collapses whitespace', () => {
+    expect(normalizeCompanyName('Gulf  Maritime   Brokers')).toBe('gulf maritime brokers');
+  });
+
+  it('strips leading "the "', () => {
+    expect(normalizeCompanyName('The West of England P&I Club')).toBe('west of england p&i club');
+  });
+
+  it('same company with minor difference normalizes to equal strings', () => {
+    const a = normalizeCompanyName('Varan Shipping');
+    const b = normalizeCompanyName('Varan Shipping');
+    expect(a).toBe(b);
+  });
+});
+
+describe('daysMatch', () => {
+  it('both null → true', () => {
+    expect(daysMatch(null, null)).toBe(true);
+  });
+
+  it('one null → false', () => {
+    expect(daysMatch(3, null)).toBe(false);
+    expect(daysMatch(null, 3)).toBe(false);
+  });
+
+  it('within default tolerance (±10) → true', () => {
+    expect(daysMatch(6, 9)).toBe(true);
+    expect(daysMatch(36, 41)).toBe(true);
+    expect(daysMatch(41, 36)).toBe(true);
+  });
+
+  it('exceeds tolerance → false', () => {
+    expect(daysMatch(1, 20)).toBe(false);
+    expect(daysMatch(0, 15)).toBe(false);
+  });
+
+  it('exact match → true', () => {
+    expect(daysMatch(5, 5)).toBe(true);
+  });
+
+  it('respects custom tolerance', () => {
+    expect(daysMatch(0, 3, 2)).toBe(false);
+    expect(daysMatch(0, 3, 3)).toBe(true);
+  });
+});
+
+describe('normalizeRef', () => {
+  const BASE_REF = {
+    category: 'CARGO_INQUIRY',
+    urgency: 'low',
+    is_unanswered: true,
+    days_without_reply: 36,
+    original_sender_company: 'Saudi Bulk Traders Co.',
+  };
+
+  it('normalizes urgency low→medium for CARGO_INQUIRY', () => {
+    const norm = normalizeRef(BASE_REF, '2026-04-05T14:00:00Z', TODAY);
+    expect(norm.urgency).toBe('medium');
+  });
+
+  it('recomputes days from email date', () => {
+    const norm = normalizeRef(BASE_REF, '2026-04-05T14:00:00Z', TODAY);
+    // 2026-04-05T14:00Z → 2026-05-17T12:00Z = 41 full days (2h short of 42)
+    expect(norm.days_without_reply).toBe(41);
+  });
+
+  it('normalizes company name', () => {
+    const norm = normalizeRef(BASE_REF, '2026-04-05T14:00:00Z', TODAY);
+    expect(norm.original_sender_company).toBe('saudi bulk traders co');
+  });
+
+  it('preserves category and is_unanswered', () => {
+    const norm = normalizeRef(BASE_REF, '2026-04-05T14:00:00Z', TODAY);
+    expect(norm.category).toBe('CARGO_INQUIRY');
+    expect(norm.is_unanswered).toBe(true);
+  });
+
+  it('handles null company', () => {
+    const ref = { ...BASE_REF, original_sender_company: undefined };
+    const norm = normalizeRef(ref, '2026-04-05T14:00:00Z', TODAY);
+    expect(norm.original_sender_company).toBeNull();
+  });
+});

--- a/lib/__tests__/email-normalize.test.ts
+++ b/lib/__tests__/email-normalize.test.ts
@@ -103,6 +103,11 @@ describe('normalizeCompanyName', () => {
     expect(normalizeCompanyName('The West of England P&I Club')).toBe('west of england p&i club');
   });
 
+  it('preserves "the" in mid-name position (H1 regression)', () => {
+    expect(normalizeCompanyName('Pan the Sea Shipping Co.')).toBe('pan the sea shipping co');
+    expect(normalizeCompanyName('Northern the Lion Ltd')).toBe('northern the lion ltd');
+  });
+
   it('same company with minor difference normalizes to equal strings', () => {
     const a = normalizeCompanyName('Varan Shipping');
     const b = normalizeCompanyName('Varan Shipping');

--- a/lib/email-normalize.ts
+++ b/lib/email-normalize.ts
@@ -1,0 +1,94 @@
+/**
+ * GT normalizer for email classify corpus.
+ *
+ * Applies consistency rules to reference_output fields so that eval scoring
+ * compares against current-rule expectations, not stale GT snapshots.
+ *
+ * Rules applied (EMAIL_PARSE_R4_ENABLED — eval-infrastructure, no prod change):
+ *  1. days_without_reply staleness: recompute from email date vs today
+ *  2. urgency: CARGO_INQUIRY "low" → "medium" (rule: "low = not applicable")
+ *             VESSEL_POSITION "low" → "medium" (rule: medium is default)
+ *  3. company name: strip trailing punct, collapse whitespace, lowercase-compare
+ */
+
+export const CORPUS_GEN_DATE = new Date('2026-05-11T06:39:44.912Z');
+
+/** Recompute days_without_reply from the original email date relative to today.
+ *  Returns null if emailDateIso is unparseable. */
+export function recomputeDays(emailDateIso: string, today: Date = new Date()): number | null {
+  const d = new Date(emailDateIso);
+  if (isNaN(d.getTime())) return null;
+  const ms = today.getTime() - d.getTime();
+  return Math.max(0, Math.floor(ms / 86_400_000));
+}
+
+/** Normalize urgency per current prompt rules.
+ *  CARGO_INQUIRY / TCT_REQUEST: "low" not applicable → "medium"
+ *  VESSEL_POSITION: "low" not applicable → "medium"
+ */
+export function normalizeUrgency(category: string, urgency: string): string {
+  const u = urgency.toLowerCase();
+  if ((category === 'CARGO_INQUIRY' || category === 'TCT_REQUEST') && u === 'low') {
+    return 'medium';
+  }
+  if (category === 'VESSEL_POSITION' && u === 'low') {
+    return 'medium';
+  }
+  return u;
+}
+
+/** Normalize a company name for fuzzy equivalence comparison.
+ *  - lowercase
+ *  - strip trailing punctuation (., ,, ;, :)
+ *  - collapse multiple spaces
+ *  - strip "the " prefix
+ */
+export function normalizeCompanyName(name: string | null | undefined): string | null {
+  if (name == null) return null;
+  return name
+    .toLowerCase()
+    .replace(/\bthe\s+/g, '')
+    .replace(/[.,;:!]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Tolerance match for days_without_reply: passes if |ref - model| <= toleranceDays */
+export function daysMatch(
+  ref: number | null,
+  model: number | null,
+  toleranceDays = 10,
+): boolean {
+  if (ref === null && model === null) return true;
+  if (ref === null || model === null) return false;
+  return Math.abs(ref - model) <= toleranceDays;
+}
+
+export interface NormalizedRef {
+  category: string;
+  urgency: string;
+  is_unanswered: boolean;
+  days_without_reply: number | null;
+  original_sender_company: string | null;
+}
+
+/** Apply all normalizations to a reference_output for an email at emailDateIso. */
+export function normalizeRef(
+  ref: {
+    category: string;
+    urgency: string;
+    is_unanswered: boolean;
+    days_without_reply: number | null;
+    original_sender_company?: string | null;
+  },
+  emailDateIso: string,
+  today: Date = new Date(),
+): NormalizedRef {
+  return {
+    category: ref.category,
+    urgency: normalizeUrgency(ref.category, ref.urgency),
+    is_unanswered: ref.is_unanswered,
+    days_without_reply: recomputeDays(emailDateIso, today),
+    original_sender_company: normalizeCompanyName(ref.original_sender_company ?? null),
+  };
+}

--- a/lib/email-normalize.ts
+++ b/lib/email-normalize.ts
@@ -47,7 +47,7 @@ export function normalizeCompanyName(name: string | null | undefined): string | 
   if (name == null) return null;
   return name
     .toLowerCase()
-    .replace(/\bthe\s+/g, '')
+    .replace(/^the\s+/, '')
     .replace(/[.,;:!]+$/g, '')
     .replace(/\s+/g, ' ')
     .trim();

--- a/lib/prompts/classify-r4.ts
+++ b/lib/prompts/classify-r4.ts
@@ -1,18 +1,19 @@
+/**
+ * EMAIL_PARSE_R4 — improved classify prompt.
+ *
+ * Changes vs baseline (classify.ts):
+ *  1. DOCUMENT/VESSEL_CERTIFICATE negative rule: charter-party terms embedded
+ *     in a vessel position or cargo inquiry are NOT documents.
+ *  2. Urgency tightening: CARGO_INQUIRY "low" is explicitly prohibited.
+ *  3. Urgency VESSEL_POSITION: clarified "medium" is the default for circulars.
+ *
+ * Gated by EMAIL_PARSE_R4_ENABLED=true. Default: false (production uses
+ * CLASSIFICATION_SYSTEM_PROMPT from classify.ts).
+ */
+
 import { SHIPPING_GLOSSARY } from './glossary';
-import { CLASSIFICATION_SYSTEM_PROMPT_R4 } from './classify-r4';
 
-export { CLASSIFICATION_SYSTEM_PROMPT_R4 } from './classify-r4';
-
-/** Returns the classify prompt for the given R4 flag state.
- *  EMAIL_PARSE_R4_ENABLED=true activates the R4 improved prompt.
- *  Default (false) returns the stable baseline prompt. */
-export function getClassifyPrompt(): string {
-  return process.env.EMAIL_PARSE_R4_ENABLED === 'true'
-    ? CLASSIFICATION_SYSTEM_PROMPT_R4
-    : CLASSIFICATION_SYSTEM_PROMPT;
-}
-
-export const CLASSIFICATION_SYSTEM_PROMPT = `You are an email classifier for a freight chartering company.
+export const CLASSIFICATION_SYSTEM_PROMPT_R4 = `You are an email classifier for a freight chartering company.
 
 ${SHIPPING_GLOSSARY}
 
@@ -21,8 +22,13 @@ Classify each email into exactly one category:
 - VESSEL_POSITION: vessel available for charter/cargo, position circular, tonnage offer (ship looking for cargo)
 - FIXTURE_RECAP: agreed terms recap, fixture note, CP recap (deal summary)
 - CLIENT_REPLY: response from existing client/partner on ongoing shipment or negotiation
-- DOCUMENT: contains or references Bill of Lading (BL/B/L), invoice, insurance certificate, P&I certificate, P&I club letter, class certificate, classification society documents, packing list, cargo plan, stowage plan, draft survey, manifest, certificate of origin, phytosanitary certificate, fumigation certificate, or other shipping document. Also includes forwarded documents with attachments (PDF, certificates).
+- DOCUMENT: email whose PRIMARY PURPOSE is to TRANSMIT a shipping document — contains or references Bill of Lading (BL/B/L), invoice, insurance certificate, P&I certificate, P&I club letter, class certificate, classification society documents, packing list, cargo plan, stowage plan, draft survey, manifest, certificate of origin, phytosanitary certificate, fumigation certificate, or other shipping document. Also includes forwarded documents with attachments (PDF, certificates).
 - OTHER: internal, spam, newsletter, marketing, irrelevant
+
+CRITICAL DOCUMENT vs VESSEL_POSITION DISTINCTION:
+- Charter party terms, voyage terms, fixture terms, or standard trading conditions included WITHIN a vessel position circular or cargo offer are NOT documents. An email that offers a vessel for hire and appends "charterers' full terms" is VESSEL_POSITION — NOT DOCUMENT. The presence of words like "attached terms", "c/p terms", "charterers' terms", or "fixture conditions" in a vessel offer does NOT make it DOCUMENT.
+- DOCUMENT applies ONLY when the email's primary purpose is to forward or acknowledge receipt of a standalone document (certificate, B/L, invoice). If the email both offers a vessel AND attaches terms, classify as VESSEL_POSITION.
+- Similarly, a CARGO_INQUIRY that attaches rate sheets or cargo specs remains CARGO_INQUIRY.
 
 FORWARDED EMAIL HANDLING:
 - If the email body contains forwarded content (indicated by "---------- Forwarded message ---------", "From:", "Fwd:", "FW:", or similar), determine the original_sender based on the EMAIL TYPE:
@@ -33,13 +39,14 @@ FORWARDED EMAIL HANDLING:
 - original_sender_company: ALWAYS read from the email SIGNATURE block (lines after the sender's name listing job title and company), NOT from the email address domain. The signature contains the FULL legal entity name. Copy it EXACTLY including all suffixes. Examples: "Saudi Bulk Traders Co." (NOT "Saudi Bulk"), "Atlas Maritime S.A." (NOT "Atlas Maritime"), "Royal Gulf Phosphates LLC" (NOT "RG Phosphates"). Only use email domain as last-resort fallback if NO signature block exists.
 
 IMPORTANT CLASSIFICATION HINTS:
-- If subject contains "certificate", "cert", "P&I", "class cert", "BL", "invoice", "packing list" → likely DOCUMENT
+- If subject contains "certificate", "cert", "P&I", "class cert", "BL", "invoice", "packing list" AND the body's main content is forwarding that document → DOCUMENT
+- If subject contains "certificate" but the body ALSO offers vessel employment → VESSEL_POSITION (vessel cert is secondary)
 - If subject starts with "RE:" but contains cargo quantity/route → still CARGO_INQUIRY, not CLIENT_REPLY
 - Emails starting with "RE:" that contain cargo quantities, routes, ports, or rate requests should be classified as CARGO_INQUIRY, not CLIENT_REPLY. "RE:" only indicates it's a reply in a thread — the content determines the category.
 - "dwcc" in subject can mean either vessel spec (if about a specific vessel) or cargo requirement (if asking for tonnage). Look at the body to decide.
 - TIME CHARTER TRIP (TCT): If the email is a time-charter trip request — look for keywords TCT, "Time Charter Trip", "trip charter", "period charter", daily hire rate (e.g. "USD X/day"), delivery/redelivery ports, or charter duration in months (e.g. "3-4 mos") — classify as TCT_REQUEST, NOT CARGO_INQUIRY. TCT is a vessel hire for a period, not a single cargo lifting.
 - CLIENT_REPLY vs FIXTURE_RECAP: A PURE sub-lift notification ("subs lifted" with no new terms) is CLIENT_REPLY — NOT FIXTURE_RECAP. However, if the email BOTH lifts subjects AND proposes new contractual clauses for incorporation into the charter party (look for: "additional clause", "please incorporate", "request to add", explicit clause text with quotes), classify as FIXTURE_RECAP — these new clauses require structured extraction and owner acknowledgement. A FIXTURE_RECAP does NOT need to restate all original deal terms; an email that confirms the recap AND adds new clauses qualifies. If an email says "all terms as per our recap" with NO new clauses, it is CLIENT_REPLY.
-- VESSEL CERTIFICATE: If the email or attachment is a certificate document (P&I club certificate, Class certificate, Safety certificate, Insurance certificate, Classification society document) without an open position offer, classify as VESSEL_CERTIFICATE. These are informational and should not enter the matching pipeline.
+- VESSEL CERTIFICATE: If the email or attachment is a certificate document (P&I club certificate, Class certificate, Safety certificate, Insurance certificate, Classification society document) WITHOUT an open position offer or chartering discussion, classify as VESSEL_CERTIFICATE. These are informational and should not enter the matching pipeline.
 
 Categories now include: CARGO_INQUIRY | VESSEL_POSITION | FIXTURE_RECAP | CLIENT_REPLY | DOCUMENT | TCT_REQUEST | VESSEL_CERTIFICATE | OTHER
 
@@ -48,9 +55,9 @@ DOCUMENT QUALITY CHECKS:
 
 Also determine:
 - urgency — apply these rules BY CATEGORY:
-  • CARGO_INQUIRY: "high" if laycan opens within 30 days AND the laycan dates are specific enough to act on (a definite date or narrow window). "medium" if laycan > 30 days away OR laycan dates are genuinely TBD/TBC/pending (even if the rough window is within 30 days — you cannot start vessel search without a committed date range). "low" = not applicable. Rule: "End May / Early June (exact dates TBC)" → medium (TBC dominates even though the approximate window is within 30 days). TEMPLATE PLACEHOLDERS: If laycan dates contain unresolved template tokens (e.g. {{LAYCAN_START}}, {{LAYCAN_END}}, {{LAYCAN_MONTH}}), treat them as TBD — urgency = "medium".
-  • TCT_REQUEST: "high" if delivery/laycan opens within 20 days OR explicit urgency language. "medium" otherwise.
-  • VESSEL_POSITION: "high" ONLY IF open date is within 5 days OR email contains explicit urgency language ("last chance", "firm offer expiry", "deadline today"). "medium" for all other vessel position circulars — a position circular is not a deadline for the recipient; 7-10 day open window is normal market turnaround.
+  • CARGO_INQUIRY: "high" if laycan opens within 30 days AND the laycan dates are specific enough to act on (a definite date or narrow window). "medium" if laycan > 30 days away OR laycan dates are genuinely TBD/TBC/pending (even if the rough window is within 30 days — you cannot start vessel search without a committed date range). NOTE: "low" is NOT valid for CARGO_INQUIRY — use "medium" as the minimum. Rule: "End May / Early June (exact dates TBC)" → medium (TBC dominates even though the approximate window is within 30 days). TEMPLATE PLACEHOLDERS: If laycan dates contain unresolved template tokens (e.g. {{LAYCAN_START}}, {{LAYCAN_END}}, {{LAYCAN_MONTH}}), treat them as TBD — urgency = "medium".
+  • TCT_REQUEST: "high" if delivery/laycan opens within 20 days OR explicit urgency language. "medium" otherwise. NOTE: "low" is NOT valid for TCT_REQUEST.
+  • VESSEL_POSITION: "high" ONLY IF open date is within 5 days OR email contains explicit urgency language ("last chance", "firm offer expiry", "deadline today"). "medium" for ALL other vessel position circulars — a position circular is the normal trading flow; the default is "medium" unless the open window is imminent. "low" is NOT valid for VESSEL_POSITION.
   • FIXTURE_RECAP: always "high" (subs deadline running, requires acknowledgement within hours).
   • CLIENT_REPLY: "high" if sub-lift notification ("subs lifted", "subjects lifted") or has explicit reply deadline (e.g. "revert by COB today", "within 24h"). "medium" otherwise.
   • DOCUMENT / VESSEL_CERTIFICATE: "low" (informational, no urgent action).

--- a/scripts/progonq/__tests__/score-classify.test.ts
+++ b/scripts/progonq/__tests__/score-classify.test.ts
@@ -89,4 +89,15 @@ describe('scoreNormalized', () => {
     expect(r.urgency_match).toBe(false);
     expect(r.is_unanswered_match).toBe(false);
   });
+
+  it('null model + null ref company → company_name_match false (H2 regression)', () => {
+    const refNoCompany = { ...REF_LOW, original_sender_company: null as unknown as string };
+    const r = scoreNormalized(refNoCompany, null, EMAIL_DATE_ISO);
+    expect(r.company_name_match).toBe(false);
+  });
+
+  it('null model + invalid email date → days_match false (H2 regression)', () => {
+    const r = scoreNormalized(REF_LOW, null, 'not-a-date');
+    expect(r.days_match).toBe(false);
+  });
 });

--- a/scripts/progonq/__tests__/score-classify.test.ts
+++ b/scripts/progonq/__tests__/score-classify.test.ts
@@ -1,4 +1,4 @@
-import { scoreClassification } from '../run-classify';
+import { scoreClassification, scoreNormalized } from '../run-classify';
 
 const REF = {
   id: 'e1',
@@ -44,5 +44,49 @@ describe('scoreClassification', () => {
     const r = scoreClassification(REF, null);
     expect(r.category_match).toBe(false);
     expect(r.urgency_match).toBe(false);
+  });
+});
+
+// REF_LOW simulates a stale GT entry: CARGO_INQUIRY with urgency=low (GT rule drift)
+const REF_LOW = {
+  ...REF,
+  urgency: 'low',
+  days_without_reply: 36,
+  original_sender_company: 'Acme Shipping Ltd.',
+};
+// EMAIL_DATE is an old email — GT was captured when it was 36 days old,
+// but today (relative to 2026-05-17) it would be ~42 days old.
+const EMAIL_DATE_ISO = '2026-04-05T14:00:00Z';
+
+describe('scoreNormalized', () => {
+  it('normalizes CARGO_INQUIRY low→medium, so medium model urgency matches', () => {
+    const model = { ...REF_LOW, urgency: 'medium', days_without_reply: 41 };
+    const r = scoreNormalized(REF_LOW, model, EMAIL_DATE_ISO);
+    expect(r.urgency_match).toBe(true);
+  });
+
+  it('still fails if model urgency is wrong after normalization', () => {
+    const model = { ...REF_LOW, urgency: 'low', days_without_reply: 41 };
+    const r = scoreNormalized(REF_LOW, model, EMAIL_DATE_ISO);
+    expect(r.urgency_match).toBe(false);
+  });
+
+  it('days_match passes when within ±10d tolerance', () => {
+    const model = { ...REF_LOW, urgency: 'medium', days_without_reply: 41 };
+    const r = scoreNormalized(REF_LOW, model, EMAIL_DATE_ISO);
+    expect(r.days_match).toBe(true);
+  });
+
+  it('company_name_match normalizes punctuation and case', () => {
+    const model = { ...REF_LOW, urgency: 'medium', days_without_reply: 41, original_sender_company: 'acme shipping ltd' };
+    const r = scoreNormalized(REF_LOW, model, EMAIL_DATE_ISO);
+    expect(r.company_name_match).toBe(true);
+  });
+
+  it('null model → all false', () => {
+    const r = scoreNormalized(REF_LOW, null, EMAIL_DATE_ISO);
+    expect(r.category_match).toBe(false);
+    expect(r.urgency_match).toBe(false);
+    expect(r.is_unanswered_match).toBe(false);
   });
 });

--- a/scripts/progonq/run-classify.ts
+++ b/scripts/progonq/run-classify.ts
@@ -123,13 +123,14 @@ export function scoreNormalized(
     category_match: model !== null && norm.category === model.category,
     urgency_match: model !== null && ciEqual(norm.urgency, model.urgency),
     is_unanswered_match: model !== null && norm.is_unanswered === model.is_unanswered,
-    days_match: daysMatch(norm.days_without_reply, model?.days_without_reply ?? null),
+    days_match: model !== null && daysMatch(norm.days_without_reply, model.days_without_reply ?? null),
     company_name_match:
-      norm.original_sender_company === null && modelCompanyNorm === null
+      model !== null &&
+      (norm.original_sender_company === null && modelCompanyNorm === null
         ? true
         : norm.original_sender_company !== null &&
           modelCompanyNorm !== null &&
-          norm.original_sender_company === modelCompanyNorm,
+          norm.original_sender_company === modelCompanyNorm),
     ref_urgency_normalized: norm.urgency,
     ref_days_normalized: norm.days_without_reply,
   };

--- a/scripts/progonq/run-classify.ts
+++ b/scripts/progonq/run-classify.ts
@@ -14,8 +14,9 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { callAiJson } from '@/lib/ai-provider';
-import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts';
+import { CLASSIFICATION_SYSTEM_PROMPT, CLASSIFICATION_SYSTEM_PROMPT_R4 } from '@/lib/prompts';
 import { CLASSIFY_SCHEMA } from '@/lib/schemas';
+import { normalizeRef, daysMatch, normalizeCompanyName } from '@/lib/email-normalize';
 
 const SCOPE = 'CLASSIFY';
 const MAX_BODY_CHARS = 3000;
@@ -59,6 +60,16 @@ export interface ClassifyMatch {
   model_sender: string | null;
 }
 
+export interface NormalizedMatch {
+  category_match: boolean;
+  urgency_match: boolean;
+  is_unanswered_match: boolean;
+  days_match: boolean;
+  company_name_match: boolean;
+  ref_urgency_normalized: string;
+  ref_days_normalized: number | null;
+}
+
 interface RunResult {
   scenario_id: string;
   category: string;
@@ -68,6 +79,7 @@ interface RunResult {
   error?: string;
   duration_ms: number;
   match: ClassifyMatch;
+  normalized_match?: NormalizedMatch;
 }
 
 function truncate(s: string, max: number): string {
@@ -100,6 +112,31 @@ export function scoreClassification(ref: AiClassification, model: AiClassificati
   };
 }
 
+export function scoreNormalized(
+  ref: AiClassification,
+  model: AiClassification | null,
+  emailDateIso: string,
+): NormalizedMatch {
+  const norm = normalizeRef(ref, emailDateIso);
+  const modelCompanyNorm = normalizeCompanyName(model?.original_sender_company ?? null);
+  return {
+    category_match: model !== null && norm.category === model.category,
+    urgency_match: model !== null && ciEqual(norm.urgency, model.urgency),
+    is_unanswered_match: model !== null && norm.is_unanswered === model.is_unanswered,
+    days_match: daysMatch(norm.days_without_reply, model?.days_without_reply ?? null),
+    company_name_match:
+      norm.original_sender_company === null && modelCompanyNorm === null
+        ? true
+        : norm.original_sender_company !== null &&
+          modelCompanyNorm !== null &&
+          norm.original_sender_company === modelCompanyNorm,
+    ref_urgency_normalized: norm.urgency,
+    ref_days_normalized: norm.days_without_reply,
+  };
+}
+
+let ACTIVE_SYSTEM_PROMPT = CLASSIFICATION_SYSTEM_PROMPT;
+
 async function classifyOne(scenario: Scenario): Promise<AiClassification | null> {
   const body = truncate(scenario.input.body, MAX_BODY_CHARS);
   const emailInput = [{
@@ -114,7 +151,7 @@ async function classifyOne(scenario: Scenario): Promise<AiClassification | null>
 
   const result = await callAiJson<{ classifications: AiClassification[] }>(
     SCOPE,
-    CLASSIFICATION_SYSTEM_PROMPT,
+    ACTIVE_SYSTEM_PROMPT,
     userPrompt,
     {
       maxTokens: 4000,
@@ -157,6 +194,7 @@ async function runScenario(scenario: Scenario): Promise<RunResult> {
     error,
     duration_ms: Date.now() - t0,
     match: scoreClassification(scenario.reference_output, model),
+    normalized_match: scoreNormalized(scenario.reference_output, model, scenario.input.date),
   };
 }
 
@@ -166,6 +204,12 @@ async function main() {
   const limitArg = process.argv.indexOf('--limit');
   const limit = limitArg >= 0 ? parseInt(process.argv[limitArg + 1], 10) : Infinity;
   const outArg = process.argv.indexOf('--output');
+  const useR4 = process.argv.includes('--r4') || process.env.EMAIL_PARSE_R4_ENABLED === 'true';
+
+  if (useR4) {
+    ACTIVE_SYSTEM_PROMPT = CLASSIFICATION_SYSTEM_PROMPT_R4;
+    console.error('[run-classify] Using R4 improved prompt (EMAIL_PARSE_R4_ENABLED)');
+  }
 
   mkdirSync(RESULTS_DIR, { recursive: true });
   const outPath = outArg >= 0
@@ -212,11 +256,25 @@ async function main() {
   const unsOk = noErr.filter((r) => r.match.is_unanswered_match).length;
   const errors = total - noErr.length;
 
+  // Normalized accuracy (removes GT staleness from urgency + days)
+  const normCatOk = noErr.filter((r) => r.normalized_match?.category_match).length;
+  const normUrgOk = noErr.filter((r) => r.normalized_match?.urgency_match).length;
+  const normUnsOk = noErr.filter((r) => r.normalized_match?.is_unanswered_match).length;
+  const normDaysOk = noErr.filter((r) => r.normalized_match?.days_match).length;
+  const normCompanyOk = noErr.filter((r) => r.normalized_match?.company_name_match).length;
+
   console.error(`\n[run-classify] DONE round=${round}`);
+  console.error('--- Raw (exact GT) ---');
   console.error(`Category accuracy:     ${catOk}/${total} (${((catOk / total) * 100).toFixed(1)}%)`);
   console.error(`Urgency accuracy:      ${urgOk}/${total} (${((urgOk / total) * 100).toFixed(1)}%)`);
   console.error(`is_unanswered match:   ${unsOk}/${total} (${((unsOk / total) * 100).toFixed(1)}%)`);
   console.error(`Errors:                ${errors}`);
+  console.error('--- Normalized (GT staleness corrected) ---');
+  console.error(`Category accuracy:     ${normCatOk}/${total} (${((normCatOk / total) * 100).toFixed(1)}%)`);
+  console.error(`Urgency accuracy:      ${normUrgOk}/${total} (${((normUrgOk / total) * 100).toFixed(1)}%)`);
+  console.error(`is_unanswered match:   ${normUnsOk}/${total} (${((normUnsOk / total) * 100).toFixed(1)}%)`);
+  console.error(`Days ±10d tolerance:   ${normDaysOk}/${total} (${((normDaysOk / total) * 100).toFixed(1)}%)`);
+  console.error(`Company name match:    ${normCompanyOk}/${total} (${((normCompanyOk / total) * 100).toFixed(1)}%)`);
   console.error(`Output: ${outPath}`);
 
   // Confusion matrix for category


### PR DESCRIPTION
## Summary

- Applies parse-cargo R26 normalizer approach to email classifier corpus (154 scenarios)
- Adds `lib/email-normalize.ts` with GT normalization functions (days staleness, urgency rule drift, company name fuzzy match)
- Adds `lib/prompts/classify-r4.ts` — improved classify prompt gated behind `EMAIL_PARSE_R4_ENABLED=false`
- Fixes VESSEL_POSITION → DOCUMENT misclassification (charter-party terms in vessel position ≠ document)

## Eval Results

**R0 Baseline (154 scenarios, gemini-2.5-flash, `EMAIL_PARSE_R4_ENABLED=false`):**
| Metric | Raw | Normalized |
|--------|-----|-----------|
| Category | 148/154 (96.1%) | — |
| Urgency | 105/154 (68.2%) | 110/154 (71.4%) |
| is_unanswered | 132/154 (85.7%) | — |
| Days ±10d | — | 148/154 (96.1%) |

**R1 (R4 prompt, 5-scenario sample):** Category 100% vs R0's 80% on same 5 (scenario-005 VESSEL_POSITION→DOCUMENT fixed).

## Category Error Breakdown (R0, 6 errors)
1. `etms-classify-005` VESSEL_POSITION → DOCUMENT ← **fixed by R4**
2. `etms-classify-026` OTHER → CARGO_INQUIRY (ambiguous email)
3. `etms-classify-076` VESSEL_POSITION → CARGO_INQUIRY (ambiguous vessel offer)
4-6. CARGO_INQUIRY → TCT_REQUEST (3 cases — "direct cargoes with TTL days" ambiguity)

## GT Normalizer Key Findings
- **days_without_reply**: GT generated 2026-05-11, today 2026-05-17 → 6-day systematic staleness; recomputed from email date
- **urgency**: 11 CARGO_INQUIRY + 5 VESSEL_POSITION GT entries have `low` urgency — violates current prompt rules; normalized to `medium`
- **company name**: string match insufficient (ETMS vs ETM Services vs ETM-Services.net); normalized for eval but LLM judge needed for final score

## Files Changed
- `lib/email-normalize.ts` — new, GT normalizer (5 pure functions)
- `lib/__tests__/email-normalize.test.ts` — new, 33 tests
- `lib/prompts/classify-r4.ts` — new, R4 improved prompt
- `lib/prompts/classify.ts` — added `getClassifyPrompt()` + R4 re-export
- `app/api/ai/classify/route.ts` — use `getClassifyPrompt()` (flag-gated, default=baseline)
- `scripts/progonq/run-classify.ts` — `scoreNormalized()`, `--r4` flag, normalized stats
- `scripts/progonq/__tests__/score-classify.test.ts` — 11 tests including scoreNormalized

## Test plan
- [x] `npx jest "email-normalize"` — 33 tests pass
- [x] `npx jest "score-classify"` — 11 tests pass (6 original + 5 scoreNormalized)
- [x] `npx jest "app/api/ai/__tests__/classify"` — 10 tests pass
- [x] Full jest suite: 5497 pass, 9 pre-existing failures in governance.test.ts (unrelated)
- [x] `EMAIL_PARSE_R4_ENABLED=false` (default): production classify route uses baseline prompt unchanged
- [x] `EMAIL_PARSE_R4_ENABLED=true`: uses R4 improved prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)