### PR TITLE
feat(alerts): add email notification channel to fireAlert (#179) [code-only]

### DIFF
--- a/__tests__/lib/knowledge/alerts-email.test.ts
+++ b/__tests__/lib/knowledge/alerts-email.test.ts
@@ -10,6 +10,7 @@ jest.mock('resend', () => ({
     emails: { send: mockEmailsSend },
   })),
 }));
+jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }));
 
 describe('sendAlertEmail (issue #179)', () => {
   const CTX = { slug: 'ofac-sanctions', consecutiveFailures: 3, lastError: 'Timeout' };
@@ -70,12 +71,31 @@ describe('sendAlertEmail (issue #179)', () => {
     expect(call.html).toContain('Connection refused');
   });
 
-  it('resolves without throwing if Resend throws (caller handles via .catch)', async () => {
+  it('rejects with transport error — caller must handle via .catch', async () => {
     process.env.RESEND_API_KEY = 'test-key';
     process.env.ALERT_EMAIL_TO = 'admin@example.com';
     mockEmailsSend.mockRejectedValue(new Error('Resend API error'));
 
     await expect(sendAlertEmail(CTX)).rejects.toThrow('Resend API error');
+  });
+
+  it('strips HTML tags from slug and lastError in email body', async () => {
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    mockEmailsSend.mockResolvedValue({ data: { id: 'email-123' }, error: null });
+
+    await sendAlertEmail({
+      slug: '<img src=x onerror=alert(1)>injected-slug',
+      consecutiveFailures: 2,
+      lastError: '<style>body{display:none}</style>injected-error',
+    });
+
+    const call = mockEmailsSend.mock.calls[0][0];
+    expect(call.html).not.toContain('<img');
+    expect(call.html).not.toContain('<style>');
+    expect(call.html).not.toContain('onerror');
+    expect(call.html).toContain('injected-slug');
+    expect(call.html).toContain('injected-error');
   });
 });
 
@@ -95,7 +115,6 @@ describe('fireAlert — email integration (fire-and-forget)', () => {
 
   it('fireAlert completes without throwing even if email would error', async () => {
     const { fireAlert } = await import('@/lib/knowledge/alerts');
-    jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }));
 
     process.env.RESEND_API_KEY = 'test-key';
     process.env.ALERT_EMAIL_TO = 'admin@example.com';
@@ -108,5 +127,30 @@ describe('fireAlert — email integration (fire-and-forget)', () => {
     // flush microtasks to let fire-and-forget promise settle
     await Promise.resolve();
     await Promise.resolve();
+  });
+
+  it('throttles repeated emails for same slug within cooldown window', async () => {
+    const { fireAlert } = await import('@/lib/knowledge/alerts');
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    mockEmailsSend.mockResolvedValue({ data: { id: 'email-123' }, error: null });
+
+    const slug = 'throttle-test-unique-slug-abc123';
+
+    await fireAlert({ slug, consecutiveFailures: 2 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+
+    // second call within cooldown should be throttled
+    await fireAlert({ slug, consecutiveFailures: 3 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('throttled'));
+
+    logSpy.mockRestore();
   });
 });

--- a/__tests__/lib/knowledge/alerts-email.test.ts
+++ b/__tests__/lib/knowledge/alerts-email.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Issue #179: email notification channel via Resend in fireAlert.
+ * Tests sendAlertEmail exported function separately from Sentry path.
+ */
+import { sendAlertEmail } from '@/lib/knowledge/alerts';
+
+const mockEmailsSend = jest.fn();
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send: mockEmailsSend },
+  })),
+}));
+
+describe('sendAlertEmail (issue #179)', () => {
+  const CTX = { slug: 'ofac-sanctions', consecutiveFailures: 3, lastError: 'Timeout' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.ALERT_EMAIL_TO;
+  });
+
+  it('no-op when RESEND_API_KEY is missing', async () => {
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    await sendAlertEmail(CTX);
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
+
+  it('no-op when ALERT_EMAIL_TO is missing', async () => {
+    process.env.RESEND_API_KEY = 'test-key';
+    await sendAlertEmail(CTX);
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+  });
+
+  it('calls Resend with correct to/from/subject when env vars are set', async () => {
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    mockEmailsSend.mockResolvedValue({ data: { id: 'email-123' }, error: null });
+
+    await sendAlertEmail(CTX);
+
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const call = mockEmailsSend.mock.calls[0][0];
+    expect(call.to).toEqual(['admin@example.com']);
+    expect(call.subject).toContain('ofac-sanctions');
+    expect(call.subject).toContain('3');
+    expect(call.html).toContain('ofac-sanctions');
+    expect(call.html).toContain('3');
+  });
+
+  it('splits comma-separated ALERT_EMAIL_TO into array', async () => {
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'a@x.com, b@y.com';
+    mockEmailsSend.mockResolvedValue({ data: { id: 'email-123' }, error: null });
+
+    await sendAlertEmail(CTX);
+
+    const call = mockEmailsSend.mock.calls[0][0];
+    expect(call.to).toEqual(['a@x.com', 'b@y.com']);
+  });
+
+  it('includes lastError in email html when provided', async () => {
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    mockEmailsSend.mockResolvedValue({ data: { id: 'email-123' }, error: null });
+
+    await sendAlertEmail({ ...CTX, lastError: 'Connection refused' });
+
+    const call = mockEmailsSend.mock.calls[0][0];
+    expect(call.html).toContain('Connection refused');
+  });
+
+  it('resolves without throwing if Resend throws (caller handles via .catch)', async () => {
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    mockEmailsSend.mockRejectedValue(new Error('Resend API error'));
+
+    await expect(sendAlertEmail(CTX)).rejects.toThrow('Resend API error');
+  });
+});
+
+describe('fireAlert — email integration (fire-and-forget)', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.RESEND_API_KEY;
+    delete process.env.ALERT_EMAIL_TO;
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('fireAlert completes without throwing even if email would error', async () => {
+    const { fireAlert } = await import('@/lib/knowledge/alerts');
+    jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }));
+
+    process.env.RESEND_API_KEY = 'test-key';
+    process.env.ALERT_EMAIL_TO = 'admin@example.com';
+    mockEmailsSend.mockRejectedValue(new Error('Resend down'));
+
+    await expect(
+      fireAlert({ slug: 'test-source', consecutiveFailures: 2 })
+    ).resolves.not.toThrow();
+
+    // flush microtasks to let fire-and-forget promise settle
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/lib/knowledge/alerts.ts
+++ b/lib/knowledge/alerts.ts
@@ -1,11 +1,16 @@
 import * as Sentry from '@sentry/nextjs';
 import { Resend } from 'resend';
+import sanitizeHtml from 'sanitize-html';
 
 export interface AlertContext {
   slug: string;
   consecutiveFailures: number;
   lastError?: string;
 }
+
+const lastAlertSent = new Map<string, number>();
+const ALERT_COOLDOWN_MS = 5 * 60 * 1000;
+setInterval(() => lastAlertSent.clear(), 60 * 60 * 1000).unref?.();
 
 /**
  * Fires an alert for a knowledge source that has failed multiple times.
@@ -45,6 +50,15 @@ export async function fireAlert(ctx: AlertContext): Promise<void> {
     console.error('fireAlert failed (best-effort):', err);
   }
 
+  // Throttle: one email per slug per ALERT_COOLDOWN_MS to prevent inbox floods
+  const now = Date.now();
+  const lastSent = lastAlertSent.get(ctx.slug);
+  if (lastSent !== undefined && now - lastSent < ALERT_COOLDOWN_MS) {
+    console.log(`[alerts] throttled ${ctx.slug}: last sent ${Math.round((now - lastSent) / 1000)}s ago`);
+    return;
+  }
+  lastAlertSent.set(ctx.slug, now);
+
   // Fire-and-forget email notification (issue #179)
   void sendAlertEmail(ctx).catch(err => {
     console.error('sendAlertEmail failed (best-effort):', err);
@@ -65,14 +79,17 @@ export async function sendAlertEmail(ctx: AlertContext): Promise<void> {
   const to = toRaw.split(',').map(s => s.trim()).filter(Boolean);
   const from = process.env.RESEND_FROM_EMAIL ?? 'Quantika Alerts <alerts@quantika.app>';
 
+  const safeSlug = sanitizeHtml(ctx.slug, { allowedTags: [], allowedAttributes: {} });
+  const safeErr = sanitizeHtml(ctx.lastError ?? '', { allowedTags: [], allowedAttributes: {} });
+
   await resend.emails.send({
     from,
     to,
     subject: `[Quantika Alert] "${ctx.slug}" failed ${ctx.consecutiveFailures}× consecutively`,
     html: [
-      `<p>Knowledge source <strong>${ctx.slug}</strong> has failed`,
+      `<p>Knowledge source <strong>${safeSlug}</strong> has failed`,
       `<strong>${ctx.consecutiveFailures}</strong> times consecutively.</p>`,
-      ctx.lastError ? `<p>Last error: <code>${ctx.lastError}</code></p>` : '',
+      safeErr ? `<p>Last error: <code>${safeErr}</code></p>` : '',
     ].join('\n'),
   });
 }

--- a/lib/knowledge/alerts.ts
+++ b/lib/knowledge/alerts.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { Resend } from 'resend';
 
 export interface AlertContext {
   slug: string;
@@ -44,5 +45,34 @@ export async function fireAlert(ctx: AlertContext): Promise<void> {
     console.error('fireAlert failed (best-effort):', err);
   }
 
-  // TODO: email channel — for Phase 1 stub. Tracked: https://github.com/Vitali2011/quantika-demo/issues/179
+  // Fire-and-forget email notification (issue #179)
+  void sendAlertEmail(ctx).catch(err => {
+    console.error('sendAlertEmail failed (best-effort):', err);
+  });
+}
+
+/**
+ * Sends an alert email via Resend.
+ * Requires RESEND_API_KEY + ALERT_EMAIL_TO env vars; no-op if either is absent.
+ * Exported for unit testing; call sites use fire-and-forget via void.
+ */
+export async function sendAlertEmail(ctx: AlertContext): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const toRaw = process.env.ALERT_EMAIL_TO;
+  if (!apiKey || !toRaw) return;
+
+  const resend = new Resend(apiKey);
+  const to = toRaw.split(',').map(s => s.trim()).filter(Boolean);
+  const from = process.env.RESEND_FROM_EMAIL ?? 'Quantika Alerts <alerts@quantika.app>';
+
+  await resend.emails.send({
+    from,
+    to,
+    subject: `[Quantika Alert] "${ctx.slug}" failed ${ctx.consecutiveFailures}× consecutively`,
+    html: [
+      `<p>Knowledge source <strong>${ctx.slug}</strong> has failed`,
+      `<strong>${ctx.consecutiveFailures}</strong> times consecutively.</p>`,
+      ctx.lastError ? `<p>Last error: <code>${ctx.lastError}</code></p>` : '',
+    ].join('\n'),
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "posthog-js": "^1.372.3",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "resend": "^6.12.3",
         "sanitize-html": "^2.17.3",
         "sqlite-vec": "^0.1.9",
         "tailwind-merge": "^3.5.0",
@@ -15943,6 +15944,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15970,6 +15972,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
     },
     "node_modules/postcss": {
       "version": "8.5.12",
@@ -16691,6 +16699,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -17997,6 +18026,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "posthog-js": "^1.372.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "resend": "^6.12.3",
     "sanitize-html": "^2.17.3",
     "sqlite-vec": "^0.1.9",
     "tailwind-merge": "^3.5.0",


### PR DESCRIPTION
## Summary

- Installs `resend` package (Resend email API)
- Adds `sendAlertEmail()` called fire-and-forget (void) after the Sentry block in `fireAlert()`
- Requires env vars: `RESEND_API_KEY` + `ALERT_EMAIL_TO` (comma-separated). No-op if either is missing
- Optional: `RESEND_FROM_EMAIL` (defaults to `Quantika Alerts <alerts@quantika.app>`)
- Email subject and HTML body include slug, failure count, and optional `lastError`

## Test plan

- [x] 7 new tests in `__tests__/lib/knowledge/alerts-email.test.ts`: no-op for missing env vars, correct Resend params, comma-split recipients, lastError in html, Resend errors propagate to caller catch
- [x] All 9 existing `fireAlert` Sentry tests pass (0 expected values changed)
- [x] All 16 alerts tests pass total

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)