### PR TITLE
fix(match): hard-filter physically impossible cargo/vessel size mismatches

### DIFF
--- a/app/api/ai/match/__tests__/deterministic-sweep.test.ts
+++ b/app/api/ai/match/__tests__/deterministic-sweep.test.ts
@@ -78,6 +78,7 @@ const DEFAULT_HARD_FILTERS: MatchHardFilters = {
   cargoVessel: { pass: true },
   destDraft: { pass: true },
   destCrane: { pass: true },
+  cargoWeight: { pass: true },
 };
 
 const DEFAULT_SANCTIONS: MatchSanctions = {

--- a/app/api/ai/match/__tests__/pipeline-score-integrity.test.ts
+++ b/app/api/ai/match/__tests__/pipeline-score-integrity.test.ts
@@ -50,6 +50,7 @@ const HARD_FILTERS_ALL_PASS: MatchHardFilters = {
   cargoVessel: { pass: true },
   destDraft: { pass: true },
   destCrane: { pass: true },
+  cargoWeight: { pass: true },
 };
 
 const SANCTIONS_NONE: MatchSanctions = { risk: 'NONE', blocking: false };

--- a/lib/__tests__/wave5-sanity.test.ts
+++ b/lib/__tests__/wave5-sanity.test.ts
@@ -98,6 +98,8 @@ describe('Fix 1 — destination port compatibility', () => {
       cargoType: 'BREAK_BULK',
       stowageFactor: null,
       grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(false);
     expect(r.checks.destDraft.reason).toMatch(/draft/i);
@@ -116,6 +118,8 @@ describe('Fix 1 — destination port compatibility', () => {
       cargoType: 'BREAK_BULK',
       stowageFactor: null,
       grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(true);
   });
@@ -132,6 +136,8 @@ describe('Fix 1 — destination port compatibility', () => {
       cargoType: 'BREAK_BULK',
       stowageFactor: null,
       grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
     });
     // origin may or may not pass depending on Ravenna — destDraft must fail regardless
     expect(r.checks.destDraft.pass).toBe(false);
@@ -150,6 +156,8 @@ describe('Fix 1 — destination port compatibility', () => {
       cargoType: 'BREAK_BULK',
       stowageFactor: null,
       grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destCrane.pass).toBe(false);
     expect(r.checks.destCrane.reason).toMatch(/crane|gearless/i);
@@ -167,6 +175,8 @@ describe('Fix 1 — destination port compatibility', () => {
       cargoType: 'BREAK_BULK',
       stowageFactor: null,
       grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(true);
     expect(r.checks.destCrane.pass).toBe(true);

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -82,6 +82,8 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     geared: v.geared,
     draftMax: cfValue(v.draftMax),
     grainCapacity: v.grainCapacity,
+    dwtSummer: cfValue(v.dwtSummer),
+    dwcc: cfValue(v.dwcc),
   });
 
   const hardFilters: MatchHardFilters = {
@@ -91,6 +93,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     cargoVessel: hf.checks.cargoVessel,
     destDraft: hf.checks.destDraft,
     destCrane: hf.checks.destCrane,
+    cargoWeight: hf.checks.cargoWeight,
   };
 
   const parsedLaycan = parseLaycan(c.laycan, refYear);

--- a/lib/sailing/__tests__/match-filters.test.ts
+++ b/lib/sailing/__tests__/match-filters.test.ts
@@ -3,9 +3,74 @@ import {
   checkCrane,
   checkVolume,
   checkCargoVesselCompat,
+  checkCargoWeight,
   runHardFilters,
   STOWAGE_FACTORS,
 } from '../match-filters';
+
+describe('checkCargoWeight', () => {
+  it('rejects when cargo weight far exceeds vessel DWT (no DWCC)', () => {
+    // N1 from R0 corpus: cargo 55000 mt × vessel 32131 dwt — ratio 1.71
+    const r = checkCargoWeight({ weightMt: 55000, dwtSummer: 32131, dwcc: null });
+    expect(r.pass).toBe(false);
+    expect(r.reason).toMatch(/exceeds vessel capacity/i);
+  });
+
+  it('rejects when cargo weight far exceeds vessel DWT (small vessel)', () => {
+    // N2 from R0 corpus: cargo 12000 mt × vessel 2570 dwt — ratio 4.67
+    const r = checkCargoWeight({ weightMt: 12000, dwtSummer: 2570, dwcc: null });
+    expect(r.pass).toBe(false);
+  });
+
+  it('prefers DWCC over DWT when both present', () => {
+    // DWCC 2000 means real cargo capacity is 2000, not 2570; cargo 2400 still fits within 5% margin
+    const r = checkCargoWeight({ weightMt: 2050, dwtSummer: 2570, dwcc: 2000 });
+    expect(r.pass).toBe(true);
+  });
+
+  it('rejects via DWCC when cargo clearly exceeds true cargo capacity', () => {
+    const r = checkCargoWeight({ weightMt: 2500, dwtSummer: 2570, dwcc: 2000 });
+    expect(r.pass).toBe(false);
+    expect(r.reason).toMatch(/DWCC/);
+  });
+
+  it('passes when cargo weight equals DWCC within margin', () => {
+    const r = checkCargoWeight({ weightMt: 2000, dwtSummer: 2570, dwcc: 2000 });
+    expect(r.pass).toBe(true);
+  });
+
+  it('passes when cargo weight is within DWT × 0.90 capacity', () => {
+    // dwt 10000 × 0.90 = 9000 effective; cargo 5000 fits
+    const r = checkCargoWeight({ weightMt: 5000, dwtSummer: 10000, dwcc: null });
+    expect(r.pass).toBe(true);
+  });
+
+  it('passes when cargo weightMt is null (unknown — graceful)', () => {
+    const r = checkCargoWeight({ weightMt: null, dwtSummer: 5000, dwcc: null });
+    expect(r.pass).toBe(true);
+  });
+
+  it('passes when both DWT and DWCC are null (unknown vessel capacity — graceful)', () => {
+    const r = checkCargoWeight({ weightMt: 5000, dwtSummer: null, dwcc: null });
+    expect(r.pass).toBe(true);
+  });
+
+  it('uses max of weightMt range for conservative check', () => {
+    // range 4000-6000, vessel 5000 DWT (capacity 4500 effective) — should reject
+    const r = checkCargoWeight({ weightMt: { min: 4000, max: 6000 }, dwtSummer: 5000, dwcc: null });
+    expect(r.pass).toBe(false);
+  });
+
+  it('5% margin tolerance: cargo 5200 vs DWCC 5000 = pass (within margin)', () => {
+    const r = checkCargoWeight({ weightMt: 5200, dwtSummer: null, dwcc: 5000 });
+    expect(r.pass).toBe(true);
+  });
+
+  it('5% margin tolerance: cargo 5300 vs DWCC 5000 = fail (exceeds margin)', () => {
+    const r = checkCargoWeight({ weightMt: 5300, dwtSummer: null, dwcc: 5000 });
+    expect(r.pass).toBe(false);
+  });
+});
 
 describe('checkDraft', () => {
   it('fails when vessel draft exceeds port max', () => {
@@ -150,6 +215,8 @@ describe('runHardFilters — destination port draft', () => {
       geared: true,
       draftMax: 12.0,   // exceeds Mykolaiv maxDraftM=10.5
       grainCapacity: 6000,
+      dwtSummer: 10000,
+      dwcc: null,
     });
     expect(r.pass).toBe(false);
     expect(r.checks.destDraft.pass).toBe(false);
@@ -169,6 +236,8 @@ describe('runHardFilters — destination port draft', () => {
       geared: true,
       draftMax: 12.0,
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(false);
     expect(r.pass).toBe(false);
@@ -186,6 +255,8 @@ describe('runHardFilters — destination port draft', () => {
       geared: true,
       draftMax: 12.0,
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(true);
     expect(r.checks.destCrane.pass).toBe(true);
@@ -203,6 +274,8 @@ describe('runHardFilters — destination port draft', () => {
       geared: false,
       draftMax: 12.0,
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(true);
     expect(r.checks.destCrane.pass).toBe(true);
@@ -222,6 +295,8 @@ describe('runHardFilters — destination port crane', () => {
       geared: false,
       draftMax: 6.0,
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.pass).toBe(false);
     expect(r.checks.destCrane.pass).toBe(false);
@@ -240,6 +315,8 @@ describe('runHardFilters — destination port crane', () => {
       geared: true,
       draftMax: 6.0,
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destCrane.pass).toBe(true);
   });
@@ -256,6 +333,8 @@ describe('runHardFilters — destination port crane', () => {
       geared: false,
       draftMax: 13.0,   // exceeds Skikda maxDraftM=12
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.checks.destDraft.pass).toBe(false);
     expect(r.checks.destCrane.pass).toBe(false);
@@ -275,6 +354,8 @@ describe('runHardFilters', () => {
       geared: true,
       draftMax: 6.0,
       grainCapacity: 6000,
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.pass).toBe(true);
     expect(r.failures).toHaveLength(0);
@@ -291,6 +372,8 @@ describe('runHardFilters', () => {
       geared: false,         // ok, Mykolaiv has cranes
       draftMax: 12.0,        // too deep
       grainCapacity: 5000,   // too small for 5000 MT wheat
+      dwtSummer: null,
+      dwcc: null,
     });
     expect(r.pass).toBe(false);
     expect(r.failures.length).toBeGreaterThanOrEqual(2); // draft + volume

--- a/lib/sailing/match-filters.ts
+++ b/lib/sailing/match-filters.ts
@@ -134,6 +134,53 @@ export function checkVolume(input: VolumeCheckInput): FilterResult {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Cargo weight check — "can vessel physically lift this weight?"
+//   Prefers DWCC (true cargo carrying capacity, after bunkers/stores deduction).
+//   Falls back to DWT × 0.90 (typical 10% deduction for fuel/water/stores).
+//   Fails when cargo weight exceeds capacity by more than 5% margin ("abt").
+//   If both DWCC and DWT are missing → graceful pass.
+// ────────────────────────────────────────────────────────────────────────────
+
+const WEIGHT_MARGIN = 1.05;        // 5% tolerance for "abt" / about-this-weight
+const DWT_TO_DWCC_RATIO = 0.90;    // typical cargo capacity = 90% of DWT
+
+export interface CargoWeightCheckInput {
+  weightMt: Range<number> | number | null;
+  dwtSummer: number | null;
+  dwcc: number | null;
+}
+
+export function checkCargoWeight(input: CargoWeightCheckInput): FilterResult {
+  const { weightMt, dwtSummer, dwcc } = input;
+  // Use max bound for conservative capacity check (worst-case scenario)
+  const effectiveWeight = isRange<number>(weightMt) ? weightMt.max : weightMt;
+  if (effectiveWeight == null || !Number.isFinite(effectiveWeight) || effectiveWeight <= 0) {
+    return { pass: true };
+  }
+
+  // Resolve effective vessel capacity: prefer DWCC (true cargo capacity)
+  let effectiveCapacity: number | null = null;
+  let capacitySource = '';
+  if (dwcc != null && Number.isFinite(dwcc) && dwcc > 0) {
+    effectiveCapacity = dwcc;
+    capacitySource = 'DWCC';
+  } else if (dwtSummer != null && Number.isFinite(dwtSummer) && dwtSummer > 0) {
+    effectiveCapacity = dwtSummer * DWT_TO_DWCC_RATIO;
+    capacitySource = `DWT × ${DWT_TO_DWCC_RATIO}`;
+  }
+  if (effectiveCapacity == null) return { pass: true };
+
+  const capacityWithMargin = effectiveCapacity * WEIGHT_MARGIN;
+  if (effectiveWeight > capacityWithMargin) {
+    return {
+      pass: false,
+      reason: `cargo ${Math.round(effectiveWeight)} mt exceeds vessel capacity ${Math.round(effectiveCapacity)} mt (${capacitySource}) by more than 5% tolerance`,
+    };
+  }
+  return { pass: true };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Cargo type × vessel type compatibility
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -213,6 +260,8 @@ export interface HardFilterInput {
   geared: boolean | null;
   draftMax: number | null;
   grainCapacity: number | null;
+  dwtSummer: number | null;
+  dwcc: number | null;
 }
 
 export interface HardFilterResult {
@@ -225,6 +274,7 @@ export interface HardFilterResult {
     cargoVessel: FilterResult;
     destDraft: FilterResult;
     destCrane: FilterResult;
+    cargoWeight: FilterResult;
   };
 }
 
@@ -243,6 +293,11 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
   });
   const destDraft = checkDraft(input.destinationPort ?? null, input.draftMax);
   const destCrane = checkCrane(input.destinationPort ?? null, input.geared);
+  const cargoWeight = checkCargoWeight({
+    weightMt: input.weightMt,
+    dwtSummer: input.dwtSummer,
+    dwcc: input.dwcc,
+  });
 
   const failures: string[] = [];
   if (!draft.pass && draft.reason) failures.push(draft.reason);
@@ -251,11 +306,12 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
   if (!cargoVessel.pass && cargoVessel.reason) failures.push(cargoVessel.reason);
   if (!destDraft.pass && destDraft.reason) failures.push(destDraft.reason);
   if (!destCrane.pass && destCrane.reason) failures.push(destCrane.reason);
+  if (!cargoWeight.pass && cargoWeight.reason) failures.push(cargoWeight.reason);
 
   return {
     pass: failures.length === 0,
     failures,
-    checks: { draft, crane, volume, cargoVessel, destDraft, destCrane },
+    checks: { draft, crane, volume, cargoVessel, destDraft, destCrane, cargoWeight },
   };
 }
 

--- a/lib/sample-data/demo-scenarios/__tests__/demo-scenarios.test.ts
+++ b/lib/sample-data/demo-scenarios/__tests__/demo-scenarios.test.ts
@@ -76,6 +76,8 @@ describe('demo scenarios — pipeline outcomes', () => {
           geared: v.geared,
           draftMax: cfValue(v.draftMax),
           grainCapacity: v.grainCapacity,
+          dwtSummer: null,
+          dwcc: null,
         });
 
         const parsedLaycan = parseLaycan(c.laycan, refYear);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -360,6 +360,7 @@ export interface MatchHardFilters {
   cargoVessel: HardFilterCheck;
   destDraft: HardFilterCheck;
   destCrane: HardFilterCheck;
+  cargoWeight: HardFilterCheck;
 }
 
 /** Sanctions screening (see lib/validation/sanctions.ts). */


### PR DESCRIPTION
## Summary

R0 baseline of match eval (#235) found two no-match scenarios where cargo weight far exceeds vessel capacity but were NOT hard-filtered — they reached the LLM and showed up as weak matches with score 35:

- **N1**: cargo 55,000 mt × vessel 32,131 dwt (cargo is 1.71× vessel capacity)
- **N2**: cargo 12,000 mt × vessel 2,570 dwt (cargo is 4.67× vessel capacity)

The system **detected** the overload (`"OVERLOAD: cargo X exceeds vessel Y"` appears in `issues[]`), but did not **block**. Physically impossible pairs were wasting LLM tokens and surfacing in broker UI as low-confidence options.

## Root cause

`runHardFilters` had `checkVolume` (cargo m³ vs grain-capacity m³) but **no** `checkCargoWeight` (cargo mt vs vessel DWT/DWCC). Most vessel records in our corpora have `grainCapacity = null`, so `checkVolume` graceful-passed every time.

## Fix

New `checkCargoWeight()`:
- Prefers **DWCC** (true cargo carrying capacity, after bunkers/stores deduction) when present
- Falls back to **DWT × 0.90** (typical 10% deduction for fuel/water/stores)
- Rejects when `cargo.weight_mt > effective_capacity × 1.05` (5% "abt" tolerance, matching existing `checkVolume` style)
- Graceful pass when weight or both DWT+DWCC are null (preserve existing tolerance for missing data)

Wired through `runHardFilters` → `pair-analyzer` → `MatchHardFilters` output type so UI can display the new filter result.

## Tests

11 new unit tests in `match-filters.test.ts` cover:
- N1+N2 real-data scenarios from R0 corpus
- DWCC preferred over DWT when both present
- 5% margin tolerance edges (5,200 / 5,000 = pass; 5,300 / 5,000 = fail)
- Range weight handling (uses max bound conservatively)
- Graceful pass on null inputs

All 77 tests in the affected suites green. Existing callsites updated with `dwtSummer / dwcc` (typically null) and `cargoWeight: { pass: true }` for mocks/fixtures.

## R1 baseline (expected after merge)

Once #235 + this PR are both on main, re-run `run-match.ts --round R1` to verify:
- Scenarios 10 + 11 → `matches=0, blocked≥1` (was `matches=1, blocked=0`)
- All other scenarios → identical scores (no scoring-side regression)

## Test plan

- [x] 77/77 tests green in affected suites
- [x] `tsc --noEmit` clean across project
- [ ] After merge: R1 eval baseline confirms N1+N2 now hard-filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
