### PR TITLE
feat(sentry): router transitions + Session Replay + prod sampling 10% [code-only]

### DIFF
--- a/.pipeline/verdicts/phase_1_sentry_tuning.json
+++ b/.pipeline/verdicts/phase_1_sentry_tuning.json
@@ -1,0 +1,24 @@
+{
+  "phase": "1",
+  "task_id": "sentry-tuning",
+  "task_description": "Sentry tuning batch: PART A onRouterTransitionStart hook, PART B Session Replay (10%/100% prod), PART C env-based tracesSampleRate (10% prod / 100% dev)",
+  "files_in_scope": [
+    "instrumentation-client.ts",
+    "sentry.server.config.ts",
+    "sentry.edge.config.ts",
+    "__tests__/sentry-wiring.test.ts",
+    "lib/__tests__/sentry.test.ts"
+  ],
+  "scope_size": 5,
+  "cross_cutting_surface": [],
+  "rule_g_triggered": false,
+  "rule_g_reason": "config-pr exclusion — Sentry init options only, not parser/auth/payments/cron/migration domain",
+  "boundary_classes_planned": [1, 7],
+  "gotchas_acknowledged": [
+    "@sentry/nextjs resolves to server build in node testEnvironment — client APIs (replayIntegration, captureRouterTransitionStart) must be mocked",
+    "A3 mock in sentry-wiring.test.ts needs replayIntegration added after PART B impl",
+    "process.env.NODE_ENV manipulation in node testEnvironment works via object spread copy"
+  ],
+  "assumptions_path": null,
+  "escalate_to": null
+}

--- a/.pipeline/verdicts/phase_2_sentry_tuning.json
+++ b/.pipeline/verdicts/phase_2_sentry_tuning.json
@@ -1,0 +1,28 @@
+{
+  "phase": "2",
+  "mode": "single-agent",
+  "impl_files": [
+    "instrumentation-client.ts",
+    "sentry.server.config.ts",
+    "sentry.edge.config.ts"
+  ],
+  "test_files": [
+    "__tests__/sentry-wiring.test.ts",
+    "lib/__tests__/sentry.test.ts"
+  ],
+  "tests_total": 27,
+  "tests_green": 27,
+  "test_rewrite_count": 1,
+  "test_patches_accepted_total": 0,
+  "pi3_triggered": false,
+  "pi2_violations": [],
+  "pi4_flag_tests_added": false,
+  "class_11_pbt_added": false,
+  "rule_g_verdicts": {
+    "phase_2a": null,
+    "phase_2b": null,
+    "needs_review_rounds": 0
+  },
+  "green_verified": true,
+  "notes": "test_rewrite_count=1: updated A3 mock to add replayIntegration + captureRouterTransitionStart after PART B impl. This is a mock setup change, not an expected-value change — PI3 threshold not triggered (threshold=5 expected-value rewrites)."
+}

--- a/.pipeline/verdicts/phase_3_sentry_tuning.json
+++ b/.pipeline/verdicts/phase_3_sentry_tuning.json
@@ -1,0 +1,18 @@
+{
+  "phase": "3",
+  "qi_persona": "default",
+  "classes_checked": [1, 7, 10, 11],
+  "findings": [],
+  "verdict": "PASS",
+  "pi3_compliance": true,
+  "phase_2_verdict_read": true,
+  "phase_2_test_rewrite_count_observed": 1,
+  "fail_rework_round": 0,
+  "notes": [
+    "Class 1: DSN guard logic unchanged, existing tests cover empty/null DSN paths",
+    "Class 7: NODE_ENV cross-ref tested by E3/E6/F1/G1",
+    "Class 10: config PR exclusion — single-agent TDD acceptable",
+    "Class 11: not applicable to Sentry init config (no parser/regex/normalizer domain)",
+    "test_rewrite_count=1 is a mock setup fix, not an expected-value rewrite — PI3 compliant"
+  ]
+}

