### PR TITLE
feat(progonq): runner+judge for parse-recap eval (baseline 55.8%)

### DIFF
--- a/scripts/progonq/judge-parse-recap.ts
+++ b/scripts/progonq/judge-parse-recap.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Semantic judge for parse-recap results.
+ *
+ * For each scenario, compares model_output[field] vs reference_output[field]
+ * across the union of GT keys. Field-pair equivalence uses:
+ *   - null/null    -> equiv
+ *   - null/value   -> NOT equiv (under-extraction)
+ *   - value/null   -> NOT equiv
+ *   - identical str/num -> equiv (deterministic)
+ *   - numeric within ±5% tolerance -> equiv
+ *   - otherwise -> semantic judge LLM call (cached)
+ *
+ * Cache: .progonq/cache/judge-cache.json (shared with parse-vessel/cargo).
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/judge-parse-recap.ts --results <path>
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { callAiText } from '@/lib/ai-provider';
+
+const CACHE_PATH = path.resolve(process.cwd(), '.progonq/cache/judge-cache.json');
+
+interface Verdict { equiv: boolean; reason: string; }
+
+interface RunResult {
+  scenario_id: string;
+  reference_output: Record<string, unknown>;
+  model_output: Record<string, unknown> | null;
+  error?: string;
+  field_verdicts?: Record<string, Verdict>;
+}
+
+function loadCache(): Map<string, Verdict> {
+  if (!existsSync(CACHE_PATH)) return new Map();
+  try { return new Map(Object.entries(JSON.parse(readFileSync(CACHE_PATH, 'utf-8')))); }
+  catch { return new Map(); }
+}
+
+function saveCache(c: Map<string, Verdict>): void {
+  mkdirSync(path.dirname(CACHE_PATH), { recursive: true });
+  writeFileSync(CACHE_PATH, JSON.stringify(Object.fromEntries(c), null, 2));
+}
+
+function pairKey(field: string, ref: unknown, model: unknown): string {
+  return `recap:${field}:` + createHash('sha256').update(JSON.stringify([ref, model])).digest('hex').slice(0, 32);
+}
+
+function getValue(v: unknown): unknown {
+  if (v == null) return null;
+  if (typeof v === 'object' && 'value' in (v as Record<string, unknown>)) {
+    return (v as { value: unknown }).value;
+  }
+  return v;
+}
+
+function toComparable(v: unknown): string | number | boolean | null {
+  const x = getValue(v);
+  if (x == null) return null;
+  if (typeof x === 'string') {
+    const trimmed = x.trim();
+    return trimmed === '' ? null : trimmed;
+  }
+  if (typeof x === 'number' || typeof x === 'boolean') return x;
+  if (Array.isArray(x)) {
+    if (x.length === 0) return null;
+    return JSON.stringify(x);
+  }
+  if (typeof x === 'object') return JSON.stringify(x);
+  return String(x);
+}
+
+function normalizeStr(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').replace(/[.,;:!?'"`]/g, '').trim();
+}
+
+function withinTolerance(a: number, b: number, tol = 0.05): boolean {
+  if (a === 0) return b === 0;
+  return Math.abs(a - b) / Math.abs(a) <= tol;
+}
+
+const SEMANTIC_JUDGE_SYSTEM = `You judge whether two values for a fixture recap field describe the SAME thing.
+
+Field-pair examples that ARE equivalent:
+- "GULF MARITIME BROKERS LLC" = "Gulf Maritime Brokers LLC"
+- "8/12 May 2026" = "08-12 May 2026" = "8th to 12th May 2026"
+- "USD 25 PMT FIOST" = "25 USD per metric ton, FIOST basis"
+- "Full despatch" = "FD" = "Despatch at demurrage rate"
+- "BIMCO GENCON 94" = "Gencon 1994" = "GENCON '94"
+
+NOT equivalent:
+- Different ports / vessels / numbers / dates outside tolerance
+- One value null, the other not (under-extraction)
+- Partial extraction missing material info
+
+Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
+
+async function judgePair(field: string, ref: unknown, model: unknown): Promise<Verdict> {
+  const userMsg = `FIELD: ${field}\nREF:   ${JSON.stringify(ref)}\nMODEL: ${JSON.stringify(model)}`;
+  let lastErr = 'unknown';
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      const raw = await callAiText('PARSE_RECAP_JUDGE', SEMANTIC_JUDGE_SYSTEM, userMsg, {
+        maxTokens: 200, timeoutMs: 30_000,
+      });
+      const cleaned = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
+      const parsed = JSON.parse(cleaned) as Verdict;
+      if (typeof parsed.equiv !== 'boolean') throw new Error('equiv not boolean');
+      return parsed;
+    } catch (e) {
+      lastErr = (e as Error).message.slice(0, 80);
+      const isRate = /too many requests|throttl|rate.?limit|429/i.test(lastErr);
+      if (attempt < 4 && isRate) { await new Promise(r => setTimeout(r, 5_000 * attempt)); continue; }
+      break;
+    }
+  }
+  console.error('[judge-pr] parse fail:', { field, ref, model, err: lastErr });
+  return { equiv: false, reason: 'judge parse error — conservative non-match' };
+}
+
+async function getCached(
+  cache: Map<string, Verdict>, field: string, ref: unknown, model: unknown,
+  stats: { judged: number; cached: number },
+): Promise<Verdict> {
+  const refC = toComparable(ref);
+  const modelC = toComparable(model);
+
+  // Deterministic checks before LLM call
+  if (refC === null && modelC === null) return { equiv: true, reason: 'both null' };
+  if (refC === null || modelC === null) return { equiv: false, reason: 'one null one not' };
+  if (refC === modelC) return { equiv: true, reason: 'identical' };
+  if (typeof refC === 'number' && typeof modelC === 'number' && withinTolerance(refC, modelC)) {
+    return { equiv: true, reason: 'within ±5%' };
+  }
+  if (typeof refC === 'string' && typeof modelC === 'string' && normalizeStr(refC) === normalizeStr(modelC)) {
+    return { equiv: true, reason: 'case/whitespace match' };
+  }
+
+  const key = pairKey(field, ref, model);
+  const hit = cache.get(key);
+  if (hit) { stats.cached++; return hit; }
+  await new Promise(r => setTimeout(r, 800));
+  const verdict = await judgePair(field, ref, model);
+  if (!verdict.reason.startsWith('judge parse error')) { cache.set(key, verdict); saveCache(cache); }
+  stats.judged++;
+  return verdict;
+}
+
+async function main() {
+  const idx = process.argv.indexOf('--results');
+  if (idx < 0) { console.error('Usage: judge-parse-recap.ts --results <path>'); process.exit(1); }
+  const resultsPath = path.resolve(process.argv[idx + 1]);
+  const results: RunResult[] = JSON.parse(readFileSync(resultsPath, 'utf-8'));
+  const cache = loadCache();
+  const stats = { judged: 0, cached: 0 };
+
+  const fieldStats = new Map<string, { pass: number; total: number }>();
+
+  for (const r of results) {
+    if (!r.reference_output) continue;
+    const refKeys = Object.keys(r.reference_output);
+    const verdicts: Record<string, Verdict> = {};
+    for (const field of refKeys) {
+      const ref = r.reference_output[field];
+      const model = r.model_output?.[field];
+      const v = await getCached(cache, field, ref, model, stats);
+      verdicts[field] = v;
+      const s = fieldStats.get(field) ?? { pass: 0, total: 0 };
+      s.total++;
+      if (v.equiv) s.pass++;
+      fieldStats.set(field, s);
+    }
+    r.field_verdicts = verdicts;
+  }
+
+  writeFileSync(resultsPath, JSON.stringify(results, null, 2));
+
+  console.error(`[judge-pr] pairs_judged=${stats.judged} cached=${stats.cached}`);
+  console.error(`[judge-pr] scenarios=${results.length}`);
+  const totalPass = [...fieldStats.values()].reduce((a, s) => a + s.pass, 0);
+  const totalAll = [...fieldStats.values()].reduce((a, s) => a + s.total, 0);
+  console.error(`[judge-pr] overall_field_accuracy: ${totalPass}/${totalAll} (${(totalPass/totalAll*100).toFixed(1)}%)`);
+  const fullPass = results.filter(r => Object.values(r.field_verdicts ?? {}).every(v => v.equiv)).length;
+  console.error(`[judge-pr] semantic_full: ${fullPass}/${results.length} (${(fullPass/results.length*100).toFixed(1)}%)`);
+  console.error('[judge-pr] per-field accuracy:');
+  const sorted = [...fieldStats.entries()].sort((a, b) => (a[1].pass/a[1].total) - (b[1].pass/b[1].total));
+  for (const [field, s] of sorted) {
+    const pct = (s.pass / s.total * 100).toFixed(1);
+    console.error(`  ${field.padEnd(28)} ${s.pass}/${s.total} (${pct}%)`);
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/progonq/run-parse-recap.ts
+++ b/scripts/progonq/run-parse-recap.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * progonq runner for parse-recap endpoint.
+ *
+ * Runs FIXTURE_RECAP_PARSER_PROMPT against .progonq/corpus/etms-parse-recap/
+ * scenarios and saves results to .progonq/results/etms-parse-recap-<round>.json.
+ * Resumable: skips scenarios already in results file.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/progonq/run-parse-recap.ts [--round R0] [--limit N] [--scenario scenario-001]
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { callAiText } from '@/lib/ai-provider';
+import { FIXTURE_RECAP_PARSER_PROMPT } from '@/lib/prompts/parse-recap';
+import { PARSE_RECAP_SCHEMA } from '@/lib/schemas';
+
+const SCOPE = 'PARSE_RECAP';
+const MAX_BODY_CHARS = 12000;
+const REQUEST_DELAY_MS = 400;
+
+const CORPUS_DIR = path.resolve(process.cwd(), '.progonq/corpus/etms-parse-recap');
+const RESULTS_DIR = path.resolve(process.cwd(), '.progonq/results');
+
+interface Scenario {
+  id: string;
+  input: {
+    subject?: string;
+    from?: string;
+    date?: string;
+    body: string;
+  };
+  reference_output: Record<string, unknown>;
+}
+
+interface RunResult {
+  scenario_id: string;
+  duration_ms: number;
+  reference_output: Record<string, unknown>;
+  model_output: Record<string, unknown> | null;
+  error?: string;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max);
+}
+
+function extractJson(text: string): unknown {
+  let s = text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  const start = s.search(/[{[]/);
+  if (start > 0) s = s.slice(start);
+  const opener = s[0];
+  if (opener !== '{' && opener !== '[') return JSON.parse(s);
+  const closer = opener === '{' ? '}' : ']';
+  let depth = 0, inStr = false, esc = false, end = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (esc) { esc = false; continue; }
+    if (c === '\\' && inStr) { esc = true; continue; }
+    if (c === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (c === opener) depth++;
+    else if (c === closer && --depth === 0) { end = i; break; }
+  }
+  return JSON.parse(end > 0 ? s.slice(0, end + 1) : s);
+}
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function runScenario(scenario: Scenario): Promise<RunResult> {
+  const t0 = Date.now();
+  const subject = scenario.input.subject ?? '';
+  const from = scenario.input.from ?? '';
+  const date = scenario.input.date ?? '';
+  const body = truncate(scenario.input.body, MAX_BODY_CHARS);
+  const userPrompt = `Subject: ${subject}\nFrom: ${from}\nDate: ${date}\n\n${body}`;
+
+  let model_output: Record<string, unknown> | null = null;
+  let lastErr = '';
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const raw = await callAiText(SCOPE, FIXTURE_RECAP_PARSER_PROMPT, userPrompt, {
+        timeoutMs: 120_000,
+        responseSchema: PARSE_RECAP_SCHEMA,
+      });
+      const parsed = extractJson(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        model_output = parsed as Record<string, unknown>;
+        break;
+      }
+      throw new Error('extracted JSON is not an object');
+    } catch (e: unknown) {
+      lastErr = (e instanceof Error ? e.message : String(e)).slice(0, 160);
+      console.error(`  [${scenario.id}] attempt ${attempt} ERR: ${lastErr} — retry in ${attempt * 2}s`);
+      await sleep(attempt * 2_000);
+    }
+  }
+
+  return {
+    scenario_id: scenario.id,
+    duration_ms: Date.now() - t0,
+    reference_output: scenario.reference_output,
+    model_output,
+    error: model_output ? undefined : lastErr,
+  };
+}
+
+async function main() {
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const roundIdx = process.argv.indexOf('--round');
+  const round = roundIdx >= 0 ? process.argv[roundIdx + 1] : 'baseline';
+  const limitIdx = process.argv.indexOf('--limit');
+  const limit = limitIdx >= 0 ? Number(process.argv[limitIdx + 1]) : Infinity;
+  const sidIdx = process.argv.indexOf('--scenario');
+  const onlySid = sidIdx >= 0 ? process.argv[sidIdx + 1] : null;
+
+  const outPath = path.join(RESULTS_DIR, `etms-parse-recap-${round}.json`);
+  const existing: RunResult[] = existsSync(outPath) ? JSON.parse(readFileSync(outPath, 'utf-8')) : [];
+  const done = new Set(existing.map(r => r.scenario_id));
+
+  const files = readdirSync(CORPUS_DIR).filter(f => f.endsWith('.json')).sort();
+  const results: RunResult[] = [...existing];
+
+  let okCount = existing.filter(r => !r.error).length;
+  let errCount = existing.filter(r => r.error).length;
+  let count = 0;
+
+  console.error(`[run-parse-recap] round=${round} total=${files.length} pending=${files.length - existing.length}`);
+
+  for (const file of files) {
+    if (count >= limit) break;
+    const sc = JSON.parse(readFileSync(path.join(CORPUS_DIR, file), 'utf-8')) as Scenario;
+    if (onlySid && sc.id !== onlySid) continue;
+    if (done.has(sc.id)) continue;
+    const r = await runScenario(sc);
+    results.push(r);
+    if (r.error) errCount++; else okCount++;
+    count++;
+    writeFileSync(outPath, JSON.stringify(results, null, 2));
+    if (count % 1 === 0) console.error(`[run-parse-recap] ${count}/${files.length} done (ok=${okCount} err=${errCount})`);
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  console.error(`\n[run-parse-recap] DONE round=${round}`);
+  console.error(`Output: ${outPath}`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Two new scripts mirroring the parse-vessel/cargo progonq pattern, building the eval harness for parse-recap.

- `scripts/progonq/run-parse-recap.ts` — runs `FIXTURE_RECAP_PARSER_PROMPT` against `.progonq/corpus/etms-parse-recap/`, resumable.
- `scripts/progonq/judge-parse-recap.ts` — for each scenario compares model vs reference across all GT keys (~49 fields). Deterministic checks first (null pair, identical, numeric ±5%, normalized string), then semantic LLM judge with cache.

## Baseline R0 (post-PR #217 schema fix, 3 corpus scenarios)

```
overall_field_accuracy: 82/147 (55.8%)
semantic_full:          0/3 (0.0%)
```

| Accuracy | Count | Examples |
|---|---|---|
| 100% | 15 | vessel_name, load_port, laycan, freight_rate, demurrage_rate, vessel_dwt, cp_form, commission_percent |
| 66.7% | 11 | cargo_quantity_max, freight_basis, law, commission_*_pct, subs, confidentiality |
| 33.3% | 13 | charterers, broker, cargo_description, loading_rate, discharging_rate, arbitration, vessel_yob, vessel_flag, acknowledgement_deadline |
| **0%** | **9** | owners, freight_payment, loading_terms, loading/discharging_working_hours, despatch_rate, vessel_draft, additional_terms, unknown_terms |

Runtime baseline 55.8% lower than static-analysis ~70% (scripts/baselines/parse-recap-baseline-2026-05-17.md) — closer to ground truth.

## What this enables

1. Runtime validation of any future parse-recap prompt/schema change
2. Identifies 9 fields silently always-null (follow-up: investigate schema/prompt format mismatch — same class as PR #216/#217 but more subtle)
3. Foundation for corpus expansion (3 → 30+ scenarios — separate task)

## Test plan
- [x] Runner generates valid JSON output (3/3 scenarios ok=3 err=0)
- [x] Judge computes per-field accuracy without crash
- [x] Cache shared with parse-vessel/cargo (prefix 'recap:')

## Follow-ups (not in this PR)

1. Add 8 missing GT fields to PARSE_RECAP_SCHEMA: vessel_yob, vessel_flag, acknowledgement_deadline, despatch_rate, commission_address_pct/amount, commission_broker_pct/amount
2. Investigate 9 always-null fields (likely schema shape mismatch for arrays/specific structures)
3. Corpus expansion 3 → 30+ scenarios