### PR TITLE
fix(ux): add loading indicator on /processing 20s pause (#32)

### DIFF
--- a/app/processing/page.tsx
+++ b/app/processing/page.tsx
@@ -49,6 +49,7 @@ export default function ProcessingPage() {
 
   const doneCount = statuses.filter(s => s === 'done' || s === 'skipped').length;
   const progress = Math.round((doneCount / PIPELINE_STEPS.length) * 100);
+  const isActive = statuses.some(s => s === 'active');
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -163,6 +164,28 @@ export default function ProcessingPage() {
           <h2 className="text-xl font-semibold">Analyzing your inbox...</h2>
           <p className="text-sm text-muted-foreground">This takes 30–60 seconds</p>
         </div>
+
+        {(isActive || (progress === 0 && !fatalError)) && (
+          <div className="flex flex-col items-center gap-2">
+            <svg
+              className="animate-spin h-10 w-10 text-primary"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <p className="w-full text-sm font-medium text-foreground" role="status">
+              Analysing your freight quote…
+            </p>
+          </div>
+        )}
 
         <div className="space-y-1">
           <Progress value={progress} className="h-2" />


### PR DESCRIPTION
Adds animated spinner + status text during 20-second AI processing wait. Prevents users from thinking the app is broken.