### PR TITLE
ci: add tag-based auto-merge workflow [code-only]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,44 @@
+name: Auto-merge (tag-based)
+# Enables GitHub's native auto-merge on PRs tagged [code-only] (in title) or
+# carrying the `code-only` label. Auto-merge then fires once required status
+# checks pass (Build / Test / TypeCheck + Audit).
+#
+# Safety guards:
+#   - Skip if title contains [deploy-affects] or [ops] (Rule 9 of orchestrator-day)
+#   - Skip on draft PRs
+#   - Skip if author is dependabot[bot] — that's handled by dependabot-auto-merge.yml
+#
+# Why this exists: previously orchestrator-day called `gh pr merge --auto --squash`
+# manually after every PR creation. This workflow automates that step so any
+# [code-only] PR self-queues for merge once CI is green.
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      !github.event.pull_request.draft &&
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.title, '[deploy-affects]') &&
+      !contains(github.event.pull_request.title, '[ops]') &&
+      (
+        contains(github.event.pull_request.title, '[code-only]') ||
+        contains(github.event.pull_request.labels.*.name, 'code-only')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-merge.yml` — automates the manual `gh pr merge --auto --squash` step that orchestrator called after every PR creation.

Was originally part of PR #253 (commit f4425e5) but landed orphan: auto-merge fired on the 3rd commit (ci.yml fix) before the 4th commit (this workflow) reached GitHub. Squash-merge took only the first 3.

## Trigger logic

Fires on PR open/edited/labeled if:
- Title contains `[code-only]` OR has `code-only` label
- AND title does NOT contain `[deploy-affects]` / `[ops]`
- AND PR not draft
- AND author not `dependabot[bot]` (handled by separate workflow)

Matches orchestrator-day Rule 9 deploy-affecting-gate policy.

## Test plan

- [ ] This PR itself self-tests: has `[code-only]` in title → once this workflow exists on this branch, it should self-enable auto-merge. (If the new workflow file isn't yet "live" until merged, orchestrator falls back to manual `gh pr merge --auto`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)