### PR TITLE
fix(middleware): add 3 missing webhook/admin endpoints to AUTH_BYPASS_PATHS

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -59,6 +59,9 @@ describe('middleware auth guard', () => {
       '/_next/image?url=x',
       '/api/whatsapp/webhook',
       '/api/integrations/pipedrive/webhook',
+      '/api/whatsapp/ingest',
+      '/api/admin/knowledge/refresh',
+      '/api/admin/knowledge-status',
     ];
 
     for (const path of bypassPaths) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,6 +20,11 @@ const AUTH_BYPASS_PATHS = new Set([
   '/api/whatsapp/webhook',
   // Pipedrive webhook has its own HMAC-SHA256 signature verification
   '/api/integrations/pipedrive/webhook',
+  // WhatsApp internal ingest has its own x-quantika-internal token
+  '/api/whatsapp/ingest',
+  // Admin knowledge endpoints have their own X-Admin-Token check (requireAdmin)
+  '/api/admin/knowledge/refresh',
+  '/api/admin/knowledge-status',
 ]);
 
 const AUTH_BYPASS_PREFIXES = ['/_next/static', '/_next/image', '/_next/webpack'];


### PR DESCRIPTION
Closes HIGH-severity gap from ROADMAP §1.3. WhatsApp ingest + admin knowledge endpoints were getting redirected to /login despite having their own auth. 22/22 middleware tests pass.