### PR TITLE
hotfix(parse-recap): normalize unknown_terms.context → .note (broken UI from #223)

### DIFF
--- a/app/api/ai/__tests__/parse-recap.test.ts
+++ b/app/api/ai/__tests__/parse-recap.test.ts
@@ -364,4 +364,35 @@ describe('parseRecapAIResponse', () => {
     expect(result.vesselDwt).toBe(75000);
     expect(result.vesselDraft).toBe(14.5);
   });
+
+  // Regression: PR #223 renamed unknown_terms inner key from "note" to "context"
+  // to match GT, but UI + ParsedFixtureRecap.unknownTerms still read .note.
+  // Parser must normalize both shapes to canonical .note so UI keeps working.
+  it('normalizes unknown_terms.context (new Gemini schema) to .note', () => {
+    const raw = JSON.stringify({
+      unknown_terms: [
+        { term: 'APP B FITTED', context: 'Vessel description anomaly' },
+        { term: 'DM', context: 'Draft maximum suffix non-standard' },
+      ],
+      subs: [],
+      additional_terms: [],
+    });
+    const result = parseRecapAIResponse(raw, 'email-ctx');
+    expect(result.unknownTerms).toHaveLength(2);
+    expect(result.unknownTerms[0]).toEqual({
+      term: 'APP B FITTED',
+      note: 'Vessel description anomaly',
+    });
+    expect(result.unknownTerms[1].note).toBe('Draft maximum suffix non-standard');
+  });
+
+  it('preserves unknown_terms.note (legacy shape) unchanged', () => {
+    const raw = JSON.stringify({
+      unknown_terms: [{ term: 'LEGACY', note: 'old shape' }],
+      subs: [],
+      additional_terms: [],
+    });
+    const result = parseRecapAIResponse(raw, 'email-legacy');
+    expect(result.unknownTerms[0].note).toBe('old shape');
+  });
 });

--- a/lib/parsing/parse-recap-helpers.ts
+++ b/lib/parsing/parse-recap-helpers.ts
@@ -44,7 +44,7 @@ interface RawFixtureRecap {
   subs?: string[];
   confidentiality?: boolean | null;
   additional_terms?: string[];
-  unknown_terms?: Array<{ term: string; note: string }>;
+  unknown_terms?: Array<{ term: string; note?: string; context?: string }>;
 }
 
 /**
@@ -117,6 +117,12 @@ export function parseRecapAIResponse(raw: string, emailId: string): ParsedFixtur
     subs: Array.isArray(result.subs) ? result.subs : [],
     confidentiality: result.confidentiality != null ? Boolean(result.confidentiality) : false,
     additionalTerms: Array.isArray(result.additional_terms) ? result.additional_terms : [],
-    unknownTerms: Array.isArray(result.unknown_terms) ? result.unknown_terms : [],
+    // Normalize: Gemini schema field is "context"; legacy is "note". Map to canonical "note".
+    unknownTerms: Array.isArray(result.unknown_terms)
+      ? result.unknown_terms.map((ut) => ({
+          term: String(ut?.term ?? ''),
+          note: String(ut?.note ?? ut?.context ?? ''),
+        }))
+      : [],
   }) as ParsedFixtureRecap;
 }


### PR DESCRIPTION
CRITICAL hotfix found by adversarial QA. PR #223 renamed schema field note→context to match GT, but UI + parser interface still read .note → /fixture/[id] showed "<term>: undefined". Parser shim normalizes both shapes to canonical .note. UI unchanged. 18/18 tests pass + 2 new regression.