### PR TITLE
fix(parse-recap): prompt rules for owners/despatch/vessel_draft + unknown_terms rename

### DIFF
--- a/lib/prompts/parse-recap.ts
+++ b/lib/prompts/parse-recap.ts
@@ -64,7 +64,10 @@ Extract fields:
 - vessel_name
 - vessel_yob: year of build (integer, if stated in the recap)
 - vessel_flag: flag state (if stated)
-- owners: shipowner or disponent owner
+- owners: SHIPOWNER or DISPONENT OWNER ONLY. Look for explicit "Owners:", "Owners/Managers:", "Disponent Owners:" prefix in the recap body. Do NOT use:
+    * email sender / signature / "From:" line — that is usually the broker
+    * "OWNERS:" label inside a one-line summary that names a different role (e.g. "OWNERS: KILYOS" where KILYOS is the agreed cargo account)
+  If the recap omits explicit owners disclosure, set value=null with confidence='uncertain' rather than guessing from headers.
 - charterers
 - account: cargo account / actual shipper if different from charterers
 - broker: broker(s) involved
@@ -83,11 +86,26 @@ Extract fields:
 - discharging_rate, discharging_terms, discharging_working_hours
 - demurrage_rate: per day rate
 - demurrage_payment: who pays, when
-- despatch_rate: if stated (complement of demurrage; e.g. "USD 2,250 per day / pro rata")
+- despatch_rate: complement of demurrage. INTERPRET standard BIMCO suffixes when present:
+    * "FD" or "FULL DESPATCH" -> despatch rate = SAME as demurrage rate (Full Despatch)
+    * "HD" or "HALF DESPATCH" -> despatch rate = HALF of demurrage rate
+    * "PDPR" -> per day pro rata (rate unit)
+    * "PDPR/FD ALL ENDS" -> Full Despatch all ends; rate equals demurrage by FD convention
+    * "PDPR FD BENDS" -> Full Despatch both ends; rate equals demurrage
+  Examples:
+    "DEMURRAGE: 1500 EURO PDPR FD" -> despatch_rate = "Full despatch (FD) at EUR 1,500 per day pro rata", confidence='interpreted'
+    "DEMURRAGE USD 8,500 PDPR/FD ALL ENDS" -> despatch_rate = "Full despatch (FD) all ends — USD 8,500 per day pro rata", confidence='interpreted'
+  If only a raw demurrage line is present with no FD/HD/despatch suffix, set despatch_rate=null.
 - load_port_agent
 - disch_port_agent
 - vessel_dwt
-- vessel_draft
+- vessel_draft: list ALL draft values stated in the recap, with their qualifiers. Include design/summer draft, maximum draft, and any cargo-dependent drafts ("max draft at X MT cargo: Y m", "owners warrant to load all cargo with Z m draft on arrival at PORT"). Format as compound string preserving each value's role. Examples:
+    "LOA/BEAM/DRAFT/DM 89,21/12,5M/4,70/6,35M" -> "4.70 m (design) / 6.35 m (maximum)"
+    "DWT 3,858 TON ON 5.84 MTR
+- Max Draft 5,50 metres" -> "5.84 m summer draught; max draft at 3000 MT cargo: 5.50 m"
+    "DWCC: 4000 MT on 6.5 M
+- OWNERS WARRANT TO LOAD WITH 6.9 METER DRAFT ARRIVAL GUYANA" -> "DWCC 4000 MT on 6.5 m draft; owners warrant to load all cargo with 6.9 m draft on arrival Guyana"
+  Single-value extraction (e.g. just "4.70M") loses critical operational context.
 - vessel_geared: boolean
 - cp_form: charter party form used (e.g. GENCON 94, NYPE 93)
 - arbitration: arbitration clause

--- a/lib/schemas/parse-recap.ts
+++ b/lib/schemas/parse-recap.ts
@@ -3,8 +3,10 @@
  *
  * Fixture recap output is a flat JSON object (not wrapped in `items`).
  * Field names MUST exactly match `RawFixtureRecap` in
- * `lib/parsing/parse-recap-helpers.ts` — that interface is the canonical
- * downstream contract. Mismatched field names silently extract as null.
+ * `lib/parsing/parse-recap-helpers.ts` for downstream consumption.
+ * Additional eval-only fields (vessel_yob, vessel_flag, etc.) are present
+ * in ground-truth references but not read by the parser — they exist so
+ * progonq evals can measure extraction quality.
  */
 
 import { Type } from '@google/genai';
