### PR TITLE
feat(C1+D8): claude-cli judge provider + BIMCO retriever allowlist

### DIFF
--- a/__tests__/lib/ai-provider-claude-cli.test.ts
+++ b/__tests__/lib/ai-provider-claude-cli.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for callClaudeCliRaw (C1: claude-cli judge provider).
+ * Mocks child_process.spawnSync to verify JSON parsing logic without running claude CLI.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+jest.mock('child_process', () => ({
+  spawnSync: jest.fn(),
+}));
+
+// Import after mock registration so the inline require() in callClaudeCliRaw
+// gets the mocked module from Jest's module registry.
+const childProcess = require('child_process') as { spawnSync: jest.Mock };
+const { callClaudeCliRaw } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
+
+const OK_RESPONSE = (result: string) => ({
+  status: 0,
+  stdout: JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result }),
+  stderr: '',
+  pid: 42,
+  output: [null, '', ''],
+  signal: null,
+  error: undefined,
+});
+
+describe('callClaudeCliRaw', () => {
+  beforeEach(() => {
+    childProcess.spawnSync.mockReset();
+  });
+
+  it('returns result text from claude CLI JSON output', () => {
+    childProcess.spawnSync.mockReturnValue(OK_RESPONSE('yes they are equivalent'));
+    const r = callClaudeCliRaw('You are a judge.', 'Is "BASF" === "BASF SE"?', 'claude-opus-4-7');
+    expect(r.text).toBe('yes they are equivalent');
+  });
+
+  it('passes --system-prompt flag when system is non-empty', () => {
+    childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+    callClaudeCliRaw('sys prompt', 'user msg', 'claude-opus-4-7');
+    const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+    expect(args).toContain('--system-prompt');
+    const idx = args.indexOf('--system-prompt');
+    expect(args[idx + 1]).toBe('sys prompt');
+  });
+
+  it('passes user message as stdin (not as positional arg)', () => {
+    childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+    callClaudeCliRaw('', 'the user message', 'claude-opus-4-7');
+    const [, , spawnOpts] = childProcess.spawnSync.mock.calls[0] as [string, string[], { input: string }];
+    expect(spawnOpts.input).toBe('the user message');
+  });
+
+  it('throws on non-zero exit status', () => {
+    childProcess.spawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'authentication failed',
+      pid: 1,
+      output: [],
+      signal: null,
+      error: undefined,
+    });
+    expect(() => callClaudeCliRaw('s', 'u', 'claude-opus-4-7')).toThrow(/exited with status 1/);
+  });
+
+  it('throws on spawn error (e.g. claude not found)', () => {
+    childProcess.spawnSync.mockReturnValue({
+      status: null,
+      stdout: '',
+      stderr: '',
+      pid: -1,
+      output: [],
+      signal: null,
+      error: new Error('ENOENT: no such file or directory'),
+    });
+    expect(() => callClaudeCliRaw('s', 'u', 'claude-opus-4-7')).toThrow(/spawn error/);
+  });
+
+  it('falls back to raw stdout when output is not JSON', () => {
+    childProcess.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: 'plain text response',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+      error: undefined,
+    });
+    const r = callClaudeCliRaw('s', 'u', 'claude-opus-4-7');
+    expect(r.text).toBe('plain text response');
+  });
+
+  it('throws when claude CLI returns is_error=true', () => {
+    childProcess.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ type: 'result', is_error: true, result: 'quota exceeded' }),
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+      error: undefined,
+    });
+    expect(() => callClaudeCliRaw('s', 'u', 'claude-opus-4-7')).toThrow(/error response/);
+  });
+});

--- a/__tests__/lib/ai-provider-claude-cli.test.ts
+++ b/__tests__/lib/ai-provider-claude-cli.test.ts
@@ -103,4 +103,47 @@ describe('callClaudeCliRaw', () => {
     });
     expect(() => callClaudeCliRaw('s', 'u', 'claude-opus-4-7')).toThrow(/error response/);
   });
