### PR TITLE
fix(judge): explain-deal Round 2 — line-anchor + FAIL severity + Arabic guards (post-#261 QA) [code-only]

### DIFF
--- a/.progonq/corpus/etms-explain-deal/scenario-004.json
+++ b/.progonq/corpus/etms-explain-deal/scenario-004.json
@@ -95,7 +95,9 @@
     "must_cite_facts": ["9500", "7500", "13500"],
     "must_not_contain": [
       "$40 per metric ton",
-      "vetting clearance approved"
+      "vetting clearance approved",
+      "40$ للطن المتري",
+      "تخليص الفحص معتمد"
     ],
     "language": "ar"
   }

--- a/scripts/progonq/__tests__/judge-explain-deal.test.ts
+++ b/scripts/progonq/__tests__/judge-explain-deal.test.ts
@@ -182,6 +182,51 @@ describe('detectLanguage', () => {
   });
 });
 
+// ─── QA Round-2 reproducers ──────────────────────────────────────────────────
+
+describe('checkSections — QA R2 adversarial', () => {
+  it('header embedded mid-sentence (no standalone header line) → FAIL, not false PASS', () => {
+    // "Market Context" appears inside Deal Rationale body, not as a section header line
+    const text = `Deal Rationale\nThis is strong from a Market Context perspective.\n\nKey Risks\nSome risks.\n\nRecommended Next Steps\nCall broker.`;
+    const results = checkSections(text, EN_HEADERS);
+    const mc = results.find(r => r.header === 'Market Context');
+    expect(mc).toBeDefined();
+    expect(mc!.verdict).toBe('FAIL');
+  });
+});
+
+describe('checkHallucinations — QA R2 Arabic guards', () => {
+  it('Arabic output with Arabic hallucination string → caught by Arabic guard', () => {
+    const arabicText =
+      'سياق السوق\nالسوق نشط.\n\nمبررات الصفقة\nالحمولة 7500 طن بسعر 40$ للطن المتري.\n\nالمخاطر الرئيسية\nمخاطر.\n\nالخطوات التالية الموصى بها\nاتصل.';
+    const guards = [
+      '40$ للطن المتري',
+      'تخليص الفحص معتمد',
+      '$40 per metric ton',
+      'vetting clearance approved',
+    ];
+    const results = checkHallucinations(arabicText, guards);
+    const caught = results.find(r => !r.passed);
+    expect(caught).toBeDefined();
+  });
+});
+
+describe('judgeOne — QA R2 fact severity', () => {
+  it('zero must_cite_facts present → overall FAIL, not WARN', () => {
+    const r = makeRunResult({
+      raw_text: `Market Context\nGood conditions.\n\nDeal Rationale\nGood fit.\n\nKey Risks\nSome risks.\n\nRecommended Next Steps\nCall broker.`,
+      expected: {
+        sections_present: EN_HEADERS,
+        must_cite_facts: ['10500', '8000'], // neither appears in raw_text
+        must_not_contain: [],
+        language: 'en',
+      },
+    });
+    const v = judgeOne(r);
+    expect(v.overall).toBe('FAIL');
+  });
+});
+
 // ─── judgeOne integration ─────────────────────────────────────────────────────
 
 describe('judgeOne', () => {

--- a/scripts/progonq/judge-explain-deal.ts
+++ b/scripts/progonq/judge-explain-deal.ts
@@ -89,6 +89,14 @@ export interface ScenarioVerdict {
  * WARN: header found but content is effectively empty (whitespace only)
  * FAIL: header not found in text
  */
+function lineAnchoredIdx(text: string, header: string): number {
+  const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp('(^|\\n)' + escaped, 'i');
+  const m = re.exec(text);
+  if (!m) return -1;
+  return m.index + m[1].length;
+}
+
 export function checkSections(text: string, expectedHeaders: string[]): SectionCheck[] {
   const results: SectionCheck[] = [];
 
@@ -96,17 +104,17 @@ export function checkSections(text: string, expectedHeaders: string[]): SectionC
     const header = expectedHeaders[i];
     const nextHeader = expectedHeaders[i + 1];
 
-    const headerIdx = text.indexOf(header);
+    const headerIdx = lineAnchoredIdx(text, header);
     if (headerIdx === -1) {
       results.push({ header, verdict: 'FAIL', note: `Section "${header}" not found in output` });
       continue;
     }
 
-    // Extract content between this header and the next
+    // Extract content between this header and the next (use line-anchored search for next too)
     const afterHeader = text.slice(headerIdx + header.length);
     let content: string;
     if (nextHeader) {
-      const nextIdx = afterHeader.indexOf(nextHeader);
+      const nextIdx = lineAnchoredIdx(afterHeader, nextHeader);
       content = nextIdx !== -1 ? afterHeader.slice(0, nextIdx) : afterHeader;
     } else {
       content = afterHeader;
@@ -231,7 +239,7 @@ export function judgeOne(r: RunResult): ScenarioVerdict {
   const factChecks = checkCitedFacts(r.raw_text, r.expected.must_cite_facts);
   for (const fc of factChecks) {
     if (fc.verdict === 'PASS') passCount++;
-    else { warnCount++; notes.push(`⚠ FACT MISSING: ${fc.note}`); }
+    else { failCount++; notes.push(`✗ FACT MISSING: ${fc.note}`); }
   }
   if (factChecks.length > 0) {
     const cited = factChecks.filter(f => f.verdict === 'PASS').length;


### PR DESCRIPTION
## Context

Round 2 fix addressing 1 HIGH + 2 MEDIUM findings from cold-start `/test-skill` QA review of PR #261 (merged via auto-merge race before QA could complete).

## Fixes

- **HIGH**: `checkSections` was using `text.indexOf(header)` without line-anchor → mid-body mentions of section names (e.g., "strong from a Market Context perspective") gave false-positive section detection. Fixed with `lineAnchoredIdx()` helper using `/(^|\n)header/i` regex.
- **MEDIUM-1**: Missing `must_cite_facts` was `warnCount++` → now `failCount++` (fact-empty output is now FAIL, not WARN).
- **MEDIUM-2**: Arabic scenario-004 had English-only hallucination guards → added Arabic equivalents ("40$ للطن المتري", "تخليص الفحص معتمد").

## Tests

22 original + 3 new (RED reproducers from QA) = 25 tests, all green.

## QA verdict source

`/root/qd-followup-2-qa/QA-VERDICT-261.md` (cold-start adversarial review).