### PR TITLE
eval(match): corpus expansion 11→25 scenarios (Phase D3)

### DIFF
--- a/.progonq/corpus/etms-match/manifest.md
+++ b/.progonq/corpus/etms-match/manifest.md
@@ -1,33 +1,60 @@
-# etms-match corpus (R1-calibrated baseline)
+# etms-match corpus (R1-calibrated + Phase D3 expansion)
 
-**Scenarios:** 11
-**Built:** 2026-05-19 (Opus 4.7 composed, R1-calibrated)
+**Scenarios:** 25 (11 R1-baseline + 14 D3-expansion)
+**Built:** 2026-05-19 (Opus 4.7 composed, R1-calibrated; D3 expansion added 2026-05-19)
 **Source:** existing parse-cargo + parse-vessel scenarios paired manually
 
-## Categories (R1-calibrated)
+## Categories
 
-| Category | Count | Purpose                                                                   |
-| -------- | ----- | ------------------------------------------------------------------------- |
-| strong   | 2     | Should be 'good' or upper 'possible' match_level (score 60+)              |
-| marginal | 2     | Should be 'possible' (score 35-70), tests under-lift/timing/long-ballast  |
-| weak     | 2     | Should be 'weak' (score 5-35), tests idle days/late vessel — prescriptive |
-| no-match | 5     | MUST be hard-filtered before LLM (size/draft impossible)                  |
+| Category | Count | Purpose                                                                                |
+| -------- | ----- | -------------------------------------------------------------------------------------- |
+| strong   | 3     | Should be 'good' or upper 'possible' match_level (score 60+)                           |
+| marginal | 5     | Should be 'possible' (score 30-70), tests under-lift/timing/long-ballast/fanout        |
+| weak     | 6     | Should be 'weak' (score 5-40), tests idle/late/sparse/under-utilization                |
+| no-match | 11    | MUST be hard-filtered before LLM (size/draft/sanctions/cargo-type incompat)            |
 
 ## Scenarios
 
