### PR TITLE
fix(parse-recap): surface 5 missing schema fields + vesselDraft compound (QA H1+H2)

### DIFF
--- a/app/api/ai/__tests__/parse-recap.test.ts
+++ b/app/api/ai/__tests__/parse-recap.test.ts
@@ -362,7 +362,42 @@ describe('parseRecapAIResponse', () => {
     const result = parseRecapAIResponse(raw, 'email-7');
     expect(result.vesselGeared).toBe(true);
     expect(result.vesselDwt).toBe(75000);
-    expect(result.vesselDraft).toBe(14.5);
+    // PR #231: vesselDraft is now string|null (was number|null) — coerces number input.
+    expect(result.vesselDraft).toBe('14.5');
+  });
+
+  // Regression: PR #231 surfaces 5 schema fields (despatch, ack_deadline,
+  // commission_address/broker pct/amount) that PRs #220 #223 added to schema
+  // but parser never read — Gemini extracted, parser threw away.
+  it('surfaces despatch_rate, acknowledgement_deadline, and commission_*_pct/amount', () => {
+    const raw = JSON.stringify({
+      despatch_rate: { value: 'Full despatch (FD) at EUR 1,500 per day pro rata' },
+      acknowledgement_deadline: 'within 30 mins of transmission',
+      commission_address_pct: 1.25,
+      commission_address_amount: 750.00,
+      commission_broker_pct: 2.5,
+      commission_broker_amount: 1500.00,
+      subs: [],
+      additional_terms: [],
+      unknown_terms: [],
+    });
+    const result = parseRecapAIResponse(raw, 'email-h2');
+    expect(result.despatchRate).toBe('Full despatch (FD) at EUR 1,500 per day pro rata');
+    expect(result.acknowledgementDeadline).toBe('within 30 mins of transmission');
+    expect(result.commissionAddressPct).toBe(1.25);
+    expect(result.commissionAddressAmount).toBe(750.00);
+    expect(result.commissionBrokerPct).toBe(2.5);
+    expect(result.commissionBrokerAmount).toBe(1500.00);
+  });
+
+  // Regression: PR #231 vesselDraft preserves compound string ("design / max").
+  it('preserves vessel_draft compound string instead of truncating to first number', () => {
+    const raw = JSON.stringify({
+      vessel_draft: { value: '4.70 m (design) / 6.35 m (maximum)' },
+      subs: [], additional_terms: [], unknown_terms: [],
+    });
+    const result = parseRecapAIResponse(raw, 'email-draft');
+    expect(result.vesselDraft).toBe('4.70 m (design) / 6.35 m (maximum)');
   });
 
   // Regression: PR #223 renamed unknown_terms inner key from "note" to "context"

--- a/lib/__tests__/commission.test.ts
+++ b/lib/__tests__/commission.test.ts
@@ -45,6 +45,13 @@ function baseRecap(overrides: Partial<ParsedFixtureRecap> = {}): ParsedFixtureRe
     confidentiality: false,
     additionalTerms: [],
     unknownTerms: [],
+    // PR #231: surfaced 5 new schema fields
+    commissionAddressPct: null,
+    commissionAddressAmount: null,
+    commissionBrokerPct: null,
+    commissionBrokerAmount: null,
+    despatchRate: null,
+    acknowledgementDeadline: null,
     ...overrides,
   };
 }

--- a/lib/parsing/parse-recap-helpers.ts
+++ b/lib/parsing/parse-recap-helpers.ts
@@ -30,8 +30,15 @@ interface RawFixtureRecap {
   load_port_agent?: string | null;
   disch_port_agent?: string | null;
   vessel_dwt?: number | string | null;
-  vessel_draft?: number | string | null;
+  vessel_draft?: number | string | null;  // compound string per prompt PR #223
   vessel_geared?: boolean | null;
+  // PR #220 + #223 added these to schema; PR #231 surfaces them downstream:
+  despatch_rate?: unknown;
+  acknowledgement_deadline?: string | null;
+  commission_address_pct?: number | string | null;
+  commission_address_amount?: number | string | null;
+  commission_broker_pct?: number | string | null;
+  commission_broker_amount?: number | string | null;
   cp_form?: string | null;
   arbitration?: string | null;
   law?: string | null;
@@ -104,7 +111,18 @@ export function parseRecapAIResponse(raw: string, emailId: string): ParsedFixtur
     loadPortAgent: result.load_port_agent || null,
     dischPortAgent: result.disch_port_agent || null,
     vesselDwt: extractNum(result.vessel_dwt),
-    vesselDraft: extractNum(result.vessel_draft),
+    // PR #231: vessel_draft is now a compound string per prompt PR #223
+    // ("4.70 m (design) / 6.35 m (maximum)"). Preserve full string instead of
+    // extractNum which only kept the first number.
+    vesselDraft: typeof result.vessel_draft === "number" ? String(result.vessel_draft) : extractStrField(result.vessel_draft),
+    despatchRate: extractStrField(result.despatch_rate),
+    acknowledgementDeadline: typeof result.acknowledgement_deadline === 'string'
+      ? result.acknowledgement_deadline
+      : null,
+    commissionAddressPct: extractNum(result.commission_address_pct),
+    commissionAddressAmount: extractNum(result.commission_address_amount),
+    commissionBrokerPct: extractNum(result.commission_broker_pct),
+    commissionBrokerAmount: extractNum(result.commission_broker_amount),
     vesselGeared: result.vessel_geared != null ? Boolean(result.vessel_geared) : null,
     cpForm: result.cp_form || null,
     arbitration: result.arbitration || null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -280,7 +280,7 @@ export interface ParsedFixtureRecap {
   dischPortAgent: string | null;
   // Vessel details
   vesselDwt: number | null;
-  vesselDraft: number | null;
+  vesselDraft: string | null;  // PR #231: compound string preserving design/max/etc
   vesselGeared: boolean | null;
   // Legal
   cpForm: string | null;
@@ -292,6 +292,13 @@ export interface ParsedFixtureRecap {
   commissionBase: string | null;
   commissionAmount: number | null;
   commissionCurrency: string | null;
+  commissionAddressPct: number | null;     // PR #231
+  commissionAddressAmount: number | null;  // PR #231
+  commissionBrokerPct: number | null;      // PR #231
+  commissionBrokerAmount: number | null;   // PR #231
+  // Operations
+  despatchRate: string | null;             // PR #231 (FD/HD interpreted text)
+  acknowledgementDeadline: string | null;  // PR #231 (broker response deadline)
   // Subs
   subs: string[];
   confidentiality: boolean;


### PR DESCRIPTION
Adversarial QA hotfixes:\n\n**H1** vessel_draft: now string|null instead of number — preserves compound "4.70 m (design) / 6.35 m (maximum)" from prompt PR #223 instead of extractNum truncating to 4.70.\n\n**H2** 5 fields surfaced: despatch_rate, acknowledgement_deadline, commission_address_pct/amount, commission_broker_pct/amount. PRs #220 + #223 added these to Gemini schema, but parser interface never listed them → Gemini extracted, parser threw away.\n\nUI display deferred to follow-up. 20/20 tests pass + 2 new regression tests.