### PR TITLE
feat(seed): fx_rates 30-day history via frankfurter.app

### DIFF
--- a/__tests__/scripts/seed-fx-rates.test.ts
+++ b/__tests__/scripts/seed-fx-rates.test.ts
@@ -1,0 +1,135 @@
+import Database from 'better-sqlite3';
+
+let mockDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: () => ({ getDb: () => mockDb }),
+}));
+
+function buildTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE fx_rates (
+      base_currency  TEXT NOT NULL,
+      quote_currency TEXT NOT NULL,
+      rate           REAL NOT NULL,
+      rate_date      TEXT NOT NULL,
+      source         TEXT NOT NULL DEFAULT 'frankfurter',
+      fetched_at     TEXT NOT NULL,
+      PRIMARY KEY (base_currency, quote_currency, rate_date)
+    );
+    CREATE INDEX IF NOT EXISTS idx_fx_rates_lookup
+      ON fx_rates(base_currency, quote_currency, rate_date DESC);
+  `);
+  return db;
+}
+
+// Import after mock setup
+import { seed } from '@/scripts/seed-fx-rates';
+
+const usdRatesData = { rates: { '2026-05-15': { EUR: 0.92, GBP: 0.79, CNY: 7.25 } } };
+const eurRatesData = { rates: { '2026-05-15': { GBP: 0.86, CNY: 7.87 } } };
+
+function okResponse(data: object): Response {
+  return { ok: true, json: async () => data } as Response;
+}
+
+function rowCount(): number {
+  return (mockDb.prepare('SELECT COUNT(*) as c FROM fx_rates').get() as { c: number }).c;
+}
+
+describe('seed-fx-rates', () => {
+  beforeEach(() => {
+    mockDb = buildTestDb();
+  });
+
+  afterEach(() => {
+    mockDb.close();
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('inserts all currency pairs on happy path', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(okResponse(usdRatesData))
+      .mockResolvedValueOnce(okResponse(eurRatesData));
+
+    await seed();
+
+    // 1 day × (3 USD pairs + 3 inverse) + (2 EUR pairs + 2 inverse) = 10 rows
+    expect(rowCount()).toBe(10);
+
+    const pairs = (
+      mockDb
+        .prepare('SELECT base_currency, quote_currency FROM fx_rates')
+        .all() as Array<{ base_currency: string; quote_currency: string }>
+    ).map(r => `${r.base_currency}_${r.quote_currency}`);
+
+    expect(pairs).toContain('USD_EUR');
+    expect(pairs).toContain('EUR_USD');
+    expect(pairs).toContain('EUR_GBP');
+    expect(pairs).toContain('GBP_EUR');
+  });
+
+  it('skips rate=0 — no Infinity written to DB', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(
+        okResponse({ rates: { '2026-05-15': { EUR: 0, GBP: 0.79, CNY: 7.25 } } }),
+      )
+      .mockResolvedValueOnce(okResponse(eurRatesData));
+
+    await seed();
+
+    // EUR=0 skipped: 4 (USD→GBP/CNY + inverse) + 4 (EUR→GBP/CNY + inverse) = 8
+    expect(rowCount()).toBe(8);
+
+    const rows = mockDb.prepare('SELECT rate FROM fx_rates').all() as { rate: number }[];
+    expect(rows.every(r => isFinite(r.rate))).toBe(true);
+  });
+
+  it('skips rate=null — no NaN/Infinity written to DB', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(
+        okResponse({
+          rates: { '2026-05-15': { EUR: null as unknown as number, GBP: 0.79, CNY: 7.25 } },
+        }),
+      )
+      .mockResolvedValueOnce(okResponse(eurRatesData));
+
+    await seed();
+
+    expect(rowCount()).toBe(8);
+
+    const rows = mockDb.prepare('SELECT rate FROM fx_rates').all() as { rate: number }[];
+    expect(rows.every(r => isFinite(r.rate))).toBe(true);
+  });
+
+  it('retries on 503 and succeeds on second attempt', async () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 } as Response) // first USD attempt
+      .mockResolvedValueOnce(okResponse(usdRatesData))               // retry succeeds
+      .mockResolvedValueOnce(okResponse(eurRatesData));               // EUR fetch
+
+    const seedPromise = seed();
+    await jest.runAllTimersAsync();
+    await seedPromise;
+
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(rowCount()).toBe(10);
+  });
+
+  it('throws and writes nothing after all 3 retries exhausted (503 every attempt)', async () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 } as Response);
+
+    const seedPromise = seed();
+    // Register rejection handler before advancing timers to avoid unhandledRejection race
+    const assertion = expect(seedPromise).rejects.toThrow('frankfurter.app');
+    await jest.runAllTimersAsync();
+    await assertion;
+
+    expect(global.fetch).toHaveBeenCalledTimes(3); // 3 attempts exhausted
+    expect(rowCount()).toBe(0);                    // nothing committed
+  });
+});

--- a/scripts/seed-fx-rates.ts
+++ b/scripts/seed-fx-rates.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**
+ * Seed script: populates fx_rates with 30 days of real FX data from frankfurter.app (ECB).
+ *
+ * Pairs seeded (both directions):
+ *   USD/EUR, USD/GBP, USD/CNY, EUR/GBP, EUR/CNY
+ *
+ * Usage:
+ *   npx tsx scripts/seed-fx-rates.ts [--dry-run]
+ *   npx tsx --env-file=.env.local scripts/seed-fx-rates.ts
+ *
+ * Idempotent: upsertFxRate uses ON CONFLICT DO UPDATE.
+ */
+
+import { getStore } from '@/lib/session-store';
+import { upsertFxRate } from '@/lib/market/fx-rates-repository';
+
+const BASE_URL = 'https://api.frankfurter.app';
+
+interface FrankfurterResponse {
+  rates: Record<string, Record<string, number>>;
+}
+
+async function fetchRates(
+  from: string,
+  to: string[],
+  startDate: string,
+  endDate: string,
+): Promise<FrankfurterResponse> {
+  const url = `${BASE_URL}/${startDate}..${endDate}?from=${from}&to=${to.join(',')}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`frankfurter.app ${res.status}: ${url}`);
+  }
+  return res.json() as Promise<FrankfurterResponse>;
+}
+
+async function seed(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+  const db = getStore().getDb();
+  const fetchedAt = new Date().toISOString();
+
+  const today = new Date();
+  const endDate = today.toISOString().split('T')[0]!;
+  const start = new Date(today);
+  start.setDate(start.getDate() - 29); // 30 days inclusive
+  const startDate = start.toISOString().split('T')[0]!;
+
+  console.log(`seed-fx-rates: ${startDate}..${endDate}${dryRun ? ' [DRY RUN]' : ''}`);
+
+  let totalRows = 0;
+
+  // Fetch 1: USD → EUR, GBP, CNY
+  const usdData = await fetchRates('USD', ['EUR', 'GBP', 'CNY'], startDate, endDate);
+  const usdDays = Object.keys(usdData.rates).length;
+  console.log(`Fetched USD→EUR/GBP/CNY × ${usdDays} days = ${usdDays * 3} rows (+ ${usdDays * 3} inverse)`);
+
+  for (const [date, quotes] of Object.entries(usdData.rates)) {
+    for (const [quote, rate] of Object.entries(quotes)) {
+      if (!dryRun) {
+        upsertFxRate(db, { base_currency: 'USD', quote_currency: quote, rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+        upsertFxRate(db, { base_currency: quote, quote_currency: 'USD', rate: 1 / rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+      }
+      totalRows += 2;
+    }
+  }
+
+  // Fetch 2: EUR → GBP, CNY
+  const eurData = await fetchRates('EUR', ['GBP', 'CNY'], startDate, endDate);
+  const eurDays = Object.keys(eurData.rates).length;
+  console.log(`Fetched EUR→GBP/CNY × ${eurDays} days = ${eurDays * 2} rows (+ ${eurDays * 2} inverse)`);
+
+  for (const [date, quotes] of Object.entries(eurData.rates)) {
+    for (const [quote, rate] of Object.entries(quotes)) {
+      if (!dryRun) {
+        upsertFxRate(db, { base_currency: 'EUR', quote_currency: quote, rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+        upsertFxRate(db, { base_currency: quote, quote_currency: 'EUR', rate: 1 / rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+      }
+      totalRows += 2;
+    }
+  }
+
+  const prefix = dryRun ? '[DRY RUN] ' : '';
+  console.log(`${prefix}seed-fx-rates complete: ${totalRows} rows ${dryRun ? 'would be written' : 'inserted/updated'}`);
+}
+
+seed().catch((err) => {
+  console.error('seed-fx-rates failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-fx-rates.ts
+++ b/scripts/seed-fx-rates.ts
@@ -10,15 +10,21 @@
  *   npx tsx --env-file=.env.local scripts/seed-fx-rates.ts
  *
  * Idempotent: upsertFxRate uses ON CONFLICT DO UPDATE.
+ * Note: endDate is UTC; ECB rates align to UTC business days.
  */
 
 import { getStore } from '@/lib/session-store';
 import { upsertFxRate } from '@/lib/market/fx-rates-repository';
 
 const BASE_URL = 'https://api.frankfurter.app';
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
 
 interface FrankfurterResponse {
   rates: Record<string, Record<string, number>>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function fetchRates(
@@ -28,14 +34,31 @@ async function fetchRates(
   endDate: string,
 ): Promise<FrankfurterResponse> {
   const url = `${BASE_URL}/${startDate}..${endDate}?from=${from}&to=${to.join(',')}`;
-  const res = await fetch(url);
-  if (!res.ok) {
+
+  for (let attempt = 0; attempt < RETRY_DELAYS_MS.length; attempt++) {
+    let res: Response;
+    try {
+      res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+    } catch (err) {
+      if (attempt < RETRY_DELAYS_MS.length - 1) {
+        await sleep(RETRY_DELAYS_MS[attempt]!);
+        continue;
+      }
+      throw err;
+    }
+
+    if (res.ok) return res.json() as Promise<FrankfurterResponse>;
+
+    if ((res.status === 429 || res.status === 503) && attempt < RETRY_DELAYS_MS.length - 1) {
+      await sleep(RETRY_DELAYS_MS[attempt]!);
+      continue;
+    }
     throw new Error(`frankfurter.app ${res.status}: ${url}`);
   }
-  return res.json() as Promise<FrankfurterResponse>;
+  throw new Error(`frankfurter.app failed after ${RETRY_DELAYS_MS.length} retries`);
 }
 
-async function seed(): Promise<void> {
+export async function seed(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
   const db = getStore().getDb();
   const fetchedAt = new Date().toISOString();
@@ -48,35 +71,48 @@ async function seed(): Promise<void> {
 
   console.log(`seed-fx-rates: ${startDate}..${endDate}${dryRun ? ' [DRY RUN]' : ''}`);
 
-  let totalRows = 0;
-
-  // Fetch 1: USD → EUR, GBP, CNY
+  // Fetch both datasets before writing — ensures atomicity (HIGH-3)
   const usdData = await fetchRates('USD', ['EUR', 'GBP', 'CNY'], startDate, endDate);
   const usdDays = Object.keys(usdData.rates).length;
   console.log(`Fetched USD→EUR/GBP/CNY × ${usdDays} days = ${usdDays * 3} rows (+ ${usdDays * 3} inverse)`);
 
-  for (const [date, quotes] of Object.entries(usdData.rates)) {
-    for (const [quote, rate] of Object.entries(quotes)) {
-      if (!dryRun) {
-        upsertFxRate(db, { base_currency: 'USD', quote_currency: quote, rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
-        upsertFxRate(db, { base_currency: quote, quote_currency: 'USD', rate: 1 / rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
-      }
-      totalRows += 2;
-    }
-  }
-
-  // Fetch 2: EUR → GBP, CNY
   const eurData = await fetchRates('EUR', ['GBP', 'CNY'], startDate, endDate);
   const eurDays = Object.keys(eurData.rates).length;
   console.log(`Fetched EUR→GBP/CNY × ${eurDays} days = ${eurDays * 2} rows (+ ${eurDays * 2} inverse)`);
 
-  for (const [date, quotes] of Object.entries(eurData.rates)) {
-    for (const [quote, rate] of Object.entries(quotes)) {
-      if (!dryRun) {
-        upsertFxRate(db, { base_currency: 'EUR', quote_currency: quote, rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
-        upsertFxRate(db, { base_currency: quote, quote_currency: 'EUR', rate: 1 / rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+  let totalRows = 0;
+
+  if (!dryRun) {
+    db.transaction(() => {
+      for (const [date, quotes] of Object.entries(usdData.rates)) {
+        for (const [quote, rate] of Object.entries(quotes)) {
+          if (typeof rate !== 'number' || rate <= 0) continue;
+          upsertFxRate(db, { base_currency: 'USD', quote_currency: quote, rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+          upsertFxRate(db, { base_currency: quote, quote_currency: 'USD', rate: 1 / rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+          totalRows += 2;
+        }
       }
-      totalRows += 2;
+      for (const [date, quotes] of Object.entries(eurData.rates)) {
+        for (const [quote, rate] of Object.entries(quotes)) {
+          if (typeof rate !== 'number' || rate <= 0) continue;
+          upsertFxRate(db, { base_currency: 'EUR', quote_currency: quote, rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+          upsertFxRate(db, { base_currency: quote, quote_currency: 'EUR', rate: 1 / rate, rate_date: date, source: 'frankfurter', fetched_at: fetchedAt });
+          totalRows += 2;
+        }
+      }
+    })();
+  } else {
+    for (const [, quotes] of Object.entries(usdData.rates)) {
+      for (const [, rate] of Object.entries(quotes)) {
+        if (typeof rate !== 'number' || rate <= 0) continue;
+        totalRows += 2;
+      }
+    }
+    for (const [, quotes] of Object.entries(eurData.rates)) {
+      for (const [, rate] of Object.entries(quotes)) {
+        if (typeof rate !== 'number' || rate <= 0) continue;
+        totalRows += 2;
+      }
     }
   }
 
@@ -84,7 +120,9 @@ async function seed(): Promise<void> {
   console.log(`${prefix}seed-fx-rates complete: ${totalRows} rows ${dryRun ? 'would be written' : 'inserted/updated'}`);
 }
 
-seed().catch((err) => {
-  console.error('seed-fx-rates failed:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  seed().catch((err) => {
+    console.error('seed-fx-rates failed:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/seed-fx-rates.ts` that fetches 30 days of real FX rates from [frankfurter.app](https://www.frankfurter.app/) (European Central Bank data, free, no API key)
- Seeds 10 currency pairs (both directions): USD/EUR, USD/GBP, USD/CNY, EUR/GBP, EUR/CNY
- Idempotent (`ON CONFLICT DO UPDATE` via existing `upsertFxRate`)
- Supports `--dry-run` flag and `--env-file` for pm2 compatibility

## Smoke test result

```
CNY|EUR|20  CNY|USD|20  EUR|CNY|20  EUR|GBP|20  EUR|USD|20
GBP|EUR|20  GBP|USD|20  USD|CNY|20  USD|EUR|20  USD|GBP|20
```

10 pairs × 20 business days = **200 rows** inserted.

## Test plan

- [ ] `npx tsx scripts/seed-fx-rates.ts --dry-run` — prints counts, no writes
- [ ] `npx tsx scripts/seed-fx-rates.ts` — seeds 200 rows
- [ ] `sqlite3 data/sessions.db "SELECT base_currency, quote_currency, COUNT(*) FROM fx_rates GROUP BY 1,2"` — shows ≥5 pairs × ~20 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)