### PR TITLE
fix(match): resolve readiness=unknown — port hints + date object input

### DIFF
--- a/lib/sailing/__tests__/date-parsing.test.ts
+++ b/lib/sailing/__tests__/date-parsing.test.ts
@@ -119,3 +119,49 @@ describe('parseLaycan', () => {
     expect(parseLaycan('xxx', REF)).toBeNull();
   });
 });
+
+
+describe('parseVesselOpenDate — object-shaped input (Phase 2C)', () => {
+  it('accepts {open: ISO, close: ISO, display} — uses .open ISO date', () => {
+    const r = parseVesselOpenDate({
+      open: '2026-05-22',
+      close: '2026-05-23',
+      display: '22-23 May 2026',
+    });
+    expect(r).not.toBeNull();
+    expect(r!.toISOString().slice(0, 10)).toBe('2026-05-22');
+  });
+
+  it('accepts {open: null, close: null, display: "spot"} — falls back to .display', () => {
+    const today = new Date(Date.UTC(2026, 4, 19));
+    const r = parseVesselOpenDate({ open: null, close: null, display: 'spot' }, 2026, today);
+    expect(r).not.toBeNull();
+    expect(r!.toISOString().slice(0, 10)).toBe('2026-05-19');
+  });
+
+  it('accepts {display: "01-05 March"} — uses display phrase', () => {
+    const r = parseVesselOpenDate({ open: null, close: null, display: '01-05 March' }, 2026);
+    expect(r).not.toBeNull();
+    expect(r!.toISOString().slice(0, 7)).toBe('2026-03');
+  });
+
+  it('returns null for {open: null, close: null, display: null}', () => {
+    expect(parseVesselOpenDate({ open: null, close: null, display: null })).toBeNull();
+  });
+
+  it('returns null for {}', () => {
+    expect(parseVesselOpenDate({})).toBeNull();
+  });
+
+  it('still accepts plain string input (legacy)', () => {
+    const r = parseVesselOpenDate('2026-05-22');
+    expect(r).not.toBeNull();
+    expect(r!.toISOString().slice(0, 10)).toBe('2026-05-22');
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(parseVesselOpenDate(null)).toBeNull();
+    expect(parseVesselOpenDate(undefined)).toBeNull();
+  });
+});
+

--- a/lib/sailing/__tests__/port-distances.test.ts
+++ b/lib/sailing/__tests__/port-distances.test.ts
@@ -1,5 +1,54 @@
 import { getPortDistance, normalizePortName, KNOWN_PORTS } from '../port-distances';
 