--- a/__tests__/sentry-wiring.test.ts
+++ b/__tests__/sentry-wiring.test.ts
@@ -60,6 +60,8 @@ describe("instrumentation-client.ts — NEXT_PUBLIC_SENTRY_DSN guard", () => {
     const mockInit = jest.fn();
     jest.doMock("@sentry/nextjs", () => ({
       init: mockInit,
+      captureRouterTransitionStart: jest.fn(),
+      replayIntegration: jest.fn(() => ({ name: "Replay" })),
       captureException: jest.fn(),
     }));
 
@@ -213,5 +215,101 @@ describe("app/error.tsx — structural contract (no jsdom)", () => {
 
     // Calling the component as a function should not throw
     expect(() => mod.default({ error: testError, reset: resetFn })).not.toThrow();
+  });
+});
+
+// ─── E. instrumentation-client.ts — sentry-tuning features ─────────────────
+
+const sentryTuningMock = () => ({
+  init: jest.fn(),
+  captureRouterTransitionStart: jest.fn(),
+  replayIntegration: jest.fn(() => ({ name: "Replay" })),
+  captureException: jest.fn(),
+});
+
+describe("instrumentation-client.ts — sentry-tuning (onRouterTransitionStart + Replay + prod sampling)", () => {
+  it("E1 — onRouterTransitionStart is exported as a function", async () => {
+    jest.doMock("@sentry/nextjs", sentryTuningMock);
+
+    const mod = await import("../instrumentation-client") as { onRouterTransitionStart?: unknown };
+    expect(typeof mod.onRouterTransitionStart).toBe("function");
+  });
+
+  it("E2 — tracesSampleRate is 1.0 in non-production (regression guard)", async () => {
+    const DSN = "https://testkey@sentry.io/123";
+    const mockInit = jest.fn();
+    jest.doMock("@sentry/nextjs", () => ({ ...sentryTuningMock(), init: mockInit }));
+
+    process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    // NODE_ENV is 'test' in this environment — not production
+    await import("../instrumentation-client");
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({ tracesSampleRate: 1.0 })
+    );
+  });
+
+  it("E3 — tracesSampleRate is 0.1 in production (Class 7: NODE_ENV config cross-ref)", async () => {
+    const DSN = "https://testkey@sentry.io/123";
+    const mockInit = jest.fn();
+    jest.doMock("@sentry/nextjs", () => ({ ...sentryTuningMock(), init: mockInit }));
+
+    process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    process.env.NODE_ENV = "production";
+    await import("../instrumentation-client");
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({ tracesSampleRate: 0.1 })
+    );
+  });
+
+  it("E4 — integrations array contains replayIntegration result", async () => {
+    const DSN = "https://testkey@sentry.io/123";
+    const mockInit = jest.fn();
+    const replayInstance = { name: "Replay" };
+    jest.doMock("@sentry/nextjs", () => ({
+      ...sentryTuningMock(),
+      init: mockInit,
+      replayIntegration: jest.fn(() => replayInstance),
+    }));
+
+    process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    await import("../instrumentation-client");
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrations: expect.arrayContaining([replayInstance]),
+      })
+    );
+  });
+
+  it("E5 — replaysSessionSampleRate is 0 in non-production (Class 7)", async () => {
+    const DSN = "https://testkey@sentry.io/123";
+    const mockInit = jest.fn();
+    jest.doMock("@sentry/nextjs", () => ({ ...sentryTuningMock(), init: mockInit }));
+
+    process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    await import("../instrumentation-client");
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({ replaysSessionSampleRate: 0 })
+    );
+  });
+
+  it("E6 — replaysSessionSampleRate is 0.1 and replaysOnErrorSampleRate is 1.0 in production (Class 7)", async () => {
+    const DSN = "https://testkey@sentry.io/123";
+    const mockInit = jest.fn();
+    jest.doMock("@sentry/nextjs", () => ({ ...sentryTuningMock(), init: mockInit }));
+
+    process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    process.env.NODE_ENV = "production";
+    await import("../instrumentation-client");
+
+    expect(mockInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1.0,
+      })
+    );
   });
 });

--- a/__tests__/sentry-wiring.test.ts
+++ b/__tests__/sentry-wiring.test.ts
@@ -255,6 +255,7 @@ describe("instrumentation-client.ts — sentry-tuning (onRouterTransitionStart +
     jest.doMock("@sentry/nextjs", () => ({ ...sentryTuningMock(), init: mockInit }));
 
     process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = "production";
     await import("../instrumentation-client");
 
@@ -302,6 +303,7 @@ describe("instrumentation-client.ts — sentry-tuning (onRouterTransitionStart +
     jest.doMock("@sentry/nextjs", () => ({ ...sentryTuningMock(), init: mockInit }));
 
     process.env.NEXT_PUBLIC_SENTRY_DSN = DSN;
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = "production";
     await import("../instrumentation-client");
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,5 +2,13 @@ import * as Sentry from "@sentry/nextjs";
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 if (dsn) {
-  Sentry.init({ dsn, tracesSampleRate: 1.0 });
+  Sentry.init({
+    dsn,
+    integrations: [Sentry.replayIntegration()],
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 0,
+    replaysOnErrorSampleRate: 1.0,
+  });
 }
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/lib/__tests__/sentry.test.ts
+++ b/lib/__tests__/sentry.test.ts
@@ -85,3 +85,65 @@ describe("instrumentation register()", () => {
     });
   });
 });
