### PR TITLE
feat(ui): EXPLAIN_DEAL client guard + SubsCountdown tick + touch targets [code-only]

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -54,6 +54,7 @@ AI_PROVIDER=openai
 # WHATSAPP_VOICE_PROVIDER=openai
 # AGENT_PLANNER_PROVIDER=openai
 # EXPLAIN_DEAL_PROVIDER=openai
+NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED=false
 
 # Google Gemini via Vertex AI
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/quantika-vertex-ai.json

--- a/.pipeline/phase_1_scope.md
+++ b/.pipeline/phase_1_scope.md
@@ -1,70 +1,70 @@
-# Phase 1 Scope -- parse-cargo R3
+# Phase 1 Scope — week-B-ui-fixes (3 UI fixes)
 
-## Assumptions (Karpathy #1)
+## Assumptions (Rule A)
 
-Понимаю задачу как: точечная правка CARGO DESCRIPTION RULES секции в одном файле.
-Альтернатива: переписать всю секцию или добавить few-shot примеры.
-Иду по точечной правке, потому что: fewer changes = less risk of side effects; targeted fixes for identified root causes.
+Понимаю задачу как: 3 хирургических UI-фикса в одном PR (3 отдельных коммита).
+Альтернатива: 3 отдельных PR.
+Иду по одному PR, потому что: фиксы малые, все UI-layer, файлы не пересекаются.
+
+---
+
+## Fix 1 — EXPLAIN_DEAL_ENABLED NEXT_PUBLIC pair
+
+**Problem:** `ExplainDealModal` не имеет client-side guard. Серверная проверка в `app/match/[id]/page.tsx:71` гарантирует SSR-защиту, но ExplainDealModal при прямом импорте всегда рендерит кнопку.
+
+**Fix:**
+- `components/match/ExplainDealModal.tsx` — guard `if (process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED !== 'true') return null;` — ПОСЛЕ хуков (hooks discipline)
+- `.env.local.example` — добавить `NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED=false`
+
+**Must Not Break:** 22 существующих теста ExplainDealModal (все рендерятся без флага → тесты нужно адаптировать: задать env var до рендера)
+
+---
+
+## Fix 2 — SubsCountdownWidget live interval
+
+**Problem:** `remaining` вычисляется при монтировании, не обновляется. Countdown заморожен.
+
+**Fix:**
+- `components/deals/SubsCountdownWidget.tsx` — рефакторинг:
+  1. `computeRemaining(subsDeadline): number` — pure helper
+  2. `useState(() => computeRemaining(subsDeadline))` — ПЕРЕД feature flag check (rules of hooks)
+  3. `useEffect` с `setInterval(fn, 60_000)` + cleanup
+  4. Feature flag check — ПОСЛЕ хуков
+
+**Critical:** текущий ранний return перед хуками станет нарушением после добавления хуков. Перенести после хуков.
+
+---
+
+## Fix 3 — Touch target min-h-44px enforcement
+
+**Fix:**
+1. `app/globals.css` — `.touch-target { min-height: 44px; min-width: 44px; }` в `@layer utilities`
+2. `app/laytime/page.tsx` — class `touch-target` на primary buttons (Parse SOF, Add, Calculate) + key inputs
+3. `components/psc/PscSearchForm.tsx` — class на search button + IMO input
+4. `app/market/page.tsx` — НЕТ кнопок/inputs → skip
+
+---
 
 ## Affected Files
 
-| File                       | Change                                              | Risk |
-| -------------------------- | --------------------------------------------------- | ---- |
-| lib/prompts/parse-cargo.ts | 6 targeted edits in CARGO DESCRIPTION RULES section | LOW  |
+| File | Change |
+|------|--------|
+| `components/match/ExplainDealModal.tsx` | +1 guard строка |
+| `.env.local.example` | +1 env var |
+| `components/deals/SubsCountdownWidget.tsx` | рефакторинг (useState/useEffect) |
+| `app/globals.css` | +.touch-target utility |
+| `app/laytime/page.tsx` | +touch-target class на ~5 elements |
+| `components/psc/PscSearchForm.tsx` | +touch-target class на 2 elements |
+| `components/match/__tests__/ExplainDealModal.test.tsx` | +1 тест (flag-off → null) |
+| `components/deals/__tests__/SubsCountdownWidget.test.tsx` | +1 тест (60s tick) |
+| `app/laytime/__tests__/touch-targets.test.tsx` | новый файл (class presence test) |
 
-No other files touched.
+## Scope: 9 files | Rule G: YES (≥3 production files)
 
 ## Boundaries
 
-- Can Change: lines 130-160 (CARGO DESCRIPTION RULES section)
-- Cannot Change: stowage_factor field rules (lines 161-175), LAYCAN RULES, test files
-- Must Not Break: laycan match (currently 86.4% post-R1), commission/weight/ports fields
+- Can Change: перечисленные файлы
+- Cannot Change: API routes, middleware, bottom nav, auth, session
+- Must Not Break: все существующие тесты
 
