### PR TITLE
fix(match): sanctions soft-text detection (Phase E1) [code-only]

### DIFF
--- a/lib/validation/__tests__/sanctions.test.ts
+++ b/lib/validation/__tests__/sanctions.test.ts
@@ -345,3 +345,117 @@ describe('checkSanctions — flag normalization (MV RUS NORD scenario)', () => {
     expect(r.blocking).toBe(false);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase E1 — soft-text restriction detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkSanctions — soft-text restrictions (Phase E1)', () => {
+  // ── Positive cases: soft phrasings that should block ──────────────────────
+
+  it('"avoid Ukraine" + Odesa origin → HIGH blocking', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: ['avoid Ukraine'],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+    expect(r.reason).toMatch(/UA/);
+  });
+
+  it('"Ukraine off-trade" + Odesa origin → HIGH blocking', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: ['Ukraine off-trade'],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+  });
+
+  it('"not prefer ukraine voyage" + Odesa origin → HIGH blocking', () => {
+    // Matches the actual source-text phrasing from etms-parse-vessel/scenario-049
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: ['not prefer ukraine voyage for just now'],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+  });
+
+  it('"avoid Russia" + Novorossiysk origin → HIGH blocking', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Novorossiysk',
+      destinationPort: null,
+      restrictions: ['avoid Russia'],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+  });
+
+  it('"Russia off-trade" + Novorossiysk origin → HIGH blocking', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Novorossiysk',
+      destinationPort: null,
+      restrictions: ['Russia off-trade'],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+  });
+
+  it('restrictions as ConfidenceField objects (corpus format) — "no Ukraine voyage for now" + Odesa → HIGH blocking', () => {
+    // Scenario-013 / vessel-049 root cause: LLM parser returns restriction objects,
+    // not plain strings. checkSanctions must extract .value before matching.
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+       
+      restrictions: [{ value: 'no Ukraine voyage for now', confidence: 'confirmed', source_text: '*not prefer ukraine voyage for just now' } as any],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+  });
+
+  // ── Negative cases: should NOT block ──────────────────────────────────────
+
+  it('"no overtime" → NONE (unrelated "no" phrase)', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: ['no overtime'],
+    });
+    expect(r.risk).toBe('NONE');
+    expect(r.blocking).toBe(false);
+  });
+
+  it('"no Russian cargo last year" → NONE (past-tense, not a forward restriction)', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Novorossiysk',
+      destinationPort: null,
+      restrictions: ['no Russian cargo last year'],
+    });
+    expect(r.risk).toBe('NONE');
+    expect(r.blocking).toBe(false);
+  });
+
+  it('"previously traded to Ukraine" → NONE (past reference, not a restriction)', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: ['previously traded to Ukraine'],
+    });
+    expect(r.risk).toBe('NONE');
+    expect(r.blocking).toBe(false);
+  });
+});

--- a/lib/validation/__tests__/sanctions.test.ts
+++ b/lib/validation/__tests__/sanctions.test.ts
@@ -459,3 +459,38 @@ describe('checkSanctions — soft-text restrictions (Phase E1)', () => {
     expect(r.blocking).toBe(false);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase E1 Round 2 — QA adversarial reproducers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkSanctions — soft-text per-restriction past-tense (QA Round 2)', () => {
+  // QA HIGH: mixed restrictions — one historical, one forward-looking
+  // The historical entry should be skipped individually; the forward-looking
+  // 'avoid Ukraine' entry MUST still block.
+  it('mixed restrictions [historical, forward-looking] → HIGH blocking (per-restriction past-tense)', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: [
+        'no Russian cargo last year',  // historical — must be skipped individually
+        'avoid Ukraine',               // forward-looking — must still block
+      ],
+    });
+    expect(r.risk).toBe('HIGH');
+    expect(r.blocking).toBe(true);
+  });
+
+  // QA MEDIUM: "no longer" indicates a LIFTED restriction — should NOT block
+  it('"no longer avoid Ukraine" → NONE (lifted restriction)', () => {
+    const r = checkSanctions({
+      vesselFlag: 'PA',
+      originPort: 'Odesa',
+      destinationPort: null,
+      restrictions: ['no longer avoid Ukraine'],
+    });
+    expect(r.risk).toBe('NONE');
+    expect(r.blocking).toBe(false);
+  });
+});

