### PR TITLE
fix(ops): auto-rebase CI trigger + deploy.yml seed + concurrency docs (T3) [code-only]

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -32,16 +32,25 @@ jobs:
   rebase-behind-prs:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Update branch on all open [code-only] PRs that are BEHIND
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -e
+          # Configure git for authenticated pushes used in the nudge-CI step below.
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+
           gh pr list \
             --repo "$REPO" \
             --state open \
-            --json number,title,labels,mergeStateStatus,autoMergeRequest \
+            --json number,title,labels,mergeStateStatus,autoMergeRequest,headRefName \
             --limit 50 \
           | jq -c '.[]' \
           | while read -r pr; do
@@ -49,6 +58,7 @@ jobs:
               title=$(echo "$pr" | jq -r '.title')
               state=$(echo "$pr" | jq -r '.mergeStateStatus')
               auto=$(echo "$pr" | jq -r '.autoMergeRequest // empty')
+              branch=$(echo "$pr" | jq -r '.headRefName')
               if [ "$state" != "BEHIND" ] || [ -z "$auto" ]; then
                 continue
               fi
@@ -58,7 +68,24 @@ jobs:
                 echo "Skip #$num: not [code-only]"
                 continue
               fi
-              echo "Updating PR #$num: $title"
-              gh api -X PUT "/repos/$REPO/pulls/$num/update-branch" \
-                || echo "  warn: update-branch failed (likely conflict)"
+              echo "Updating PR #$num: $title (branch: $branch)"
+              if gh api -X PUT "/repos/$REPO/pulls/$num/update-branch"; then
+                # Nudge CI: the update-branch REST API call (under GITHUB_TOKEN) does not
+                # fire pull_request:synchronize — GitHub's anti-recursion suppresses events
+                # from API mutations made by GITHUB_TOKEN. A direct git push to the PR branch
+                # (a different target than this workflow's push-to-main trigger) does fire the
+                # synchronize event, which causes CI to re-run on the updated PR branch.
+                # Uses git commit-tree to avoid a branch checkout, keeping the working tree clean.
+                git fetch origin "$branch" \
+                  && parent=$(git rev-parse "origin/$branch") \
+                  && tree=$(git rev-parse "origin/$branch^{tree}") \
+                  && commit=$(git commit-tree \
+                       -m "ci: nudge CI after auto-rebase [skip cd]" \
+                       -p "$parent" "$tree") \
+                  && git push origin "${commit}:refs/heads/${branch}" \
+                  && echo "  CI nudge pushed to $branch" \
+                  || echo "  warn: CI nudge push failed for $branch (non-fatal)"
+              else
+                echo "  warn: update-branch failed (likely conflict)"
+              fi
             done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,22 @@ name: Deploy to prod
 # /root/deploy-quantika-demo.sh.
 #
 # Health check + auto-rollback live in deploy-quantika-demo.sh (60s window).
-# Concurrency group prevents stampedes; in-flight deploy finishes before next.
+#
+# Concurrency group (cancel-in-progress: false) behaviour:
+#   Only ONE deploy runs at a time. While a deploy is in-flight, GitHub keeps
+#   at most ONE additional run pending — a newer push discards the previous
+#   pending run. Result: N code-touching merges in quick succession may produce
+#   fewer than N deploy runs (the in-flight finishes, then the LATEST pending
+#   fires). This is intentional: it avoids deploying stale intermediate commits
+#   and prevents run stampedes. If you expect N deploys for N merges, use
+#   cancel-in-progress: true instead (each merge gets its own slot, but earlier
+#   ones get killed).
 #
 # paths-ignore: pure docs/config changes don't deploy (still merge to main,
 # just no rebuild). Workflow self-changes (.github/**) also skip deploy to
 # avoid infinite-loop after workflow edits.
+# Note: GitHub evaluates paths-ignore against the squash-merge commit diff,
+# not individual PR commits. Mixed PRs (code + docs) trigger deploy.
 
 on:
   push:
@@ -46,10 +57,10 @@ jobs:
               -o ConnectTimeout=10 \
               root@185.249.225.169 \
               "quantika-demo ${{ github.sha }}"
