### PR TITLE
fix(matches): M3 hardening (4 LOW findings from QA)

### DIFF
--- a/__tests__/api/matches-bulk-empty-ids.test.ts
+++ b/__tests__/api/matches-bulk-empty-ids.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression test — DELETE /api/matches/bulk with empty ids (M-4 hardening).
+ *
+ * Current behaviour is correct (400) but had no explicit test guarding it.
+ * A future refactor must not regress this to a 200 / 500 / no-op.
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest, NextResponse } from 'next/server';
+import migration032 from '@/lib/migrations/032-matches';
+import { requireSession } from '@/lib/session';
+import { requireAdmin } from '@/lib/auth/admin';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: () => testDb })),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/admin', () => ({
+  requireAdmin: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+const mockRequireAdmin = requireAdmin as jest.Mock;
+
+const AUTHENTICATED_SESSION = {
+  session: { id: 'sess-1', parsedCargos: [], parsedVessels: [] },
+  sessionId: 'test-sid',
+};
+
+function migration033Up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE matches ADD COLUMN reason_structured TEXT;
+    ALTER TABLE matches ADD COLUMN cargo_type TEXT;
+    ALTER TABLE matches ADD COLUMN load_port TEXT;
+    ALTER TABLE matches ADD COLUMN discharge_port TEXT;
+    ALTER TABLE matches ADD COLUMN laycan_start INTEGER;
+    ALTER TABLE matches ADD COLUMN laycan_end INTEGER;
+    ALTER TABLE matches ADD COLUMN vessel_dwt INTEGER;
+  `);
+}
+
+beforeEach(() => {
+  mockRequireSession.mockReturnValue(AUTHENTICATED_SESSION);
+  mockRequireAdmin.mockReturnValue(undefined);
+});
+
+describe('bulk endpoints — empty ids array regression', () => {
+  let db: Database.Database;
+  const originalEnv = process.env.MATCHES_ENABLED;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration032.up(db);
+    migration033Up(db);
+    testDb = db;
+    process.env.MATCHES_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    db.close();
+    process.env.MATCHES_ENABLED = originalEnv;
+  });
+
+  it('DELETE /api/matches/bulk with ids:[] → 400', async () => {
+    const { DELETE } = await import('@/app/api/matches/bulk/route');
+    const res = await DELETE(
+      new NextRequest('http://localhost/api/matches/bulk', {
+        method: 'DELETE',
+        body: JSON.stringify({ ids: [] }),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/non-empty/i);
+  });
+
+  it('PATCH /api/matches/bulk with ids:[] → 400 (parity)', async () => {
+    const { PATCH } = await import('@/app/api/matches/bulk/route');
+    const res = await PATCH(
+      new NextRequest('http://localhost/api/matches/bulk', {
+        method: 'PATCH',
+        body: JSON.stringify({ ids: [], status: 'saved' }),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/non-empty/i);
+  });
+});

--- a/__tests__/api/matches-bulk.test.ts
+++ b/__tests__/api/matches-bulk.test.ts
@@ -1,6 +1,5 @@
-// @ts-nocheck — RED phase: bulk route doesn't exist yet; impl agent creates it
 /**
- * RED tests — PATCH /api/matches/bulk + DELETE /api/matches/bulk
+ * Tests — PATCH /api/matches/bulk + DELETE /api/matches/bulk
  */
 
 import Database from 'better-sqlite3';

--- a/__tests__/api/matches-filters.test.ts
+++ b/__tests__/api/matches-filters.test.ts
@@ -1,6 +1,5 @@
-// @ts-nocheck — RED phase: route doesn't support M3 filters yet; impl agent adds them
 /**
- * RED tests — GET /api/matches — M3 advanced filter query params
+ * Tests — GET /api/matches — M3 advanced filter query params
  *
  * Covers (Class 9 — E2E behavioral via real NextRequest/NextResponse route import):
  *   - ?cargo_type=grain → filters by single cargo_type

--- a/__tests__/api/matches-range-validation.test.ts
+++ b/__tests__/api/matches-range-validation.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests — GET /api/matches reverse-range validation (M-2 hardening).
+ *
+ * Reversed ranges (min > max) used to silently return an empty list, hiding
+ * the user's mistake. They must now return 400 with an explanatory error.
+ *
+ * Out-of-domain score_min (<0 or >100) is also caught at the API boundary.
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest, NextResponse } from 'next/server';
+import migration032 from '@/lib/migrations/032-matches';
+import { requireSession } from '@/lib/session';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: () => testDb })),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+
+const AUTHENTICATED_SESSION = {
+  session: { id: 'sess-1', parsedCargos: [], parsedVessels: [] },
+  sessionId: 'test-sid',
+};
+
+function migration033Up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE matches ADD COLUMN reason_structured TEXT;
+    ALTER TABLE matches ADD COLUMN cargo_type TEXT;
+    ALTER TABLE matches ADD COLUMN load_port TEXT;
+    ALTER TABLE matches ADD COLUMN discharge_port TEXT;
+    ALTER TABLE matches ADD COLUMN laycan_start INTEGER;
+    ALTER TABLE matches ADD COLUMN laycan_end INTEGER;
+    ALTER TABLE matches ADD COLUMN vessel_dwt INTEGER;
+  `);
+}
+
+beforeEach(() => {
+  mockRequireSession.mockReturnValue(AUTHENTICATED_SESSION);
+});
+
+describe('GET /api/matches — reverse range validation', () => {
+  let db: Database.Database;
+  const originalEnv = process.env.MATCHES_ENABLED;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration032.up(db);
+    migration033Up(db);
+    testDb = db;
+    process.env.MATCHES_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    db.close();
+    process.env.MATCHES_ENABLED = originalEnv;
+  });
+
+  it('dwt_min > dwt_max → 400', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(new NextRequest('http://localhost/api/matches?dwt_min=10&dwt_max=5'));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/dwt_min/);
+    expect(json.error).toMatch(/dwt_max/);
+  });
+
+  it('dwt_min === dwt_max → 200 (boundary OK)', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(new NextRequest('http://localhost/api/matches?dwt_min=50000&dwt_max=50000'));
+    expect(res.status).toBe(200);
+  });
+
+  it('laycan_from > laycan_to → 400', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(
+      new NextRequest('http://localhost/api/matches?laycan_from=2026-12-31&laycan_to=2026-01-01')
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/laycan/);
+  });
+
+  it('laycan_from === laycan_to → 200 (boundary OK)', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(
+      new NextRequest('http://localhost/api/matches?laycan_from=2026-06-01&laycan_to=2026-06-01')
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('score_min > 100 → 400', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(new NextRequest('http://localhost/api/matches?score_min=150'));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/score_min/);
+  });
+
+  it('score_min < 0 → 400', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(new NextRequest('http://localhost/api/matches?score_min=-5'));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/score_min/);
+  });
+
+  it('score_min === 0 and score_min === 100 → 200 (boundary OK)', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res0 = await GET(new NextRequest('http://localhost/api/matches?score_min=0'));
+    expect(res0.status).toBe(200);
+
+    const res100 = await GET(new NextRequest('http://localhost/api/matches?score_min=100'));
+    expect(res100.status).toBe(200);
+  });
+
+  it('valid forward range still works (regression)', async () => {
+    const { GET } = await import('@/app/api/matches/route');
+    const res = await GET(
+      new NextRequest('http://localhost/api/matches?dwt_min=10000&dwt_max=80000&score_min=50')
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/lib/matching/like-escape.test.ts
+++ b/__tests__/lib/matching/like-escape.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests — listMatches LIKE pattern escaping (M-1 hardening).
+ *
+ * Route search params containing SQL LIKE metacharacters (%, _, \) must match
+ * literally, not as wildcards. Otherwise:
+ *   - `route=_` would match every load_port (false positives)
+ *   - `route=%foo%` would inject extra wildcards
+ *   - `route=\` would break the ESCAPE clause if not handled
+ */
+
+import Database from 'better-sqlite3';
+import migration032 from '@/lib/migrations/032-matches';
+import { listMatches } from '@/lib/matching/matches-repository';
+
+function migration033Up(db: Database.Database): void {
+  db.exec(`
+    ALTER TABLE matches ADD COLUMN reason_structured TEXT;
+    ALTER TABLE matches ADD COLUMN cargo_type TEXT;
+    ALTER TABLE matches ADD COLUMN load_port TEXT;
+    ALTER TABLE matches ADD COLUMN discharge_port TEXT;
+    ALTER TABLE matches ADD COLUMN laycan_start INTEGER;
+    ALTER TABLE matches ADD COLUMN laycan_end INTEGER;
+    ALTER TABLE matches ADD COLUMN vessel_dwt INTEGER;
+  `);
+}
+
+function seed(db: Database.Database, load: string, discharge: string, cargo_id = `c-${load}-${discharge}`): void {
+  db.prepare(
+    `INSERT INTO matches
+      (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+       load_port, discharge_port)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(cargo_id, 'v-1', 70, '{}', 'shortlist', null, Date.now(), Date.now(), load, discharge);
+}
+
+describe('listMatches — LIKE pattern escaping (route filter)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration032.up(db);
+    migration033Up(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('underscore in route is treated literally, not as wildcard', () => {
+    seed(db, 'NLRTM', 'USHOU', 'c-rtm');
+    seed(db, 'XX_YY', 'ZZAAA', 'c-underscore');
+
+    const results = listMatches(db, {
+      sortBy: 'score',
+      sortDir: 'desc',
+      route: '_',
+    });
+
+    // `_` must match only the row that literally contains `_`
+    expect(results.map((r) => r.cargo_id).sort()).toEqual(['c-underscore']);
+  });
+
+  it('percent in route is treated literally, not as wildcard', () => {
+    seed(db, 'NLRTM', 'USHOU', 'c-rtm');
+    seed(db, '50%PORT', 'AABBB', 'c-percent');
+
+    const results = listMatches(db, {
+      sortBy: 'score',
+      sortDir: 'desc',
+      route: '%',
+    });
+
+    // `%` must match only the row that literally contains `%`
+    expect(results.map((r) => r.cargo_id).sort()).toEqual(['c-percent']);
+  });
+
+  it('backslash in route is treated literally and does not break the ESCAPE clause', () => {
+    seed(db, 'NLRTM', 'USHOU', 'c-rtm');
+    seed(db, 'A\\B', 'CCDDD', 'c-backslash');
+
+    const results = listMatches(db, {
+      sortBy: 'score',
+      sortDir: 'desc',
+      route: '\\',
+    });
+
+    expect(results.map((r) => r.cargo_id).sort()).toEqual(['c-backslash']);
+  });
+
+  it('combined metacharacters: route="%_\\" matches only literal occurrence', () => {
+    seed(db, 'PLAIN', 'PORT', 'c-plain');
+    seed(db, 'WEIRD%_\\NAME', 'XXYYY', 'c-weird');
+
+    const results = listMatches(db, {
+      sortBy: 'score',
+      sortDir: 'desc',
+      route: '%_\\',
+    });
+
+    expect(results.map((r) => r.cargo_id)).toEqual(['c-weird']);
+  });
+
+  it('normal alphabetic route still works (regression)', () => {
+    seed(db, 'NLRTM', 'USHOU', 'c-rtm');
+    seed(db, 'DEHAM', 'BRSSZ', 'c-ham');
+
+    const results = listMatches(db, {
+      sortBy: 'score',
+      sortDir: 'desc',
+      route: 'RTM',
+    });
+
+    expect(results.map((r) => r.cargo_id)).toEqual(['c-rtm']);
+  });
+
+  it('case-insensitive matching is preserved (regression)', () => {
+    seed(db, 'NLRTM', 'USHOU', 'c-rtm');
+
+    const results = listMatches(db, {
+      sortBy: 'score',
+      sortDir: 'desc',
+      route: 'rtm',
+    });
+
+    expect(results.map((r) => r.cargo_id)).toEqual(['c-rtm']);
+  });
+});

--- a/app/api/matches/route.ts
+++ b/app/api/matches/route.ts
@@ -69,6 +69,26 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const _dwtMax = dwtMaxParam ? parseInt(dwtMaxParam, 10) : undefined;
     const dwtMax = _dwtMax !== undefined && !isNaN(_dwtMax) ? _dwtMax : undefined;
 
+    // Reverse / out-of-domain range validation (return 400, not silently empty).
+    if (dwtMin !== undefined && dwtMax !== undefined && dwtMin > dwtMax) {
+      return NextResponse.json(
+        { error: 'dwt_min must be <= dwt_max' },
+        { status: 400 }
+      );
+    }
+    if (laycanFromMs !== undefined && laycanToMs !== undefined && laycanFromMs > laycanToMs) {
+      return NextResponse.json(
+        { error: 'laycan_from must be <= laycan_to' },
+        { status: 400 }
+      );
+    }
+    if (scoreMin !== undefined && (scoreMin < 0 || scoreMin > 100)) {
+      return NextResponse.json(
+        { error: 'score_min must be between 0 and 100' },
+        { status: 400 }
+      );
+    }
+
     const matches = listMatches(db, {
       status,
       sortBy,

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -152,8 +152,14 @@ export function listMatches(db: Database.Database, opts: ListMatchesOptions): St
   }
 
   if (route !== undefined && route !== '') {
-    conditions.push(`(LOWER(load_port) LIKE LOWER(?) OR LOWER(discharge_port) LIKE LOWER(?))`);
-    const pattern = `%${route}%`;
+    // Escape SQL LIKE metacharacters so user input matches literally.
+    // Backslash must be escaped first; ESCAPE '\' tells SQLite to treat
+    // \%, \_, \\ as literal characters.
+    const escaped = route.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+    conditions.push(
+      `(LOWER(load_port) LIKE LOWER(?) ESCAPE '\\' OR LOWER(discharge_port) LIKE LOWER(?) ESCAPE '\\')`
+    );
+    const pattern = `%${escaped}%`;
     params.push(pattern, pattern);
   }
 


### PR DESCRIPTION
## Summary

Follow-up to [#234](https://github.com/Vitali2011/quantika-demo/pull/234) (M3 polish). Addresses 4 LOW findings from adversarial QA review — all in new M3 code, safe for separate PR.

- **M-1 (HIGH-LOW):** Escape `%`, `_`, `\` in `?route=` filter so user input matches literally (was: false positives + SQL pattern injection vector).
- **M-2:** Reverse / out-of-domain ranges (`dwt_min > dwt_max`, `laycan_from > laycan_to`, `score_min < 0 || > 100`) now return 400 instead of silently empty.
- **M-3:** Removed `// @ts-nocheck — RED phase` relics from `matches-filters.test.ts` and `matches-bulk.test.ts` (TDD scaffolding that silently disabled TS coverage).
- **M-4:** Regression test for empty `ids: []` on `DELETE/PATCH /api/matches/bulk` (current 400 behaviour locked in).

## Test plan

- [x] RED→GREEN: 6 failures → 16/16 new tests pass
- [x] No regression: 192/192 matches suite green
- [x] `test_rewrite_count = 0`
- [ ] Smoke after merge: `GET /api/matches?route=_` matches only literal-underscore rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)