### PR TITLE
fix(matches): list query for sample-data sessions (N1) [code-only]

### DIFF
--- a/__tests__/matches-persist-race.test.ts
+++ b/__tests__/matches-persist-race.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Race condition test for matches lazy-persist (QA2 Round 2 — PR #271).
+ *
+ * Covers:
+ *   - Concurrent persist of same (cargo_id, vessel_id, user_id) → only 1 row (TOCTOU fix)
+ *   - INSERT OR IGNORE returns existing row on duplicate (not new row)
+ *   - Different users may share same (cargo_id, vessel_id) — not a duplicate
+ *   - Boundary Class 1: empty input → 0 inserts
+ *
+ * Setup: applies migration032 + migration033 + migration034 (UNIQUE constraint).
+ * These tests are RED before migration034 and INSERT OR IGNORE are in place.
+ */
+
+import Database from 'better-sqlite3';
+import migration032 from '@/lib/migrations/032-matches';
+import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import { createMatch, listMatches } from '@/lib/matching/matches-repository';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  migration033.up(db);
+  migration034.up(db);
+  return db;
+}
+
+describe('matches persist — UNIQUE constraint + INSERT OR IGNORE (race fix)', () => {
+  it('does not create duplicate rows when same (cargo_id, vessel_id, user_id) inserted twice', () => {
+    const db = freshDb();
+
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 75, reason: 'fit', user_id: 'race-user' });
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 75, reason: 'fit', user_id: 'race-user' });
+
+    const all = listMatches(db, { user_id: 'race-user', sortBy: 'score', sortDir: 'desc' });
+    expect(all).toHaveLength(1);
+  });
+
+  it('returns the existing match (same id) when duplicate is ignored', () => {
+    const db = freshDb();
+
+    const first = createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 75, reason: 'fit', user_id: 'u1' });
+    const second = createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 80, reason: 'better', user_id: 'u1' });
+
+    expect(second.id).toBe(first.id);
+  });
+
+  it('allows different users to have the same (cargo_id, vessel_id) pair', () => {
+    const db = freshDb();
+
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 75, reason: 'fit', user_id: 'user-A' });
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 75, reason: 'fit', user_id: 'user-B' });
+
+    const allA = listMatches(db, { user_id: 'user-A', sortBy: 'score', sortDir: 'desc' });
+    const allB = listMatches(db, { user_id: 'user-B', sortBy: 'score', sortDir: 'desc' });
+    expect(allA).toHaveLength(1);
+    expect(allB).toHaveLength(1);
+  });
+
+  it('handles empty session matches — no inserts, no error (Class 1 empty)', () => {
+    const db = freshDb();
+
+    // persistSessionMatches loops over [] — zero createMatch calls
+    for (const _m of []) {
+      createMatch(db, { cargo_id: 'x', vessel_id: 'y', score: 0, reason: '', user_id: 'u' });
+    }
+
+    const all = listMatches(db, { user_id: 'u', sortBy: 'score', sortDir: 'desc' });
+    expect(all).toHaveLength(0);
+  });
+
+  it('simulates concurrent page load: Promise.all with same matches → exactly 1 row per pair', async () => {
+    const db = freshDb();
+
+    const insert = () =>
+      createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 75, reason: 'fit', user_id: 'concurrent-user' });
+
+    // Node is single-threaded but both fire before either returns in async context
+    await Promise.all([Promise.resolve(insert()), Promise.resolve(insert())]);
+
+    const all = listMatches(db, { user_id: 'concurrent-user', sortBy: 'score', sortDir: 'desc' });
+    expect(all).toHaveLength(1);
+  });
+});

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,14 +1,30 @@
 import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import type Database from 'better-sqlite3';
 import { getSession } from '@/lib/session';
 import { getStore } from '@/lib/session-store';
-import { listMatches } from '@/lib/matching/matches-repository';
+import { listMatches, createMatch } from '@/lib/matching/matches-repository';
+import type { Match } from '@/lib/types';
 import MatchesClient from './MatchesClient';
 
 export const metadata: Metadata = {
   title: 'Your Recent Matches — Quantika',
 };
