### PR TITLE
corpus(parse-cargo): normalize 64 cargo_description REFs to Maximalist if-present

### DIFF
--- a/.progonq/corpus/etms-parse-cargo/scenario-003.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-003.json
@@ -32,7 +32,7 @@
           "source_text": "Georgetown (Guyana)"
         },
         "cargo_description": {
-          "value": "Barite in break bulk",
+          "value": "Barite in big bags",
           "confidence": "confirmed",
           "source_text": "3000mts Barite in b.b"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-005.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-005.json
@@ -32,7 +32,7 @@
           "source_text": "Izmail - Egypt med"
         },
         "cargo_description": {
-          "value": "Wheat, stowage factor approximately 47-49 cubic feet per metric ton",
+          "value": "Wheat, stowage factor approximately 47-49",
           "confidence": "confirmed",
           "source_text": "8000 mts 10 pct wheat stw abt 47-49'"
         },
@@ -134,7 +134,7 @@
           "source_text": "Chornomorsk - Marghera"
         },
         "cargo_description": {
-          "value": "Steel scrap, stowage factor approximately 68-70 cubic feet per metric ton, approximately 200,000 cubic feet required for full cargo",
+          "value": "Steel scrap, stowage factor approximately 68-70, approximately 200,000 cubic feet required for full cargo of approximately 3,000 metric tons",
           "confidence": "confirmed",
           "source_text": "Need abt 200 000 cft for full cgo abt 3000 mts of steel scrap stw abt 68-70'"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-009.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-009.json
@@ -32,7 +32,7 @@
           "source_text": "Izmail / Antalya"
         },
         "cargo_description": {
-          "value": "Coal tar pitch in bulk bags",
+          "value": "Coal tar pitch in big bags, dimensions 1.4x1.4x1.1, unit weight 1.2 MT, about 2600 m3 required",
           "confidence": "confirmed",
           "source_text": "1500 mts +/-10% coal tar pitch in bb"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-014.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-014.json
@@ -28,7 +28,7 @@
           "value": null
         },
         "cargo_description": {
-          "value": "Steel products",
+          "value": "Steel products, stowage equals deadweight",
           "confidence": "confirmed",
           "source_text": "4300-4500 TS STEEL PRODUCTS STW DWT"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-015.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-015.json
@@ -32,7 +32,7 @@
           "source_text": "Varna West/Alexandria"
         },
         "cargo_description": {
-          "value": "Soda ash dense, bulk",
+          "value": "Soda dense, bulk, stowage factor about 1.1",
           "confidence": "confirmed",
           "source_text": "soda dense bulk"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-016.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-016.json
@@ -121,7 +121,7 @@
           "source_text": "Reni - Marmara or Izmir, in ch's op."
         },
         "cargo_description": {
-          "value": "Steel scrap (loose bulk); vessel required with approximately 250,000 cubic feet cargo capacity",
+          "value": "Scrap cargo; vessel required with 250000 cubic feet (+/-) capacity, but may try any vessel's intake",
           "confidence": "confirmed",
           "source_text": "need vessel with 250000 cub.ft. (+/-) for scrap cargo (but may try any vessel's intake)"
         },
@@ -205,7 +205,7 @@
           "source_text": "Chornomorsk - Poti"
         },
         "cargo_description": {
-          "value": "Sugar in big bags; bag dimensions 120x100x110 cm, unit weight approximately 1.0 tonnes",
+          "value": "Sugar in big bags; bag dimensions 120x100x110 cm, unit weight approximately 1.0 tonnes, no tiers limitations",
           "confidence": "confirmed",
           "source_text": "3000-3500 mts of sugar in bb (dims: LxBxH: 120x100x110cm, UW: abt 1,0 tns)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-017.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-017.json
@@ -140,7 +140,7 @@
           "source_text": "El Arish / Tartous"
         },
         "cargo_description": {
-          "value": "Bagged cement in jumbo bags",
+          "value": "6000-7000 tons bagged cement in jumbo bags",
           "confidence": "confirmed",
           "source_text": "6000 - 7000tns baged cement (Jumbo bags)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-018.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-018.json
@@ -229,7 +229,7 @@
           "source_text": "Hereke/Birkenhead"
         },
         "cargo_description": {
-          "value": "Wire Mesh",
+          "value": "Wire Mesh, about 4500 cbm",
           "confidence": "confirmed",
           "source_text": "2000 mt Wire Mesh (Abt 4500 cbm)"
         },
