### PR TITLE
fix(auth): PR #270 follow-ups — analytics TODO, session guard, mobile CTA (#41)

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -2,12 +2,18 @@ jest.mock('next/headers', () => ({
   cookies: jest.fn(),
 }));
 
+jest.mock('../../lib/session', () => ({
+  getSession: jest.fn(),
+}));
+
 import { cookies } from 'next/headers';
+import { getSession } from '../../lib/session';
 import LandingPage from '../../app/page';
 import { EmailUploadCTA } from '../../components/onboarding/EmailUploadCTA';
 import { LandingPageClient } from '../../components/LandingPageClient';
 
 const mockCookies = cookies as jest.Mock;
+const mockGetSession = getSession as jest.Mock;
 
 describe('LandingPage — session gate', () => {
   beforeEach(() => {
@@ -20,11 +26,21 @@ describe('LandingPage — session gate', () => {
     expect(element.type).toBe(EmailUploadCTA);
   });
 
-  it('renders LandingPageClient when session_id cookie is present', async () => {
+  it('renders LandingPageClient when session_id cookie is present and session is valid', async () => {
     mockCookies.mockResolvedValue({
       get: (name: string) => (name === 'session_id' ? { value: 'sess-123' } : undefined),
     });
+    mockGetSession.mockReturnValue({ emails: [] });
     const element = await LandingPage();
     expect(element.type).toBe(LandingPageClient);
+  });
+
+  it('renders EmailUploadCTA when session_id is present but session is invalid or expired', async () => {
+    mockCookies.mockResolvedValue({
+      get: (name: string) => (name === 'session_id' ? { value: 'expired-sess' } : undefined),
+    });
+    mockGetSession.mockReturnValue(null);
+    const element = await LandingPage();
+    expect(element.type).toBe(EmailUploadCTA);
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import { getSession } from '@/lib/session';
 import { EmailUploadCTA } from '@/components/onboarding/EmailUploadCTA';
 import { LandingPageClient } from '@/components/LandingPageClient';
 
@@ -6,7 +7,7 @@ export default async function LandingPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
 
-  if (!sessionId) {
+  if (!sessionId || !getSession(sessionId)) {
     return <EmailUploadCTA />;
   }
 

--- a/components/LandingPageClient.tsx
+++ b/components/LandingPageClient.tsx
@@ -31,7 +31,7 @@ export function LandingPageClient() {
               type="submit"
               className="inline-flex items-center justify-center rounded-md border border-transparent bg-foreground text-background px-6 py-3 text-sm font-medium hover:opacity-90 transition-opacity"
             >
-              Demo: ETMS Circulars
+              ETMS Circulars
             </button>
           </form>
           <form method="POST" action="/api/sample" onSubmit={() => track('sample_started')}>
@@ -55,7 +55,7 @@ export function LandingPageClient() {
           <div className="flex items-start gap-3">
             <Trash2 className="h-5 w-5 text-green-600 shrink-0 mt-0.5" />
             <div>
-              <p className="text-sm font-medium">Data deleted after demo</p>
+              <p className="text-sm font-medium">Data deleted after session</p>
               <p className="text-xs text-muted-foreground">Your data is processed in memory and deleted automatically</p>
             </div>
           </div>

--- a/components/onboarding/EmailUploadCTA.tsx
+++ b/components/onboarding/EmailUploadCTA.tsx
@@ -1,7 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { Lock, Trash2, EyeOff } from 'lucide-react';
+import { initAnalytics, track } from '@/lib/analytics';
 
 export function EmailUploadCTA() {
+  useEffect(() => {
+    initAnalytics();
+    track('cta_upload_viewed');
+  }, []);
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-white px-6">
       <div className="w-full max-w-md text-center space-y-8">
@@ -19,15 +28,16 @@ export function EmailUploadCTA() {
           <Link
             href="/processing"
             aria-label="Go to email processing to upload your first email"
+            onClick={() => track('cta_upload_clicked')}
             className="inline-flex items-center justify-center rounded-md border border-transparent bg-foreground text-background px-6 py-3 text-sm font-medium hover:opacity-90 transition-opacity w-full sm:w-auto"
           >
             Upload &amp; analyse emails
           </Link>
-          <form method="POST" action="/api/sample">
+          <form method="POST" action="/api/sample" className="w-full sm:w-auto" onSubmit={() => track('cta_sample_clicked')}>
             <button
               type="submit"
               aria-label="Try the app with pre-loaded sample freight emails"
-              className="inline-flex items-center justify-center rounded-md border border-input bg-background px-6 py-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+              className="inline-flex items-center justify-center rounded-md border border-input bg-background px-6 py-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors w-full sm:w-auto"
             >
               Try with Sample Data
             </button>
@@ -45,7 +55,7 @@ export function EmailUploadCTA() {
           <div className="flex items-start gap-3">
             <Trash2 className="h-5 w-5 text-green-600 shrink-0 mt-0.5" />
             <div>
-              <p className="text-sm font-medium">Data deleted after demo</p>
+              <p className="text-sm font-medium">Data deleted after session</p>
               <p className="text-xs text-muted-foreground">Your data is processed in memory and deleted automatically</p>
             </div>
           </div>


### PR DESCRIPTION
Closes 4 QA1 findings from PR #270 (empty-state CTA for new/unauthenticated users).

## Findings fixed

| # | Severity | Finding | Fix |
|---|---|---|---|
| F1 | CRITICAL | CTA click has no analytics tracking | Added posthog `track()` calls: `cta_upload_viewed`, `cta_upload_clicked`, `cta_sample_clicked` using existing infra |
| F2 | HIGH | Session validity not checked — expired `session_id` cookie renders LandingPageClient silently | `app/page.tsx` now calls `getSession(sessionId)`; null → shows `EmailUploadCTA` with re-auth flow |
| F3 | MEDIUM | "Data deleted after demo" and "Demo: ETMS Circulars" are dev-facing text | → "Data deleted after session" / "ETMS Circulars" |
| F4 | LOW | Sample Data button not full-width on mobile | Added `w-full sm:w-auto` to button + form wrapper |

## Files changed
- `components/onboarding/EmailUploadCTA.tsx` — F1, F3, F4
- `app/page.tsx` — F2
- `components/LandingPageClient.tsx` — F3
- `__tests__/app/page.test.tsx` — new test: expired session → EmailUploadCTA

## Test plan
- [x] `__tests__/app/page.test.tsx` — 3 tests pass (was 2, +1 for expired session case)
- [x] ESLint: clean
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)