### PR TITLE
fix(schemas/classify): enum constraints for category + urgency (defensive)

### DIFF
--- a/lib/schemas/classify.ts
+++ b/lib/schemas/classify.ts
@@ -12,8 +12,23 @@ const classificationItemSchema = {
   type: Type.OBJECT,
   properties: {
     id: { type: Type.STRING },
-    category: { type: Type.STRING },
-    urgency: { type: Type.STRING },
+    category: {
+      type: Type.STRING,
+      enum: [
+        'CARGO_INQUIRY',
+        'VESSEL_POSITION',
+        'FIXTURE_RECAP',
+        'CLIENT_REPLY',
+        'DOCUMENT',
+        'TCT_REQUEST',
+        'VESSEL_CERTIFICATE',
+        'OTHER',
+      ],
+    },
+    urgency: {
+      type: Type.STRING,
+      enum: ['low', 'medium', 'high'],
+    },
     confidence: { type: Type.NUMBER },
     is_unanswered: { type: Type.BOOLEAN },
     days_without_reply: { type: Type.NUMBER, nullable: true },


### PR DESCRIPTION
Adds enum allowed-values to classify schema (category 8 values, urgency 3 values). Pure defense against future model drift. No accuracy delta expected (Gemini already produces canonical values — R10 cat 100%, urg 70.8% baseline). Prompt rule for urgency was tested + reverted (regressed urgency to 57.8% — GT criteria are not deadline-based).