@@ -327,7 +327,7 @@
           "source_text": "Hereke/Greenore"
         },
         "cargo_description": {
-          "value": "Wire Mesh",
+          "value": "Wire Mesh (Abt 2500 cbm)",
           "confidence": "confirmed",
           "source_text": "1000 mt Wire Mesh (Abt 2500 cbm)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-021.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-021.json
@@ -35,7 +35,7 @@
         },
         "weight_per_port": null,
         "cargo_description": {
-          "value": null
+          "value": ""
         },
         "cargo_origin_country": null,
         "weight_mt": {

--- a/.progonq/corpus/etms-parse-cargo/scenario-022.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-022.json
@@ -32,7 +32,7 @@
           "source_text": "Savona /  Samsun"
         },
         "cargo_description": {
-          "value": "Metallurgical coke (metcoke) in bulk, 3 grades: Grade 1 2,000 MT 60-140mm stw abt 74/75 ft³/MT; Grade 2 6,000 MT 60-100mm stw abt 69/70 ft³/MT; Grade 3 2,000 MT 90-250mm stw abt 76/77 ft³/MT. Holdwise grade separation required.",
+          "value": "Metallurgical coke (metcoke) in bulk, 3 grades: Grade 1 2,000 MT (+/-10%) 60-140mm stowage factor about 74-75; Grade 2 6,000 MT (+/-10%) 60-100mm stowage factor about 69-70; Grade 3 2,000 MT (+/-10%) 90-250mm stowage factor about 76-77. Holdwise grade separation required.",
           "confidence": "confirmed",
           "source_text": "metcoke in bulk,3 grades"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-026.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-026.json
@@ -32,7 +32,7 @@
           "source_text": "Thisvi  / Monfalcone"
         },
         "cargo_description": {
-          "value": null,
+          "value": "",
           "confidence": null
         },
         "cargo_origin_country": {

--- a/.progonq/corpus/etms-parse-cargo/scenario-031.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-031.json
@@ -32,7 +32,7 @@
           "source_text": "Iskenderun/Constanta"
         },
         "cargo_description": {
-          "value": "Bulk minerals, non-IMO (non-hazardous)",
+          "value": "Bulk minerals, non-IMO",
           "confidence": "confirmed",
           "source_text": "7.000mts blk minerals,not imo"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-034.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-034.json
@@ -32,7 +32,7 @@
           "source_text": "Kavkaz/Berbera"
         },
         "cargo_description": {
-          "value": "Wheat, stowage factor 47 ft³/MT",
+          "value": "Wheat, stowage factor 47",
           "confidence": "confirmed",
           "source_text": "30000 mt 10% in OO wheat SF 47"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-035.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-035.json
@@ -138,7 +138,7 @@
           "confidence": null
         },
         "cargo_description": {
-          "value": "Salt in big bags (1.1m x 1.1m x 1.1m, unit weight 1.25 MT/bag) + Rice in big bags (1.05m x 1.05m x 1.35m, unit weight 1.0 MT/bag); combined cargo break bulk",
+          "value": "Salt in big bags (1.1m x 1.1m x 1.1m, unit weight 1.25 MT/bag) + Rice in big bags (1.05m x 1.05m x 1.35m, unit weight 1.0 MT/bag)",
           "confidence": "confirmed",
           "source_text": "6000 -7000 mts of salt/rice in bb (1,1x1,1x1,1, uw 1,25) + rice (1,05x1,05x1,35, uw 1 mt)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-037.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-037.json
@@ -211,7 +211,7 @@
           "source_text": "Reni - Marmara or Izmir, in ch's op."
         },
         "cargo_description": {
-          "value": "Steel scrap",
+          "value": "scrap cargo",
           "confidence": "confirmed",
           "source_text": "need vessel with 250000 cub.ft. (+/-) for scrap cargo (but may try any vessel's intake)"
         },
@@ -386,7 +386,7 @@
           "source_text": "Chornomorsk - Poti"
         },
         "cargo_description": {
-          "value": "Sugar in big bags, dimensions 120x100x110cm (LxBxH), unit weight approximately 1.0 tonnes per bag",
+          "value": "Sugar in big bags, dimensions 120x100x110cm (LxBxH), unit weight approximately 1.0 tonnes per bag, no tiers limitations",
           "confidence": "confirmed",
           "source_text": "3000-3500 mts of sugar in bb (dims: LxBxH: 120x100x110cm, UW: abt 1,0 tns)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-039.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-039.json
@@ -160,7 +160,7 @@
           "source_text": "1 Sbp Birkenhead, Uk"
         },
         "cargo_description": {
-          "value": "Hot Rolled Coils (HRC), max 2 tiers, unit weight approximately 26 MT. Expected quantity 5,330 MT.",
+          "value": "Hot Rolled Coils (HRC), minimum 5,250 MT 5 pct more chopt, max 2 tiers, unit weight approximately 26 MT, expected quantity 5,330 MT",
           "confidence": "confirmed",
           "source_text": "Min 5,250 Mts Hrc 5 Pct More Chopt Max 2 Tiers Uw Abt 26 Mt (Expect 5,330 Mts)"
         },