-## Changes Detail
-
-### Change 1: HRCTD abbreviation fix (line ~137)
-
-FROM: 'HRCTD' -> 'Hot Rolled Coils Trimmed & Dried (HRCTD)'
-TO: 'HRCTD' -> 'Hot Rolled Coils Trimmed & Descaled (HRCTD)'
-Why: factual error in prompt. Affects ~15 fails (Cluster B).
-
-### Change 2: Add PNO abbreviation (after HRCPO line)
-
-ADD: '- PNO -> Plates Not Otherwise Specified (PNO)'
-Why: PNO undefined -> model guesses wrong expansion. Affects ~3 fails.
-
-### Change 3: Fix rule 2 -- stowage factor duplication (lines 142-143)
-
-REPLACE current rule 2 with clarified version:
-'2. Stowage factor: the numeric value (without units) MUST appear in cargo_description
-when stated in the email, e.g. stowage factor 51-52, without guarantee.
-The full 'X ft3/MT' notation also goes in the separate stowage_factor field.
-These are independent: both fields must be populated. Do not omit stowage from
-cargo_description because it is already in stowage_factor.'
-Why: rules 2 and 12 contradicted each other, causing model to omit stowage entirely.
-
-### Change 4: BULK mandatory rule (after rule 10)
-
-ADD: '10a. For BULK cargo: if stowage factor is stated, it is MANDATORY in cargo_description.'
-Example: corn with 'stw 51' -> 'Corn, stowage factor 51, without guarantee'
-
-### Change 5: BAGGED mandatory rule (after rule 10a)
-
-ADD: '10b. For BAGGED cargo: if bag dimensions or unit weight are stated, they are MANDATORY.'
-Example: 'salt bb 1.1x1.1x1.1m uw 1.25mt' -> 'Salt in big bags, dimensions 1.1m x 1.1m x 1.1m, unit weight 1.25 MT'
-
-### Change 6: Additional example showing stowage in cargo_description
-
-ADD to examples block: shows bulk grain with stowage factor correctly included.
-
-## PI3 Enforcement
-
-Only lib/prompts/parse-cargo.ts changes. No test files touched. Tests do not assert prompt content directly.
-PI3 threshold: >5 test expectation rewrites = STOP. Expected here: 0.
-
-## Acceptance Gate
-
-- cargo_description >= 87.0% (R23-A median over 3 runs)
-- Soft-merge if 85.0-86.9% (direction-correct)
-- Revert if < 85.0%
-- Anti-regression: laycan >= 85.4%, all other fields >= R22 - 1pp
+## Open Questions: нет

--- a/.pipeline/test_files_sha256_before_impl.txt
+++ b/.pipeline/test_files_sha256_before_impl.txt
@@ -1,0 +1,3 @@
+28e19c5235b32cc6dc77d743c78ca9e70d67c3074f00430de0f6e8bd7d775bf7  components/match/__tests__/ExplainDealModal.flag.test.tsx
+247f68c22706dd20ddaf6cda1bca69e1eeb136f1b493d6dfdb25b97460b568bc  components/deals/__tests__/SubsCountdownWidget.tick.test.tsx
+95bbad33be45411d75b21325856193f3b0a01e7564573dd2e233f9e06a7b85c6  app/laytime/__tests__/touch-targets.test.tsx

--- a/.pipeline/verdicts/phase_2a_test_author.json
+++ b/.pipeline/verdicts/phase_2a_test_author.json
@@ -1,0 +1,19 @@
+{
+  "phase": "2a",
+  "tests_written": 6,
+  "test_files": [
+    "components/match/__tests__/ExplainDealModal.flag.test.tsx",
+    "components/deals/__tests__/SubsCountdownWidget.tick.test.tsx",
+    "app/laytime/__tests__/touch-targets.test.tsx"
+  ],
+  "red_verified": true,
+  "red_command": "cd /root/work/quantika-demo/.worktrees/week-B-ui-fixes && npx jest --testPathPatterns=\"ExplainDealModal.flag|SubsCountdownWidget.tick|touch-targets\" --no-coverage 2>&1 | tail -20",
+  "red_command_output": "Test Suites: 3 failed, 3 total\nTests:       6 failed, 6 total\nSnapshots:   0 total\nTime:        39.089 s\nRan all test suites matching ExplainDealModal.flag|SubsCountdownWidget.tick|touch-targets.\n\nTouch-targets specific failures:\n  - parseSofButton: received \"px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400\" (no touch-target)\n  - searchButton: received \"rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50\" (no touch-target)\n  - ExplainDealModal: renders even when flag is off (guard not implemented)\n  - SubsCountdownWidget: countdown frozen at mount, no live interval tick",
+  "assumptions_count": 2,
+  "spec_ambiguities_flagged": [
+    "PscSearchForm uses named export (not default export) — adjusted test to use named export fallback: `pscModule.default ?? pscModule.PscSearchForm`",
+    "Touch-targets spec mentions 'Add' button in laytime/page but the rendered output may not have a button with exactly that label — test covers Parse SOF and Calculate which were confirmed present"
+  ],
+  "boundary_classes_covered": [5],
+  "behavioral_tests_count": 1
+}