-| ID  | Category | Cargo | Vessel | Expected level | Score range |
-| --- | -------- | ----- | ------ | -------------- | ----------- |
-| 001 | no-match | C042  | V004   | —              | —           |
-| 002 | strong   | C024  | V048   | good           | 60-85       |
-| 003 | strong   | C030  | V028   | possible       | 45-75       |
-| 004 | marginal | C018  | V020   | possible       | 35-65       |
-| 005 | no-match | C054  | V036   | —              | —           |
-| 006 | marginal | C060  | V012   | possible       | 40-70       |
-| 007 | weak     | C066  | V040   | weak           | 10-35       |
-| 008 | no-match | C006  | V052   | —              | —           |
-| 009 | weak     | C036  | V008   | weak           | 10-30       |
-| 010 | no-match | C012  | V036   | —              | —           |
-| 011 | no-match | C054  | V004   | —              | —           |
+| ID  | Category | Cargo | Vessel | Expected level | Score range | Trigger                                |
+| --- | -------- | ----- | ------ | -------------- | ----------- | -------------------------------------- |
+| 001 | no-match | C042  | V004   | —              | —           | DWCC overload                          |
+| 002 | strong   | C024  | V048   | good           | 60-85       | East Med bulk spot                     |
+| 003 | strong   | C030  | V028   | possible       | 45-75       | Aliaga→Varna geared                    |
+| 004 | marginal | C018  | V020   | possible       | 35-65       | Long-ballast                           |
+| 005 | no-match | C054  | V036   | —              | —           | Vessel draft exceeds Sfax              |
+| 006 | marginal | C060  | V012   | possible       | 40-70       | Red Sea→East Med tight                 |
+| 007 | weak     | C066  | V040   | weak           | 10-35       | Idle months                            |
+| 008 | no-match | C006  | V052   | —              | —           | Severe under-lift                      |
+| 009 | weak     | C036  | V008   | weak           | 10-30       | Late vessel                            |
+| 010 | no-match | C012  | V036   | —              | —           | Undersized + wrong region              |
+| 011 | no-match | C054  | V004   | —              | —           | Tiny vessel                            |
+| 012 | no-match | C091  | V011   | —              | —           | Sanctions HIGH (no Ukraine + Odesa)    |
+| 013 | no-match | C088  | V049   | —              | —           | Sanctions HIGH (no Ukraine voyage)     |
+| 014 | no-match | C009  | V036   | —              | —           | Draft (Izmail 7.1m < 10.55m)           |
+| 015 | no-match | C078  | V027   | —              | —           | Draft (Reni 7.0m < 9.573m)             |
+| 016 | marginal | C037  | V027   | possible       | 30-65       | Multi-cargo fanout (6 items)           |
+| 017 | weak     | C059  | V046   | weak           | 5-35        | Multi-cargo sparse fanout (11 items)   |
+| 018 | marginal | C024  | V020   | possible       | 35-70       | Multi-vessel fanout (8 vessels)        |
+| 019 | weak     | C022  | V018   | weak           | 10-40       | Multi-vessel under-lift (10 vessels)   |
+| 020 | no-match | C001  | V011   | —              | —           | PROJECT cargo on BULK CARRIER          |
+| 021 | no-match | C002  | V011   | —              | —           | BREAK_BULK cargo on BULK CARRIER       |
+| 022 | weak     | C083  | V026   | weak           | 10-40       | Russia route, NO flag-block (anti-halluc) |
+| 023 | strong   | C022  | V035   | good           | 70-90       | Perfect spot Savona→Samsun 99% fit     |
+| 024 | marginal | C015  | V026   | possible       | 35-70       | Spot-aligned long ballast              |
+| 025 | weak     | C026  | V013   | weak           | 5-35        | Sparse cargo (null weight)             |
+
+## D3 expansion rationale (12-25)
+
+Broadens coverage from 11 baseline pairs (mostly DWCC/draft hard-filters + simple bulk pairs) to test:
+
+- **Sanctions path** (012, 013) — vessel.restrictions regex match on UA route, blocking=true (different from baseline's size/draft hard-filters)
+- **Draft origin-port** (014, 015) — shallow ports (Izmail UAIZM 7.1m, Reni UAREN 7.0m) blocking deep-draft vessels
+- **Multi-item fanout** (016, 017, 018, 019) — cargo-emails with 6-11 items and vessel-emails with 8-10 vessels; tests pair-analyzer evaluates each pairing independently
+- **Cargo-type compatibility matrix** (020, 021) — PROJECT and BREAK_BULK on BULK CARRIER, hard-filter via checkCargoVesselCompat
+- **Sanctions-citation guard** (022) — Russia origin without RU-flagged vessel must NOT produce sanctions citation (parser hallucination guard)
+- **Upper-bound strong** (023) — 99% size fit + 3-day ballast + spot/spot alignment, tests scoring head-room
+- **Long-ballast marginal** (024) — 10+ day Atlantic→Black Sea reposition; readiness boundary
+- **Sparse data weak** (025) — null cargo weight, gearless vessel; tests robustness against missing fields
 
 ## Calibration changelog (R0 → R1)
 
@@ -60,3 +87,4 @@ For `no-match` category: scenario passes if pair does NOT appear in `matches[]` 
 - Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it
 - Charterer-specific policy (e.g., 'Cargill strict on CII') — never allowed from external knowledge
 - Vetting clearance — only valid if vessel input has vetting fields
+- Sanctions risk citation — only valid if vessel flag is RU/IR/BY/CU/MM or vessel.restrictions matches a regex on a route country

--- a/.progonq/corpus/etms-match/scenario-012.json
+++ b/.progonq/corpus/etms-match/scenario-012.json
@@ -1,0 +1,15 @@
+{
+  "id": "etms-match-012-no-match-sanctions-ukraine-odesa",
+  "category": "no-match",
+  "cargo_ref": "etms-parse-cargo/scenario-091",
+  "vessel_ref": "etms-parse-vessel/scenario-011",
+  "expected": {
+    "should_be_hard_filtered": true,
+    "match_level": null,
+    "score_range": null,
+    "must_cite_facts": [],
+    "must_NOT_invent": [],
+    "hard_filter_reason": "vessel restriction \"No Ukraine trading\" matches Odesa origin (Ukraine) — HIGH sanctions risk, blocking"
+  },
+  "notes": "Cargo Odesa→East Coast Italy 12000 mt wheat. Vessel MV GLORY TOM Casablanca 63695 dwt has explicit restrictions list including \"No Ukraine trading\" — regex /\\bno\\s+ukr\\b/i matches, route includes UA → checkSanctions returns risk=HIGH blocking=true → pair-analyzer filters out before LLM. Tests the vessel.restrictions sanctions path (not flag-based). Note: vessel 63695 dwt also overloads cargo at 535% — either filter is sufficient, sanctions is primary."
+}

--- a/.progonq/corpus/etms-match/scenario-013.json
+++ b/.progonq/corpus/etms-match/scenario-013.json
@@ -1,0 +1,15 @@
+{
+  "id": "etms-match-013-no-match-sanctions-ukraine-soya-odesa",
+  "category": "no-match",
+  "cargo_ref": "etms-parse-cargo/scenario-088",
+  "vessel_ref": "etms-parse-vessel/scenario-049",
+  "expected": {
+    "should_be_hard_filtered": true,
+    "match_level": null,
+    "score_range": null,
+    "must_cite_facts": [],
+    "must_NOT_invent": [],
+    "hard_filter_reason": "vessel restriction \"no Ukraine voyage for now\" matches Odesa origin (Ukraine) — HIGH sanctions risk, blocking"
+  },
+  "notes": "Cargo Odesa→TBS 7500 mt soyabean SF~51. Vessel MV PROPUS Marmara 10430 dwt restriction \"no Ukraine voyage for now\" — regex /\\bno\\s+ukr\\b/i matches \"no Ukraine\", route countries includes UA → blocking=true. Tests softer phrasing (\"voyage for now\") still triggers. Size-wise cargo 7500 < dwt 10430 fits (72% util), so without sanctions this would otherwise be a possible match — clean isolation of the sanctions path."
+}

--- a/.progonq/corpus/etms-match/scenario-014.json
+++ b/.progonq/corpus/etms-match/scenario-014.json
@@ -1,0 +1,15 @@
+{
+  "id": "etms-match-014-no-match-draft-izmail-shallow",
+  "category": "no-match",
+  "cargo_ref": "etms-parse-cargo/scenario-009",
+  "vessel_ref": "etms-parse-vessel/scenario-036",
+  "expected": {
+    "should_be_hard_filtered": true,
+    "match_level": null,
+    "score_range": null,
+    "must_cite_facts": [],
+    "must_NOT_invent": [],
+    "hard_filter_reason": "vessel draft 10.55 m exceeds Izmail port max draft 7.1 m — cannot load"
+  },
+  "notes": "Cargo Izmail (UAIZM, port-master draft 7.1 m) → Antalya, 1500 mt break-bulk coal tar pitch big-bags. Vessel MV LADY MERAL Marmara dwt=32131 draft=10.55 m. checkDraft(originPort, draft_max) → 10.55 > 7.1 → fail. Pure draft hard-filter test (origin port shallow). Vessel is also 20× oversized for cargo — secondary under-utilization concern, but draft alone is decisive."
+}

--- a/.progonq/corpus/etms-match/scenario-015.json
+++ b/.progonq/corpus/etms-match/scenario-015.json
@@ -1,0 +1,15 @@
+{
+  "id": "etms-match-015-no-match-draft-reni-river",
+  "category": "no-match",
+  "cargo_ref": "etms-parse-cargo/scenario-078",
+  "vessel_ref": "etms-parse-vessel/scenario-027",
+  "expected": {
+    "should_be_hard_filtered": true,
+    "match_level": null,
+    "score_range": null,
+    "must_cite_facts": [],
+    "must_NOT_invent": [],
+    "hard_filter_reason": "vessel draft 9.573 m exceeds Reni port max draft 7.0 m (Danube river port) — cannot load"
+  },
+  "notes": "Cargo Reni (UAREN, river port, port-master draft 7.0 m) → Tartous, 7300 mt bulk wheat, spot. Vessel MV LADY ZEHMA Adriatic dwt=32328 draft=9.573 m. checkDraft fails: 9.573 > 7.0. Tests inland river port (Danube) draft restriction. Also note vessel UA-route — if vessel had \"no Ukraine\" restriction this would double-block; current corpus vessel-027 has no such restriction → pure draft path."
+}

--- a/.progonq/corpus/etms-match/scenario-016.json
+++ b/.progonq/corpus/etms-match/scenario-016.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-016-marginal-multi-cargo-black-sea-fanout",
+  "category": "marginal",
+  "cargo_ref": "etms-parse-cargo/scenario-037",
+  "vessel_ref": "etms-parse-vessel/scenario-027",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "possible",
+    "score_range": [30, 65],
+    "must_cite_facts": [
+      "Cargo email contains 6 items, vessel matched against each separately (fanout)",
+      "At least one Black Sea item (e.g. Chornomorsk→Douala 30000 mt or Reni→Marmara) potentially compatible with vessel DWT 32328 mt",
+      "Vessel open Adriatic, several cargo origins are Black Sea — 1-2 day Bosphorus ballast",
+      "Multiple items have null/unspecified weights → confidence penalty"
+    ],
+    "must_NOT_invent": [
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Specific cargo nominated as primary — system should evaluate items independently, not pick favorite",
+      "Reni/Giurgiulesti draft compatibility — vessel-027 draft 9.573 m exceeds Reni 7.0 m and Giurgiulesti is shallow Danube; only Chornomorsk/POC items pass draft"
+    ]
+  },
+  "notes": "Multi-cargo fanout test. Cargo-037 has 6 items (Giurgiulesti, Reni×2, POC×2, Chornomorsk). Vessel-027 LADY ZEHMA 32328 dwt draft 9.573 m. Several items have null weight or shallow Danube draft → most pairs filter out. The Chornomorsk→Douala 30000 mt item is the closest fit (vessel DWT 32328 vs 30000). Tests that pair-analyzer evaluates each cargo item separately and does not collapse to single representative."
+}

