### PR TITLE
fix(parse-recap): schema completeness +8 fields, judge passes extracted values

### DIFF
--- a/lib/schemas/parse-recap.ts
+++ b/lib/schemas/parse-recap.ts
@@ -3,8 +3,10 @@
  *
  * Fixture recap output is a flat JSON object (not wrapped in `items`).
  * Field names MUST exactly match `RawFixtureRecap` in
- * `lib/parsing/parse-recap-helpers.ts` — that interface is the canonical
- * downstream contract. Mismatched field names silently extract as null.
+ * `lib/parsing/parse-recap-helpers.ts` for downstream consumption.
+ * Additional eval-only fields (vessel_yob, vessel_flag, etc.) are present
+ * in ground-truth references but not read by the parser — they exist so
+ * progonq evals can measure extraction quality.
  */
 
 import { Type } from '@google/genai';
@@ -13,6 +15,15 @@ const confidenceFieldString = {
   type: Type.OBJECT,
   properties: {
     value: { type: Type.STRING },
+    confidence: { type: Type.STRING },
+    source_text: { type: Type.STRING },
+  },
+};
+
+const confidenceFieldNumber = {
+  type: Type.OBJECT,
+  properties: {
+    value: { type: Type.NUMBER },
     confidence: { type: Type.STRING },
     source_text: { type: Type.STRING },
   },
@@ -31,8 +42,10 @@ export const PARSE_RECAP_SCHEMA = {
   properties: {
     // Vessel
     vessel_name: confidenceFieldString,
+    vessel_yob: confidenceFieldNumber,
+    vessel_flag: confidenceFieldString,
     vessel_dwt: { type: Type.STRING, nullable: true },
-    vessel_draft: { type: Type.STRING, nullable: true },
+    vessel_draft: confidenceFieldString,
     vessel_geared: { type: Type.BOOLEAN, nullable: true },
     // Parties
     owners: confidenceFieldString,
@@ -55,17 +68,18 @@ export const PARSE_RECAP_SCHEMA = {
     // Freight
     freight_rate: confidenceFieldString,
     freight_basis: { type: Type.STRING, nullable: true },
-    freight_payment: { type: Type.STRING, nullable: true },
+    freight_payment: confidenceFieldString,
     // Laytime
     loading_rate: confidenceFieldString,
     loading_terms: confidenceFieldString,
-    loading_working_hours: { type: Type.STRING, nullable: true },
+    loading_working_hours: confidenceFieldString,
     discharging_rate: confidenceFieldString,
     discharging_terms: confidenceFieldString,
-    discharging_working_hours: { type: Type.STRING, nullable: true },
-    // Demurrage
+    discharging_working_hours: confidenceFieldString,
+    // Demurrage & Despatch
     demurrage_rate: confidenceFieldString,
     demurrage_payment: { type: Type.STRING, nullable: true },
+    despatch_rate: confidenceFieldString,
     // Legal
     cp_form: { type: Type.STRING, nullable: true },
     arbitration: { type: Type.STRING, nullable: true },
@@ -77,8 +91,13 @@ export const PARSE_RECAP_SCHEMA = {
     commission_base: { type: Type.STRING, nullable: true },
     commission_amount: { type: Type.STRING, nullable: true },
     commission_currency: { type: Type.STRING, nullable: true },
+    commission_address_pct: { type: Type.NUMBER, nullable: true },
+    commission_address_amount: { type: Type.STRING, nullable: true },
+    commission_broker_pct: { type: Type.NUMBER, nullable: true },
+    commission_broker_amount: { type: Type.STRING, nullable: true },
     // Meta
     subs: { type: Type.ARRAY, items: { type: Type.STRING }, nullable: true },
+    acknowledgement_deadline: { type: Type.STRING, nullable: true },
     confidentiality: { type: Type.BOOLEAN, nullable: true },
     additional_terms: { type: Type.ARRAY, items: { type: Type.STRING }, nullable: true },
     unknown_terms: { type: Type.ARRAY, items: unknownTermItem, nullable: true },

--- a/scripts/progonq/judge-parse-recap.ts
+++ b/scripts/progonq/judge-parse-recap.ts
@@ -99,7 +99,7 @@ NOT equivalent:
 Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
 
 async function judgePair(field: string, ref: unknown, model: unknown): Promise<Verdict> {
-  const userMsg = `FIELD: ${field}\nREF:   ${JSON.stringify(ref)}\nMODEL: ${JSON.stringify(model)}`;
+  const userMsg = `FIELD: ${field}\nREF:   ${JSON.stringify(toComparable(ref))}\nMODEL: ${JSON.stringify(toComparable(model))}`;
   let lastErr = 'unknown';
   for (let attempt = 1; attempt <= 4; attempt++) {
     try {


### PR DESCRIPTION
See commit message. R1 vs R0: 55.8% -> 57.8% overall, +5 fields at 100%, +2 fields at 67%. Schema adds 8 GT-present fields (vessel_yob, vessel_flag, acknowledgement_deadline, despatch_rate, commission_address_pct/amount, commission_broker_pct/amount) and upgrades 5 string fields to confidenceFieldString shape. Judge bug fix: passes toComparable() extracted values not raw CF objects.