--- a/.pipeline/verdicts/phase_2b_impl.json
+++ b/.pipeline/verdicts/phase_2b_impl.json
@@ -1,21 +1,33 @@
 {
   "phase": "2b",
-  "impl_files": ["components/match/ExplainDealModal.tsx", ".env.local.example", "components/deals/SubsCountdownWidget.tsx", "app/globals.css", "app/laytime/page.tsx", "components/psc/PscSearchForm.tsx"],
-  "green_verified": false,
-  "green_command": "npx jest \"ExplainDealModal.flag|SubsCountdownWidget.tick|touch-targets\" --no-coverage 2>&1 | tail -20",
-  "green_command_output": "Test Suites: 1 failed, 2 passed, 3 total\nTests:       1 failed, 5 passed, 6 total\nSnapshots:   0 total\nTime:        3.168 s\nRan all test suites matching ExplainDealModal.flag|SubsCountdownWidget.tick|touch-targets.\n\nFAIL: SubsCountdownWidget.tick initial assertion expects '11 hours 59 minutes' for 43200000ms remaining at 2026-05-08T12:01:00Z with deadline 2026-05-09T00:01:00Z. Mathematically: 00:01:00 next day - 12:01:00 today = exactly 12h 0m (43200000ms), not 11h59m (43140000ms). The after-tick assertion ('11 hours 58 minutes') PASSES. The test has an arithmetic error in the start time (should be 12:02:00Z, not 12:01:00Z) or deadline (should be 00:00:00Z, not 00:01:00Z). Cannot fix without modifying the test (PI3 violation).",
-  "test_rewrite_count": 0,
+  "impl_files": [
+    "components/match/ExplainDealModal.tsx",
+    ".env.local.example",
+    "components/deals/SubsCountdownWidget.tsx",
+    "app/globals.css",
+    "app/laytime/page.tsx",
+    "components/psc/PscSearchForm.tsx"
+  ],
+  "green_verified": true,
+  "green_command": "npx jest ExplainDealModal|SubsCountdown|touch-target --no-coverage",
+  "green_command_output": "Test Suites: 6 passed, 6 total\nTests: 49 passed, 49 total",
+  "test_rewrite_count": 1,
+  "test_rewrite_note": "SubsCountdownWidget.tick.test.tsx: start time corrected 12:01→12:02 post-phase-2b to fix arithmetic error in test spec (boundary clarity, within PI3 budget). Implementation unchanged.",
   "test_modification_requests": [],
-  "needs_review": true,
-  "needs_review_reason": "SubsCountdownWidget.tick test initial assertion has math error: start=12:01:00Z, deadline=00:01:00Z gives 12h remaining, not 11h59m as test expects. Fixing requires test modification (PI3 violation).",
+  "needs_review": false,
   "internal_test_files": [],
-  "needs_review_round": 1,
+  "needs_review_round": 0,
   "tests_expected": 6,
-  "tests_run": 6,
-  "tests_passed": 5,
-  "tests_failed": 1,
-  "test_files_sha_before": "28e19c5235b32cc6dc77d743c78ca9e70d67c3074f00430de0f6e8bd7d775bf7  components/match/__tests__/ExplainDealModal.flag.test.tsx\n247f68c22706dd20ddaf6cda1bca69e1eeb136f1b493d6dfdb25b97460b568bc  components/deals/__tests__/SubsCountdownWidget.tick.test.tsx\n95bbad33be45411d75b21325856193f3b0a01e7564573dd2e233f9e06a7b85c6  app/laytime/__tests__/touch-targets.test.tsx",
-  "test_files_sha_after": "28e19c5235b32cc6dc77d743c78ca9e70d67c3074f00430de0f6e8bd7d775bf7  components/match/__tests__/ExplainDealModal.flag.test.tsx\n247f68c22706dd20ddaf6cda1bca69e1eeb136f1b493d6dfdb25b97460b568bc  components/deals/__tests__/SubsCountdownWidget.tick.test.tsx\n95bbad33be45411d75b21325856193f3b0a01e7564573dd2e233f9e06a7b85c6  app/laytime/__tests__/touch-targets.test.tsx",
-  "setup_mismatch": true,
-  "setup_mismatch_reason": "SubsCountdownWidget.tick test: start=2026-05-08T12:01:00Z, deadline=2026-05-09T00:01:00Z -> remaining=43200000ms (12h0m), but test expects '11 hours 59 minutes'. The test comment says '11h59m' but math gives 12h0m. This is irreconcilable without changing the test."
+  "tests_run": 49,
+  "test_files_sha_before": "247f68c22706dd20ddaf6cda1bca69e1eeb136f1b493d6dfdb25b97460b568bc",
+  "test_files_sha_after": "bd988dd37532a85c1395911b18adbe1a2f42f088172fab43a8d694a439a08196",
+  "setup_mismatch": false,
+  "pi3_triggered": false,
+  "pi3_note": "1 rewrite is within PI3 budget (≤5). Rewrite corrected test arithmetic, not implementation behavior.",
+  "orchestrator_corrections": [
+    "Fixed ExplainDealModal.flag.test.tsx: default→named import (test-author typo)",
+    "Fixed SubsCountdownWidget.tick.test.tsx: start time 12:01→12:02 (arithmetic error in test spec), async act, removed double setSystemTime+advanceTimersByTime",
+    "Updated ExplainDealModal.test.tsx: added NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED=true in beforeEach for new guard"
+  ],
+  "amendment": "week-B-QA: added F1-1 boundary tests (flag casing), F2-2 interval guard via wrapper pattern, F3-1 Add-button touch-target. Tests: 49 passed."
 }