+
+  // HIGH-01 regression: must throw when called in Next.js runtime context
+  it('throws when NEXT_RUNTIME is set (Next.js request handler guard)', () => {
+    const original = process.env.NEXT_RUNTIME;
+    process.env.NEXT_RUNTIME = 'nodejs';
+    try {
+      expect(() => callClaudeCliRaw('s', 'u', 'claude-opus-4-7')).toThrow(/must not be used in Next\.js runtime/);
+    } finally {
+      if (original === undefined) {
+        delete process.env.NEXT_RUNTIME;
+      } else {
+        process.env.NEXT_RUNTIME = original;
+      }
+    }
+  });
+
+  // MEDIUM-01 regression: maxBuffer must be passed to spawnSync
+  it('passes maxBuffer: 10 MB to spawnSync options', () => {
+    childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+    callClaudeCliRaw('s', 'u', 'claude-opus-4-7');
+    const [, , spawnOpts] = childProcess.spawnSync.mock.calls[0] as [string, string[], { maxBuffer: number }];
+    expect(spawnOpts.maxBuffer).toBe(10 * 1024 * 1024);
+  });
+
+  // MEDIUM-02 regression: --max-budget-usd must be in args with default 0.05
+  it('passes --max-budget-usd 0.05 by default', () => {
+    childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+    callClaudeCliRaw('s', 'u', 'claude-opus-4-7');
+    const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+    const idx = args.indexOf('--max-budget-usd');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('0.05');
+  });
+
+  // MEDIUM-02 regression: opts.maxBudgetUsd is forwarded to args
+  it('passes custom maxBudgetUsd to --max-budget-usd arg', () => {
+    childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+    callClaudeCliRaw('s', 'u', 'claude-opus-4-7', { maxBudgetUsd: 0.10 });
+    const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+    const idx = args.indexOf('--max-budget-usd');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('0.1');
+  });
 });

--- a/__tests__/lib/knowledge/embeddings/retriever-sqlite-bimco.test.ts
+++ b/__tests__/lib/knowledge/embeddings/retriever-sqlite-bimco.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for D8: bimco_vec + bimco_fts in retriever-sqlite allowlist.
+ * Verifies searchVec0('bimco_vec') does not throw "Invalid table name".
+ */
+
+import { jest, describe, it, expect } from '@jest/globals';
+
+jest.mock('@/lib/knowledge/flags', () => ({
+  isRagEnabled: jest.fn(() => true),
+}));
+
+jest.mock('@/lib/db', () => ({
+  getDb: jest.fn(() => ({
+    prepare: jest.fn(() => ({
+      all: jest.fn(() => []),
+    })),
+  })),
+}));
+
+const { searchVec0 } = require('@/lib/knowledge/embeddings/retriever-sqlite') as typeof import('@/lib/knowledge/embeddings/retriever-sqlite');
+
+describe('retriever-sqlite BIMCO allowlist (D8)', () => {
+  const embedding = new Float32Array(768).fill(0);
+
+  it('searchVec0 with bimco_vec does not throw Invalid table name', () => {
+    expect(() => searchVec0(embedding, 'bimco_vec', 5)).not.toThrow();
+  });
+
+  it('searchVec0 with bimco_vec returns an array', () => {
+    const results = searchVec0(embedding, 'bimco_vec', 5);
+    expect(Array.isArray(results)).toBe(true);
+  });
+
+  it('searchVec0 with unknown table still throws Invalid table name', () => {
+    expect(() => searchVec0(embedding, 'unknown_vec', 5)).toThrow('Invalid table name');
+  });
+});

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -15,7 +15,7 @@ import * as openaiLib from '@/lib/openai';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type Provider = 'openai' | 'gemini' | 'bedrock';
+export type Provider = 'openai' | 'gemini' | 'bedrock' | 'claude-cli';
 
 export interface AiOpts {
   /** Override timeout in milliseconds (default: 85_000). */
@@ -304,6 +304,68 @@ function writeAuditRecord(row: AiAuditRow): void {
   }
 }
 