--- a/.progonq/corpus/etms-match/scenario-017.json
+++ b/.progonq/corpus/etms-match/scenario-017.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-017-weak-multi-cargo-sparse-asia-fanout",
+  "category": "weak",
+  "cargo_ref": "etms-parse-cargo/scenario-059",
+  "vessel_ref": "etms-parse-vessel/scenario-046",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "weak",
+    "score_range": [5, 35],
+    "must_cite_facts": [
+      "Cargo email contains 11 items, most with null weight — sparse data",
+      "Vessel MV ADAMAR open East Coast India dwt 17660 mt, draft 8.598 m, geared",
+      "A few items in same region (Ras Al Khaimah→Shuaiba 50000 mt, Fujairah→Mogadishu 50000 mt) overload vessel — should hard-filter individually",
+      "Remaining BREAK_BULK items with null weight produce low-confidence weak matches"
+    ],
+    "must_NOT_invent": [
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Specific freight rate or laycan window beyond what cargo email states",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Charterer name or shipper identity unless explicit in cargo email"
+    ]
+  },
+  "notes": "Multi-cargo sparse-data fanout. Cargo-059 has 11 items, several with null weights and vague origin/destination ('Sudan port unspecified', 'Lirquén' Chile). Vessel-046 ADAMAR East Coast India 17660 dwt geared MPP. Tests robustness against null fields — overall match level should be weak because most pairs either hard-filter (50K mt items overload) or produce low confidence (null weights, unknown ports)."
+}