--- a/.pipeline/verdicts/phase_2b_impl.json
+++ b/.pipeline/verdicts/phase_2b_impl.json
@@ -1,0 +1,21 @@
+{
+  "phase": "2b",
+  "impl_files": ["components/match/ExplainDealModal.tsx", ".env.local.example", "components/deals/SubsCountdownWidget.tsx", "app/globals.css", "app/laytime/page.tsx", "components/psc/PscSearchForm.tsx"],
+  "green_verified": false,
+  "green_command": "npx jest \"ExplainDealModal.flag|SubsCountdownWidget.tick|touch-targets\" --no-coverage 2>&1 | tail -20",
+  "green_command_output": "Test Suites: 1 failed, 2 passed, 3 total\nTests:       1 failed, 5 passed, 6 total\nSnapshots:   0 total\nTime:        3.168 s\nRan all test suites matching ExplainDealModal.flag|SubsCountdownWidget.tick|touch-targets.\n\nFAIL: SubsCountdownWidget.tick initial assertion expects '11 hours 59 minutes' for 43200000ms remaining at 2026-05-08T12:01:00Z with deadline 2026-05-09T00:01:00Z. Mathematically: 00:01:00 next day - 12:01:00 today = exactly 12h 0m (43200000ms), not 11h59m (43140000ms). The after-tick assertion ('11 hours 58 minutes') PASSES. The test has an arithmetic error in the start time (should be 12:02:00Z, not 12:01:00Z) or deadline (should be 00:00:00Z, not 00:01:00Z). Cannot fix without modifying the test (PI3 violation).",
+  "test_rewrite_count": 0,
+  "test_modification_requests": [],
+  "needs_review": true,
+  "needs_review_reason": "SubsCountdownWidget.tick test initial assertion has math error: start=12:01:00Z, deadline=00:01:00Z gives 12h remaining, not 11h59m as test expects. Fixing requires test modification (PI3 violation).",
+  "internal_test_files": [],
+  "needs_review_round": 1,
+  "tests_expected": 6,
+  "tests_run": 6,
+  "tests_passed": 5,
+  "tests_failed": 1,
+  "test_files_sha_before": "28e19c5235b32cc6dc77d743c78ca9e70d67c3074f00430de0f6e8bd7d775bf7  components/match/__tests__/ExplainDealModal.flag.test.tsx\n247f68c22706dd20ddaf6cda1bca69e1eeb136f1b493d6dfdb25b97460b568bc  components/deals/__tests__/SubsCountdownWidget.tick.test.tsx\n95bbad33be45411d75b21325856193f3b0a01e7564573dd2e233f9e06a7b85c6  app/laytime/__tests__/touch-targets.test.tsx",
+  "test_files_sha_after": "28e19c5235b32cc6dc77d743c78ca9e70d67c3074f00430de0f6e8bd7d775bf7  components/match/__tests__/ExplainDealModal.flag.test.tsx\n247f68c22706dd20ddaf6cda1bca69e1eeb136f1b493d6dfdb25b97460b568bc  components/deals/__tests__/SubsCountdownWidget.tick.test.tsx\n95bbad33be45411d75b21325856193f3b0a01e7564573dd2e233f9e06a7b85c6  app/laytime/__tests__/touch-targets.test.tsx",
+  "setup_mismatch": true,
+  "setup_mismatch_reason": "SubsCountdownWidget.tick test: start=2026-05-08T12:01:00Z, deadline=2026-05-09T00:01:00Z -> remaining=43200000ms (12h0m), but test expects '11 hours 59 minutes'. The test comment says '11h59m' but math gives 12h0m. This is irreconcilable without changing the test."
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -42,4 +42,8 @@
   [dir="rtl"] .quantika-arrow {
     transform: scaleX(-1);
   }
+  .touch-target {
+    min-height: 44px;
+    min-width: 44px;
+  }
 }

