### PR TITLE
fix(schema): parse-vessel required fields — reduce sparse Gemini output

### DIFF
--- a/lib/schemas/__tests__/parse-vessel-schema.test.ts
+++ b/lib/schemas/__tests__/parse-vessel-schema.test.ts
@@ -1,0 +1,35 @@
+import { PARSE_VESSEL_SCHEMA } from '@/lib/schemas/parse-vessel';
+
+describe('PARSE_VESSEL_SCHEMA — vesselItemSchema required fields', () => {
+  const itemSchema = (PARSE_VESSEL_SCHEMA as any).properties.items.items;
+
+  it('vesselItemSchema has a required array', () => {
+    expect(Array.isArray(itemSchema.required)).toBe(true);
+  });
+
+  it('required includes vessel_name', () => {
+    expect(itemSchema.required).toContain('vessel_name');
+  });
+
+  it('required includes built', () => {
+    expect(itemSchema.required).toContain('built');
+  });
+
+  it('required includes dwt_summer', () => {
+    expect(itemSchema.required).toContain('dwt_summer');
+  });
+
+  it('required includes flag', () => {
+    expect(itemSchema.required).toContain('flag');
+  });
+
+  it('required includes open_position', () => {
+    expect(itemSchema.required).toContain('open_position');
+  });
+
+  it('all required fields are defined in properties', () => {
+    for (const field of itemSchema.required as string[]) {
+      expect(itemSchema.properties[field]).toBeDefined();
+    }
+  });
+});

--- a/lib/schemas/parse-vessel.ts
+++ b/lib/schemas/parse-vessel.ts
@@ -63,6 +63,7 @@ const vesselItemSchema = {
     consumption_ballast: { type: Type.NUMBER, nullable: true },
     consumption_laden: { type: Type.NUMBER, nullable: true },
   },
+  required: ['vessel_name', 'built', 'dwt_summer', 'flag', 'open_position'],
 };
 
 export const PARSE_VESSEL_SCHEMA = {


### PR DESCRIPTION
## Summary

- Adds `required: ['vessel_name', 'built', 'dwt_summer', 'flag', 'open_position']` to `vesselItemSchema` in `lib/schemas/parse-vessel.ts`
- Adds 7 schema shape tests in `lib/schemas/__tests__/parse-vessel-schema.test.ts`

## Root cause (R0 eval baseline)

R0 showed 91% sparse-output failures in parse-vessel. The dominant pattern: when input uses vessel-seeking-cargo language ("please offer cargo for this vessel"), Gemini enters minimal output mode and omits most schema fields silently. The 4 most-affected fields were `built`, `dwt_summer`, `flag`, and `open_position`.

## Why `required` is the right fix

Gemini structured-output respects the `required` array as a hard constraint: the model must include those keys in its response. Without it, Gemini can legally skip any field. With `required`, even if a field value is unknown, Gemini must emit the key (possibly as `null` for nullable fields or `{ value: null, confidence: "unknown" }` for confidence objects).

**Important note on nullable fields:** `flag` is typed as `{ type: Type.STRING, nullable: true }`. Adding it to `required` is valid per Gemini schema spec — `required` means the key must be present, not that the value must be non-null. This is the same behaviour as JSON Schema.

`vessel_name` was already the highest-extraction field; including it as an anchor is safe and ensures the most critical identifier is never omitted.

## Files changed

| File | Change |
|------|--------|
| `lib/schemas/parse-vessel.ts` | +1 line: `required` array on `vesselItemSchema` |
| `lib/schemas/__tests__/parse-vessel-schema.test.ts` | New: 7 structural schema tests |

## PI3 compliance

0 existing test expectation changes. All 38 pre-existing parse-vessel tests pass unchanged.

## Test plan

- [x] 7 new schema shape tests pass (RED → GREEN cycle verified)
- [x] 38 existing parse-vessel tests pass unmodified
- [x] No changes to `lib/ai-provider.ts` (M2-A territory)
- [x] No changes to `lib/prompts/parse-vessel.ts` (M2-C territory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)