### PR TITLE
fix(backup): use HEARTBEAT_URL (localhost) for cron heartbeat — bypass CF header strip

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -190,7 +190,8 @@ SEAROUTE_SERVICE_URL=http://127.0.0.1:8200
 # Default: empty (public endpoint, token may be required in future)
 EU_SANCTIONS_TOKEN=
 
-# Cron heartbeat webhook URL (C7 — sanctions refresh monitoring)
+# Cron heartbeat webhook URL (used by backup.sh + refresh-sanctions cron)
+# Keep as localhost — Cloudflare strips X-Cron-Secret on public APP_URL requests.
 # Default: http://localhost:3000/api/admin/cron-heartbeat
 HEARTBEAT_URL=http://localhost:3000/api/admin/cron-heartbeat
 

--- a/scripts/ops/README-backup.md
+++ b/scripts/ops/README-backup.md
@@ -68,8 +68,10 @@ On success, `backup.sh` POSTs to `/api/admin/cron-heartbeat` with
 `cron_name=quantika-backup`. If no heartbeat is seen for > 24 h, the monitoring
 dashboard will flag it.
 
-`backup.sh` reads `CRON_SECRET` and `NEXT_PUBLIC_APP_URL` automatically from
-`.env.local` — no separate configuration needed.
+`backup.sh` reads `CRON_SECRET` and `HEARTBEAT_URL` automatically from
+`.env.local` — no separate configuration needed. `HEARTBEAT_URL` defaults to
+`http://localhost:3000/api/admin/cron-heartbeat` so heartbeats always go via
+localhost, bypassing Cloudflare (which strips the `X-Cron-Secret` header).
 
 The backup also pre-flight-checks `.env.local` size (aborts if < 100 bytes),
 preventing a repeat of the 2026-05-17 incident pattern where a truncated file
@@ -109,7 +111,7 @@ pm2 restart quantika-demo --update-env
 | `DAILY_KEEP` | `7` | Number of daily archives to retain |
 | `WEEKLY_KEEP` | `4` | Number of weekly archives to retain |
 | `CRON_SECRET` | from `.env.local` | For heartbeat POST auth |
-| `APP_URL` | from `NEXT_PUBLIC_APP_URL` | Heartbeat target base URL |
+| `HEARTBEAT_URL` | `http://localhost:3000/api/admin/cron-heartbeat` | Heartbeat target URL (localhost avoids Cloudflare stripping `X-Cron-Secret`) |
 
 ## Logs
 

--- a/scripts/ops/backup.sh
+++ b/scripts/ops/backup.sh
@@ -14,6 +14,7 @@
 #   BACKUP_DIR=/var/backups/quantika
 #   DAILY_KEEP=7
 #   WEEKLY_KEEP=4
+#   HEARTBEAT_URL=http://localhost:3000/api/admin/cron-heartbeat
 
 set -euo pipefail
 
@@ -32,14 +33,14 @@ log() {
 }
 die() { log "ERROR: $*"; exit 1; }
 
-# ── Resolve env from .env.local (CRON_SECRET, NEXT_PUBLIC_APP_URL) ───────────
+# ── Resolve env from .env.local (CRON_SECRET, HEARTBEAT_URL) ─────────────────
 ENV_FILE="${APP_DIR}/.env.local"
 if [[ -f "$ENV_FILE" ]]; then
   CRON_SECRET="${CRON_SECRET:-$(grep -E '^CRON_SECRET=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')}"
-  APP_URL="${APP_URL:-$(grep -E '^NEXT_PUBLIC_APP_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')}"
+  HEARTBEAT_URL="${HEARTBEAT_URL:-$(grep -E '^HEARTBEAT_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')}"
 fi
 CRON_SECRET="${CRON_SECRET:-}"
-APP_URL="${APP_URL:-}"
+HEARTBEAT_URL="${HEARTBEAT_URL:-http://localhost:3000/api/admin/cron-heartbeat}"
 
 # ── Sources (priority order) ─────────────────────────────────────────────────
 declare -a SOURCES=(
@@ -68,7 +69,7 @@ if $DRY_RUN; then
     fi
   done
   log "DRY-RUN: backup dir: ${BACKUP_DIR} (retention: ${DAILY_KEEP} daily / ${WEEKLY_KEEP} weekly)"
-  log "DRY-RUN: heartbeat: ${APP_URL:-<APP_URL not set>}/api/admin/cron-heartbeat"
+  log "DRY-RUN: heartbeat: ${HEARTBEAT_URL}"
   log "DRY-RUN: CRON_SECRET: ${CRON_SECRET:+set (${#CRON_SECRET} chars)}"
   $ALL_OK || die "DRY-RUN: critical sources missing — backup would fail"
   log "DRY-RUN: OK — all critical sources present"
@@ -139,10 +140,10 @@ log "Daily backups kept: $(ls "${BACKUP_DIR}/daily/"*.tar.gz 2>/dev/null | wc -l
 log "Weekly backups kept: $(ls "${BACKUP_DIR}/weekly/"*.tar.gz 2>/dev/null | wc -l)/${WEEKLY_KEEP}"
 
 # ── Heartbeat ─────────────────────────────────────────────────────────────────
-if [[ -n "$CRON_SECRET" && -n "$APP_URL" ]]; then
+if [[ -n "$CRON_SECRET" ]]; then
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
     --max-time 10 \
-    -X POST "${APP_URL}/api/admin/cron-heartbeat" \
+    -X POST "${HEARTBEAT_URL}" \
     -H "Content-Type: application/json" \
     -H "X-Cron-Secret: ${CRON_SECRET}" \
     -d '{"cron_name":"quantika-backup"}' 2>/dev/null) || HTTP_CODE="000"
