### PR TITLE
fix(upgrade): aria-labels + plan constants + touch targets F2-F4 (#47)

### DIFF
--- a/__tests__/app/upgrade/page.test.tsx
+++ b/__tests__/app/upgrade/page.test.tsx
@@ -43,4 +43,10 @@ describe('/upgrade page — T1 polish', () => {
   it('Free tier shows "You\'re on this plan" disabled indicator', () => {
     expect(screen.getByText(/you.re on this plan/i)).toBeInTheDocument();
   });
+
+  it('interactive CTA elements have aria-label attributes (F2)', () => {
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label');
+    expect(screen.getByRole('link', { name: /upgrade to pro/i })).toHaveAttribute('aria-label');
+    expect(screen.getByTestId('enterprise-cta')).toHaveAttribute('aria-label');
+  });
 });

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -5,6 +5,8 @@ export const metadata: Metadata = {
   title: 'Upgrade Your Quantika Plan',
 };
 
+const PLAN_IDS = { PRO: 'pro' } as const;
+
 const TIERS = [
   {
     name: 'Free',
@@ -18,7 +20,7 @@ const TIERS = [
     price: '$49',
     priceNote: '/mo',
     features: ['Unlimited deals', 'AI explain-deal', 'WhatsApp digest', 'RAG clauses'],
-    cta: { type: 'upgrade' as const, href: '/billing/checkout?plan=pro', label: 'Upgrade to Pro' },
+    cta: { type: 'upgrade' as const, href: `/billing/checkout?plan=${PLAN_IDS.PRO}`, label: 'Upgrade to Pro' },
     highlighted: true,
   },
   {

--- a/components/upgrade/UpgradeTierCard.tsx
+++ b/components/upgrade/UpgradeTierCard.tsx
@@ -55,7 +55,8 @@ export function UpgradeTierCard({
           {cta.type === 'current' && (
             <button
               disabled
-              className="w-full px-4 py-2 text-sm text-gray-400 bg-gray-100 rounded cursor-not-allowed border border-gray-200"
+              aria-label={cta.label}
+              className="w-full px-4 py-3 min-h-[44px] text-sm text-gray-400 bg-gray-100 rounded cursor-not-allowed border border-gray-200"
             >
               {cta.label}
             </button>
@@ -63,7 +64,8 @@ export function UpgradeTierCard({
           {cta.type === 'upgrade' && (
             <a
               href={cta.href}
-              className="block w-full px-4 py-2 text-center text-sm font-semibold text-white bg-blue-600 rounded hover:bg-blue-700 transition-colors"
+              aria-label={cta.label}
+              className="block w-full px-4 py-3 min-h-[44px] text-center text-sm font-semibold text-white bg-blue-600 rounded hover:bg-blue-700 transition-colors"
             >
               {cta.label}
             </a>
@@ -71,8 +73,9 @@ export function UpgradeTierCard({
           {cta.type === 'contact' && (
             <a
               href={cta.href}
+              aria-label={cta.label}
               data-testid="enterprise-cta"
-              className="block w-full px-4 py-2 text-center text-sm font-medium text-gray-700 bg-white rounded hover:bg-gray-50 transition-colors border border-gray-300"
+              className="block w-full px-4 py-3 min-h-[44px] text-center text-sm font-medium text-gray-700 bg-white rounded hover:bg-gray-50 transition-colors border border-gray-300"
             >
               {cta.label}
             </a>


### PR DESCRIPTION
## Summary

- F2: add `aria-label={cta.label}` to all 3 interactive CTA elements (disabled button + upgrade link + contact link)
- F3: extract hardcoded `'pro'` string to `PLAN_IDS.PRO` constant in upgrade page
- F4: `py-2` → `py-3` + `min-h-[44px]` on all CTA buttons/links for WCAG 44px touch targets

Closes F2, F3, F4 from PR #273 QA. Skips F1 (dead /billing/checkout CTA) per user decision.

## Test plan

- [x] RED test written for F2 (`interactive CTA elements have aria-label attributes`) — confirmed failing before fix
- [x] 5 tests GREEN after fix (`npm test __tests__/app/upgrade/page.test.tsx`)
- [x] PI3: 0 existing test rewrites (1 new test added)
- [x] ESLint clean, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)