+describe('normalizePortName — parenthetical hint fallback (Phase 2C)', () => {
+  it('"Hereke (Marmara)" resolves via parenthetical hint to Marmara', () => {
+    // Hereke is a small port in the Sea of Marmara — primary name resolves
+    // directly via the new alias entry, OR via parenthetical fallback if absent.
+    expect(normalizePortName('Hereke (Marmara)')).toBe('Marmara');
+  });
+
+  it('"Some Obscure Port (Marmara)" — unknown primary, hint rescues', () => {
+    expect(normalizePortName('Some Obscure Port (Marmara)')).toBe('Marmara');
+  });
+
+  it('"Bay of Biscay (Bayonne/Bilbao range)" — slash-separated hint tokens', () => {
+    // Either Bayonne or Bilbao resolution acceptable — both are valid hints
+    const r = normalizePortName('Bay of Biscay (Bayonne/Bilbao range)');
+    expect(['Bayonne', 'Bilbao']).toContain(r);
+  });
+
+  it('"Alexandria (EG)" — 2-letter country code skipped, primary still matches', () => {
+    // Primary "Alexandria" resolves directly; parenthetical (EG) is just a hint.
+    expect(normalizePortName('Alexandria (EG)')).toBe('Alexandria');
+  });
+
+  it('"Unknown Place (XX)" — country-code-only hint, returns null', () => {
+    // Only a 2-letter code in parens → no usable hint, no fallback → null
+    expect(normalizePortName('Unknown Place (XX)')).toBe(null);
+  });
+
+  it('"Marmara Sea" resolves to Marmara (new alias)', () => {
+    expect(normalizePortName('Marmara Sea')).toBe('Marmara');
+  });
+
+  it('"Hereke" alone resolves via direct alias (new)', () => {
+    expect(normalizePortName('Hereke')).toBe('Marmara');
+  });
+
+  it('"Gemlik" — south Marmara cluster, new alias', () => {
+    expect(normalizePortName('Gemlik')).toBe('Marmara');
+  });
+
+  it('"sea of marmara" — case-insensitive new alias', () => {
+    expect(normalizePortName('sea of marmara')).toBe('Marmara');
+  });
+
+  it('Primary name takes precedence over hint when both resolve', () => {
+    // "Antwerp (Rotterdam range)" — both are valid ports, primary wins
+    expect(normalizePortName('Antwerp (Rotterdam range)')).toBe('Antwerp');
+  });
+});
+
 describe('normalizePortName — JSON-only ports (port-master corpus)', () => {
   it('fuzzy-matches Fos-sur-Mer with dropped letter to canonical JSON name', () => {
     // "Fos-sr-Mer" is a dropped-'u' typo of "Fos-sur-Mer".

--- a/lib/sailing/date-parsing.ts
+++ b/lib/sailing/date-parsing.ts
@@ -71,13 +71,37 @@ function phraseToRange(phrase: string, year: number, monthIdx0: number): [number
  * @param refYear   year to use when only month/day are given
  * @param today     reference "now" for TODAY/spot (defaults to `new Date()`)
  */
+/**
+ * Extract a usable date string from a structured vessel-open-date value.
+ *
+ * The fixture-recap parser may emit `open_date.value` as either:
+ *   - a plain string (legacy / simple format), or
+ *   - an object {open: ISO|null, close: ISO|null, display: string|null}
+ *     where `open` is the parsed ISO date for range-start, and `display`
+ *     is the original human-readable text ("spot", "01-05 March", etc.).
+ *
+ * Prefers `open` (ISO-formatted, easier to parse) then `display` (fallback
+ * for phrase-style values like "spot"/"prompt"/"end March").
+ */
+function normalizeOpenDateInput(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    const obj = raw as { open?: unknown; display?: unknown };
+    if (typeof obj.open === 'string' && obj.open.trim()) return obj.open;
+    if (typeof obj.display === 'string' && obj.display.trim()) return obj.display;
+  }
+  return null;
+}
+
 export function parseVesselOpenDate(
-  raw: string | null | undefined,
+  raw: string | { open?: string | null; close?: string | null; display?: string | null } | null | undefined,
   refYear: number = new Date().getUTCFullYear(),
   today: Date = new Date(),
 ): Date | null {
-  if (!raw || typeof raw !== 'string') return null;
-  const s = raw.trim();
+  const normalized = normalizeOpenDateInput(raw);
+  if (!normalized) return null;
+  const s = normalized.trim();
   if (!s) return null;
 
   // TODAY / spot / prompt → reference "now"

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -102,7 +102,14 @@ const PORT_ALIASES: Record<string, KnownPort> = {
   'smyrna': 'Izmir',            // former name
   'marmara': 'Marmara',
   'marmara island': 'Marmara',
+  'marmara sea': 'Marmara',
+  'sea of marmara': 'Marmara',
   'bandirma': 'Marmara',        // same Sea of Marmara region
+  'hereke': 'Marmara',          // Hereke (Korfez Bay) — Marmara cluster
+  'gemlik': 'Marmara',          // Gemlik Bay — south Marmara
+  'mudanya': 'Marmara',         // Mudanya — south Marmara
+  'tekirdag': 'Marmara',        // Tekirdag — north Marmara
+  'tekirdağ': 'Marmara',
   'derince': 'Derince',         // Derince/Izmit — own canonical entry (hasShoreCranes fix)
   'izmit': 'Derince',           // Izmit is adjacent to Derince on Gulf of Izmit
   'izmit-derince': 'Derince',
@@ -953,36 +960,82 @@ export function setFuzzyCorpus(entries: Array<{ lookup: string; canonical: strin
  *   - Legacy aliases: "Odessa" → "Odesa", "Efesan" → "Aliaga", "Nikolaev" → "Mykolaiv"
  *   - Partial substring fallback: tries longest alias key that appears in the input
  */
+/**
+ * Extract parenthetical hint tokens from a raw port name.
+ * Example: "Hereke (Marmara)" → ["marmara"]; "Bay of Biscay (Bayonne/Bilbao range)" → ["bayonne", "bilbao"].
+ * Filters out 2-letter country codes (e.g. "TR", "EG") and noise words ("range", "cluster", "region", "area").
+ */
+function extractParenHints(raw: string): string[] {
+  const hints: string[] = [];
+  const pat = /\(([^)]+)\)/g;
+  let m: RegExpExecArray | null;
+  const noise = /\b(range|cluster|region|area)\b/gi;
+  while ((m = pat.exec(raw)) !== null) {
+    const content = m[1].replace(noise, '').trim();
+    if (!content) continue;
+    // Split on slash/comma/space to get individual port-name candidates
+    const tokens = content.split(/[\s/,]+/).filter(Boolean);
+    for (const tok of tokens) {
+      const lower = tok.toLowerCase();
+      // Skip 2-letter ISO country codes
+      if (/^[a-z]{2}$/.test(lower)) continue;
+      hints.push(lower);
+    }
+  }
+  return hints;
+}
+
 export function normalizePortName(raw: string | null | undefined): string | null {
   if (!raw || typeof raw !== 'string') return null;
+  // Capture parenthetical hints BEFORE stripping (used as fallback if primary name fails)
+  const parenHints = extractParenHints(raw);
   let s = stripCountry(stripParenthetical(raw)).trim();
   s = stripCountryCodeSuffix(s);
   s = stripPortPrefix(s);
-  if (!s) return null;
 
-  // Direct lowercase alias lookup
-  const direct = PORT_ALIASES[s.toLowerCase()];
-  if (direct) return direct;
+  if (s) {
+    // Direct lowercase alias lookup
+    const direct = PORT_ALIASES[s.toLowerCase()];
+    if (direct) return direct;
 
-  // Try each word/segment separately (handles "Bay of Biscay Bayonne" or "Izmir/Aliaga")
-  const parts = s.split(/[\s/()\-,]+/).filter(Boolean);
-  for (const part of parts) {
-    const hit = PORT_ALIASES[part.toLowerCase()];
-    if (hit) return hit;
+    // Try each word/segment separately (handles "Bay of Biscay Bayonne" or "Izmir/Aliaga")
+    const parts = s.split(/[\s/()\-,]+/).filter(Boolean);
+    for (const part of parts) {
+      const hit = PORT_ALIASES[part.toLowerCase()];
+      if (hit) return hit;
+    }
+
+    // Fuzzy fallback (typos, casing) — uses fuzzysort over alias + canonical
+    // names. fuzzysort v3 scores are in [0,1] (not the legacy negative scale).
+    // Threshold 0.3 is the empirical floor that catches single-letter typos
+    // ("Karsu"→Karasu scores ~0.35) while filtering near-garbage subsequences.
+    // Minimum length guard: inputs shorter than 4 chars are too ambiguous for
+    // fuzzy matching and are left to the direct alias table above.
+    const corpus = getFuzzyCorpus();
+    const cleaned = s.toLowerCase();
+    if (cleaned.length >= 4) {
+      const results = fuzzysort.go(cleaned, corpus, { key: 'lookup', threshold: 0.3, limit: 1 });
+      if (results.length > 0) {
+        return results[0].obj.canonical;
+      }
+    }
   }
 
-  // Fuzzy fallback (typos, casing) — uses fuzzysort over alias + canonical
-  // names. fuzzysort v3 scores are in [0,1] (not the legacy negative scale).
-  // Threshold 0.3 is the empirical floor that catches single-letter typos
-  // ("Karsu"→Karasu scores ~0.35) while filtering near-garbage subsequences.
-  // Minimum length guard: inputs shorter than 4 chars are too ambiguous for
-  // fuzzy matching and are left to the direct alias table above.
-  const corpus = getFuzzyCorpus();
-  const cleaned = s.toLowerCase();
-  if (cleaned.length < 4) return null;
-  const results = fuzzysort.go(cleaned, corpus, { key: 'lookup', threshold: 0.3, limit: 1 });
-  if (results.length > 0) {
-    return results[0].obj.canonical;
+  // Parenthetical-hint fallback: e.g. "Hereke (Marmara)" — primary "Hereke" failed,
+  // but "Marmara" is a known cluster name. This is broker-style geographic hinting
+  // ("[obscure port] ([known region])") that the parser surfaces in the cargo input.
+  for (const hint of parenHints) {
+    const direct = PORT_ALIASES[hint];
+    if (direct) return direct;
+  }
+  // Second pass on hints via fuzzy fallback
+  for (const hint of parenHints) {
+    if (hint.length < 4) continue;
+    const corpus = getFuzzyCorpus();
+    const results = fuzzysort.go(hint, corpus, { key: 'lookup', threshold: 0.3, limit: 1 });
+    if (results.length > 0) {
+      return results[0].obj.canonical;
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary

R0 baseline of match eval (#235) found `readiness.verdict='unknown'` for **all 11** match scenarios. This caps every match score 15–20 points below where it should be because the readiness branch awards only partial credit (laycan 8/20, geographic 6/20) when temporal feasibility can't be computed.

Phase 2B agent investigation traced this to **two independent root causes**, either of which alone triggers the `'unknown'` branch:

### Cause A — port resolver dropped parenthetical hints

```
Input:  "Hereke (Marmara)"   ← broker-style geo hinting
Old:    stripParenthetical → "Hereke" → not in PORT_ALIASES / KNOWN_PORTS / port-master.json (439 ports) → null
Result: distance=null → readiness verdict="unknown"
```

The Marmara cluster has only 10 Turkish ports in `port-master.json`; Hereke, Gemlik, Mudanya, Tekirdag are common in broker emails but absent.

### Cause B — date parser rejected object input

The fixture-recap parser emits `open_date.value` as a structured shape:

```js
{ open: null, close: null, display: "spot" }
// or
{ open: "2026-05-22", close: "2026-05-23", display: "22-23 May 2026" }
```

But `parseVesselOpenDate` had `typeof raw !== 'string' → return null`. Every vessel input → `openDate=null` → `readiness verdict="unknown"`.

## Fix

### `lib/sailing/port-distances.ts`

- New helper `extractParenHints()` pulls parenthetical content as hint tokens (filtered to exclude 2-letter ISO country codes).
- `normalizePortName()` tries hints as fallback **only when primary name fails to resolve**. So `"Antwerp (Rotterdam range)"` → Antwerp (primary wins), `"Hereke (Marmara)"` → Marmara (hint rescues).
- Direct aliases added for Marmara cluster (`hereke`, `gemlik`, `mudanya`, `tekirdag`, `marmara sea`, `sea of marmara`) so the hint fallback isn't the only path.

### `lib/sailing/date-parsing.ts`

- New helper `normalizeOpenDateInput()` accepts string OR `{open, close, display}` object. Prefers `.open` (ISO, cleanest parse) then `.display` (phrase style for spot/prompt/etc).
- `parseVesselOpenDate` signature updated to the union type — existing string callers continue working.

## Tests

- `port-distances.test.ts` +10 cases — Hereke/Marmara fallback, slash-separated hints (Bayonne/Bilbao), country-code filter, primary-takes-precedence, new direct aliases. **110/110 green.**
- `date-parsing.test.ts` +7 cases — object with `.open` ISO, object with `.display` fallback, all-null, empty `{}`, legacy string, null/undefined. **28/28 green.**

## Production impact

**HIGH.** This affects ALL match scoring in prod, not just eval. Any broker email with:

- Parenthetical port hint (`"Hereke (Marmara)"`, `"Some Bay (Bayonne range)"`)
- Structured `open_date` shape from the parser (i.e. since wave-beta)

would previously fall into the `'unknown'` readiness branch and lose ~15-20 score points per match. Strong matches were being mis-graded as weak.

## R1 baseline (running on outreach-vps now)

Will append numbers once complete. Early result on S1: `matches=0 blocked=2` (was matches=2 score=35 R0) — hard-filter #236 also kicks in. R1 measures combined delta of #236 + this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