--- a/.progonq/corpus/etms-match/scenario-018.json
+++ b/.progonq/corpus/etms-match/scenario-018.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-018-marginal-multi-vessel-east-med-fanout",
+  "category": "marginal",
+  "cargo_ref": "etms-parse-cargo/scenario-024",
+  "vessel_ref": "etms-parse-vessel/scenario-020",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "possible",
+    "score_range": [35, 70],
+    "must_cite_facts": [
+      "Vessel email contains 8 GULF-series vessels, cargo matched against each (fanout)",
+      "Cargo Mersin→Tartous 5000 mt bulk spot — East Med short-haul",
+      "Several vessels open in Med region (EMED, CMED, Aegean, Marmara) — 1-3 day repositioning",
+      "Vessel DWT range 3827-5244 — closest fit MV GULF EXPRESS 5244 (95% utilization)"
+    ],
+    "must_NOT_invent": [
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Geared/gearless status — vessel-020 entries do not specify, do not assume",
+      "Specific draft compatibility for Mersin (14.5 m) — vessels' drafts not provided, do not invent"
+    ]
+  },
+  "notes": "Multi-vessel fanout test. Cargo-024 (Mersin→Tartous 5000 mt) matched against 8 GULF vessels in vessel-020. Vessels range 3827-5244 dwt. Largest GULF EXPRESS 5244 is best size fit. Tests that all 8 cargo×vessel pairs are evaluated, not just first/last. Score expected upper-marginal because several vessels are East Med spot positions."
+}