@@ -288,7 +288,7 @@
           "source_text": "1 Sb-2 Sp Gemlik And Yildiz Entegre"
         },
         "cargo_description": {
-          "value": "Hot Rolled Coils / Plates Not Otherwise specified (HRC/PNO), max 2 tiers, unit weight approximately 26 MT. Expected: Gemlik 12,700 MT, Yildiz Entegre 5,000 MT.",
+          "value": "Hot Rolled Coils (HRC) / Plates Not Otherwise Specified (PNO), max 2 tiers, unit weight approximately 26 MT, expected Gemlik 12,700 MT and Yildiz Entegre 5,000 MT",
           "confidence": "confirmed",
           "source_text": "Min 17,500 Mts Hrc/Pno 5 Pct More Chopt Max 2 Tiers Uw Abt 26 Mt (Expect Gemlik 12,700 Mts And Yildiz Entegre: 5,000 Mts)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-042.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-042.json
@@ -32,7 +32,7 @@
           "source_text": "Marmara (Hereke) / Constanta"
         },
         "cargo_description": {
-          "value": "PC Strand coils, Diameter: 130-140 cm, H: 80 cm, Unit Weight: 3-3.5 MT, Tier limit: 2",
+          "value": "PC Strand, Diameter: 130-140 cm, H: 80 cm, Unit Weight: 3-3.5 MT, Tier limit: 2",
           "confidence": "confirmed",
           "source_text": "PC Strand,  Diameter :130-140 cm,  H: 80 cm UW: 3-3,5 MT, Tier limit: 2"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-046.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-046.json
@@ -32,7 +32,7 @@
           "source_text": "izmir  Alsancak  /  Arzew"
         },
         "cargo_description": {
-          "value": "10 units mobile machinery, part cargo, over-deck stowage acceptable, drawings available",
+          "value": "10 units mobile machinery, total weight about 600 MT, part cargo, over-deck stowage acceptable, drawings available",
           "confidence": "confirmed",
           "source_text": "10 units mobile machinery"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-048.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-048.json
@@ -32,7 +32,7 @@
           "source_text": "2 SB Iskenderun - POC/Ukraine"
         },
         "cargo_description": {
-          "value": "Steel products (5000 MT from Tosyali + 2700-2800 MT from Isdemir), stowage equals deadweight",
+          "value": "Steel products (5000 MT from Tosyali + 2700-2800 MT from Isdemir), stowage equals deadweight, all hold type workable",
           "confidence": "confirmed",
           "source_text": "7700-7800 Mts steel prod. stw=dwt\n(5000 + 2700 or 2800mts)\nNote: Will load 5000mts fm Tosyali + 2700-2800mtd fm Isdemir"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-053.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-053.json
@@ -32,7 +32,7 @@
           "source_text": "Pivdennyi / La Coruna"
         },
         "cargo_description": {
-          "value": "Rapeseed meal pellets in bulk",
+          "value": "Rapeseed meal pellets in bulk, stowage factor 58",
           "confidence": "confirmed",
           "source_text": "6000 mts +/-10% of rapeseed meal pellets in bulk, sf  58'"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-054.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-054.json
@@ -32,7 +32,7 @@
           "source_text": "Sfax, Tunisia  / Dakar"
         },
         "cargo_description": {
-          "value": "Olive pomace, stowage factor 58 ft³/MT, non-IMO",
+          "value": "Olive pomace, stowage factor 58, non-IMO",
           "confidence": "confirmed",
           "source_text": "min 12.000 mts Olive pomace stw factor 58' (non IMO)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-055.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-055.json
@@ -28,7 +28,7 @@
         },
         "destination_country": null,
         "cargo_description": {
-          "value": "Salt in break bulk, bags 1.1m x 1.1m x 1.1m, unit weight 1.25 mt",
+          "value": "Salt in big bags, 1.1x1.1x1.1, unit weight 1.25 mt",
           "confidence": "confirmed",
           "source_text": "5500 mts of salt in bb  (1,1x1,1x1,1, uw 1,25)  Egypt Med/POC"
         },
@@ -101,7 +101,7 @@
         },
         "destination_country": null,
         "cargo_description": {
-          "value": "Combined cargo of salt and rice in break bulk. Salt: bags 1.1m x 1.1m x 1.1m, unit weight 1.25 mt. Rice: bags 1.05m x 1.05m x 1.35m, unit weight 1.0 mt. Two load ports: Damietta (Egypt) and Mersin (Turkey).",
+          "value": "6000-7000 mts of salt/rice in big bags, salt dimensions 1.1x1.1x1.1, unit weight 1.25 mt, rice dimensions 1.05x1.05x1.35, unit weight 1 mt",
           "confidence": "confirmed",
           "source_text": "6000 -7000 mts of salt/rice in bb \n(1,1x1,1x1,1, uw 1,25) + rice (1,05x1,05x1,35, uw 1 mt) \nDamietta+Mersin/POC"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-056.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-056.json
@@ -30,7 +30,7 @@
           "value": null
         },
         "cargo_description": {
-          "value": "Not specified — vessel solicitation for box/box-like vessel",
+          "value": "",
           "confidence": "uncertain",
           "source_text": "need 2500/3000 box,boxlike"
         },
@@ -132,7 +132,7 @@
           "source_text": "1 Marmara/1 Continent"
         },
         "cargo_description": {
-          "value": "Not specified — vessel solicitation for box/box-like vessel",
+          "value": "",
           "confidence": "uncertain",
           "source_text": "3500/3800 dwcc, box/boxlike vsl"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-057.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-057.json
@@ -32,7 +32,7 @@
           "source_text": "NEMRUT / SAGUNTO"
         },
         "cargo_description": {
-          "value": "HRC (Hot Rolled Coils) + HRCPO, unit weight approximately 10/27 metric tons per piece",
+          "value": "Hot Rolled Coils (HRC) + HRCPO, unit weight approximately 10/27 metric tons per piece",
           "confidence": "interpreted",
           "source_text": "11,375mts 2PCT MOLCHOPT HRC + HRCPO UW ABT 10/27TS"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-059.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-059.json
@@ -220,7 +220,7 @@
           "source_text": "FUJAIRAH/ MOGADISHU 11 M DRAFT"
         },
         "cargo_description": {
-          "value": "Bulk Aggregate",
+          "value": "Bulk Aggregate, geared and grabber for discharge",
           "confidence": "confirmed",
           "source_text": "50,000 MTS +/- 10% BULK AGGREGATE"
         },
@@ -324,7 +324,7 @@
           "source_text": "POD: Sohar"
         },
         "cargo_description": {
-          "value": "Sawn Timber in bundles",
+          "value": "Sawn Timber in bundles, on-deck loading ok",
           "confidence": "confirmed",
           "source_text": "Cargo Type: Sawn Timber in bundles"
         },