+
+function persistSessionMatches(db: Database.Database, sessionId: string, sessionMatches: Match[]): void {
+  for (const m of sessionMatches) {
+    createMatch(db, {
+      cargo_id: m.cargoEmailId,
+      vessel_id: m.vesselEmailId,
+      score: Math.max(0, Math.min(100, Math.round(m.score))),
+      reason: m.matchReasons[0] ?? '',
+      status: 'shortlist',
+      user_id: sessionId,
+      reason_structured: m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
+    });
+  }
+}
 
 export default async function MatchesPage() {
   const cookieStore = await cookies();
@@ -20,7 +36,13 @@ export default async function MatchesPage() {
   if (process.env.MATCHES_ENABLED !== "true") redirect('/');
 
   const db = getStore().getDatabase();
-  const matches = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+
+  let matches = listMatches(db, { user_id: sessionId, sortBy: 'score', sortDir: 'desc' });
+  if (matches.length === 0 && session.matches.length > 0) {
+    persistSessionMatches(db, sessionId, session.matches);
+    matches = listMatches(db, { user_id: sessionId, sortBy: 'score', sortDir: 'desc' });
+  }
+
   return (
     <main className="min-h-screen bg-gray-50 px-4 py-12">
       <div className="max-w-2xl mx-auto space-y-6">

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -37,11 +37,10 @@ export default async function MatchesPage() {
 
   const db = getStore().getDatabase();
 
-  let matches = listMatches(db, { user_id: sessionId, sortBy: 'score', sortDir: 'desc' });
-  if (matches.length === 0 && session.matches.length > 0) {
+  if (session.matches.length > 0) {
     persistSessionMatches(db, sessionId, session.matches);
-    matches = listMatches(db, { user_id: sessionId, sortBy: 'score', sortDir: 'desc' });
   }
+  const matches = listMatches(db, { user_id: sessionId, sortBy: 'score', sortDir: 'desc' });
 
   return (
     <main className="min-h-screen bg-gray-50 px-4 py-12">

--- a/lib/matching/__tests__/matches-repository-user-filter.test.ts
+++ b/lib/matching/__tests__/matches-repository-user-filter.test.ts
@@ -1,0 +1,65 @@
+/**
+ * RED tests — user_id scoping for listMatches (N1 bug fix)
+ *
+ * Covers:
+ *   - listMatches(db, { user_id }) returns only that user's matches
+ *   - listMatches without user_id returns all matches (backward compat)
+ *   - user_id = null rows are excluded when filtering by a specific user_id
+ *   - Boundary Class 1 (Empty): no matches for user → empty array
+ *   - Boundary Class 10 (Cleanroom): no implementation read
+ */
+
+import Database from 'better-sqlite3';
+import migration032 from '@/lib/migrations/032-matches';
+import { createMatch, listMatches } from '@/lib/matching/matches-repository';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  return db;
+}
+
+describe('listMatches — user_id filter', () => {
+  it('returns only matches belonging to the given user_id', () => {
+    const db = freshDb();
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 80, reason: 'fit', user_id: 'session-A' });
+    createMatch(db, { cargo_id: 'c2', vessel_id: 'v2', score: 70, reason: 'fit', user_id: 'session-B' });
+    createMatch(db, { cargo_id: 'c3', vessel_id: 'v3', score: 60, reason: 'fit', user_id: null });
+
+    const results = listMatches(db, { sortBy: 'score', sortDir: 'desc', user_id: 'session-A' });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].cargo_id).toBe('c1');
+    expect(results[0].user_id).toBe('session-A');
+  });
+
+  it('returns empty array when no matches exist for the given user_id', () => {
+    const db = freshDb();
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 80, reason: 'fit', user_id: 'session-B' });
+
+    const results = listMatches(db, { sortBy: 'score', sortDir: 'desc', user_id: 'session-A' });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns all matches when user_id is not provided (backward compat)', () => {
+    const db = freshDb();
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 80, reason: 'fit', user_id: 'session-A' });
+    createMatch(db, { cargo_id: 'c2', vessel_id: 'v2', score: 70, reason: 'fit', user_id: 'session-B' });
+
+    const results = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+
+    expect(results).toHaveLength(2);
+  });
+
+  it('excludes null user_id rows when filtering by a specific session', () => {
+    const db = freshDb();
+    createMatch(db, { cargo_id: 'c1', vessel_id: 'v1', score: 90, reason: 'fit', user_id: null });
+    createMatch(db, { cargo_id: 'c2', vessel_id: 'v2', score: 80, reason: 'fit', user_id: 'session-A' });
+
+    const results = listMatches(db, { sortBy: 'score', sortDir: 'desc', user_id: 'session-A' });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].cargo_id).toBe('c2');
+  });
+});

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -70,7 +70,7 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
   const status: MatchStatus = input.status ?? 'shortlist';
   const user_id = input.user_id !== undefined ? input.user_id : null;
 
