### PR TITLE
feat(market): restore Bunker/EUA/BHSI KPI cards (#177) [code-only]

### DIFF
--- a/__tests__/api/market/benchmark-route-bunker-eua.test.ts
+++ b/__tests__/api/market/benchmark-route-bunker-eua.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #177: BUNKER_ROTTERDAM + EUA indicators added to /api/market/benchmark.
+ */
+import { GET } from '@/app/api/market/benchmark/route';
+
+const mockGetDatabase = jest.fn();
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: mockGetDatabase })),
+}));
+
+const mockGetLatestBunkerPrice = jest.fn();
+jest.mock('@/lib/market/bunker-repository', () => ({
+  getLatestBunkerPrice: (...args: unknown[]) => mockGetLatestBunkerPrice(...args),
+}));
+
+const mockGetLatestEuaPrice = jest.fn();
+jest.mock('@/lib/market/eua-repository', () => ({
+  getLatestEuaPrice: (...args: unknown[]) => mockGetLatestEuaPrice(...args),
+}));
+
+jest.mock('@/lib/market/baltic-repository', () => ({
+  getLatestBalticIndex: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@/lib/market/benchmark', () => ({
+  getCurrentBenchmark: jest.fn().mockResolvedValue(null),
+}));
+
+function makeRequest(indicator?: string): Request {
+  const url = indicator
+    ? `http://localhost/api/market/benchmark?indicator=${indicator}`
+    : 'http://localhost/api/market/benchmark';
+  return new Request(url);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetDatabase.mockReturnValue({});
+});
+
+describe('GET /api/market/benchmark — BUNKER_ROTTERDAM (issue #177)', () => {
+  const BUNKER_ROW = {
+    port_unlocode: 'NLRTM',
+    fuel_grade: 'VLSFO',
+    price_usd_per_mt: 620,
+    price_date: '2026-05-15',
+    source: 'https://shipandbunker.com',
+    fetched_at: new Date().toISOString(),
+  };
+
+  it('R-177-1: ?indicator=BUNKER_ROTTERDAM → 200 with value and unit USD/MT', async () => {
+    mockGetLatestBunkerPrice.mockReturnValue(BUNKER_ROW);
+
+    const res = await GET(makeRequest('BUNKER_ROTTERDAM'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.indicator).toBe('BUNKER_ROTTERDAM');
+    expect(json.value).toBe(620);
+    expect(json.unit).toBe('USD/MT');
+  });
+
+  it('R-177-2: BUNKER_ROTTERDAM queries NLRTM + VLSFO from DB', async () => {
+    mockGetLatestBunkerPrice.mockReturnValue(BUNKER_ROW);
+
+    await GET(makeRequest('BUNKER_ROTTERDAM'));
+
+    expect(mockGetLatestBunkerPrice).toHaveBeenCalledWith(expect.anything(), 'NLRTM', 'VLSFO');
+  });
+
+  it('R-177-3: BUNKER_ROTTERDAM with no DB row → 404', async () => {
+    mockGetLatestBunkerPrice.mockReturnValue(null);
+
+    const res = await GET(makeRequest('BUNKER_ROTTERDAM'));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/market/benchmark — EUA (issue #177)', () => {
+  const EUA_ROW = {
+    price_date: '2026-05-15',
+    price_eur_per_tco2: 65.4,
+    contract_type: 'spot',
+    source: 'https://ember-climate.org',
+    fetched_at: new Date().toISOString(),
+  };
+
+  it('R-177-4: ?indicator=EUA → 200 with value and unit EUR/tCO₂', async () => {
+    mockGetLatestEuaPrice.mockReturnValue(EUA_ROW);
+
+    const res = await GET(makeRequest('EUA'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.indicator).toBe('EUA');
+    expect(json.value).toBe(65.4);
+    expect(json.unit).toBe('EUR/tCO₂');
+  });
+
+  it('R-177-5: EUA with no DB row → 404', async () => {
+    mockGetLatestEuaPrice.mockReturnValue(null);
+
+    const res = await GET(makeRequest('EUA'));
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/components/dashboard-market-intelligence.test.tsx
+++ b/__tests__/components/dashboard-market-intelligence.test.tsx
@@ -1,15 +1,11 @@
 /**
- * TDD tests for γ-cleanup-4 F2: MarketIntelligence dashboard cleanup.
+ * TDD tests for MarketIntelligence KPI cards.
  *
- * All 4 KPI cards showed "Unavailable": Bunker Rotterdam + EUA EU ETS have
- * url=null (no backend), BHSI returns 503 (not implemented in benchmark.ts).
- * Fix: keep only Toepfer TMI (the only working indicator).
+ * Issue #177: Bunker Rotterdam + EUA EU ETS + BHSI restored now that
+ * /api/market/benchmark supports all three indicators via their respective
+ * DB repositories (bunker_prices, eua_prices, market_indices).
  *
- * Uses static JSX source analysis (fs.readFileSync) so no jsdom / React
- * setup overhead; the component file is the source of truth.
- *
- * We check for KpiCard label="…" patterns specifically — so TODO/JSDoc
- * comments mentioning removed labels do not cause false positives.
+ * Uses static JSX source analysis (fs.readFileSync) — component source is truth.
  */
 
 import * as fs from 'fs';
@@ -18,26 +14,24 @@ import * as path from 'path';
 const componentPath = path.join(process.cwd(), 'components/dashboard/MarketIntelligence.tsx');
 const source = fs.readFileSync(componentPath, 'utf8');
 
-// Extract only the JSX/TSX portion — strip single-line and multi-line comments
-// so TODO comments mentioning old label names don't cause false positives.
 const withoutComments = source
-  .replace(/\/\*[\s\S]*?\*\//g, '')   // block comments
-  .replace(/\/\/.*$/gm, '');           // line comments
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\/\/.*$/gm, '');
 
-describe('MarketIntelligence dashboard cleanup (γ-cleanup-4 F2)', () => {
-  it('contains Toepfer TMI KpiCard (the only implemented indicator)', () => {
+describe('MarketIntelligence KPI cards (issue #177)', () => {
+  it('renders Toepfer TMI KpiCard', () => {
     expect(withoutComments).toContain('Toepfer TMI');
   });
 
-  it('does NOT render Bunker Rotterdam KpiCard (url=null, no backend)', () => {
-    expect(withoutComments).not.toContain('Bunker Rotterdam');
+  it('renders Bunker Rotterdam KpiCard (backend implemented via bunker_prices DB)', () => {
+    expect(withoutComments).toContain('Bunker Rotterdam');
   });
 
-  it('does NOT render EUA EU ETS KpiCard (url=null, no backend)', () => {
-    expect(withoutComments).not.toContain('EUA EU ETS');
+  it('renders EUA EU ETS KpiCard (backend implemented via eua_prices DB)', () => {
+    expect(withoutComments).toContain('EUA EU ETS');
   });
 
-  it('does NOT render BHSI KpiCard (backend returns 503)', () => {
-    expect(withoutComments).not.toContain('BHSI');
+  it('renders BHSI KpiCard (backend implemented via market_indices DB)', () => {
+    expect(withoutComments).toContain('BHSI');
   });
 });

--- a/app/api/market/benchmark/route.ts
+++ b/app/api/market/benchmark/route.ts
@@ -2,12 +2,16 @@ import { NextResponse } from 'next/server';
 import type { MarketBenchmark, MarketIndicator } from '@/lib/types';
 import { getCurrentBenchmark } from '@/lib/market/benchmark';
 import { getLatestBalticIndex } from '@/lib/market/baltic-repository';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
+import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { getStore } from '@/lib/session-store';
 
 const VALID_INDICATORS: ReadonlySet<string> = new Set<MarketIndicator>([
   'TOEPFER_TMI',
   'DREWRY_BREAKBULK',
   'BHSI',
+  'BUNKER_ROTTERDAM',
+  'EUA',
 ]);
 
 /** Indicators sourced from the baltic_indices DB table (static seed). */
@@ -47,6 +51,32 @@ export async function GET(request: Request): Promise<NextResponse> {
     const row = getLatestBalticIndex(db, typedIndicator);
     if (row) {
       benchmark = rowToMarketBenchmark(row, typedIndicator);
+    }
+  } else if (typedIndicator === 'BUNKER_ROTTERDAM') {
+    const db = getStore().getDatabase();
+    const row = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
+    if (row) {
+      benchmark = {
+        indicator: typedIndicator,
+        value: row.price_usd_per_mt,
+        unit: 'USD/MT',
+        period: row.price_date,
+        sourceUrl: row.source,
+        fetchedAt: new Date().toISOString(),
+      };
+    }
+  } else if (typedIndicator === 'EUA') {
+    const db = getStore().getDatabase();
+    const row = getLatestEuaPrice(db);
+    if (row) {
+      benchmark = {
+        indicator: typedIndicator,
+        value: row.price_eur_per_tco2,
+        unit: 'EUR/tCO₂',
+        period: row.price_date,
+        sourceUrl: row.source,
+        fetchedAt: new Date().toISOString(),
+      };
     }
   }
 

--- a/components/dashboard/MarketIntelligence.tsx
+++ b/components/dashboard/MarketIntelligence.tsx
@@ -25,9 +25,21 @@ export function MarketIntelligence({ noActiveDeals }: MarketIntelligenceProps) {
           url="/api/market/benchmark?indicator=TOEPFER_TMI"
           unit="USD/day"
         />
-        {/* TODO(γ-cleanup-4 F2): Bunker Rotterdam, EUA EU ETS, BHSI placeholder cards
-            removed — backend not implemented. Restore when /api/market/benchmark
-            supports those indicators. Tracked: https://github.com/Vitali2011/quantika-demo/issues/177 */}
+        <KpiCard
+          label="BHSI"
+          url="/api/market/benchmark?indicator=BHSI"
+          unit="index"
+        />
+        <KpiCard
+          label="Bunker Rotterdam VLSFO"
+          url="/api/market/benchmark?indicator=BUNKER_ROTTERDAM"
+          unit="USD/MT"
+        />
+        <KpiCard
+          label="EUA EU ETS"
+          url="/api/market/benchmark?indicator=EUA"
+          unit="EUR/tCO₂"
+        />
       </div>
       {noActiveDeals && (
         <p className="text-sm text-gray-500 text-center py-2">

--- a/components/dashboard/__tests__/MarketIntelligence.test.tsx
+++ b/components/dashboard/__tests__/MarketIntelligence.test.tsx
@@ -26,22 +26,21 @@ describe('MarketIntelligence', () => {
     expect(screen.getByText(/Toepfer TMI/i)).toBeTruthy();
   });
 
-  // γ-cleanup-4 F2: Bunker Rotterdam, EUA, BHSI cards removed —
-  // backend not implemented (url=null placeholders / 503-only).
-  // Negative-contract tests guard against re-introduction without backend fix.
-  it('does NOT render Bunker Rotterdam (γ-cleanup-4 F2 — removed pending backend)', () => {
+  // Issue #177: Bunker Rotterdam, EUA, BHSI restored — backend now implemented
+  // via bunker_prices, eua_prices, and market_indices DB repositories.
+  it('renders Bunker Rotterdam card (issue #177 — backend implemented)', () => {
     render(<MarketIntelligence />);
-    expect(screen.queryByText(/Bunker Rotterdam/i)).toBeNull();
+    expect(screen.getByText(/Bunker Rotterdam/i)).toBeTruthy();
   });
 
-  it('does NOT render EUA (γ-cleanup-4 F2 — removed pending backend)', () => {
+  it('renders EUA card (issue #177 — backend implemented)', () => {
     render(<MarketIntelligence />);
-    expect(screen.queryByText(/EUA/i)).toBeNull();
+    expect(screen.getByText(/EUA/i)).toBeTruthy();
   });
 
-  it('does NOT render BHSI (γ-cleanup-4 F2 — removed pending backend)', () => {
+  it('renders BHSI card (issue #177 — backend implemented)', () => {
     render(<MarketIntelligence />);
-    expect(screen.queryByText(/BHSI/i)).toBeNull();
+    expect(screen.getByText(/BHSI/i)).toBeTruthy();
   });
 
   it('shows empty-state suggestion when no active deals', () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -79,7 +79,7 @@ export interface FuelEuResult {
 
 // ── Market Benchmark ──
 
-export type MarketIndicator = 'TOEPFER_TMI' | 'DREWRY_BREAKBULK' | 'BHSI';
+export type MarketIndicator = 'TOEPFER_TMI' | 'DREWRY_BREAKBULK' | 'BHSI' | 'BUNKER_ROTTERDAM' | 'EUA';
 
 export interface MarketBenchmark {
   indicator: MarketIndicator;


### PR DESCRIPTION
## Summary

- Extends `MarketIndicator` type with `BUNKER_ROTTERDAM` and `EUA`
- `/api/market/benchmark` now handles `BUNKER_ROTTERDAM` (reads `bunker_prices` table, port=NLRTM, grade=VLSFO) and `EUA` (reads `eua_prices` table, spot contract)
- `MarketIntelligence.tsx` restores all 3 missing KpiCards: BHSI, Bunker Rotterdam VLSFO, EUA EU ETS

## Test plan

- [x] 5 new tests in `__tests__/api/market/benchmark-route-bunker-eua.test.ts` (BUNKER_ROTTERDAM + EUA success/404/query params)
- [x] Negative-contract tests from γ-cleanup-4 F2 updated to positive-contract — backend now exists
- [x] All 160 market tests pass, all 26 benchmark tests pass
- [x] PI3 acknowledged: 6 existing assertions inverted (intentional — backend is now implemented)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)