-      - name: Post-deploy seed guard
-        run: |
-          ssh -i ~/.ssh/deploy_key \
-              -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=10 \
-              root@185.249.225.169 \
-              "bash /root/quantika-demo/scripts/ops/post-deploy-seed.sh"
+      # Post-deploy seed guard: NOT called from here.
+      # The SSH key uses a forced command: command="/root/deploy.sh $SSH_ORIGINAL_COMMAND"
+      # which routes by service name. Sending "bash /path/to/script.sh" makes deploy.sh
+      # receive "bash" as the service name → "ERROR: unknown service: bash".
+      # Seed logic must live inside /root/deploy-quantika-demo.sh on the VPS (after the
+      # health check, before exit). See docs/runbooks/post-deploy-seed.md for manual run
+      # instructions and the VPS integration note.

--- a/docs/runbooks/post-deploy-seed.md
+++ b/docs/runbooks/post-deploy-seed.md
@@ -1,0 +1,65 @@
+# Runbook: Post-deploy seed guard
+
+## What it does
+
+`scripts/ops/post-deploy-seed.sh` is an idempotent seed guard that runs after
+deploy. It checks `COUNT(*)` for each required table and seeds it only if empty.
+
+Tables guarded:
+
+- `roi_metrics` — required for ROI guarantee feature (`ROI_GUARANTEE_ENABLED`)
+- `fx_rates` — required for multi-currency display (`MULTI_CURRENCY_V2_ENABLED`)
+
+Re-runs are safe: existing rows are never overwritten.
+
+## Why the deploy workflow doesn't call it automatically
+
+The SSH key on `outreach-vps` uses a forced command:
+
+```
+command="/root/deploy.sh $SSH_ORIGINAL_COMMAND"
+```
+
+`/root/deploy.sh` is a dispatcher that routes by service name:
+`"quantika-demo <sha>"` → `/root/deploy-quantika-demo.sh <sha>`. Sending
+`"bash /root/quantika-demo/scripts/ops/post-deploy-seed.sh"` passes `bash` as
+the service name, which `deploy.sh` doesn't recognise → `ERROR: unknown service: bash`.
+
+## Manual run (when needed)
+
+SSH directly if you have a key that bypasses the forced command, or run from the VPS:
+
+```bash
+# From outreach-vps (root session):
+cd /root/quantika-demo
+bash scripts/ops/post-deploy-seed.sh
+```
+
+Or via SSH with a privileged key:
+
+```bash
+ssh -i ~/.ssh/your_admin_key root@185.249.225.169 \
+  "cd /root/quantika-demo && bash scripts/ops/post-deploy-seed.sh"
+```
+
+## VPS integration — action required
+
+To run the seed automatically after each deploy, inline the seed call inside
+`/root/deploy-quantika-demo.sh` on `outreach-vps`, after the health check and
+before the final `exit 0`:
+
+```bash
+# --- add after health check ---
+echo "[deploy] Running post-deploy seed guard..."
+(cd /root/quantika-demo && bash scripts/ops/post-deploy-seed.sh) \
+  || echo "[deploy] WARN: seed guard failed — check manually"
+```
+
+This edit must be made **directly on the VPS** — `/root/deploy-quantika-demo.sh`
+is not tracked in the repository.
+
+## When to run manually
+
+- After first deploy to a fresh VPS instance
+- After a database reset or migration that drops `roi_metrics` or `fx_rates`
+- When the ROI guarantee or multi-currency features show "no data" errors


### PR DESCRIPTION
## Summary

T3 cleanup of 3 deferred ops tasks (#28+#29+#30):

- **#28 — auto-rebase-prs.yml** — adds empty-commit nudge step after `gh api update-branch` to trigger downstream CI (workaround for GITHUB_TOKEN anti-recursion)
- **#29 — deploy.yml** — documents paths-ignore quirk (GitHub Actions concurrency.cancel-in-progress cancels overlapping pushes; only the latest fires)
- **#30 — Post-deploy seed integration** — removes failing inline `bash ...` step from deploy.yml (SSH forced command blocks arbitrary bash). New runbook `docs/runbooks/post-deploy-seed.md` documents manual seed flow + Phase 2 plan (embed in /root/deploy-quantika-demo.sh on outreach-vps).

## Files

- `.github/workflows/auto-rebase-prs.yml` — empty-commit step
- `.github/workflows/deploy.yml` — remove failing seed step + concurrency doc comment
- `docs/runbooks/post-deploy-seed.md` — new runbook

## Test plan

- [ ] CI green (yaml validation, no jest changes)
- [ ] After merge — verify auto-rebase still works on next BEHIND PR via workflow_dispatch
- [ ] Manual VPS task tracked separately: edit /root/deploy-quantika-demo.sh to inline seed guard (post-restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)