### PR TITLE
fix(backup): heartbeat via localhost (CF strips X-Cron-Secret)

### DIFF
--- a/scripts/ops/backup.sh
+++ b/scripts/ops/backup.sh
@@ -142,7 +142,7 @@ log "Weekly backups kept: $(ls "${BACKUP_DIR}/weekly/"*.tar.gz 2>/dev/null | wc 
 if [[ -n "$CRON_SECRET" && -n "$APP_URL" ]]; then
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
     --max-time 10 \
-    -X POST "${APP_URL}/api/admin/cron-heartbeat" \
+    -X POST "${HEARTBEAT_URL:-http://localhost:3000/api/admin/cron-heartbeat}" \
     -H "Content-Type: application/json" \
     -H "X-Cron-Secret: ${CRON_SECRET}" \
     -d '{"cron_name":"quantika-backup"}' 2>/dev/null) || HTTP_CODE="000"


### PR DESCRIPTION
## Summary
Backup script heartbeat to /api/admin/cron-heartbeat was returning 401 in prod because Cloudflare strips the non-standard `X-Cron-Secret` header at the edge before it reaches Next.js.

## Root cause
- Localhost POST with X-Cron-Secret → HTTP 200 ✅
- HTTPS POST via Cloudflare with same header → HTTP 401 (header dropped) ❌

## Fix
Route heartbeat through `HEARTBEAT_URL` env (default `http://localhost:3000/api/admin/cron-heartbeat`) instead of public APP_URL. Cron jobs run on the same VPS — no need for the public round-trip.

## Smoke
```
[2026-05-17T13:09:17+0200] Heartbeat: OK (HTTP 200)
```

## Follow-up
Other cron jobs that hit the same endpoint may have the same silent 401 — needs audit (separate spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