+interface ClaudeCliOutput {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+}
+
+/**
+ * Calls the claude CLI via spawnSync for judge/eval workloads.
+ * Auth: CLAUDE_CODE_OAUTH_TOKEN picked up automatically by the claude CLI.
+ * Exported for unit testing (mock spawnSync in tests).
+ *
+ * Set *_JUDGE_PROVIDER=claude-cli (or AI_PROVIDER=claude-cli) to route judge
+ * scopes (CLASSIFY_JUDGE, PARSE_CARGO_JUDGE, PARSE_VESSEL_JUDGE) here instead
+ * of Bedrock, eliminating AWS credentials for eval runs.
+ */
+export function callClaudeCliRaw(
+  system: string,
+  user: string,
+  model: string,
+  opts?: AiOpts,
+): { text: string } {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { spawnSync } = require('child_process') as typeof import('child_process');
+
+  const args = ['--print', '--model', model, '--output-format', 'json'];
+  if (system) {
+    args.push('--system-prompt', system);
+  }
+
+  const result = spawnSync('claude', args, {
+    input: user,
+    encoding: 'utf8',
+    timeout: opts?.timeoutMs ?? 85_000,
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw new Error(`claude CLI spawn error: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr : '';
+    throw new Error(
+      `claude CLI exited with status ${result.status}: ${stderr.slice(0, 200)}`,
+    );
+  }
+
+  const stdout = typeof result.stdout === 'string' ? result.stdout : '';
+  let parsed: ClaudeCliOutput;
+  try {
+    parsed = JSON.parse(stdout) as ClaudeCliOutput;
+  } catch {
+    return { text: stdout };
+  }
+
+  if (parsed.is_error) {
+    throw new Error(`claude CLI returned error response: ${parsed.result ?? 'unknown'}`);
+  }
+
+  return { text: parsed.result ?? '' };
+}
+
 // ─── Public routing API ───────────────────────────────────────────────────────
 
 /**
@@ -314,7 +376,7 @@ export function getProvider(scope: string): Provider {
   const scopeEnv = process.env[toScopeEnv(scope)];
   const globalEnv = process.env.AI_PROVIDER;
   const raw = scopeEnv || globalEnv || 'openai';
-  if (raw !== 'openai' && raw !== 'gemini' && raw !== 'bedrock') {
+  if (raw !== 'openai' && raw !== 'gemini' && raw !== 'bedrock' && raw !== 'claude-cli') {
     logger.warn({ scope, raw }, '[ai-provider] unknown provider value, falling back to openai');
     return 'openai';
   }
@@ -338,6 +400,8 @@ export function getModel(scope: string): string {
       return process.env.AI_MODEL_GEMINI_DEFAULT ?? 'gemini-2.5-flash';
     case 'bedrock':
       return process.env.BEDROCK_MODEL_ID ?? 'us.anthropic.claude-opus-4-7';
+    case 'claude-cli':
+      return 'claude-opus-4-7';
     case 'openai':
     default:
       return process.env.AI_MODEL_HEAVY ?? 'gpt-5.5';
@@ -654,6 +718,11 @@ export async function callAiJson<T>(
         result = JSON.parse(extractJson(r.text)) as T;
         break;
       }
+      case 'claude-cli': {
+        const r = callClaudeCliRaw(system, user, model, opts);
+        result = JSON.parse(extractJson(r.text)) as T;
+        break;
+      }
       case 'openai':
       default:
         result = await callOpenAiJson<T>(scope, system, user, opts);
@@ -707,6 +776,11 @@ export async function callAiText(
       case 'bedrock': {
         const r = await callBedrockText(system, user, model, opts);
         usage = r.usage;
+        result = r.text;
+        break;
+      }
+      case 'claude-cli': {
+        const r = callClaudeCliRaw(system, user, model, opts);
         result = r.text;
         break;
       }

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -49,6 +49,8 @@ export interface AiOpts {
   topK?: number;
   /** Random seed for reproducibility (Gemini Vertex AI supports). */
   seed?: number;
+  /** Max USD budget per claude-cli call (default: 0.05). Only used by claude-cli provider. */
+  maxBudgetUsd?: number;
 }
 
 /**
@@ -326,10 +328,19 @@ export function callClaudeCliRaw(
   model: string,
   opts?: AiOpts,
 ): { text: string } {
+  if (process.env.NEXT_RUNTIME) {
+    throw new Error(
+      "claude-cli provider must not be used in Next.js runtime (request handlers). " +
+      "spawnSync blocks the event loop for up to 85s. " +
+      "Use claude-cli only in eval scripts (scripts/progonq/, scripts/eval/)."
+    );
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { spawnSync } = require('child_process') as typeof import('child_process');
 
-  const args = ['--print', '--model', model, '--output-format', 'json'];
+  const budget = opts?.maxBudgetUsd ?? 0.05;
+  const args = ['--print', '--model', model, '--output-format', 'json', '--max-budget-usd', String(budget)];
   if (system) {
     args.push('--system-prompt', system);
   }
@@ -338,6 +349,7 @@ export function callClaudeCliRaw(
     input: user,
     encoding: 'utf8',
     timeout: opts?.timeoutMs ?? 85_000,
+    maxBuffer: 10 * 1024 * 1024,
     env: process.env,
   });
 

--- a/lib/knowledge/embeddings/retriever-sqlite.ts
+++ b/lib/knowledge/embeddings/retriever-sqlite.ts
@@ -22,8 +22,8 @@ import { isRagEnabled } from '@/lib/knowledge/flags';
 import type { RetrievedChunk, ChunkMetadata } from '@/lib/knowledge/embeddings/chunks';
 import Database from 'better-sqlite3';
 
-const ALLOWED_VEC_TABLES = ['imsbc_vec', 'igc_vec', 'jwc_vec'] as const;
-const ALLOWED_FTS_TABLES = ['imsbc_fts', 'igc_fts', 'jwc_fts'] as const;
+const ALLOWED_VEC_TABLES = ['imsbc_vec', 'igc_vec', 'jwc_vec', 'bimco_vec'] as const;
+const ALLOWED_FTS_TABLES = ['imsbc_fts', 'igc_fts', 'jwc_fts', 'bimco_fts'] as const;
 
 /**
  * Vec0 cosine k-NN retriever (spec-08)


### PR DESCRIPTION
## Summary

- **C1**: Adds `claude-cli` provider to `lib/ai-provider.ts` that spawns `claude --print --model claude-opus-4-7 --output-format json` via `spawnSync`. Eliminates AWS Bedrock dependency for eval/judge workloads. Set `*_JUDGE_PROVIDER=claude-cli` (or `AI_PROVIDER=claude-cli`) to route judge scopes here. Bedrock provider is kept for backward compat.
- **D8**: Adds `bimco_vec` + `bimco_fts` to the sqlite retriever allowlists in `retriever-sqlite.ts`, enabling BIMCO RAG via the hybrid FTS5+vec0 backend.

## Test plan

- [x] `callClaudeCliRaw` unit tests (6 cases): JSON parsing, `--system-prompt` flag, stdin routing, non-zero exit, spawn error, plain-text fallback, `is_error` throw
- [x] `retriever-sqlite-bimco` regression tests (3 cases): `searchVec0('bimco_vec')` does not throw, returns array, unknown table still throws
- [x] Full related test suite: 121/121 pass (`ai-provider*`, `retriever-sqlite*`, `retriever-rrf*`)
- [x] Bedrock provider unchanged — existing tests unaffected

## Usage

```bash
# For all judge scopes (eval runs)
CLASSIFY_JUDGE_PROVIDER=claude-cli \
PARSE_CARGO_JUDGE_PROVIDER=claude-cli \
PARSE_VESSEL_JUDGE_PROVIDER=claude-cli \
npx tsx --env-file=.env.local scripts/progonq/judge-parse-cargo.ts --results ...

# Or globally
AI_PROVIDER=claude-cli npx tsx ...
```

Auth: `CLAUDE_CODE_OAUTH_TOKEN` in environment (claude CLI picks up automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)