@@ -417,7 +417,7 @@
           "source_text": "Discharge Port – Fujairah"
         },
         "cargo_description": {
-          "value": "Pine Sawn Timber",
+          "value": "Pine Sawn Timber, stowage factor about 52",
           "confidence": "confirmed",
           "source_text": "Pine Sawn Timber"
         },
@@ -753,7 +753,7 @@
           "source_text": "POD: Jeddah"
         },
         "cargo_description": {
-          "value": "MDF (Medium Density Fibreboard)",
+          "value": "MDF (Medium Density Fibreboard), 1 net CBM = 1.12 gross CBM",
           "confidence": "interpreted",
           "source_text": "MDF"
         },
@@ -919,7 +919,7 @@
           "source_text": "POD: Conakry"
         },
         "cargo_description": {
-          "value": "Thai Parboiled Rice 100% Sorted (12,500 MT) and Thai White Rice 25% Broken (12,500 MT)",
+          "value": "Thai Parboiled Rice 100% Sorted (12,500 MT) and Thai White Rice 25% Broken (12,500 MT), packing in new PP of 50 kgs with Jumbo bag total 1 MT",
           "confidence": "confirmed",
           "source_text": "1- Thai Parboiled Rice 100% Sorted , Quantity 12,500 mt 2-Thai White Rice 25% Broken , Quantity 12,500 mt"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-061.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-061.json
@@ -34,11 +34,13 @@
         "destination_port_rotation": ["Banjul", "Dakar"],
         "weight_per_port": [10000, 30000],
         "cargo_description": {
-          "value": "Bagged rice, stowage factor 48-50 ft³/MT WOG",
+          "value": "Bagged rice, stowage factor 48-50 WOG, 10,000 MT to Banjul and 30,000 MT to Dakar",
           "confidence": "confirmed",
           "source_text": "40,000 mts of bagged rice sf 48-50 wog"
         },
-        "cargo_origin_country": { "value": null },
+        "cargo_origin_country": {
+          "value": null
+        },
         "weight_mt": {
           "value": 40000,
           "confidence": "confirmed",
@@ -91,7 +93,9 @@
           "confidence": "confirmed",
           "source_text": "3.75pct"
         },
-        "commission_terms": { "value": null },
+        "commission_terms": {
+          "value": null
+        },
         "special_requirements": {
           "value": "Bagged cargo; stowage factor 48-50 WOG. Rotation: 10,000 MT to Banjul (2,000 MT/day) then 30,000 MT to Dakar (1,500 MT/day PWWD SSHEX EIU). 'sshe eiu' for Dakar assumed SSHEX EIU.",
           "confidence": "confirmed",

--- a/.progonq/corpus/etms-parse-cargo/scenario-062.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-062.json
@@ -32,7 +32,7 @@
           "source_text": "discharge port : 10,000 mts to banjul, gambia + 30,000 mts to dakar, senegal"
         },
         "cargo_description": {
-          "value": "Bagged rice, stowage factor 48-50 ft³/MT (WOG)",
+          "value": "Bagged rice, stowage factor 48-50, without guarantee",
           "confidence": "confirmed",
           "source_text": "40,000 mts of bagged rice sf 48-50 wog"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-064.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-064.json
@@ -156,7 +156,7 @@
           "source_text": "conakary, west africa (10m sw)"
         },
         "cargo_description": {
-          "value": "Rice in 50 kg bags",
+          "value": "Rice in 50 kg bags, stowage factor about 1.4, without guarantee",
           "confidence": "confirmed",
           "source_text": "30,000 mt 10% moloo rice in 50 kgs bags (sf abt 1.4 cbm/mt wog)"
         },
@@ -281,7 +281,7 @@
           "source_text": "dhamra, ec india / durban, south africa"
         },
         "cargo_description": {
-          "value": "Bagged rice in 50 kg bags",
+          "value": "Bagged rice in 50 kg bags, stowage factor about 1.4, without guarantee",
           "confidence": "confirmed",
           "source_text": "25000/35000 mt bgd rice in 50 kg bags (sf abt 1.4 cbm/mt wog)"
         },
@@ -404,7 +404,7 @@
           "source_text": "dssch port conakary, guinea"
         },
         "cargo_description": {
-          "value": "Rice in bags; two load ports: Ko Si Chang (10,000 MT) and Kakinada Anchorage (balance). Max draft at discharge port 10.00m.",
+          "value": "30,000 MT +/-10% rice in bags; Kosichang 10,000 MT and Kakinada Anchorage balance",
           "confidence": "confirmed",
           "source_text": "30,000 mt 10% rice in bags (max draft at dsch port 10.00m)\nkosichang (10,000 mt) + kakinada anchorage (balance)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-065.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-065.json
@@ -32,7 +32,7 @@
           "source_text": "1 Marmara"
         },
         "cargo_description": {
-          "value": "Bulk sunflower seeds, stowage factor approximately 87 ft³/MT",
+          "value": "Bulk sunflower seeds, stowage factor approximately 87",
           "confidence": "confirmed",
           "source_text": "2,000 mts 10% bulk sunflower seeds, sf.abt 87'"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-067.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-067.json
@@ -33,7 +33,7 @@
           "source_text": "TO 1SP LIBYA OR MERSIN IN CHOPT"
         },
         "cargo_description": {
-          "value": "Bagged sugar, stowage factor approximately 50 ft³/MT",
+          "value": "Bagged sugar, stowage factor approximately 50",
           "confidence": "confirmed",
           "source_text": "15.000 MTS BAGGED SUGAR STW FACTOR ABT 50'"
         },