+
+// ─── sentry-tuning: PART C prod sampling (Class 7: NODE_ENV cross-ref) ──────
+
+describe("sentry.server.config — prod sampling (sentry-tuning PART C)", () => {
+  const savedNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedNodeEnv;
+  });
+
+  it("F1 — tracesSampleRate is 0.1 in production", () => {
+    process.env.SENTRY_DSN = "https://test@sentry.io/456";
+    process.env.NODE_ENV = "production";
+    jest.isolateModules(() => {
+      require("../../sentry.server.config");
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({ tracesSampleRate: 0.1 })
+      );
+    });
+  });
+
+  it("F2 — tracesSampleRate is 1.0 in development (regression guard)", () => {
+    process.env.SENTRY_DSN = "https://test@sentry.io/456";
+    process.env.NODE_ENV = "development";
+    jest.isolateModules(() => {
+      require("../../sentry.server.config");
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({ tracesSampleRate: 1.0 })
+      );
+    });
+  });
+});
+
+describe("sentry.edge.config — prod sampling (sentry-tuning PART C)", () => {
+  const savedNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedNodeEnv;
+  });
+
+  it("G1 — tracesSampleRate is 0.1 in production", () => {
+    process.env.SENTRY_DSN = "https://test@sentry.io/789";
+    process.env.NODE_ENV = "production";
+    jest.isolateModules(() => {
+      require("../../sentry.edge.config");
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({ tracesSampleRate: 0.1 })
+      );
+    });
+  });
+
+  it("G2 — tracesSampleRate is 1.0 in development (regression guard)", () => {
+    process.env.SENTRY_DSN = "https://test@sentry.io/789";
+    process.env.NODE_ENV = "development";
+    jest.isolateModules(() => {
+      require("../../sentry.edge.config");
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({ tracesSampleRate: 1.0 })
+      );
+    });
+  });
+});

--- a/lib/__tests__/sentry.test.ts
+++ b/lib/__tests__/sentry.test.ts
@@ -92,11 +92,13 @@ describe("sentry.server.config — prod sampling (sentry-tuning PART C)", () => 
   const savedNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = savedNodeEnv;
   });
 
   it("F1 — tracesSampleRate is 0.1 in production", () => {
     process.env.SENTRY_DSN = "https://test@sentry.io/456";
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = "production";
     jest.isolateModules(() => {
       require("../../sentry.server.config");
@@ -108,6 +110,7 @@ describe("sentry.server.config — prod sampling (sentry-tuning PART C)", () => 
 
   it("F2 — tracesSampleRate is 1.0 in development (regression guard)", () => {
     process.env.SENTRY_DSN = "https://test@sentry.io/456";
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = "development";
     jest.isolateModules(() => {
       require("../../sentry.server.config");
@@ -122,11 +125,13 @@ describe("sentry.edge.config — prod sampling (sentry-tuning PART C)", () => {
   const savedNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = savedNodeEnv;
   });
 
   it("G1 — tracesSampleRate is 0.1 in production", () => {
     process.env.SENTRY_DSN = "https://test@sentry.io/789";
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = "production";
     jest.isolateModules(() => {
       require("../../sentry.edge.config");
@@ -138,6 +143,7 @@ describe("sentry.edge.config — prod sampling (sentry-tuning PART C)", () => {
 
   it("G2 — tracesSampleRate is 1.0 in development (regression guard)", () => {
     process.env.SENTRY_DSN = "https://test@sentry.io/789";
+    // @ts-expect-error - readonly in strict types but writable at runtime
     process.env.NODE_ENV = "development";
     jest.isolateModules(() => {
       require("../../sentry.edge.config");

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,5 +2,5 @@ import * as Sentry from "@sentry/nextjs";
 
 const dsn = process.env.SENTRY_DSN;
 if (dsn) {
-  Sentry.init({ dsn, tracesSampleRate: 1.0 });
+  Sentry.init({ dsn, tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0 });
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,5 +2,5 @@ import * as Sentry from "@sentry/nextjs";
 
 const dsn = process.env.SENTRY_DSN;
 if (dsn) {
-  Sentry.init({ dsn, tracesSampleRate: 1.0 });
+  Sentry.init({ dsn, tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0 });
 }


### PR DESCRIPTION
## Summary

Three Sentry tuning improvements on top of PR #209 wiring:

- **PART A — onRouterTransitionStart hook**: exports `Sentry.captureRouterTransitionStart` from `instrumentation-client.ts`, resolving the Sentry build warning and enabling App Router navigation spans in traces.
- **PART B — Session Replay**: added `replayIntegration()` with 10% session sampling in prod / 0% in dev, and 100% sampling on all errors (`replaysOnErrorSampleRate: 1.0`).
- **PART C — Production sampling 10%**: replaced hardcoded `tracesSampleRate: 1.0` with `NODE_ENV === 'production' ? 0.1 : 1.0` in all three init files (`instrumentation-client.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts`) — full local visibility, cost control on prod traffic.

## Test plan

- [ ] `npx jest "__tests__/sentry-wiring|lib/__tests__/sentry" --no-coverage` → 27/27 pass
- [ ] `npm run build` → compiled successfully, no Sentry warning
- [ ] `npx tsc --noEmit` → no type errors
- [ ] Verify replay sessions appear in Sentry dashboard after next prod deploy
- [ ] Verify navigation spans visible in Sentry traces for page transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)