--- a/.progonq/corpus/etms-match/scenario-019.json
+++ b/.progonq/corpus/etms-match/scenario-019.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-019-weak-multi-vessel-mixed-region-fanout",
+  "category": "weak",
+  "cargo_ref": "etms-parse-cargo/scenario-022",
+  "vessel_ref": "etms-parse-vessel/scenario-018",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "weak",
+    "score_range": [10, 40],
+    "must_cite_facts": [
+      "Vessel email contains 10 SKY/SEA-series vessels, cargo matched against each (fanout)",
+      "Cargo Savona→Samsun 10000 mt bulk 11/14 May — Med→Black Sea via Bosphorus",
+      "Vessel DWT range 3662-6795 — all under-lift cargo 10000 mt (smallest 36%, largest 68% utilization)",
+      "Most SKY vessels are 3662-5128 dwt — physical impossibility for 10000 mt as single carry"
+    ],
+    "must_NOT_invent": [
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Open date — vessel-018 entries have null open_date, do not invent timing",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Two-vessel split shipment — system should not propose combining vessels"
+    ]
+  },
+  "notes": "Multi-vessel under-lift fanout. Cargo 10000 mt vs 10 vessels ranging 3662-6795 dwt — all undersized. Most pairs should hard-filter (cargoWeight check fails) since DWT < cargo. Only the largest (SEA LINE 6795) is below threshold (68% of cargo). Tests fanout + cargoWeight check across multiple vessels. Several positions (Ravenna, Marmara, EMED, Izmit) geographically reasonable, but size dominates."
+}

--- a/.progonq/corpus/etms-match/scenario-020.json
+++ b/.progonq/corpus/etms-match/scenario-020.json
@@ -1,0 +1,15 @@
+{
+  "id": "etms-match-020-no-match-cargo-vessel-project-on-bulker",
+  "category": "no-match",
+  "cargo_ref": "etms-parse-cargo/scenario-001",
+  "vessel_ref": "etms-parse-vessel/scenario-011",
+  "expected": {
+    "should_be_hard_filtered": true,
+    "match_level": null,
+    "score_range": null,
+    "must_cite_facts": [],
+    "must_NOT_invent": [],
+    "hard_filter_reason": "cargo type PROJECT (14 oversized storage tanks) incompatible with vessel category bulk (MV GLORY TOM is BULK CARRIER) — needs MPP/heavy-lift"
+  },
+  "notes": "Cargo-001: 14 pcs storage tanks (10×160m3 + 4×80m3), dimensions 4.3×15.7×4.3 m and 12.1×3.2×3.2 m, on-deck stowage. Cargo type = PROJECT. Vessel-011 MV GLORY TOM type = \"BULK CARRIER\" → categorizeVessel → 'bulk'. COMPATIBILITY[PROJECT][bulk] = false → checkCargoVesselCompat fails → hard-filter via cargoVessel path. Tests the cargo-type compatibility matrix path, independent of size."
+}