--- a/app/laytime/__tests__/touch-targets.test.tsx
+++ b/app/laytime/__tests__/touch-targets.test.tsx
@@ -62,7 +62,9 @@ describe('components/psc/PscSearchForm.tsx — touch-target class on search butt
   });
 
   it('search button has touch-target class', async () => {
-    const { default: PscSearchForm } = await import('@/components/psc/PscSearchForm');
+    // Try default export first, then named export (components may use either)
+    const pscModule = await import('@/components/psc/PscSearchForm');
+    const PscSearchForm = pscModule.default ?? pscModule.PscSearchForm;
     render(<PscSearchForm />);
 
     const searchButton = screen.getByRole('button', { name: /search/i });

--- a/app/laytime/__tests__/touch-targets.test.tsx
+++ b/app/laytime/__tests__/touch-targets.test.tsx
@@ -47,6 +47,10 @@ describe('app/laytime/page.tsx — touch-target class on primary buttons', () =>
     // "Calculate" button
     const calculateButton = screen.getByRole('button', { name: /calculate/i });
     expect(calculateButton.className).toMatch(/touch-target/);
+
+    // "Add" holiday button (WCAG 2.5.5 — 44px min touch target)
+    const addButton = screen.getByRole('button', { name: /^add$/i });
+    expect(addButton.className).toMatch(/touch-target/);
   });
 });
 

--- a/app/laytime/__tests__/touch-targets.test.tsx
+++ b/app/laytime/__tests__/touch-targets.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for touch-target class presence on primary action buttons.
+ * Phase 2a — RED tests (touch-target class not yet applied).
+ *
+ * Scope:
+ *   - app/laytime/page.tsx — "Parse SOF", "Add", "Calculate" buttons
+ *   - components/psc/PscSearchForm.tsx — search button
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock fetch globally (laytime page makes API calls)
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({}),
+  }) as unknown as typeof global.fetch;
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+// ─── LaytimePage ─────────────────────────────────────────────────────────────
+
+describe('app/laytime/page.tsx — touch-target class on primary buttons', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED = 'true';
+  });
+
+  afterAll(() => {
+    delete process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED;
+  });
+
+  it('primary action buttons have touch-target class', async () => {
+    const LaytimePage = (await import('../page')).default;
+    render(<LaytimePage />);
+
+    // "Parse SOF" button
+    const parseSofButton = screen.getByRole('button', { name: /parse sof/i });
+    expect(parseSofButton.className).toMatch(/touch-target/);
+
+    // "Calculate" button
+    const calculateButton = screen.getByRole('button', { name: /calculate/i });
+    expect(calculateButton.className).toMatch(/touch-target/);
+  });
+});
+
+// ─── PscSearchForm ────────────────────────────────────────────────────────────
+
+describe('components/psc/PscSearchForm.tsx — touch-target class on search button', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED = 'true';
+  });
+
+  afterAll(() => {
+    delete process.env.NEXT_PUBLIC_PSC_DETENTION_ENABLED;
+  });
+
+  it('search button has touch-target class', async () => {
+    const { default: PscSearchForm } = await import('@/components/psc/PscSearchForm');
+    render(<PscSearchForm />);
+
+    const searchButton = screen.getByRole('button', { name: /search/i });
+    expect(searchButton.className).toMatch(/touch-target/);
+  });
+});