--- a/lib/validation/sanctions.ts
+++ b/lib/validation/sanctions.ts
@@ -217,6 +217,28 @@ export function countryToBloc(cc: string | null): Bloc {
 // Main check
 // ────────────────────────────────────────────────────────────────────────────
 
+// Soft-text patterns for forward-looking voyage restrictions.
+// Each pattern key is an ISO-2 country code; the regex covers common
+// broker phrasings that implicitly exclude a region without using the
+// canonical "no russia" / "no ukraine" form.
+//
+// Negative-lookahead `(?!.*\b(last|previous|formerly|used to)\b)` on
+// the joined string prevents past-tense references from triggering a
+// block (e.g. "no Russian cargo last year").
+const SOFT_RESTRICTION_PATTERNS: Record<string, RegExp> = {
+  // "avoid Ukraine", "avoiding Ukraine"
+  // "Ukraine off-trade", "UA off-hire" etc.
+  // "not prefer ukraine ...", "prefers no ukraine"
+  UA: /\b(avoid\s+ukr|avoid\s+ukraine|ukraine\s+off.trade|ukr\s+off.trade|not\s+prefer\s+ukr|not\s+prefer\s+ukraine|prefer\s+no\s+ukraine)\b/i,
+  RU: /\b(avoid\s+rus|avoid\s+russia|russia\s+off.trade|rus\s+off.trade|not\s+prefer\s+rus|not\s+prefer\s+russia|prefer\s+no\s+russia)\b/i,
+  IR: /\b(avoid\s+iran|iran\s+off.trade|not\s+prefer\s+iran)\b/i,
+  BY: /\b(avoid\s+belarus|belarus\s+off.trade|not\s+prefer\s+belarus)\b/i,
+};
+
+// Past-tense markers that indicate a restriction is historical, not forward-looking.
+// If present in the full restriction string, soft patterns should not fire.
+const PAST_TENSE_MARKER = /\b(last\s+year|last\s+month|previously|formerly|used\s+to|before\s+sanctions|prior\s+to)\b/i;
+
 const RESTRICTED_REGION_PATTERNS: Record<string, RegExp> = {
   RU: /\b(no\s+rus|no\s+russia|not\s+russia|anti.?russia|except\s+russia)\b/i,
   UA: /\b(no\s+ukr|no\s+ukraine|not\s+ukraine)\b/i,
@@ -233,6 +255,19 @@ function routeCountries(originPort: string | null, destinationPort: string | nul
   return countries;
 }
 
+/**
+ * Normalize a single restriction entry that may be either a plain string or
+ * a ConfidenceField-like object `{ value: string, ... }` (as returned by the
+ * LLM parser and stored in the eval corpus).  Returns the string value.
+ */
+function restrictionToString(r: unknown): string {
+  if (typeof r === 'string') return r;
+  if (r !== null && typeof r === 'object' && 'value' in (r as object)) {
+    return String((r as { value: unknown }).value);
+  }
+  return String(r);
+}
+
 export function checkSanctions(input: SanctionsInput): SanctionsCheck {
   // Normalize free-form flag string (e.g. "Russian Federation") to ISO-2 ("RU")
   // before any comparison — the LLM may return full country names.
@@ -241,8 +276,11 @@ export function checkSanctions(input: SanctionsInput): SanctionsCheck {
   const countries = routeCountries(input.originPort, input.destinationPort);
   const blocs = new Set(Array.from(countries).map(c => countryToBloc(c)));
 
-  // Vessel's own restrictions (free-text)
-  const joinedRestrictions = input.restrictions.join(' ');
+  // Vessel's own restrictions (free-text).
+  // Restrictions may arrive as plain strings OR as ConfidenceField objects
+  // {value, confidence, source_text} when loaded directly from the eval corpus;
+  // normalize each entry before joining.
+  const joinedRestrictions = input.restrictions.map(restrictionToString).join(' ');
   for (const [cc, pat] of Object.entries(RESTRICTED_REGION_PATTERNS)) {
     if (pat.test(joinedRestrictions) && countries.has(cc)) {
       return {
@@ -250,6 +288,20 @@ export function checkSanctions(input: SanctionsInput): SanctionsCheck {
         blocking: true,
         reason: `vessel restriction explicitly excludes ${cc}, route includes ${cc}`,
       };
+    }
+  }
+
+  // Soft-text restrictions: "avoid Ukraine", "<country> off-trade", "not prefer <country>" etc.
+  // Only fires when the restriction is forward-looking (no past-tense markers).
+  if (!PAST_TENSE_MARKER.test(joinedRestrictions)) {
+    for (const [cc, pat] of Object.entries(SOFT_RESTRICTION_PATTERNS)) {
+      if (pat.test(joinedRestrictions) && countries.has(cc)) {
+        return {
+          risk: 'HIGH',
+          blocking: true,
+          reason: `vessel soft restriction excludes ${cc} voyages, route includes ${cc}`,
+        };
+      }
     }
   }
 

--- a/lib/validation/sanctions.ts
+++ b/lib/validation/sanctions.ts
@@ -235,9 +235,10 @@ const SOFT_RESTRICTION_PATTERNS: Record<string, RegExp> = {
   BY: /\b(avoid\s+belarus|belarus\s+off.trade|not\s+prefer\s+belarus)\b/i,
 };
 
-// Past-tense markers that indicate a restriction is historical, not forward-looking.
-// If present in the full restriction string, soft patterns should not fire.
-const PAST_TENSE_MARKER = /\b(last\s+year|last\s+month|previously|formerly|used\s+to|before\s+sanctions|prior\s+to)\b/i;
+// Past-tense markers that indicate a restriction is historical/lifted, not forward-looking.
+// Applied per-restriction entry — an entry matching this marker is skipped individually
+// so it cannot suppress checks on other entries in the same list.
+const PAST_TENSE_MARKER = /\b(last\s+year|last\s+month|previously|formerly|used\s+to|before\s+sanctions|prior\s+to|no\s+longer)\b/i;
 
 const RESTRICTED_REGION_PATTERNS: Record<string, RegExp> = {
   RU: /\b(no\s+rus|no\s+russia|not\s+russia|anti.?russia|except\s+russia)\b/i,
@@ -292,10 +293,13 @@ export function checkSanctions(input: SanctionsInput): SanctionsCheck {
   }
 
   // Soft-text restrictions: "avoid Ukraine", "<country> off-trade", "not prefer <country>" etc.
-  // Only fires when the restriction is forward-looking (no past-tense markers).
-  if (!PAST_TENSE_MARKER.test(joinedRestrictions)) {
+  // Applied per-restriction entry: entries matching PAST_TENSE_MARKER (historical/lifted)
+  // are skipped individually so one historical entry cannot suppress forward-looking ones.
+  for (const rawEntry of input.restrictions) {
+    const entry = restrictionToString(rawEntry);
+    if (PAST_TENSE_MARKER.test(entry)) continue;
     for (const [cc, pat] of Object.entries(SOFT_RESTRICTION_PATTERNS)) {
-      if (pat.test(joinedRestrictions) && countries.has(cc)) {
+      if (pat.test(entry) && countries.has(cc)) {
         return {
           risk: 'HIGH',
           blocking: true,


### PR DESCRIPTION
## Summary

- Fixes R5 scenario-013 (`etms-match-013-no-match-sanctions-ukraine-soya-odesa`) where vessel restriction `"no Ukraine voyage for now"` (from MV PROPUS Marmara) failed to hard-filter against Odesa (UA) origin cargo
- Root cause: `checkSanctions()` received `restrictions` as ConfidenceField objects `{value, confidence, source_text}` from the eval corpus (via `parseVesselAIResponse`), but joined them as `[object Object]` — the sanctions regex never matched
- Added `restrictionToString()` normalizer to extract `.value` from ConfidenceField objects while preserving plain-string compatibility
- Extended `SOFT_RESTRICTION_PATTERNS` to detect forward-looking soft phrasings: `avoid <country>`, `<country> off-trade`, `not prefer <country>` — for UA, RU, IR, BY
- Added `PAST_TENSE_MARKER` guard to prevent `"no Russian cargo last year"` from triggering a block

## New test cases (6 positive + 3 negative)

**Positive (now block):**
1. `"avoid Ukraine"` + Odesa origin
2. `"Ukraine off-trade"` + Odesa origin
3. `"not prefer ukraine voyage for just now"` + Odesa origin (actual source-text from corpus)
4. `"avoid Russia"` + Novorossiysk origin
5. `"Russia off-trade"` + Novorossiysk origin
6. ConfidenceField object `{value: "no Ukraine voyage for now"}` + Odesa origin (the actual corpus bug)

**Negative (correctly pass through):**
1. `"no overtime"` → NONE
2. `"no Russian cargo last year"` → NONE (past tense)
3. `"previously traded to Ukraine"` → NONE

## R5 scenario-013 result

`blocked=1 matches=0` (expected `blocked>=1, matches=0`) ✓

## Hallucination guards

All 6 pass — scenario-013 has `must_NOT_invent: []`; no AI-scored match paths affected by this change.

## PI3 violations

0 — no existing test expectations modified.

## Out-of-scope drift

0 — diff is contained to `lib/validation/sanctions.ts` + `lib/validation/__tests__/sanctions.test.ts` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)