@@ -13,6 +15,15 @@ const confidenceFieldString = {
   type: Type.OBJECT,
   properties: {
     value: { type: Type.STRING },
+    confidence: { type: Type.STRING },
+    source_text: { type: Type.STRING },
+  },
+};
+
+const confidenceFieldNumber = {
+  type: Type.OBJECT,
+  properties: {
+    value: { type: Type.NUMBER },
     confidence: { type: Type.STRING },
     source_text: { type: Type.STRING },
   },
@@ -31,8 +42,10 @@ export const PARSE_RECAP_SCHEMA = {
   properties: {
     // Vessel
     vessel_name: confidenceFieldString,
+    vessel_yob: confidenceFieldNumber,
+    vessel_flag: confidenceFieldString,
     vessel_dwt: { type: Type.STRING, nullable: true },
-    vessel_draft: { type: Type.STRING, nullable: true },
+    vessel_draft: confidenceFieldString,
     vessel_geared: { type: Type.BOOLEAN, nullable: true },
     // Parties
     owners: confidenceFieldString,
@@ -55,17 +68,18 @@ export const PARSE_RECAP_SCHEMA = {
     // Freight
     freight_rate: confidenceFieldString,
     freight_basis: { type: Type.STRING, nullable: true },
-    freight_payment: { type: Type.STRING, nullable: true },
+    freight_payment: confidenceFieldString,
     // Laytime
     loading_rate: confidenceFieldString,
     loading_terms: confidenceFieldString,
-    loading_working_hours: { type: Type.STRING, nullable: true },
+    loading_working_hours: confidenceFieldString,
     discharging_rate: confidenceFieldString,
     discharging_terms: confidenceFieldString,
-    discharging_working_hours: { type: Type.STRING, nullable: true },
-    // Demurrage
+    discharging_working_hours: confidenceFieldString,
+    // Demurrage & Despatch
     demurrage_rate: confidenceFieldString,
     demurrage_payment: { type: Type.STRING, nullable: true },
+    despatch_rate: confidenceFieldString,
     // Legal
     cp_form: { type: Type.STRING, nullable: true },
     arbitration: { type: Type.STRING, nullable: true },
@@ -77,8 +91,13 @@ export const PARSE_RECAP_SCHEMA = {
     commission_base: { type: Type.STRING, nullable: true },
     commission_amount: { type: Type.STRING, nullable: true },
     commission_currency: { type: Type.STRING, nullable: true },
+    commission_address_pct: { type: Type.NUMBER, nullable: true },
+    commission_address_amount: { type: Type.STRING, nullable: true },
+    commission_broker_pct: { type: Type.NUMBER, nullable: true },
+    commission_broker_amount: { type: Type.STRING, nullable: true },
     // Meta
     subs: { type: Type.ARRAY, items: { type: Type.STRING }, nullable: true },
+    acknowledgement_deadline: { type: Type.STRING, nullable: true },
     confidentiality: { type: Type.BOOLEAN, nullable: true },
     additional_terms: { type: Type.ARRAY, items: { type: Type.STRING }, nullable: true },
     unknown_terms: { type: Type.ARRAY, items: unknownTermItem, nullable: true },

--- a/lib/schemas/parse-recap.ts
+++ b/lib/schemas/parse-recap.ts
@@ -33,7 +33,7 @@ const unknownTermItem = {
   type: Type.OBJECT,
   properties: {
     term: { type: Type.STRING },
-    note: { type: Type.STRING },
+    context: { type: Type.STRING },
   },
 };
 

--- a/scripts/progonq/judge-parse-recap.ts
+++ b/scripts/progonq/judge-parse-recap.ts
@@ -99,7 +99,7 @@ NOT equivalent:
 Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
 
 async function judgePair(field: string, ref: unknown, model: unknown): Promise<Verdict> {
-  const userMsg = `FIELD: ${field}\nREF:   ${JSON.stringify(ref)}\nMODEL: ${JSON.stringify(model)}`;
+  const userMsg = `FIELD: ${field}\nREF:   ${JSON.stringify(toComparable(ref))}\nMODEL: ${JSON.stringify(toComparable(model))}`;
   let lastErr = 'unknown';
   for (let attempt = 1; attempt <= 4; attempt++) {
     try {


### PR DESCRIPTION
Three targeted prompt rules + schema rename for previously always-null fields. owners 0->33%, despatch_rate 0->33%, vessel_draft 0->67% in R2. See commit message for details. Overall variance noise on 3 scenarios — needs corpus expansion to stabilise.