### PR TITLE
fix(ai): Gemini maxOutputTokens — prevent vessel JSON truncation

### DIFF
--- a/__tests__/lib/ai-provider-sampling.test.ts
+++ b/__tests__/lib/ai-provider-sampling.test.ts
@@ -37,6 +37,7 @@ describe("buildGeminiSamplingFields", () => {
     expect(cfg.seed).toBeUndefined();
     expect(cfg.topP).toBeUndefined();
     expect(cfg.topK).toBeUndefined();
+    expect(cfg.maxOutputTokens).toBeUndefined();
   });
 
   it("includes all provided sampling fields", () => {
@@ -45,6 +46,16 @@ describe("buildGeminiSamplingFields", () => {
     expect(cfg.topP).toBe(0.95);
     expect(cfg.topK).toBe(40);
     expect(cfg.seed).toBe(1);
+  });
+
+  it("maps maxTokens to maxOutputTokens for Gemini", () => {
+    const cfg = buildGeminiSamplingFields({ maxTokens: 8192 });
+    expect(cfg.maxOutputTokens).toBe(8192);
+  });
+
+  it("omits maxOutputTokens when maxTokens is not provided", () => {
+    const cfg = buildGeminiSamplingFields({ temperature: 0.5 });
+    expect(cfg.maxOutputTokens).toBeUndefined();
   });
 });
 

--- a/app/api/ai/parse-vessel/route.ts
+++ b/app/api/ai/parse-vessel/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       const prompt = buildVesselPrompt(email);
       let raw: string;
       try {
-        raw = await callAiText('PARSE_VESSEL', VESSEL_POSITION_PARSER_PROMPT, prompt, { timeoutMs: endpointLlmTimeout(60), responseSchema: PARSE_VESSEL_SCHEMA });
+        raw = await callAiText('PARSE_VESSEL', VESSEL_POSITION_PARSER_PROMPT, prompt, { timeoutMs: endpointLlmTimeout(60), responseSchema: PARSE_VESSEL_SCHEMA, maxTokens: 8192 });
       } catch (err) {
         // γ-1: per-email timeout isolation — a single LLM timeout must NOT
         // poison the whole batch. Skip this email; user retries the route.

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -63,6 +63,7 @@ export function buildGeminiSamplingFields(opts: AiOpts): Record<string, unknown>
   if (opts.topP !== undefined) cfg.topP = opts.topP;
   if (opts.topK !== undefined) cfg.topK = opts.topK;
   if (opts.seed !== undefined) cfg.seed = opts.seed;
+  if (opts.maxTokens !== undefined) cfg.maxOutputTokens = opts.maxTokens;
   return cfg;
 }
 


### PR DESCRIPTION
## Root cause

`buildGeminiSamplingFields()` in `lib/ai-provider.ts` did not forward `opts.maxTokens` to Gemini's `generationConfig`. Gemini therefore used its model default output token limit, which is too low for multi-vessel emails. 6 out of 56 eval scenarios (001, 011, 019, 044, 052, 053) produced truncated JSON as a result.

Bedrock already correctly sets `max_tokens: opts.maxTokens ?? 16_000` — this PR brings Gemini to parity.

## Changes

- **`lib/ai-provider.ts`** — `buildGeminiSamplingFields`: add `if (opts.maxTokens !== undefined) cfg.maxOutputTokens = opts.maxTokens;`
- **`app/api/ai/parse-vessel/route.ts`** — pass `maxTokens: 8192` to `callAiText` (vessel JSON output is typically 2–5 KB even for 3–4 vessels; 8192 tokens gives safe headroom)

## Tests

Two new unit tests added to `__tests__/lib/ai-provider-sampling.test.ts` (written RED before impl):
- `maps maxTokens to maxOutputTokens for Gemini` — asserts the mapping works
- `omits maxOutputTokens when maxTokens is not provided` — asserts the field is absent when not set

All 86 ai-provider tests pass.

## Out of scope

- Prompt content (`lib/prompts/parse-vessel.ts`) — M2-C
- Schema changes (`lib/schemas/parse-vessel.ts`) — M2-B