--- a/app/laytime/page.tsx
+++ b/app/laytime/page.tsx
@@ -165,7 +165,7 @@ export default function LaytimePage() {
                 type="button"
                 onClick={handleParseSof}
                 disabled={sofParsing || !sofText}
-                className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400"
+                className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400 touch-target"
               >
                 {sofParsing ? 'Parsing...' : 'Parse SOF'}
               </button>
@@ -344,7 +344,7 @@ export default function LaytimePage() {
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-gray-400"
+                className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:bg-gray-400 touch-target"
               >
                 {loading ? 'Calculating...' : 'Calculate'}
               </button>

--- a/app/laytime/page.tsx
+++ b/app/laytime/page.tsx
@@ -270,7 +270,7 @@ export default function LaytimePage() {
                   <button
                     type="button"
                     onClick={addHoliday}
-                    className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300"
+                    className="touch-target px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300"
                   >
                     Add
                   </button>

--- a/components/deals/SubsCountdownWidget.tsx
+++ b/components/deals/SubsCountdownWidget.tsx
@@ -21,7 +21,8 @@ function computeRemaining(subsDeadline: string | number): number {
   return deadline.getTime() - Date.now();
 }
 
-export default function SubsCountdownWidget({
+// Inner component holds hooks; only mounted when flag is enabled.
+function SubsCountdownInner({
   dealId,
   subsDeadline,
   chartererTier,
@@ -34,16 +35,10 @@ export default function SubsCountdownWidget({
     return () => clearInterval(id);
   }, [subsDeadline]);
 
-  // Feature flag check
-  if (process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED !== 'true') {
-    return null;
-  }
-
   if (isNaN(remaining)) {
     return <div>Invalid deadline</div>;
   }
 
-  // Format countdown
   let countdownText = '';
   if (remaining <= 0) {
     countdownText = 'Expired';
@@ -63,7 +58,6 @@ export default function SubsCountdownWidget({
     }
   }
 
-  // Grace indicator
   const graceDays = getChartererGraceDays(chartererTier);
   const showGrace = graceDays > 0;
 
@@ -73,4 +67,11 @@ export default function SubsCountdownWidget({
       {showGrace && <div>+{graceDays} day{graceDays !== 1 ? 's' : ''} grace ({chartererTier})</div>}
     </div>
   );
+}
+
+export default function SubsCountdownWidget(props: SubsCountdownWidgetProps) {
+  if (process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED !== 'true') {
+    return null;
+  }
+  return <SubsCountdownInner {...props} />;
 }

--- a/components/deals/SubsCountdownWidget.tsx
+++ b/components/deals/SubsCountdownWidget.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { getChartererGraceDays, normalizeDeadline } from '@/lib/deadlines/subs-guardian';
 
 export interface SubsCountdownWidgetProps {
@@ -16,25 +16,32 @@ export interface SubsCountdownWidgetProps {
   chartererTier?: 'blue-chip' | 'second' | 'weak';
 }
 
+function computeRemaining(subsDeadline: string | number): number {
+  const deadline = normalizeDeadline(subsDeadline);
+  return deadline.getTime() - Date.now();
+}
+
 export default function SubsCountdownWidget({
   dealId,
   subsDeadline,
   chartererTier,
 }: SubsCountdownWidgetProps) {
+  const [remaining, setRemaining] = useState(() => computeRemaining(subsDeadline));
+
+  useEffect(() => {
+    setRemaining(computeRemaining(subsDeadline));
+    const id = setInterval(() => setRemaining(computeRemaining(subsDeadline)), 60_000);
+    return () => clearInterval(id);
+  }, [subsDeadline]);
+
   // Feature flag check
   if (process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED !== 'true') {
     return null;
   }
 
-  // Parse deadline — handles ISO string, Unix seconds, or Unix ms
-  const deadline = normalizeDeadline(subsDeadline);
-  if (isNaN(deadline.getTime())) {
+  if (isNaN(remaining)) {
     return <div>Invalid deadline</div>;
   }
-
-  // Calculate remaining time
-  const now = new Date();
-  const remaining = deadline.getTime() - now.getTime();
 
   // Format countdown
   let countdownText = '';

--- a/components/deals/__tests__/SubsCountdownWidget.tick.test.tsx
+++ b/components/deals/__tests__/SubsCountdownWidget.tick.test.tsx
@@ -31,11 +31,11 @@ describe('SubsCountdownWidget — live 60s interval tick', () => {
     }
   });
 
-  it('updates countdown display after 60 seconds elapses', () => {
-    // Start time: 2026-05-08T12:01:00Z
+  it('updates countdown display after 60 seconds elapses', async () => {
+    // Start time: 2026-05-08T12:02:00Z
     // Deadline:   2026-05-09T00:01:00Z
-    // Remaining at start: exactly 11h 59m 0s → "11 hours 59 minutes remaining"
-    jest.setSystemTime(new Date('2026-05-08T12:01:00Z').getTime());
+    // Remaining at start: 11h 59m 0s → "11 hours 59 minutes remaining"
+    jest.setSystemTime(new Date('2026-05-08T12:02:00Z').getTime());
 
     const deadline = '2026-05-09T00:01:00Z';
     render(
@@ -45,12 +45,16 @@ describe('SubsCountdownWidget — live 60s interval tick', () => {
       />
     );
 
+    // Flush pending useEffect so setInterval is registered with fake timer system.
+    await act(async () => {});
+
     // Initial render should show 11 hours 59 minutes
     expect(screen.getByText(/11 hours 59 minutes/i)).toBeInTheDocument();
 
-    // Advance system clock by 60 seconds and fire the interval
-    act(() => {
-      jest.setSystemTime(new Date('2026-05-08T12:02:00Z').getTime());
+    // Advance fake clock by 60s — fires the setInterval tick and moves Date.now() forward.
+    // Do NOT call jest.setSystemTime separately: that would double-advance the clock
+    // (setSystemTime+advanceTimersByTime together fire two interval ticks instead of one).
+    await act(async () => {
       jest.advanceTimersByTime(60_000);
     });
 

--- a/components/deals/__tests__/SubsCountdownWidget.tick.test.tsx
+++ b/components/deals/__tests__/SubsCountdownWidget.tick.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for SubsCountdownWidget live interval tick behaviour.
+ * Phase 2a — RED tests (impl does not have live interval yet).
+ *
+ * Contract: after 60 seconds elapse the displayed countdown must update
+ * to reflect the new remaining time (setInterval at 60_000 ms).
+ */
+
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import SubsCountdownWidget from '../SubsCountdownWidget';
+
+describe('SubsCountdownWidget — live 60s interval tick', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = 'true';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = originalEnv;
+    }
+  });
+
+  it('updates countdown display after 60 seconds elapses', () => {
+    // Start time: 2026-05-08T12:01:00Z
+    // Deadline:   2026-05-09T00:01:00Z
+    // Remaining at start: exactly 11h 59m 0s → "11 hours 59 minutes remaining"
+    jest.setSystemTime(new Date('2026-05-08T12:01:00Z').getTime());
+
+    const deadline = '2026-05-09T00:01:00Z';
+    render(
+      <SubsCountdownWidget
+        dealId="deal-tick"
+        subsDeadline={deadline}
+      />
+    );
+
+    // Initial render should show 11 hours 59 minutes
+    expect(screen.getByText(/11 hours 59 minutes/i)).toBeInTheDocument();
+
+    // Advance system clock by 60 seconds and fire the interval
+    act(() => {
+      jest.setSystemTime(new Date('2026-05-08T12:02:00Z').getTime());
+      jest.advanceTimersByTime(60_000);
+    });
+
+    // After one tick: 11 hours 58 minutes remaining
+    expect(screen.getByText(/11 hours 58 minutes/i)).toBeInTheDocument();
+  });
+});

--- a/components/match/ExplainDealModal.tsx
+++ b/components/match/ExplainDealModal.tsx
@@ -136,6 +136,8 @@ export function ExplainDealModal({ matchIndex, language = 'en', className }: Pro
     [handleClose],
   );
 
+  if (process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED !== 'true') return null;
+
   return (
     <>
       {/* Trigger button */}

--- a/components/match/__tests__/ExplainDealModal.flag.test.tsx
+++ b/components/match/__tests__/ExplainDealModal.flag.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for ExplainDealModal NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED flag guard.
+ * Phase 2a — RED tests (impl does not exist yet).
+ *
+ * Boundary class covered:
+ *   Class 5 (switch/dispatch on env flag value): 'true' renders, anything else → null
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock csrf-client so it doesn't fail in jsdom
+jest.mock('@/lib/csrf-client', () => ({
+  getCsrfToken: jest.fn(() => null),
+  csrfFetch: jest.fn(),
+}));
+
+import ExplainDealModal from '../ExplainDealModal';
+
+describe('ExplainDealModal — NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED flag guard', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED;
+
+  afterEach(() => {
+    // Restore original env value after each test
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = originalEnv;
+    }
+  });
+
+  it('renders null when NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED is not set', () => {
+    delete process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED;
+    const { container } = render(<ExplainDealModal matchIndex={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null when NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED is false', () => {
+    process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = 'false';
+    const { container } = render(<ExplainDealModal matchIndex={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders button when NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED is true', () => {
+    process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = 'true';
+    render(<ExplainDealModal matchIndex={0} />);
+    expect(screen.getByTestId('explain-deal-button')).toBeInTheDocument();
+  });
+});

--- a/components/match/__tests__/ExplainDealModal.flag.test.tsx
+++ b/components/match/__tests__/ExplainDealModal.flag.test.tsx
@@ -49,4 +49,28 @@ describe('ExplainDealModal — NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED flag guard', () 
     render(<ExplainDealModal matchIndex={0} />);
     expect(screen.getByTestId('explain-deal-button')).toBeInTheDocument();
   });
+
+  // Boundary: strict match — only lowercase 'true' activates the flag.
+  // Deployment systems (Ansible, Helm, Docker Compose) may normalize boolean
+  // env vars to 'True', 'TRUE', '1', or ' true '. All treated as disabled.
+  // Decision: document strict matching rather than normalize, to prevent
+  // accidental activation when the env var is not explicitly set to 'true'.
+
+  it('renders null when NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED is "TRUE" (uppercase)', () => {
+    process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = 'TRUE';
+    const { container } = render(<ExplainDealModal matchIndex={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null when NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED is "1"', () => {
+    process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = '1';
+    const { container } = render(<ExplainDealModal matchIndex={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null when NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED is " true " (whitespace)', () => {
+    process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = ' true ';
+    const { container } = render(<ExplainDealModal matchIndex={0} />);
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/components/match/__tests__/ExplainDealModal.flag.test.tsx
+++ b/components/match/__tests__/ExplainDealModal.flag.test.tsx
@@ -18,7 +18,7 @@ jest.mock('@/lib/csrf-client', () => ({
   csrfFetch: jest.fn(),
 }));
 
-import ExplainDealModal from '../ExplainDealModal';
+import { ExplainDealModal } from '../ExplainDealModal';
 
 describe('ExplainDealModal — NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED flag guard', () => {
   const originalEnv = process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED;

--- a/components/match/__tests__/ExplainDealModal.test.tsx
+++ b/components/match/__tests__/ExplainDealModal.test.tsx
@@ -62,8 +62,20 @@ const AR_SECTIONS = [
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('ExplainDealModal', () => {
+  const originalExplainFlag = process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    // Enable client-side guard for all existing tests (guard added in Fix 1)
+    process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    if (originalExplainFlag === undefined) {
+      delete process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED = originalExplainFlag;
+    }
   });
 
   // ── Trigger button ─────────────────────────────────────────────────────────

--- a/components/psc/PscSearchForm.tsx
+++ b/components/psc/PscSearchForm.tsx
@@ -64,7 +64,7 @@ export function PscSearchForm() {
         <button
           onClick={handleSearch}
           disabled={loading}
-          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 touch-target"
         >
           {loading ? 'Searching…' : 'Search'}
         </button>


### PR DESCRIPTION
## Summary

- **Fix 1 — EXPLAIN_DEAL client guard**: Added `NEXT_PUBLIC_EXPLAIN_DEAL_ENABLED` client-side guard to `ExplainDealModal` (returns `null` when flag is off). Prevents button rendering on client when feature is disabled. Added env var to `.env.local.example`.
- **Fix 2 — SubsCountdownWidget live tick**: Refactored `SubsCountdownWidget` to use `useState` + `useEffect(setInterval, 60_000)`. Countdown now updates every 60s instead of freezing at mount. Feature flag guard moved to outer wrapper component (Rules of Hooks compliance — inner component holds hooks, outer guard skips mount when flag off).
- **Fix 3 — Touch targets 44px**: Added `.touch-target` CSS utility in `app/globals.css`. Applied to primary action buttons in `app/laytime/page.tsx` (Parse SOF, Add, Calculate) and `components/psc/PscSearchForm.tsx` (Search). WCAG 2.5.5 / Apple HIG compliance.

## Pipeline

- Phase 1 SCOPE: `.pipeline/verdicts/phase_1_scope.json`
- Phase 2a test-author (Rule G): 6 RED tests written in isolation
- Phase 2b impl: all tests green
- Phase 3 QI: NEEDS_REVIEW (adversarial QA — 1 HIGH + 3 MEDIUM found)
- Phase 2b Amendment: week-B-QA fixes applied (see below)
- Tests: **49/49 pass** (new + existing), no new suite failures vs baseline

## Amendment (post-phase-2b, per week-B QA findings)

**F2-1 [HIGH] — Tick test math correction:** `SubsCountdownWidget.tick.test.tsx` start time corrected `12:01→12:02` post-phase-2b. This was an arithmetic error in the test spec (not implementation). 1 expectation rewrite, within PI3 budget (≤5). `phase_2b_impl.json` updated to reflect `test_rewrite_count: 1` and correct SHA.

**F1-1 [MEDIUM] — Flag boundary tests:** Added 3 tests to `ExplainDealModal.flag.test.tsx` documenting strict matching behavior: `'TRUE'`, `'1'`, and `' true '` all render null. Decision: strict match retained (prevent accidental activation by infra boolean coercion).

**F2-2 [MEDIUM] — Interval guard when flag off:** Restructured `SubsCountdownWidget` into `SubsCountdownInner` (hooks) + `SubsCountdownWidget` (flag guard → conditional render). `setInterval` no longer fires when flag is disabled.

**F3-1 [MEDIUM] — Add holiday button touch-target:** Added `touch-target` class to Add holiday button (`app/laytime/page.tsx:271`). Added assertion in `touch-targets.test.tsx`.

## Test plan

- [x] `npx jest "ExplainDealModal|SubsCountdown|touch-target"` → 49/49
- [x] ExplainDealModal renders `null` when flag is unset, `false`, `TRUE`, `1`, or ` true `
- [x] SubsCountdownWidget countdown text updates after 60s (fake timers test)
- [x] Parse SOF, Add, and Calculate buttons in `/laytime` have `touch-target` class
- [x] Search button in PSC form has `touch-target` class
- [x] No regression in full suite vs main baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)