@@ -129,7 +129,7 @@
           "source_text": "TO 1SP TURKISH EAST MED OR 1SP SYRIA OR 1SP LEBANON OR 1SP LIBYA IN CHOPT"
         },
         "cargo_description": {
-          "value": "Bagged sugar, stowage factor approximately 50 ft³/MT",
+          "value": "Bagged sugar, stowage factor approximately 50",
           "confidence": "confirmed",
           "source_text": "ABT 5-10.000 MTS BAGGED SUGAR STW FACTOR ABT 50'"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-069.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-069.json
@@ -32,7 +32,7 @@
           "source_text": "Ambarli to Grimsby"
         },
         "cargo_description": {
-          "value": "Soft stainless steel scrap, stowage approximately 66 ft³/MT WOG, no trimming/pressing inside hold",
+          "value": "Soft stainless scrap, stowage factor approximately 66, without guarantee, no trimming/pressing inside hold",
           "confidence": "confirmed",
           "source_text": "abt 3500 mts of soft stainless SCRAP stw abt 66' wog (no trimming/pressing inside hold)"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-072.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-072.json
@@ -32,7 +32,7 @@
           "source_text": "1 sp Sweden"
         },
         "cargo_description": {
-          "value": "Bulk cargo (type unspecified)",
+          "value": "Bulk cargo",
           "confidence": "uncertain",
           "source_text": "3.500/8.000 mts bulk cargo"
         },
@@ -126,7 +126,7 @@
           "source_text": "1 sp Sweden"
         },
         "cargo_description": {
-          "value": "Bulk cargo (type unspecified)",
+          "value": "Bulk cargo",
           "confidence": "uncertain",
           "source_text": "3.500/8.000 mts bulk cargo"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-074.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-074.json
@@ -32,7 +32,7 @@
           "source_text": "1 North spain / 1 Portugal"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous), owners option",
+          "value": "Bulk non-IMO cargo, in owners option",
           "confidence": "interpreted",
           "source_text": "3000-6000  mtons of bulk non imo in owners option"
         },
@@ -135,7 +135,7 @@
           "source_text": "1 Portugal  / 1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous), owners option",
+          "value": "Bulk non-IMO cargo, owners option",
           "confidence": "interpreted",
           "source_text": "3000-6000  mtons of bulk non imo in owners option"
         },
@@ -238,7 +238,7 @@
           "source_text": "1 Portugal  / 1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous), owners option",
+          "value": "Bulk non-IMO cargo, owners option",
           "confidence": "interpreted",
           "source_text": "6000  mtons of bulk non imo in owners option"
         },
@@ -340,7 +340,7 @@
           "source_text": "1 Algeria / 1 Portugal"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "Bulk non-IMO cargo",
           "confidence": "interpreted",
           "source_text": "7000-7700  mtons of bulk non imo"
         },
@@ -444,7 +444,7 @@
           "source_text": "1 Portugal  / 1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous), owners option",
+          "value": "Bulk non-IMO cargo, owners option",
           "confidence": "interpreted",
           "source_text": "3500-5000  mtons of bulk non imo in owners option"
         },
@@ -546,7 +546,7 @@
           "source_text": "1 Portugal  / 1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous), owners option",
+          "value": "bulk non-IMO, in owners option",
           "confidence": "interpreted",
           "source_text": "5000  mtons of bulk non imo in owners option"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-075.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-075.json
@@ -32,7 +32,7 @@
           "source_text": "1 North spain / 1 Portugal"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "Bulk non-IMO cargo",
           "confidence": "interpreted",
           "source_text": "3000-6000  mtons of bulk non imo in owners option"
         },
@@ -133,7 +133,7 @@
           "source_text": "1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "bulk non-IMO in owners option",
           "confidence": "interpreted",
           "source_text": "3000-6000  mtons of bulk non imo in owners option"
         },
@@ -235,7 +235,7 @@
           "source_text": "1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "bulk non-IMO cargo",
           "confidence": "interpreted",
           "source_text": "6000  mtons of bulk non imo in owners option"
         },
@@ -336,7 +336,7 @@
           "source_text": "1 Algeria / 1 Portugal"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "Bulk non-IMO cargo",
           "confidence": "interpreted",
           "source_text": "7000-7700  mtons of bulk non imo"
         },
@@ -439,7 +439,7 @@
           "source_text": "1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "Bulk non-IMO cargo in owners option",
           "confidence": "interpreted",
           "source_text": "3500-5000  mtons of bulk non imo in owners option"
         },
@@ -540,7 +540,7 @@
           "source_text": "1  Spanmed"
         },
         "cargo_description": {
-          "value": "Bulk non-IMO cargo (non-hazardous)",
+          "value": "Bulk non-IMO cargo in owners option",
           "confidence": "interpreted",
           "source_text": "5000  mtons of bulk non imo in owners option"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-076.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-076.json
@@ -27,13 +27,17 @@
           "confidence": "uncertain",
           "source_text": "1 out of POC"
         },
