### PR TITLE
fix(explain-deal): anchor parseSections headers to prevent prose false-split

### DIFF
--- a/app/api/ai/__tests__/explain-deal.test.ts
+++ b/app/api/ai/__tests__/explain-deal.test.ts
@@ -425,4 +425,33 @@ describe('POST /api/ai/explain-deal', () => {
     const req = makeRequest({ matchIndex: 0 }, 'sess-1');
     await expect(POST(req)).rejects.toThrow('unexpected');
   });
+
+  // Regression: parseSections must anchor header matches so prose mentions
+  // like "Considering the Market Context" don't false-split a section.
+  it('does not false-match header inside body prose', async () => {
+    mockGetSession.mockReturnValue(baseSession);
+    // Model output where "Market Context" appears INSIDE Deal Rationale prose
+    // before the real "Deal Rationale" header — naive indexOf would split here.
+    mockCallAiText.mockResolvedValue(`Market Context
+Bulk freight market is firm.
+
+Deal Rationale
+Considering the Market Context above, this vessel matches the cargo well.
+DWT 25,000 fits the stem of 20,000 MT.
+
+Key Risks
+- Tight laycan window
+- Port congestion at discharge
+
+Recommended Next Steps
+Verify vessel certificates and confirm bunker plan.`);
+    const req = makeRequest({ matchIndex: 0 }, 'sess-1');
+    const res = await POST(req);
+    const body = await res.json();
+    const drs = body.sections.find((s: { heading: string }) => s.heading === 'Deal Rationale');
+    // Deal Rationale must contain its full prose, not be truncated at the
+    // "Market Context" mention.
+    expect(drs.content).toContain('Considering the Market Context above');
+    expect(drs.content).toContain('DWT 25,000');
+  });
 });

--- a/app/api/ai/explain-deal/route.ts
+++ b/app/api/ai/explain-deal/route.ts
@@ -59,12 +59,30 @@ function parseSections(
 ): ExplainDealSection[] {
   const sections: ExplainDealSection[] = [];
 
+  // Anchor headers to a heading-like context so we don't false-match the
+  // phrase inside body prose (e.g. "Considering the Market Context, ...").
+  // Accept: start-of-line, markdown bold (**Header**), numbered prefix (1.),
+  // optional leading hash. Falls back to indexOf if no anchored match found.
+  function findHeader(haystack: string, header: string): number {
+    const escaped = header.replace(/[.*+?^\${}()|[\]\\]/g, '\\$&');
+    // Try anchored matches first: line-start optionally preceded by **, ##, or N.
+    const anchored = new RegExp(
+      `(^|\\n)\\s*(?:\\*\\*|#{1,4}\\s*|\\d+\\.\\s*)?${escaped}(?:\\*\\*|:)?\\s*(?=\\n|$)`,
+    );
+    const m = anchored.exec(haystack);
+    if (m) {
+      // Position of the actual header text, not the leading whitespace/markers
+      return m.index + m[0].indexOf(header);
+    }
+    // Fallback to substring scan (legacy behavior)
+    return haystack.indexOf(header);
+  }
+
   for (let i = 0; i < headers.length; i++) {
     const header = headers[i];
     const nextHeader = headers[i + 1];
 
-    // Find the position of this header in the text
-    const headerIdx = text.indexOf(header);
+    const headerIdx = findHeader(text, header);
     if (headerIdx === -1) {
       // Header not found — include empty section so UI knows structure
       sections.push({ heading: header, content: '' });
@@ -73,12 +91,12 @@ function parseSections(
 
     // Content starts after the header line
     const afterHeader = text.slice(headerIdx + header.length);
-    // Strip leading newlines/colons
+    // Strip leading newlines/colons/markdown
     const contentStart = afterHeader.replace(/^[\s:*\n]+/, '');
 
     let content: string;
     if (nextHeader) {
-      const nextIdx = contentStart.indexOf(nextHeader);
+      const nextIdx = findHeader(contentStart, nextHeader);
       content = nextIdx !== -1
         ? contentStart.slice(0, nextIdx).trim()
         : contentStart.trim();


### PR DESCRIPTION
parseSections used naive text.indexOf which false-matched if model wrote header phrase inside body prose (e.g. "Considering the Market Context above"). Fix: anchored regex first (line-start + optional markdown markers), substring fallback. Regression test added. 24/24 tests pass.