--- a/.progonq/corpus/etms-match/scenario-021.json
+++ b/.progonq/corpus/etms-match/scenario-021.json
@@ -1,0 +1,15 @@
+{
+  "id": "etms-match-021-no-match-cargo-vessel-breakbulk-on-bulker",
+  "category": "no-match",
+  "cargo_ref": "etms-parse-cargo/scenario-002",
+  "vessel_ref": "etms-parse-vessel/scenario-011",
+  "expected": {
+    "should_be_hard_filtered": true,
+    "match_level": null,
+    "score_range": null,
+    "must_cite_facts": [],
+    "must_NOT_invent": [],
+    "hard_filter_reason": "cargo type BREAK_BULK (cement in sling, 30000 mt) incompatible with vessel category bulk (MV GLORY TOM is BULK CARRIER) — needs MPP/general-cargo"
+  },
+  "notes": "Cargo-002 Suez→Nacala 30000 mt cement in slings (BREAK_BULK). Vessel-011 GLORY TOM type = \"BULK CARRIER\" → categorizeVessel returns 'bulk'. COMPATIBILITY[BREAK_BULK][bulk] = false → hard-filter via cargoVessel. Note: size-wise vessel 63695 dwt easily fits 30000 mt cargo, and route Suez→Nacala is feasible — sanctions restrictions also do not apply to this route. Pure cargo-type compatibility test, clean isolation."
+}

--- a/.progonq/corpus/etms-match/scenario-022.json
+++ b/.progonq/corpus/etms-match/scenario-022.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-022-weak-russia-route-no-flag-block",
+  "category": "weak",
+  "cargo_ref": "etms-parse-cargo/scenario-083",
+  "vessel_ref": "etms-parse-vessel/scenario-026",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "weak",
+    "score_range": [10, 40],
+    "must_cite_facts": [
+      "Cargo Tuapse (Russia, Black Sea) → Gijón (Spain) 7000 mt anthracite bulk spot",
+      "Vessel MV LADY HATICE Agadir 18930 dwt, draft 8.49 m, Liberia flag, geared",
+      "Vessel flag Liberia (LR) — not RU/IR/BY → checkSanctions returns risk=NONE, no hard-filter",
+      "Long ballast Agadir → Tuapse (Atlantic → Gibraltar → Mediterranean → Bosphorus → Black Sea) ~8-10 days"
+    ],
+    "must_NOT_invent": [
+      "Sanctions risk — vessel flag is Liberia, not RU/IR/BY; do not invent sanctions concerns",
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Charterer-specific EU compliance policy — not in cargo data"
+    ]
+  },
+  "notes": "Tests that a Russia-origin route does NOT auto-trigger sanctions hard-filter without flag/restriction match. Vessel-026 LR-flagged, no restrictions list with Russia. Should score weak due to (a) long ballast Atlantic→Black Sea, (b) under-utilization 7000/18930=37%, (c) anthracite cargo + general-cargo vessel mismatch (BULK on mpp = compatible per matrix but suboptimal). Sanctions citation is a common hallucination — guard against it explicitly."
+}

--- a/.progonq/corpus/etms-match/scenario-023.json
+++ b/.progonq/corpus/etms-match/scenario-023.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-023-strong-perfect-spot-med-black-sea",
+  "category": "strong",
+  "cargo_ref": "etms-parse-cargo/scenario-022",
+  "vessel_ref": "etms-parse-vessel/scenario-035",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "good",
+    "score_range": [70, 90],
+    "must_cite_facts": [
+      "DWT 10074 mt vs cargo 10000 mt (99% utilization — near-perfect fit)",
+      "Vessel open Gibraltar, cargo loads Savona — Western Med ~3 days ballast to Italian Riviera",
+      "Cargo laycan 11/14 May 2026 — vessel spot, dates align tightly",
+      "Vessel geared MPP (2×30T cranes + 1×30T derrick) suitable for bulk loading"
+    ],
+    "must_NOT_invent": [
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Charterer-specific policy (e.g., 'Cargill strict on CII') — never allowed from external knowledge",
+      "Vetting clearance — only valid if vessel input has vetting fields"
+    ]
+  },
+  "notes": "Designed as a clean strong-match: 99% size fit, 3-day ballast, spot/spot timing alignment, geared MPP on bulk cargo (works). Tests upper-bound scoring. Savona (port-master draft 7.5+ m, present in some configs) and Samsun (12.5 m) — vessel draft 9.219 m fits both. Cargo Savona→Samsun via Bosphorus ~6 days laden. Tween-decker classification (MPP family) compatible with BULK per matrix."
+}