@@ -154,5 +155,5 @@ if [[ -n "$CRON_SECRET" && -n "$APP_URL" ]]; then
     # separate concern tracked by the monitoring dashboard.
   fi
 else
-  log "WARNING: CRON_SECRET or APP_URL not set — heartbeat skipped"
+  log "WARNING: CRON_SECRET not set — heartbeat skipped"
 fi

--- a/scripts/ops/tests/backup-unit.sh
+++ b/scripts/ops/tests/backup-unit.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Regression tests for backup.sh HIGH findings:
 #   HIGH-1: tar || true allowed partial archives to exit 0
-#   HIGH-2: quoted .env.local values broke CRON_SECRET/APP_URL extraction
+#   HIGH-2: quoted .env.local values broke CRON_SECRET/HEARTBEAT_URL extraction
+#   HIGH-3: backup.sh used APP_URL (public/CF-proxied) instead of HEARTBEAT_URL
 #
 # Run: bash scripts/ops/tests/backup-unit.sh
 # Exits 0 on all pass, 1 if any fail.
@@ -54,7 +55,7 @@ trap 'rm -f "$TMP_ENV"' EXIT
 cat > "$TMP_ENV" <<'EOF'
 # Next.js .env.local
 CRON_SECRET="my-real-secret"
-NEXT_PUBLIC_APP_URL="https://example.com"
+HEARTBEAT_URL="http://localhost:3000/api/admin/cron-heartbeat"
 OTHER_VAR=irrelevant
 EOF
 
@@ -63,10 +64,27 @@ got_secret=$(grep -E '^CRON_SECRET=' "$TMP_ENV" | head -1 | cut -d= -f2- | sed "
   && pass "HIGH-2: CRON_SECRET extracted from quoted .env.local" \
   || fail "HIGH-2: CRON_SECRET extraction → got '$got_secret', want 'my-real-secret'"
 
-got_url=$(grep -E '^NEXT_PUBLIC_APP_URL=' "$TMP_ENV" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')
-[[ "$got_url" == "https://example.com" ]] \
-  && pass "HIGH-2: NEXT_PUBLIC_APP_URL extracted from quoted .env.local" \
-  || fail "HIGH-2: APP_URL extraction → got '$got_url', want 'https://example.com'"
+got_url=$(grep -E '^HEARTBEAT_URL=' "$TMP_ENV" | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ')
+[[ "$got_url" == "http://localhost:3000/api/admin/cron-heartbeat" ]] \
+  && pass "HIGH-2: HEARTBEAT_URL extracted from quoted .env.local" \
+  || fail "HIGH-2: HEARTBEAT_URL extraction → got '$got_url', want 'http://localhost:3000/api/admin/cron-heartbeat'"
+
+# ── HIGH-3: HEARTBEAT_URL defaults to localhost (not public APP_URL) ──────────
+
+# Verify backup.sh uses HEARTBEAT_URL env var (not NEXT_PUBLIC_APP_URL/APP_URL)
+BACKUP_SH="${BASH_SOURCE[0]%/tests/*}/backup.sh"
+if grep -qE 'HEARTBEAT_URL' "$BACKUP_SH" && ! grep -qE '\$\{APP_URL\}' "$BACKUP_SH"; then
+  pass "HIGH-3: backup.sh uses HEARTBEAT_URL (not APP_URL) for heartbeat curl"
+else
+  fail "HIGH-3: backup.sh still references \${APP_URL} for heartbeat — CF will strip X-Cron-Secret"
+fi
+
+# Verify default value is localhost (not public URL)
+if grep -qE 'HEARTBEAT_URL:-http://localhost:3000' "$BACKUP_SH"; then
+  pass "HIGH-3: HEARTBEAT_URL defaults to localhost (bypasses Cloudflare)"
+else
+  fail "HIGH-3: HEARTBEAT_URL default not localhost — cron may use public CF-proxied URL"
+fi
 
 # ── HIGH-1: tar failure removes partial archive and exits non-zero ────────────
 


### PR DESCRIPTION
## Problem

`backup.sh` was sending heartbeat POSTs to `${APP_URL}/api/admin/cron-heartbeat`, where `APP_URL` was derived from `NEXT_PUBLIC_APP_URL` (i.e., `https://demo.quantika.org`). Cloudflare silently strips the `X-Cron-Secret` header on proxied requests → 401 → no heartbeat recorded → monitoring false-positives.

Same root cause as tracked in PR #176 for the general backup.sh fix.

## What changed

`backup.sh` now reads `HEARTBEAT_URL` from `.env.local` (falling back to `http://localhost:3000/api/admin/cron-heartbeat`), matching the same pattern already used by `refresh-sanctions.ts`.

Cloudflare is not in the path for localhost requests, so `X-Cron-Secret` reaches the endpoint intact.

## Scope

| File | Change |
|------|--------|
| `scripts/ops/backup.sh` | Read `HEARTBEAT_URL` from `.env.local`; default localhost; remove `APP_URL` for heartbeat |
| `scripts/ops/README-backup.md` | Updated env var table + Cloudflare explanation |
| `scripts/ops/tests/backup-unit.sh` | Updated HIGH-2 NEXT_PUBLIC_APP_URL→HEARTBEAT_URL; added HIGH-3 regression test |
| `.env.local.example` | Updated HEARTBEAT_URL comment to mention backup.sh |

`refresh-sanctions.ts` was already correct (uses `HEARTBEAT_URL` with localhost default) — no change needed.

## Test plan

- [x] `bash scripts/ops/tests/backup-unit.sh` → 11/11 PASS
- [x] HIGH-3 new test: verifies `backup.sh` uses `HEARTBEAT_URL`, not `${APP_URL}`, and defaults to localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)