### PR TITLE
fix(schemas/parse-recap): align field names with RawFixtureRecap (same bug class as #216)

### DIFF
--- a/lib/schemas/parse-recap.ts
+++ b/lib/schemas/parse-recap.ts
@@ -2,38 +2,85 @@
  * Gemini structured-output schema for the parse-recap endpoint.
  *
  * Fixture recap output is a flat JSON object (not wrapped in `items`).
- * Fields are described in lib/prompts/parse-recap.ts.
+ * Field names MUST exactly match `RawFixtureRecap` in
+ * `lib/parsing/parse-recap-helpers.ts` — that interface is the canonical
+ * downstream contract. Mismatched field names silently extract as null.
  */
 
 import { Type } from '@google/genai';
 
+const confidenceFieldString = {
+  type: Type.OBJECT,
+  properties: {
+    value: { type: Type.STRING },
+    confidence: { type: Type.STRING },
+    source_text: { type: Type.STRING },
+  },
+};
+
+const unknownTermItem = {
+  type: Type.OBJECT,
+  properties: {
+    term: { type: Type.STRING },
+    note: { type: Type.STRING },
+  },
+};
+
 export const PARSE_RECAP_SCHEMA = {
   type: Type.OBJECT,
   properties: {
-    vessel_name: { type: Type.STRING, nullable: true },
-    imo: { type: Type.STRING, nullable: true },
-    charterer: { type: Type.STRING, nullable: true },
-    owner: { type: Type.STRING, nullable: true },
+    // Vessel
+    vessel_name: confidenceFieldString,
+    vessel_dwt: { type: Type.STRING, nullable: true },
+    vessel_draft: { type: Type.STRING, nullable: true },
+    vessel_geared: { type: Type.BOOLEAN, nullable: true },
+    // Parties
+    owners: confidenceFieldString,
+    charterers: confidenceFieldString,
+    account: confidenceFieldString,
     broker: { type: Type.STRING, nullable: true },
-    cargo_description: { type: Type.STRING, nullable: true },
-    cargo_quantity_mt: { type: Type.NUMBER, nullable: true },
-    load_port: { type: Type.STRING, nullable: true },
-    discharge_port: { type: Type.STRING, nullable: true },
-    laycan_start: { type: Type.STRING, nullable: true },
-    laycan_end: { type: Type.STRING, nullable: true },
-    freight_rate: { type: Type.STRING, nullable: true },
-    freight_type: { type: Type.STRING, nullable: true },
-    commission_percent: { type: Type.NUMBER, nullable: true },
-    commission_breakdown: { type: Type.STRING, nullable: true },
-    demurrage_rate: { type: Type.STRING, nullable: true },
-    loading_rate: { type: Type.STRING, nullable: true },
-    discharge_rate: { type: Type.STRING, nullable: true },
-    loading_terms: { type: Type.STRING, nullable: true },
-    discharge_terms: { type: Type.STRING, nullable: true },
+    // Ports
+    load_port: confidenceFieldString,
+    disch_port: confidenceFieldString,
+    load_port_agent: { type: Type.STRING, nullable: true },
+    disch_port_agent: { type: Type.STRING, nullable: true },
+    // Cargo
+    cargo_description: confidenceFieldString,
+    cargo_quantity_min: { type: Type.STRING, nullable: true },
+    cargo_quantity_max: { type: Type.STRING, nullable: true },
+    cargo_packaging: { type: Type.STRING, nullable: true },
+    // Dates
+    laycan: confidenceFieldString,
+    transit_time: { type: Type.STRING, nullable: true },
+    // Freight
+    freight_rate: confidenceFieldString,
+    freight_basis: { type: Type.STRING, nullable: true },
+    freight_payment: { type: Type.STRING, nullable: true },
+    // Laytime
+    loading_rate: confidenceFieldString,
+    loading_terms: confidenceFieldString,
+    loading_working_hours: { type: Type.STRING, nullable: true },
+    discharging_rate: confidenceFieldString,
+    discharging_terms: confidenceFieldString,
+    discharging_working_hours: { type: Type.STRING, nullable: true },
+    // Demurrage
+    demurrage_rate: confidenceFieldString,
+    demurrage_payment: { type: Type.STRING, nullable: true },
+    // Legal
     cp_form: { type: Type.STRING, nullable: true },
-    subjects: { type: Type.STRING, nullable: true },
-    subjects_deadline: { type: Type.STRING, nullable: true },
-    additional_clauses: { type: Type.STRING, nullable: true },
-    notes: { type: Type.STRING, nullable: true },
+    arbitration: { type: Type.STRING, nullable: true },
+    law: { type: Type.STRING, nullable: true },
+    // Commission
+    commission: { type: Type.STRING, nullable: true },
+    commission_percent: { type: Type.NUMBER, nullable: true },
+    commission_pct: { type: Type.NUMBER, nullable: true },
+    commission_base: { type: Type.STRING, nullable: true },
+    commission_amount: { type: Type.STRING, nullable: true },
+    commission_currency: { type: Type.STRING, nullable: true },
+    // Meta
+    subs: { type: Type.ARRAY, items: { type: Type.STRING }, nullable: true },
+    confidentiality: { type: Type.BOOLEAN, nullable: true },
+    additional_terms: { type: Type.ARRAY, items: { type: Type.STRING }, nullable: true },
+    unknown_terms: { type: Type.ARRAY, items: unknownTermItem, nullable: true },
   },
 };


### PR DESCRIPTION
## Summary

Production bug — `lib/schemas/parse-recap.ts` (Gemini structured-output) had 10 wrong field names and was missing ~25 fields entirely. `PARSE_RECAP_PROVIDER=gemini` on prod, so Gemini emits fields the downstream parser never reads → always null.

Same class of bug as merged PR #216 (parse-vessel). Identified in static-analysis baseline (`scripts/baselines/parse-recap-baseline-2026-05-17.md` §6, HIGH severity).

### Wrong field names (schema → RawFixtureRecap)

| Schema | Expected | Effect |
|---|---|---|
| `charterer` | `charterers` | always null |
| `owner` | `owners` | always null |
| `discharge_port` | `disch_port` | always null |
| `cargo_quantity_mt` | `cargo_quantity_min` + `cargo_quantity_max` | both null |
| `laycan_start` + `laycan_end` | `laycan` (single combined string) | always null |
| `freight_type` | `freight_basis` | always null |
| `discharge_rate` | `discharging_rate` | always null |
| `discharge_terms` | `discharging_terms` | always null |
| `subjects` (string) | `subs` (array) | always empty |
| `additional_clauses` (string) | `additional_terms` (array) | always empty |

### Fields added (were absent from schema)

vessel_dwt, vessel_draft, vessel_geared, account, transit_time, freight_payment, loading_working_hours, discharging_working_hours, demurrage_payment, load_port_agent, disch_port_agent, arbitration, law, commission, commission_pct, commission_base, commission_amount, commission_currency, confidentiality, unknown_terms (array of {term, note})

### Also

ConfidenceField-bearing string fields (vessel_name, owners, charterers, account, load_port, disch_port, cargo_description, laycan, freight_rate, loading_rate, loading_terms, discharging_rate, discharging_terms, demurrage_rate) switched to object shape `{ value, confidence, source_text }` so Gemini emits the structure the prompt and `parseRecapAIResponse` expect.

### Test plan
- [x] Schema diff matches RawFixtureRecap interface (canonical downstream type)
- [x] No downstream callers of old names (verified)
- [ ] No runtime validation — no progonq runner exists for parse-recap yet, corpus is only 3 scenarios (baseline was static-analysis only, see scripts/baselines/parse-recap-baseline-2026-05-17.md)

### Expected impact

Hard to quantify without runner, but baseline doc estimated ~70% on OpenAI path where schema was ignored. On Gemini path with broken schema ~10 of 30+ fields were silently always-null. Aligning schema should lift these ~30pp+ overall, mirroring PR #216 outcome.