--- a/.progonq/corpus/etms-match/scenario-024.json
+++ b/.progonq/corpus/etms-match/scenario-024.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-024-marginal-spot-aligned-long-ballast",
+  "category": "marginal",
+  "cargo_ref": "etms-parse-cargo/scenario-015",
+  "vessel_ref": "etms-parse-vessel/scenario-026",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "possible",
+    "score_range": [35, 70],
+    "must_cite_facts": [
+      "DWT 18930 mt vs cargo 10500 mt (55% utilization)",
+      "Cargo Varna West → Alexandria 10500 mt bulk laycan 14/16 May 2026",
+      "Vessel MV LADY HATICE open Agadir, geared, draft 8.49 m fits Varna (11.5 m) and Alexandria (12.5 m)",
+      "Long ballast Agadir → Varna (~10-12 days via Gibraltar + Bosphorus)"
+    ],
+    "must_NOT_invent": [
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Hold cleanliness restriction — only valid if cargo.restrictions[] literally contains it",
+      "Sanctions concern — Bulgaria origin / Egypt destination + Liberia flag = no sanctions",
+      "Specific freight rate — neither cargo nor vessel provides one"
+    ]
+  },
+  "notes": "Marginal case: size fit fine, draft fine, no sanctions, but long ballast Agadir→Varna will likely make readiness late or unknown given 14/16 May laycan. If vessel needs 10+ days to reposition and is currently spot, exact arrival timing matters. Tests scoring under long-ballast + moderate utilization. Bulgaria (Varna BG) and Egypt (Alexandria EG) — no sanctions blocs hit."
+}

--- a/.progonq/corpus/etms-match/scenario-025.json
+++ b/.progonq/corpus/etms-match/scenario-025.json
@@ -1,0 +1,24 @@
+{
+  "id": "etms-match-025-weak-sparse-cargo-null-weight",
+  "category": "weak",
+  "cargo_ref": "etms-parse-cargo/scenario-026",
+  "vessel_ref": "etms-parse-vessel/scenario-013",
+  "expected": {
+    "should_be_hard_filtered": false,
+    "match_level": "weak",
+    "score_range": [5, 35],
+    "must_cite_facts": [
+      "Cargo Thisvi (Greece) → Monfalcone (Italy NE Adriatic) bulk, weight UNSPECIFIED in cargo email",
+      "Vessel MV IMI Vassiliko 4300 dwt, draft 5.62 m, MPP, gearless",
+      "Cargo laycan 17/22 May 2026 — vessel spot",
+      "Null weight on cargo input → cargoWeight hard-filter silently passes, score confidence penalty applies"
+    ],
+    "must_NOT_invent": [
+      "Specific cargo weight (e.g. '4000 mt') — cargo email did not state weight",
+      "P&I IG-club satisfied — only valid if vessel input has pi_club field",
+      "Cargo description detail beyond \"bulk\" — desc not in cargo email",
+      "Crane requirement — Thisvi/Monfalcone port crane availability unknown, vessel gearless"
+    ]
+  },
+  "notes": "Edge case: cargo with null weight (no weight_mt, no min/max). Tests parser robustness — system should still produce a match record with low confidence rather than crash or hard-filter. Vessel-013 IMI 4300 dwt, MPP, gearless. Thisvi → Monfalcone is short Med (Aegean → Adriatic ~4 days). Weak score expected because confidence penalty stacks (null weight, unknown port cranes for gearless vessel). Hallucination guard: model must not invent a weight to make math work."
+}


### PR DESCRIPTION
## Summary

Expands `.progonq/corpus/etms-match/` from 11 → 25 scenarios to broaden Phase D3 eval coverage beyond the R1 baseline (which focused on DWCC/draft hard-filters + simple bulk pairs).

## New scenarios (012–025)

