### PR TITLE
fix(charterers): remove redundant requireSession from API handlers

### DIFF
--- a/__tests__/api/charterers-id.test.ts
+++ b/__tests__/api/charterers-id.test.ts
@@ -259,57 +259,93 @@ describe('DELETE /api/charterers/[id]', () => {
   });
 });
 
-describe('Auth: /api/charterers/[id]', () => {
+describe('Auth contract: handler bypasses requireSession (demo flow)', () => {
+  let db: Database.Database;
   const originalEnv = process.env.CHARTERER_CREDIT_ENABLED;
 
   beforeEach(() => {
+    db = new Database(':memory:');
+    migration026.up(db);
+    testDb = db;
     process.env.CHARTERER_CREDIT_ENABLED = 'true';
+    // Simulate "no session_id" state. If any handler called requireSession,
+    // this mock would force 401 and the assertions below would fail.
+    // Regression contract: re-adding requireSession to a handler breaks these tests.
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
   });
 
   afterEach(() => {
+    db.close();
     process.env.CHARTERER_CREDIT_ENABLED = originalEnv;
   });
 
-  // PI4 RC test — auth returns 401 when no session
-  it('GET returns 401 when session is missing', async () => {
-    mockRequireSession.mockReturnValueOnce(
-      NextResponse.json({ error: 'No session' }, { status: 401 })
-    );
+  it('GET returns 200 for existing charterer when no session_id is available', async () => {
+    upsertCharterer(db, {
+      id: 'c1',
+      name: 'Demo Corp',
+      tier: 'blue-chip',
+      payment_history: '[]',
+      require_lc: 0,
+      notes: null,
+    });
 
     const { GET } = await import('@/app/api/charterers/[id]/route');
     const res = await GET(
       new NextRequest('http://localhost/api/charterers/c1'),
       { params: Promise.resolve({ id: 'c1' }) }
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.name).toBe('Demo Corp');
   });
 
-  it('PUT returns 401 when session is missing', async () => {
-    mockRequireSession.mockReturnValueOnce(
-      NextResponse.json({ error: 'No session' }, { status: 401 })
+  it('GET returns 404 for missing charterer when no session_id (not 401)', async () => {
+    const { GET } = await import('@/app/api/charterers/[id]/route');
+    const res = await GET(
+      new NextRequest('http://localhost/api/charterers/missing-id'),
+      { params: Promise.resolve({ id: 'missing-id' }) }
     );
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT returns 200 when no session_id is available', async () => {
+    upsertCharterer(db, {
+      id: 'c1',
+      name: 'Original',
+      tier: 'blue-chip',
+      payment_history: '[]',
+      require_lc: 0,
+      notes: null,
+    });
 
     const { PUT } = await import('@/app/api/charterers/[id]/route');
     const res = await PUT(
       new NextRequest('http://localhost/api/charterers/c1', {
         method: 'PUT',
-        body: JSON.stringify({ name: 'Test' }),
+        body: JSON.stringify({ name: 'Updated' }),
       }),
       { params: Promise.resolve({ id: 'c1' }) }
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
   });
 
-  it('DELETE returns 401 when session is missing', async () => {
-    mockRequireSession.mockReturnValueOnce(
-      NextResponse.json({ error: 'No session' }, { status: 401 })
-    );
+  it('DELETE returns 204 when no session_id is available', async () => {
+    upsertCharterer(db, {
+      id: 'c1',
+      name: 'Demo',
+      tier: 'blue-chip',
+      payment_history: '[]',
+      require_lc: 0,
+      notes: null,
+    });
 
     const { DELETE } = await import('@/app/api/charterers/[id]/route');
     const res = await DELETE(
       new NextRequest('http://localhost/api/charterers/c1', { method: 'DELETE' }),
       { params: Promise.resolve({ id: 'c1' }) }
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(204);
   });
 });

--- a/__tests__/api/charterers.test.ts
+++ b/__tests__/api/charterers.test.ts
@@ -271,39 +271,46 @@ describe('POST /api/charterers', () => {
   });
 });
 
-describe('Auth: /api/charterers', () => {
+describe('Auth contract: handler bypasses requireSession (demo flow)', () => {
+  let db: Database.Database;
   const originalEnv = process.env.CHARTERER_CREDIT_ENABLED;
 
   beforeEach(() => {
+    db = new Database(':memory:');
+    migration026.up(db);
+    testDb = db;
     process.env.CHARTERER_CREDIT_ENABLED = 'true';
+    // Simulate "no session_id" state. If handler called requireSession
+    // (which it must NOT — auth gating belongs to middleware demo_auth),
+    // this mock forces 401 and the assertions below would fail.
+    // Regression contract: re-adding requireSession to the handler breaks these tests.
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
   });
 
   afterEach(() => {
+    db.close();
     process.env.CHARTERER_CREDIT_ENABLED = originalEnv;
   });
 
-  // PI4 RC test — auth returns 401 when no session
-  it('GET returns 401 when session is missing', async () => {
-    mockRequireSession.mockReturnValueOnce(
-      NextResponse.json({ error: 'No session' }, { status: 401 })
-    );
-
+  it('GET returns 200 with empty list when no session_id is available', async () => {
     const { GET } = await import('@/app/api/charterers/route');
     const res = await GET(new NextRequest('http://localhost/api/charterers'));
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.charterers).toEqual([]);
   });
 
-  it('POST returns 401 when session is missing', async () => {
-    mockRequireSession.mockReturnValueOnce(
-      NextResponse.json({ error: 'No session' }, { status: 401 })
-    );
-
+  it('POST returns 201 when no session_id is available (demo user can create)', async () => {
     const { POST } = await import('@/app/api/charterers/route');
     const req = new NextRequest('http://localhost/api/charterers', {
       method: 'POST',
-      body: JSON.stringify({ name: 'Test', tier: 'blue-chip' }),
+      body: JSON.stringify({ name: 'Demo Corp', tier: 'blue-chip' }),
     });
     const res = await POST(req);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.name).toBe('Demo Corp');
   });
 });

--- a/app/api/charterers/[id]/route.ts
+++ b/app/api/charterers/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStore } from '@/lib/session-store';
-import { requireSession } from '@/lib/session';
 import {
   getCharterer,
   upsertCharterer,
@@ -16,6 +15,9 @@ export const dynamic = 'force-dynamic';
  * - PUT: updates charterer or 404
  * - DELETE: deletes charterer or 404
  * - Empty id → 404 or routing error
+ *
+ * Auth: gated by middleware demo_auth cookie. Charterers are shared reference
+ * data (not session-scoped), so no handler-level session_id check.
  */
 
 function isFeatureEnabled(): boolean {
@@ -26,9 +28,6 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
-  const authResult = requireSession(request);
-  if (authResult instanceof NextResponse) return authResult;
-
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },
@@ -62,9 +61,6 @@ export async function PUT(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
-  const authResult = requireSession(request);
-  if (authResult instanceof NextResponse) return authResult;
-
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },
@@ -124,9 +120,6 @@ export async function DELETE(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
-  const authResult = requireSession(request);
-  if (authResult instanceof NextResponse) return authResult;
-
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },

--- a/app/api/charterers/route.ts
+++ b/app/api/charterers/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStore } from '@/lib/session-store';
-import { requireSession } from '@/lib/session';
 import { listCharterers, upsertCharterer } from '@/lib/market/charterers-repository';
 import { randomBytes } from 'crypto';
 
@@ -14,6 +13,9 @@ export const dynamic = 'force-dynamic';
  * - POST: missing name/tier → 400 validation error
  * - POST: invalid tier → 400 validation error
  * - POST: empty name → 400 validation error
+ *
+ * Auth: gated by middleware demo_auth cookie. Charterers are shared reference
+ * data (not session-scoped), so no handler-level session_id check.
  */
 
 function isFeatureEnabled(): boolean {
@@ -21,9 +23,6 @@ function isFeatureEnabled(): boolean {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  const authResult = requireSession(request);
-  if (authResult instanceof NextResponse) return authResult;
-
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },
@@ -47,9 +46,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  const authResult = requireSession(request);
-  if (authResult instanceof NextResponse) return authResult;
-
   if (!isFeatureEnabled()) {
     return NextResponse.json(
       { error: 'Feature disabled' },


### PR DESCRIPTION
## Summary

- Demo user gets 401 on `/charterers` and `/charterers/[id]` because handler-level `requireSession` checks `session_id` cookie, which demo flow (post `/api/auth/login`) doesn't have — login sets only `demo_auth`. `session_id` is set by `/api/sample`, `/api/etms-demo`, `/api/auth/google` after email upload.
- **Fix:** Remove `requireSession` from both charterer route handlers. Charterers is shared reference data (no session-scoping in repository functions). Middleware `demo_auth` cookie remains the auth gate — `/api/charterers/*` is NOT in `AUTH_BYPASS_PATHS`.
- **Tests:** 5 obsolete \"Auth: returns 401\" tests replaced with 6 regression tests under \"Auth contract: handler bypasses requireSession\" that fail if anyone re-adds `requireSession` to the handler.

## Prod repro (2026-05-19)

\`\`\`
POST /api/auth/login (admin / DEMO_AUTH_PASSWORD) → 303 Set-Cookie: demo_auth=...
GET  /api/charterers           (cookie: demo_auth) → 401 {\"error\":\"No session\"}
GET  /api/charterers/1         (cookie: demo_auth) → 401 {\"error\":\"No session\"}
\`\`\`

After fix, these should return 200 (list) and 404 (id=1 doesn't exist in prod DB).

## Pipeline artifacts

Audited via `/dev-pipeline-deep` (strict 4-phase):
- Phase 1 SCOPE — 4 files, Rule G skipped (pure deletion refactor)
- Phase 2 TDD — RED verified (6 new tests fail with current impl) → GREEN (25/25)
- Phase 3 QI — cold-context security-auditor agent: **PASS** (0 CRITICAL, 0 HIGH)
- Class 6 (substring leak) / Class 7 (config cross-ref) / Class 9 (E2E property) — all clean

## Out of scope

- `/processing 403`: different root cause (CSRF cookie missing from `/api/auth/login`, not session_id). Follow-up PR.

## Test plan

- [x] Unit tests green locally: 25/25 (charterers api), 37/37 (charterers + page tests + dashboard link tests)
- [x] Cross-cutting grep: `requireSession` still active in extension/, matches/, agent/, audit/, sample/, ai/, emails/ — only charterers cleaned up
- [x] No junk markers (TODO/FIXME/console.log) in changed files
- [x] Prod 401 reproduced before fix
- [ ] CI green
- [ ] Smoke on prod after deploy: login → /charterers (no 401 in Console), /charterers/1 (graceful 404 \"Charterer not found\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)