-        "destination_country": { "value": null },
+        "destination_country": {
+          "value": null
+        },
         "cargo_description": {
-          "value": "Salt (non-food, industrial grade); El Arish: fully bulk; El Dekheila: 1 hold big-bags + other holds bulk",
+          "value": "Salt (non-food, industrial grade); El Arish: fully bulk; El Dekheila: 1 hold big-bags + other hold bulk",
           "confidence": "confirmed",
           "source_text": "salt (non-food, industrial grade), 1 HO in big-bags, other HO in bulk"
         },
-        "cargo_origin_country": { "value": null },
+        "cargo_origin_country": {
+          "value": null
+        },
         "weight_mt": {
           "value": 16000,
           "confidence": "interpreted",
@@ -69,9 +73,17 @@
           "confidence": "interpreted",
           "source_text": "LC 02.02 - onward"
         },
-        "loading_rate": { "value": 3000, "confidence": "confirmed", "source_text": "3000/1000" },
+        "loading_rate": {
+          "value": 3000,
+          "confidence": "confirmed",
+          "source_text": "3000/1000"
+        },
         "loading_terms": null,
-        "discharge_rate": { "value": 1000, "confidence": "confirmed", "source_text": "3000/1000" },
+        "discharge_rate": {
+          "value": 1000,
+          "confidence": "confirmed",
+          "source_text": "3000/1000"
+        },
         "discharge_terms": null,
         "commission_percent": {
           "value": 2.5,

--- a/.progonq/corpus/etms-parse-cargo/scenario-079.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-079.json
@@ -33,7 +33,7 @@
           "source_text": "Conakry, Guinea"
         },
         "cargo_description": {
-          "value": "Bulk corn, stowage factor approximately 51 ft³/MT",
+          "value": "Bulk corn, stowage factor approximately 51",
           "confidence": "confirmed",
           "source_text": "20,000/22,000 mt bulk corn 51abt"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-083.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-083.json
@@ -32,7 +32,7 @@
           "source_text": "TUAPSE / GIJON"
         },
         "cargo_description": {
-          "value": "Anthracite, stowage factor 43 ft³/MT",
+          "value": "Anthracite, stowage factor 43",
           "confidence": "confirmed",
           "source_text": "7.000 mts anthracite sf 43"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-085.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-085.json
@@ -32,7 +32,7 @@
           "source_text": "TUAPSE / GIJON"
         },
         "cargo_description": {
-          "value": "Anthracite, stowage factor 43 ft³/MT",
+          "value": "Anthracite, stowage factor 43",
           "confidence": "confirmed",
           "source_text": "7.000 mts anthracite sf 43"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-086.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-086.json
@@ -32,7 +32,7 @@
           "source_text": "THESSALONIKI =>1 MARMARA (INT.TEKIRDAG)"
         },
         "cargo_description": {
-          "value": "Paddy rice in bulk, stowage factor approximately 62 ft³/MT",
+          "value": "Paddy rice in bulk, stowage factor approximately 62",
           "confidence": "confirmed",
           "source_text": "5.000 PADDY RICE IN BLK,SF ABT 62'"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-088.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-088.json
@@ -33,7 +33,7 @@
           "source_text": "tbs/marmara/izmir range /mersin range"
         },
         "cargo_description": {
-          "value": "Soyabean, stowage factor approximately 51 ft³/MT",
+          "value": "Soyabean, stowage factor approximately 51",
           "confidence": "confirmed",
           "source_text": "6500-7500k soyabean sf abt 51"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-090.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-090.json
@@ -32,7 +32,7 @@
           "source_text": "Pidennyi - Cyprus"
         },
         "cargo_description": {
-          "value": "Corn, stowage factor 50 ft³/MT",
+          "value": "Corn, stowage factor 50",
           "confidence": "confirmed",
           "source_text": "5000-6000 mt Corn sf 50"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-091.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-091.json
@@ -32,7 +32,7 @@
           "source_text": "Odesa to EC Italy"
         },
         "cargo_description": {
-          "value": "Wheat, stowage factor approximately 47 cubic feet per metric ton, without guarantee",
+          "value": "Wheat, stowage factor approximately 47, without guarantee",
           "confidence": "confirmed",
           "source_text": "7200 – 12 000 mts of Wheat sf abt 47' wog"
         },

--- a/.progonq/corpus/etms-parse-cargo/scenario-093.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-093.json
@@ -32,7 +32,7 @@
           "source_text": "NEMRUT / CATANIA"
         },
         "cargo_description": {
-          "value": "Hot Rolled Coils (HRC), unit weight approximately 1.8–2.1 tons, stowage max 50 inches",
+          "value": "WRIC, unit weight approximately 1.8/2.1 tons, stowage factor max 50",
           "confidence": "interpreted",
           "source_text": "3,000MTS 1PCT MOLCHOPT WRIC UW ABT 1,8/2,1TS STW MAX 50'"
         },

