### PR TITLE
fix(test): use fake timers in sanctions_rtl_trial to remove flake [code-only]

### DIFF
--- a/__tests__/regression/test_sanctions_rtl_trial.test.ts
+++ b/__tests__/regression/test_sanctions_rtl_trial.test.ts
@@ -99,6 +99,15 @@ describe('A7 — detectTextDirection', () => {
 // A8 — trial daysRemaining / TRIAL_DAYS
 // ---------------------------------------------------------------------------
 describe('A8 — daysRemaining clamp + TRIAL_DAYS constant', () => {
+  // Freeze Date.now() so daysRemaining() is deterministic regardless of execution time.
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date('2026-05-17T12:00:00Z') });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   // Import synchronously since trial.ts has no top-level async side-effects
   // We avoid importing session-store by only importing the pure functions.
   // daysRemaining and isExpired are pure (no DB access); startTrial uses DB.


### PR DESCRIPTION
## Summary

- The test `ends_at = now + 1ms → daysRemaining = 1` in A8 was flaky because it relied on a 1ms race: if test execution took >1ms between `Date.now() + 1` and the `daysRemaining()` call, `ends_at` fell in the past and the function returned 0 instead of 1.
- Added `jest.useFakeTimers({ now: new Date('2026-05-17T12:00:00Z') })` / `jest.useRealTimers()` in `beforeEach`/`afterEach` of the A8 describe block to freeze `Date.now()` for the entire describe.
- `lib/trial.ts` is untouched — the logic was always correct; only the test harness needed deterministic time.

## Test plan

- [x] `npx jest __tests__/regression/test_sanctions_rtl_trial.test.ts` → 12/12 pass
- [x] ×10 consecutive runs — all green, no flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)