### PR TITLE
chore: path-scoped rules/*.md for ai-provider, retriever, admin-api

### DIFF
--- a/.claude/rules/admin-api.md
+++ b/.claude/rules/admin-api.md
@@ -1,0 +1,21 @@
+# Rules: app/api/admin/\*\* + middleware.ts
+
+## Invariants
+
+- Каждый `/api/admin/*` handler обязан начинаться с `requireAdmin(req)` из `lib/auth/admin.ts`. Если `ADMIN_TOKEN` не задан → `500`. Если заголовок `X-Admin-Token` отсутствует/неверен → `401`.
+- Пути, у которых есть своя auth (cron, market, knowledge, whatsapp, pipedrive), **обязаны** быть в `AUTH_BYPASS_PATHS` в `middleware.ts`. Иначе middleware перехватит запрос и переадресует на `/login` до того, как handler проверит свой токен.
+- `AUTH_BYPASS_PATHS` — точные пути (`Set.has`), не префиксы. Добавление нового пути должно быть точным строковым совпадением.
+- `AUTH_BYPASS_PREFIXES` — только для Next.js статики (`/_next/*`). Не добавлять туда API-пути.
+
+## Anti-patterns (история регрессий)
+
+- **Новый admin endpoint без bypass**: если добавить `/api/admin/X` с `requireAdmin`, но не добавить путь в `AUTH_BYPASS_PATHS` → middleware редиректит на `/login` → handler никогда не вызывается → silent 302 вместо 401/200. (ref: memory feedback_middleware_admin_whitelist.md)
+- **Bypass без requireAdmin**: убрать `requireAdmin` из handler, оставив путь в bypass → endpoint становится публичным без auth. Оба шага обязательны вместе.
+- **Тест bypass без проверки middleware-auth.test.ts**: при добавлении нового bypass-пути — добавить его в `bypassPaths` массив теста `__tests__/middleware-auth.test.ts`.
+
+## Checklist перед commit'ом
+
+- [ ] Новый `/api/admin/*` → `requireAdmin(req)` первой строкой в handler
+- [ ] Путь добавлен в `AUTH_BYPASS_PATHS` в `middleware.ts`
+- [ ] Путь добавлен в `bypassPaths` в `__tests__/middleware-auth.test.ts`
+- [ ] `ADMIN_TOKEN` env var задокументирован в `.env.local.example` (если есть)

--- a/.claude/rules/ai-provider.md
+++ b/.claude/rules/ai-provider.md
@@ -1,0 +1,23 @@
+# Rules: lib/ai-provider.ts
+
+## Invariants
+
+- Провайдер выбирается по цепочке: `<SCOPE>_PROVIDER` → `AI_PROVIDER` → `"openai"`. Не хардкодить провайдера в коде — только через env.
+- Все LLM-вызовы обязаны передавать `signal?: AbortSignal` из `AiOpts` и уважать `timeoutMs` (дефолт 85 000 мс). Без таймаута endpoint зависнет навсегда.
+- `callAiJson` для Gemini: если передан `responseSchema` — парсить ответ напрямую (`r.text.trim()`). Если нет — сначала `extractJson()`. Нельзя пропускать `extractJson` для Bedrock: Sonnet 4.6 стабильно добавляет CoT-преамбулу.
+- `claude-cli` провайдер запрещён в Next.js request handlers (`NEXT_RUNTIME` guard). Только в eval-скриптах.
+- Каждый вызов пишет запись в `ai_audit` через `writeAuditRecord`. Ошибка записи не должна ронять основной вызов (try/catch внутри).
+- OpenAI vision и OpenAI audio не реализованы — кидают `Error` с явным сообщением. Замена: Gemini.
+
+## Anti-patterns (история регрессий)
+
+- **Gemini structured-output mismatch**: если `responseSchema` не передан, а промпт ожидает JSON → модель оборачивает ответ в ``\`\`\`json```→`JSON.parse`падает. Решение: всегда передавать`responseSchema`при`callAiJson` для Gemini. (ref: memory project_quantika_demo_wave_gamma_complete_2026_05_05.md, ai_audit 2026-05-13)
+- **CoT-preamble у Bedrock Sonnet 4.6**: 9/10 MATCH-failures в 24ч с `"Unexpected token 'I'"` — не убирать `extractJson()` из Bedrock-ветки. (ref: комментарий в extractJson, ai_audit)
+- **Добавление нового провайдера без guard**: если провайдер неизвестен → `getProvider` возвращает `"openai"`, не падает. Это намеренно (fallback), но тихо.
+
+## Checklist перед commit'ом
+
+- [ ] Новый LLM-вызов получает `signal` из `opts` и пробрасывает таймаут
+- [ ] Для Gemini JSON-ответа: передан `responseSchema` или явно вызван `extractJson`
+- [ ] `claude-cli` вызовы — только вне `NEXT_RUNTIME`
+- [ ] `writeAuditRecord` вызывается в `finally` блоке

--- a/.claude/rules/retriever.md
+++ b/.claude/rules/retriever.md
@@ -1,0 +1,22 @@
+# Rules: lib/knowledge/embeddings/retriever\*
+
+## Invariants
+
+- Диспетчер `retriever.ts` маршрутизирует по `KNOWLEDGE_BACKEND`: `"vertex"` → Vertex AI, всё остальное → SQLite (дефолт).
+- `KNOWLEDGE_RAG_ENABLED=true` — обязательный флаг для `searchVec0` и `retrieve` SQLite. При `false` — `throw Error('RAG is not enabled')`.
+- Vec0 принимает только `Float32Array[768]`. Любая другая размерность → `RangeError`. Не использовать обычный `Array<number>`.
+- Имена таблиц — строго из allowlist: `imsbc_vec/fts`, `igc_vec/fts`, `jwc_vec/fts`, `bimco_vec/fts`. SQLite выбросит исключение на произвольном имени.
+- Vertex-бэкенд — lazy import (`await import(...)`), чтобы не тянуть SDK при sqlite-режиме.
+
+## Anti-patterns (история регрессий)
+
+- **Vertex AI Search сломан на Standard-tier**: `extractiveContentSpec` — Enterprise-only. При ошибке от Vertex — не молчать, делать явный fallback на SQLite или бросать наружу. Prod-инцидент: 100% failures, rollback потребовался вручную. (ref: memory project_quantika_demo_vertex_broken_2026_05_17.md)
+- **topK > 1000 без clamp**: SQLite retriever делает clamp до 1000; Vertex может вести себя иначе — проверять при добавлении нового бэкенда.
+- **Пустой query без guard**: `""` → возвращает `[]` без API-вызова. Не убирать этот early-return — иначе дорогой embed-вызов на пустой строке.
+
+## Checklist перед commit'ом
+
+- [ ] `KNOWLEDGE_RAG_ENABLED` проверяется перед обращением к БД
+- [ ] Embedding — `Float32Array`, размерность 768
+- [ ] Новый бэкенд добавлен в `knowledgeBackend()` в `flags.ts`, не в `retriever.ts` напрямую
+- [ ] Vertex-код — за `await import()`, не на верхнем уровне модуля

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,19 @@
 - После изменения `.env.local` на VPS: `pm2 restart quantika-demo --update-env`
   (НЕ `pm2 reload` — он не перечитывает env).
 - Новые страницы дают «client reference manifest does not exist» до полного `npm run build`.
+
+## Доступные скиллы (quantika-specific)
+
+- `/next-best-practices` — ambient скилл для Next.js: RSC boundaries, async patterns, route handlers,
+  image/font optimization, hydration errors, bundling. Применяется при любой работе с app/ или pages/.
+- `/next-cache-components` — точечно при работе с PPR (Partial Pre-rendering), `'use cache'`,
+  ISR или Server Component кешированием.
+- `/taste-skill` — minimalist editorial preset. **Использовать ТОЛЬКО для marketing / landing страниц** (/about, /pricing). Для data-dense pages (matches, compare-routes, dashboard) использовать `/frontend-design`. Подробнее: SKILL.md «Scope Override».
+
+## Path-scoped rules
+
+Перед редактированием модулей с историей регрессий — прочитать соответствующий файл:
+
+- `lib/ai-provider.ts` → `.claude/rules/ai-provider.md`
+- `lib/knowledge/embeddings/retriever*` → `.claude/rules/retriever.md`
+- `app/api/admin/**` + `middleware.ts` → `.claude/rules/admin-api.md`


### PR DESCRIPTION
## Summary

- Добавляет `.claude/rules/ai-provider.md` — инварианты shim-провайдера: `responseSchema` для Gemini JSON, `extractJson` для Bedrock CoT-preamble, запрет `claude-cli` в NEXT_RUNTIME, `writeAuditRecord` в `finally`
- Добавляет `.claude/rules/retriever.md` — `KNOWLEDGE_RAG_ENABLED` guard, `Float32Array[768]` контракт, lazy-import Vertex, история prod-инцидента (Vertex Standard-tier)
- Добавляет `.claude/rules/admin-api.md` — `requireAdmin` + `AUTH_BYPASS_PATHS` должны добавляться вместе, синхронизация с `middleware-auth.test.ts`
- Обновляет `CLAUDE.md` секцией «Path-scoped rules» со ссылками модуль → файл

## Мотивация

Идея из "6 months tuning Claude Code": path-scoped `.claude/rules/*.md` — агент читает правила конкретного модуля перед редактированием, а не держит весь контекст в голове. Каждый файл ≤30 строк, только проверенные инварианты из реальных регрессий (ai_audit 2026-05-13, Vertex prod-incident, middleware bypass history).

## Test plan

- [ ] docs/config-only PR — тесты не должны падать
- [ ] CI TypeCheck + Jest green
- [ ] Прочитать три created файла, убедиться что содержимое корректно отображается в GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)