| ID | Category | Cargo | Vessel | Trigger |
| -- | -------- | ----- | ------ | ------- |
| 012 | no-match | C091 | V011 | Sanctions HIGH — vessel restriction 'No Ukraine trading' + Odesa origin |
| 013 | no-match | C088 | V049 | Sanctions HIGH — 'no Ukraine voyage for now' softer phrasing + Odesa |
| 014 | no-match | C009 | V036 | Draft — Izmail (UAIZM, 7.1m) < vessel 10.55m |
| 015 | no-match | C078 | V027 | Draft — Reni (UAREN, 7.0m, Danube river) < vessel 9.573m |
| 016 | marginal | C037 | V027 | Multi-cargo fanout (6 items, Black Sea) |
| 017 | weak | C059 | V046 | Multi-cargo sparse fanout (11 items, several null weights) |
| 018 | marginal | C024 | V020 | Multi-vessel fanout (8 GULF-series vessels) |
| 019 | weak | C022 | V018 | Multi-vessel under-lift (10 SKY-series vessels, all < cargo) |
| 020 | no-match | C001 | V011 | PROJECT cargo (storage tanks) on BULK CARRIER — checkCargoVesselCompat |
| 021 | no-match | C002 | V011 | BREAK_BULK cargo (cement in slings) on BULK CARRIER |
| 022 | weak | C083 | V026 | Russia origin + Liberia-flagged vessel — sanctions citation hallucination guard |
| 023 | strong | C022 | V035 | Perfect spot — Savona→Samsun 10000mt + ELFRIEDE Gibraltar 10074dwt geared (99% fit, 3-day ballast) |
| 024 | marginal | C015 | V026 | Spot-aligned long ballast — Agadir→Varna ~10-12 days reposition |
| 025 | weak | C026 | V013 | Sparse cargo (null weight) on gearless MPP — robustness against missing fields |

## Coverage rationale

- **Sanctions vessel.restrictions path** (012, 013) — R1 corpus has no vessel-flag-based or restriction-based sanctions test; this adds two scenarios that exercise the `/\bno\s+ukr\b/i` regex in `lib/validation/sanctions.ts:220-227` with both literal ('No Ukraine trading') and softer ('no Ukraine voyage for now') phrasings
- **Origin-port draft hard-filter** (014, 015) — R1 only had destination-port draft (Sfax/005); these add origin-port draft on shallow Danube ports
- **Multi-item fanout** (016–019) — R1 used only single-item cargo and single-vessel emails; D3 adds 4 scenarios with cargo containing 6–11 items or vessel containing 8–10 vessels, exercising pair-analyzer's cartesian product
- **Cargo-type compatibility matrix** (020, 021) — R1 has no cargo-type incompat test; PROJECT/BREAK_BULK on BULK CARRIER is the most common matrix-fail path (`COMPATIBILITY[PROJECT][bulk] = false`)
- **Anti-hallucination guard** (022) — explicitly tests that a Russia-origin route without RU/IR-flagged vessel does NOT trigger a sanctions citation in match_reasons (common LLM hallucination)
- **Upper-bound strong** (023) — R1 strong scenarios topped out at 60-85; adds 70-90 ceiling test
- **Sparse-data edge** (025) — null cargo weight on gearless MPP, tests system does not crash and does not invent a weight

## What's NOT in scope

- Pure gearless-vessel + no-crane-port test (skipped — no corpus cargo loads at no-crane ports per port-master.json)
- New parser scenarios — etms-parse-cargo and etms-parse-vessel corpora used read-only
- R5 baseline run — deferred to follow-up after merge (parallel agents busy)
- Modifications to existing scenarios 001–011 — left untouched per task constraints

## Test plan

- [x] All 25 scenario JSON files pass `jq empty` validation
- [x] All cargo_ref / vessel_ref point to existing parser scenarios (verified via file existence)
- [x] Manifest count summary updated 11 → 25 with per-scenario rows
- [x] New common hallucination guard added for sanctions citations
- [ ] R5 eval baseline run on new corpus (deferred, separate PR)
- [ ] Spot-check 2-3 scenarios against pair-analyzer in dev to confirm category prediction

🤖 Generated with [Claude Code](https://claude.com/claude-code)