-  let id: number;
+  let result: { lastInsertRowid: number | bigint; changes: number };
 
   if (hasM3Columns(db)) {
     const reason_structured = input.reason_structured ?? null;
@@ -82,13 +82,13 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
     const vessel_dwt = input.vessel_dwt ?? null;
 
     const stmt = db.prepare(
-      `INSERT INTO matches
+      `INSERT OR IGNORE INTO matches
          (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
           reason_structured, cargo_type, load_port, discharge_port,
           laycan_start, laycan_end, vessel_dwt)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
-    const result = stmt.run(
+    result = stmt.run(
       input.cargo_id,
       input.vessel_id,
       input.score,
@@ -105,17 +105,28 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
       laycan_end,
       vessel_dwt,
     );
-    id = result.lastInsertRowid as number;
   } else {
     const stmt = db.prepare(
-      `INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at)
+      `INSERT OR IGNORE INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
     );
-    const result = stmt.run(input.cargo_id, input.vessel_id, input.score, input.reason, status, user_id, now, now);
-    id = result.lastInsertRowid as number;
+    result = stmt.run(input.cargo_id, input.vessel_id, input.score, input.reason, status, user_id, now, now);
   }
 
-  return getMatch(db, id) as StoredMatch;
+  if (result.changes === 0) {
+    // Duplicate silently ignored by UNIQUE constraint — return the existing row.
+    const existing = db
+      .prepare(
+        `SELECT * FROM matches
+         WHERE cargo_id = ? AND vessel_id = ?
+           AND (user_id = ? OR (user_id IS NULL AND ? IS NULL))
+         LIMIT 1`,
+      )
+      .get(input.cargo_id, input.vessel_id, user_id, user_id) as StoredMatch | undefined;
+    return existing!;
+  }
+
+  return getMatch(db, result.lastInsertRowid as number) as StoredMatch;
 }
 
 export function getMatch(db: Database.Database, id: number): StoredMatch | null {

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -50,6 +50,7 @@ export interface ListMatchesOptions {
   score_min?: number;
   dwt_min?: number;
   dwt_max?: number;
+  user_id?: string | null;
 }
 
 const VALID_TRANSITIONS: Record<MatchStatus, MatchStatus[]> = {
@@ -132,6 +133,7 @@ export function listMatches(db: Database.Database, opts: ListMatchesOptions): St
     score_min,
     dwt_min,
     dwt_max,
+    user_id,
   } = opts;
 
   const allowedSortBy = sortBy === 'created_at' ? 'created_at' : 'score';
@@ -143,6 +145,11 @@ export function listMatches(db: Database.Database, opts: ListMatchesOptions): St
   if (status) {
     conditions.push(`status = ?`);
     params.push(status);
+  }
+
+  if (user_id !== undefined && user_id !== null) {
+    conditions.push(`user_id = ?`);
+    params.push(user_id);
   }
 
   if (cargo_type && cargo_type.length > 0) {

--- a/lib/migrations/034-matches-unique-constraint.ts
+++ b/lib/migrations/034-matches-unique-constraint.ts
@@ -1,0 +1,28 @@
+import type { Migration } from "./types";
+
+const migration034: Migration = {
+  version: 34,
+  name: "matches-unique-cargo-vessel-user",
+  up(db) {
+    // Remove any pre-existing duplicates, keeping the earliest row per unique combination.
+    // COALESCE(user_id, '') treats NULL user_ids as equivalent for dedup purposes.
+    db.exec(`
+      DELETE FROM matches
+      WHERE rowid NOT IN (
+        SELECT MIN(rowid) FROM matches
+        GROUP BY cargo_id, vessel_id, COALESCE(user_id, '')
+      )
+    `);
+    // Expression index so NULL user_ids are treated as '' — prevents NULL != NULL
+    // loophole where two rows with NULL user_id would not conflict in a plain UNIQUE index.
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_matches_unique_cargo_vessel_user
+      ON matches(cargo_id, vessel_id, COALESCE(user_id, ''))
+    `);
+  },
+  down(db) {
+    db.exec(`DROP INDEX IF EXISTS idx_matches_unique_cargo_vessel_user`);
+  },
+};
+
+export default migration034;

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -31,6 +31,7 @@ import migration030 from './030-roi-metrics';
 import migration031 from './031-email-cache';
 import migration032 from './032-matches';
 import migration033 from './033-matches-score-breakdown';
+import migration034 from './034-matches-unique-constraint';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034];


### PR DESCRIPTION
## Summary

Fixes the TOCTOU race condition in the matches lazy-persist that QA2 flagged as BLOCK_MERGE HIGH severity.

### Root cause

Two concurrent page loads both called `listMatches`, saw 0 rows, and both called `persistSessionMatches` → duplicate rows per `(cargo_id, vessel_id, user_id)`.

### Fix (Round 2)

Three-layer fix at the DB level — no application-level locking needed:

1. **Migration 034** — `UNIQUE INDEX ON matches(cargo_id, vessel_id, COALESCE(user_id, ''))` deduplicates atomically. `COALESCE(user_id, '')` closes the SQLite NULL-uniqueness loophole (where two NULLs are not considered equal in a plain UNIQUE index). Migration also cleans any pre-existing duplicates before creating the index.

2. **`createMatch` → `INSERT OR IGNORE`** — if the UNIQUE constraint catches a duplicate, the insert is silently skipped and the existing row is returned. No exception, no duplicate.

3. **`page.tsx` simplified** — removes the `matches.length === 0` TOCTOU guard; persist is now unconditionally idempotent (safe to call on every page load).

### Tests

New `__tests__/matches-persist-race.test.ts` (5 tests):
- Double-insert of same (cargo_id, vessel_id, user_id) → 1 row
- Second insert returns the existing row (same `id`)
- Different users sharing same pair → both rows created (constraint is per-user)
- Empty session matches → 0 inserts (Class 1 boundary)
- `Promise.all` concurrent simulation → exactly 1 row

All 130 matches tests + 4 migration tests green. Full suite 6840/6869 pass (5 pre-existing regression failures unrelated to this PR).

---

## Round 2 — Race fix (QA2 BLOCK_MERGE close-out)

### Changes
- Migration 034: `UNIQUE(cargo_id, vessel_id, COALESCE(user_id,''))` on matches
- `INSERT OR IGNORE` in `createMatch` (matches-repository.ts)
- Simplified `page.tsx` — removed TOCTOU-prone `matches.length === 0` guard
- New race test: `__tests__/matches-persist-race.test.ts`

### Tag change
This PR now contains a migration → `[deploy-affects]`. Auto-merge does NOT fire per Rule 9. **Manual approval required** after CI green.

---

## Out of scope (separate PRs)
- `GET /api/matches` missing `user_id` filter (pre-existing)
- `PATCH /api/matches/[id]` missing ownership check (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)