### PR TITLE
fix(misc): 4 QA follow-ups — aria-live, scenario-003 rationale, Savona+Figueira draft refinement (Phase F1)

### DIFF
--- a/.progonq/corpus/etms-match/scenario-003.json
+++ b/.progonq/corpus/etms-match/scenario-003.json
@@ -19,5 +19,6 @@
       "Vetting clearance — only valid if vessel input has vetting fields"
     ]
   },
+  "_calibration_rationale": "Under-lift IS penalised in component scores (cargo type 11.2/20, volume 8.4/15) but doesn't drop below 'good' threshold. Acceptable commercial behaviour — vessel still profitable despite suboptimal utilization. If future changes reduce under-lift penalty further (scores >80), revisit.",
   "notes": "Tests under-lift handling. Should be 'possible' (not 'good') because vessel cannot carry full cargo. If scorer ignores under-lift and gives 'good', that's a regression. [R1 update] Got score=53 with readiness=unknown — distance to Aliaga and Marmara->Aliaga corridor not in matrix yet. Phase 2D may help. Hard-filter correctly blocked the second permutation (under-lift). [E2 recalibration] R5 got score=73.6 (good, ideal 0.87d gap) — D1-D3 fixes added Marmara→Aliaga corridor; timing now ideal. Under-lift IS penalised in component scores (cargo 11.2/20, volume 8.4/15) but overall 73.6 crosses good threshold. 73.6/good is correct commercial behaviour — adjusted: range 45-75→65-80, level possible→good."
 }

--- a/__tests__/matches-vague-region-hint.test.tsx
+++ b/__tests__/matches-vague-region-hint.test.tsx
@@ -105,3 +105,19 @@ describe('MatchesClient.tsx — vague-region hint conditionality', () => {
     expect(src).toMatch(/vagueRegionAdjustment|reason_structured/);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 7. Accessibility — role + aria-live (Phase F1 QA fix)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('MatchesClient.tsx — vague-region hint accessibility', () => {
+  it('hint div has role="alert"', () => {
+    const src = readSource();
+    expect(src).toMatch(/role=["']alert["']/);
+  });
+
+  it('hint div has aria-live="polite"', () => {
+    const src = readSource();
+    expect(src).toMatch(/aria-live=["']polite["']/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -370,7 +370,11 @@ export default function MatchesClient({ initialMatches }: Props) {
                         // use generic hint
                       }
                       return (
-                        <div className="mt-1 text-xs text-amber-700 bg-amber-50 rounded px-2 py-1">
+                        <div
+                          role="alert"
+                          aria-live="polite"
+                          className="mt-1 text-xs text-amber-700 bg-amber-50 rounded px-2 py-1"
+                        >
                           {hintText}
                         </div>
                       );

--- a/data/ports/port-master.json
+++ b/data/ports/port-master.json
@@ -7065,7 +7065,7 @@
     "country": "IT",
     "lat": 44.312,
     "lon": 8.494,
-    "maxDraftM": 10.0,
+    "maxDraftM": 15.0,
     "hasShoreCranes": true,
     "berthType": "deep-sea",
     "maxLOA": 250,
@@ -7075,6 +7075,7 @@
     "dataConfidence": "high",
     "sourceNote": "maritimeoptima.com/ITSVN; SeaRates/Savona; MarineTraffic",
     "aliases": ["Savona-Vado", "Porto di Savona"],
+    "_note": "Includes Vado Ligure SECH terminal — confirm specific berth for >12m vessels",
     "note": "Italian Ligurian coast; RORO, container, bulk — common Western Med cargo origin (Phase E5)"
   },
   {
@@ -7083,7 +7084,7 @@
     "country": "PT",
     "lat": 40.143,
     "lon": -8.846,
-    "maxDraftM": 6.5,
+    "maxDraftM": 5.5,
     "hasShoreCranes": true,
     "berthType": "river",
     "maxLOA": 180,
@@ -7093,6 +7094,7 @@
     "dataConfidence": "high",
     "sourceNote": "cogoport.com/Figueira da Foz; latitude.to; MarineTraffic PTFDF",
     "aliases": ["Figueira", "Figueira Foz", "Porto de Figueira da Foz"],
+    "_note": "Bar depth at HW reaches 6.5m, but inner cargo berths cap at 4.9-6.1m. Conservative 5.5m for vessel-fit checks.",
     "note": "Portuguese river port on Mondego; forest products/pulp/grain; tidal access, max draft 6.5 m (Phase E5)"
   },
   {

--- a/lib/sailing/__tests__/port-master.test.ts
+++ b/lib/sailing/__tests__/port-master.test.ts
@@ -143,3 +143,28 @@ describe('port-master gap-fill: Bug E1 — 4 missing ports', () => {
     expect(getPortMaster('ANTALYA')).toEqual(getPortMaster('Antalya'));
   });
 });
+
+describe('port-master Phase F1 — Savona + Figueira da Foz draft corrections', () => {
+  it('Savona (ITSVN) maxDraftM is 15 (includes Vado Ligure SECH terminal)', () => {
+    const m = getPortMaster('Savona');
+    expect(m).not.toBeNull();
+    expect(m!.maxDraftM).toBe(15);
+  });
+
+  it('"Savona-Vado" alias is present in port-master JSON aliases field', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ports = require('@/data/ports/port-master.json') as Array<{ unlocode: string; aliases?: string[] }>;
+    const savona = ports.find((p) => p.unlocode === 'ITSVN');
+    expect(savona?.aliases).toContain('Savona-Vado');
+  });
+
+  it('Figueira da Foz (PTFDF) maxDraftM is 5.5 (conservative cargo berth depth)', () => {
+    const m = getPortMaster('Figueira da Foz');
+    expect(m).not.toBeNull();
+    expect(m!.maxDraftM).toBe(5.5);
+  });
+
+  it('Figueira da Foz is tidal', () => {
+    expect(getPortMaster('Figueira da Foz')!.tidal).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix 1 (LOW QA-#251)** — `app/matches/MatchesClient.tsx`: add `role="alert"` + `aria-live="polite"` to vague-region hint div (polite, not assertive — not an emergency interrupt)
- **Fix 2 (MEDIUM QA-#256)** — `.progonq/corpus/etms-match/scenario-003.json`: add `_calibration_rationale` documenting why under-lift scores stay in "good" range; no behaviour change
- **Fix 3 (MEDIUM QA-#262)** — `data/ports/port-master.json` Savona (ITSVN): raise `maxDraftM` 10→15 (Vado Ligure SECH terminal handles 15-17m vessels), keep `"Savona-Vado"` alias, add `_note` to confirm berth for >12m
- **Fix 4 (MEDIUM QA-#262)** — `data/ports/port-master.json` Figueira da Foz (PTFDF): lower `maxDraftM` 6.5→5.5 (conservative; inner cargo berths cap at 4.9-6.1m), add `_note` explaining bar vs. berth depth distinction

## Tests

- 4 RED → GREEN tests added (aria-live attrs × 2, Savona draft + alias JSON, Figueira draft)
- 530 suites, 6220 tests passing; PI3 violations: 0

## Out of scope

No matcher logic changes, no new ports, no other QA findings.