--- a/scripts/progonq/normalize-cargo-refs.ts
+++ b/scripts/progonq/normalize-cargo-refs.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Normalize cargo_description REFs in corpus scenarios.
+ *
+ * Standard: Maximalist if-present.
+ *   REF MUST include every cargo detail mentioned in the source email:
+ *   stowage factor, dimensions, unit weight, per-port/per-mill quantity split,
+ *   tier limit, handling notes (no trimming, separation required, etc.),
+ *   IMO classification, on-deck stowage permission, packaging form.
+ *   If NOT mentioned in the email, MUST NOT be added.
+ *
+ * Output: .progonq/normalize/cargo-refs-proposed.json with proposed normalized
+ * REFs + per-item reason + confidence. NO writes to corpus yet — review first.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local /tmp/normalize-cargo-refs.ts [--limit N] [--scenario sid]
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { callAiText } from '@/lib/ai-provider';
+
+const CORPUS_DIR = path.resolve(process.cwd(), '.progonq/corpus/etms-parse-cargo');
+const OUT_DIR = path.resolve(process.cwd(), '.progonq/normalize');
+const OUT_PATH = path.join(OUT_DIR, 'cargo-refs-proposed.json');
+
+const SYSTEM = `You normalize cargo_description ground truth REFs for a shipping cargo inquiry parser eval corpus.
+
+STANDARD — Maximalist if-present:
+A correct REF cargo_description for an item MUST include every cargo detail the source email mentions for that specific cargo:
+- Stowage factor (e.g. "stowage factor 51-52", "stowage equals deadweight" if STW DWT)
+- Dimensions (LxHxW or DxH for bags/coils)
+- Unit weight / per-piece weight
+- Per-port / per-mill quantity split when the email gives different qty per load port or mill source (e.g. "5000 MT from Tosyali + 2700 MT from Isdemir", "Ko Si Chang 10,000 MT and Kakinada balance")
+- Tier / stacking limit when stated
+- Handling / hold-treatment notes (no trimming, no pressing, holdwise separation, on-deck permitted, IMO non-IMO classification)
+- Multi-grade specifics (grade name + quantity + size range + stowage)
+- Packaging form (bagged / break-bulk / in bulk / containers — keep EXACTLY as email says)
+
+A correct REF MUST NOT include details that are NOT in the email — no invented stowage, no hallucinated CBM, no fabricated unit weight.
+
+Format rules:
+- Concise noun phrase, NOT a sentence.
+- Expand abbreviations: HRC → "Hot Rolled Coils (HRC)", PNO → "Plates Not Otherwise Specified (PNO)", bb → "big bags", stw → "stowage factor".
+- Normalize European decimals: "1,25" → "1.25".
+- Do NOT include unit notations (ft³/MT, m³/MT) inside cargo_description — units go in separate stowage_factor field.
+- Stowage factor in cargo_description = bare number range, e.g. "stowage factor 51-52, without guarantee".
+- If email says commodity is TBN/awaiting nomination/not specified, write exactly "Not specified".
+- If email mentions no commodity at all (vessel position circular), use empty string "".
+
+You will receive: source email body + current REF cargo_description for ONE item.
+Return STRICT JSON with no preamble or markdown:
+{
+  "normalized_ref": "<the corrected REF following Maximalist if-present>",
+  "changed": <true if normalized_ref differs from current REF, else false>,
+  "reason": "<short explanation: what was added/removed/kept and why>",
+  "confidence": "<high|medium|low>"
+}
+
+confidence=low when: email is ambiguous, multiple cargos in one email and item-level mapping unclear, or you're uncertain a detail belongs to THIS item vs another.
+
+CRITICAL — minimal-change discipline:
+If the current REF already contains all email-mentioned cargo details (under the Maximalist if-present rule), return it UNCHANGED — set changed=false and normalized_ref=current_ref exactly. Do NOT make cosmetic changes:
+- Do NOT change capitalization unless the current REF has a clear case error
+- Do NOT expand short forms like "max" → "maximum" when both are clear
+- Do NOT rephrase wording for style
+- Do NOT add punctuation/spacing tweaks
+ONLY change the REF when there is SUBSTANTIVE information difference: adding an email-mentioned detail that's missing, or removing a detail that's NOT in the email (hallucination).`;
+
+interface Proposed {
+  scenario_id: string;
+  item_index: number;
+  current_ref: string;
+  normalized_ref: string;
+  changed: boolean;
+  reason: string;
+  confidence: string;
+  error?: string;
+}
+
+async function normalizeOne(email: string, currentRef: string, itemIdx: number, totalItems: number): Promise<Omit<Proposed, 'scenario_id' | 'item_index'>> {
+  const user = `=== SOURCE EMAIL ===\n${email.slice(0, 6000)}\n\n=== CURRENT REF (item ${itemIdx + 1} of ${totalItems}) ===\n${currentRef}\n\nReturn the JSON.`;
+  let lastErr = '';
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      const text = await callAiText('JUDGE', SYSTEM, user, { temperature: 0 });
+      // Strip code fences if present
+      let body = text.trim();
+      body = body.replace(/^```(?:json)?\s*/m, '').replace(/```\s*$/m, '').trim();
+      // raw_decode-like: find first { and parse
+      const idx = body.indexOf('{');
+      if (idx === -1) throw new Error('no json object found');
+      // Try parsing greedily from idx; if fails, find last } and try
+      const candidate = body.slice(idx);
+      let parsed: any;
+      try {
+        parsed = JSON.parse(candidate);
+      } catch {
+        // Truncate to last balanced brace
+        let depth = 0, end = -1;
+        for (let i = 0; i < candidate.length; i++) {
+          if (candidate[i] === '{') depth++;
+          else if (candidate[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+        }
+        if (end === -1) throw new Error('unbalanced json');
+        parsed = JSON.parse(candidate.slice(0, end + 1));
+      }
+      return {
+        current_ref: currentRef,
+        normalized_ref: String(parsed.normalized_ref ?? ''),
+        changed: Boolean(parsed.changed),
+        reason: String(parsed.reason ?? ''),
+        confidence: String(parsed.confidence ?? 'medium'),
+      };
+    } catch (e: any) {
+      lastErr = String(e?.message ?? e).slice(0, 200);
+      if (attempt < 4) await new Promise(r => setTimeout(r, 2000 * attempt));
+    }
+  }
+  return {
+    current_ref: currentRef,
+    normalized_ref: currentRef,
+    changed: false,
+    reason: '',
+    confidence: 'low',
+    error: lastErr,
+  };
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // Resume
+  const existing: Proposed[] = existsSync(OUT_PATH) ? JSON.parse(readFileSync(OUT_PATH, 'utf-8')) : [];
+  const done = new Set(existing.map(p => `${p.scenario_id}#${p.item_index}`));
+
+  const limitIdx = process.argv.indexOf('--limit');
+  const limit = limitIdx >= 0 ? Number(process.argv[limitIdx + 1]) : Infinity;
+  const sidIdx = process.argv.indexOf('--scenario');
+  const onlySid = sidIdx >= 0 ? process.argv[sidIdx + 1] : null;
+
+  const files = readdirSync(CORPUS_DIR).filter(f => f.endsWith('.json')).sort();
+  const proposed: Proposed[] = [...existing];
+
+  let count = 0;
+  for (const file of files) {
+    if (count >= limit) break;
+    const sc = JSON.parse(readFileSync(path.join(CORPUS_DIR, file), 'utf-8'));
+    if (onlySid && sc.id !== onlySid) continue;
+    const items = (sc.reference_output?.items ?? []) as any[];
+    if (!items.length) continue;
+    const email = `Subject: ${sc.input.subject}\nFrom: ${sc.input.from}\nDate: ${sc.input.date}\n\n${sc.input.body}`;
+    for (let i = 0; i < items.length; i++) {
+      const key = `${sc.id}#${i}`;
+      if (done.has(key)) continue;
+      const currentRef = items[i]?.cargo_description?.value ?? '';
+      if (currentRef === '' || currentRef == null) {
+        // Skip empty REFs — keep as is
+        proposed.push({ scenario_id: sc.id, item_index: i, current_ref: '', normalized_ref: '', changed: false, reason: 'skip: empty REF', confidence: 'high' });
+        done.add(key);
+        continue;
+      }
+      const result = await normalizeOne(email, String(currentRef), i, items.length);
+      proposed.push({ scenario_id: sc.id, item_index: i, ...result });
+      done.add(key);
+      count++;
+      writeFileSync(OUT_PATH, JSON.stringify(proposed, null, 2));
+      const mark = result.error ? 'ERR' : (result.changed ? 'CHG' : 'sam');
+      console.error(`[${mark}] ${sc.id}#${i} conf=${result.confidence}${result.error ? ` err=${result.error}` : ''}`);
+      // small pacing
+      await new Promise(r => setTimeout(r, 250));
+    }
+  }
+
+  const changed = proposed.filter(p => p.changed).length;
+  const errors = proposed.filter(p => p.error).length;
+  console.error(`\nDONE: total=${proposed.length} changed=${changed} errors=${errors}`);
+  console.error(`Output: ${OUT_PATH}`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

R22 baseline (cargo 84.4%) was inflated by inconsistent ground truth — some REFs were maximalist, others concise even when the email mentioned stowage/dimensions/per-port splits. This noisy GT created a ceiling for prompt-tuning experiments (R25 attempt: 17 wins / 22 regressions = -4.1pp net).

This PR normalizes 64 of 147 cargo items in the parse-cargo eval corpus to a consistent **Maximalist if-present** standard:
- REF MUST include every cargo detail mentioned in the source email
- REF MUST NOT add details not in the email (no hallucinated stowage, no invented CBM)
- Unit notations live in separate `stowage_factor` field
- Empty REF for vessel-position circulars; "Not specified" for explicit TBN

## Process

1. **Normalizer** (`scripts/progonq/normalize-cargo-refs.ts`): Bedrock Sonnet 4.6 proposed changes to 67/147 items (45%), 66 conf=high + 1 conf=medium, 0 errors
2. **Opus review** (separate session): approved 60, revised 3 (scenario-064#3 +/-10%, scenario-072#0/#1 capitalization), rejected 1 (scenario-081#0)
3. Applied 64 changes across 44 scenario JSONs

## Validation (Gemini 2.5 Pro, NEW GT, 3 runs)

| Field | R22 old GT | R22-fair (old output, NEW GT) | R26 median (new run, NEW GT) |
|---|---|---|---|
| cargo_description | 84.4% | **79.6%** | **91.8%** (+12.2pp) |
| ports | 94.6% | 95.2% | 93.9% |
| weight | 96.6% | 95.9% | 95.9% |
| laycan | 86.4% | 86.4% | 85.0% |
| commission | 98.6% | 98.6% | 98.0% |

**Cargo +12.2pp confirmed:** variance across 3 R26 runs only 1.3pp (91.2-92.5%). Other fields stable within Gemini run-to-run noise.

R26 result files on outreach-vps: `.progonq/results/etms-parse-cargo-R26-{baseline,A-2,A-3}.json`

## Test plan

- [x] All 44 modified scenario JSONs are valid JSON
- [x] 3 independent R26 runs confirm cargo +12.2pp stable
- [x] Non-cargo fields (ports/weight/laycan/commission) within ±2pp Gemini variance
- [x] Original corpus backed up locally: `.progonq/corpus/etms-parse-cargo.r22-original-backup-20260517/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)