### PR TITLE
fix(ai): remove us.anthropic cross-region prefix causing 524 timeouts (C5) [code-only]

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -69,13 +69,13 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# AWS Bedrock model selector (US cross-region inference profiles)
-# - For Claude Opus 4.7 (most capable, expensive): us.anthropic.claude-opus-4-7
-# - For Claude Sonnet 4.6 (good balance, 5x cheaper): us.anthropic.claude-sonnet-4-6
-BEDROCK_MODEL_ID=us.anthropic.claude-opus-4-7
+# AWS Bedrock model selector (direct inference — no cross-region us./eu. prefix)
+# - For Claude Opus 4.7 (most capable, expensive): anthropic.claude-opus-4-7
+# - For Claude Sonnet 4.6 (good balance, 5x cheaper): anthropic.claude-sonnet-4-6
+BEDROCK_MODEL_ID=anthropic.claude-opus-4-7
 
 # Per-scope override (Wave γ — match endpoint can use cheaper Sonnet):
-# MATCH_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6
+# MATCH_MODEL=anthropic.claude-sonnet-4-6
 
 # ── Knowledge Layer (Phase 1) ───────────────────────────────────────────────────
 # Feature flag: use real OFAC+EU corpus from database instead of fixtures

--- a/lib/__tests__/ai-provider.test.ts
+++ b/lib/__tests__/ai-provider.test.ts
@@ -347,8 +347,8 @@ describe('getModel', () => {
 
   it('returns bedrock model when AI_PROVIDER=bedrock', () => {
     const { getModel } = require('@/lib/ai-provider');
-    setEnv({ AI_PROVIDER: 'bedrock', BEDROCK_MODEL_ID: 'us.anthropic.claude-opus-4-7' });
-    expect(getModel('match')).toBe('us.anthropic.claude-opus-4-7');
+    setEnv({ AI_PROVIDER: 'bedrock', BEDROCK_MODEL_ID: 'anthropic.claude-opus-4-7' });
+    expect(getModel('match')).toBe('anthropic.claude-opus-4-7');
   });
 
   it('returns default openai model when no env set', () => {
@@ -393,7 +393,7 @@ describe('computeCostUsd — QA L-1', () => {
     // 1000*15/1M + 500*75/1M = 0.015 + 0.0375 = 0.0525
     expect(computeCostUsd(
       'bedrock',
-      'us.anthropic.claude-opus-4-7',
+      'anthropic.claude-opus-4-7',
       1000,
       500,
     )).toBeCloseTo(0.0525, 6);
@@ -404,7 +404,7 @@ describe('computeCostUsd — QA L-1', () => {
     // 1000*3/1M + 500*15/1M = 0.003 + 0.0075 = 0.0105
     expect(computeCostUsd(
       'bedrock',
-      'us.anthropic.claude-sonnet-4-6',
+      'anthropic.claude-sonnet-4-6',
       1000,
       500,
     )).toBeCloseTo(0.0105, 6);
@@ -480,7 +480,7 @@ describe('callAiJson + ai_audit cost_usd integration — QA L-1', () => {
       AWS_REGION: 'us-east-1',
       AWS_ACCESS_KEY_ID: 'k',
       AWS_SECRET_ACCESS_KEY: 's',
-      BEDROCK_MODEL_ID: 'us.anthropic.claude-opus-4-7',
+      BEDROCK_MODEL_ID: 'anthropic.claude-opus-4-7',
     });
 
     const { BedrockRuntimeClient } = require('@aws-sdk/client-bedrock-runtime');

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -128,15 +128,11 @@ const COST_TABLE_PER_M_TOKENS: Record<string, { in: number; out: number }> = {
   // Deep Think suffix is used by the eval script to track thinkingBudget runs separately in ai_audit.
   // Billing rate is the same underlying model, but output token usage is higher in practice (2-3×).
   'gemini:gemini-2.5-pro-deepthink': { in: 1.25, out: 5.0 },
-  // Claude Opus 4.7 — AWS Bedrock cross-region inference profiles (no date suffix starting Opus 4.x)
-  'bedrock:us.anthropic.claude-opus-4-7': { in: 15, out: 75 },
-  'bedrock:eu.anthropic.claude-opus-4-7': { in: 15, out: 75 },
-  'bedrock:global.anthropic.claude-opus-4-7': { in: 15, out: 75 },
+  // Claude Opus 4.7 — AWS Bedrock direct inference (no cross-region us./eu./global. prefix)
+  'bedrock:anthropic.claude-opus-4-7': { in: 15, out: 75 },
   // Claude Sonnet 4.6 — cost-optimized alternative: ~5× cheaper than Opus 4.7
-  // Use case: per-scope override via MATCH_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6
-  'bedrock:us.anthropic.claude-sonnet-4-6': { in: 3, out: 15 },
-  'bedrock:eu.anthropic.claude-sonnet-4-6': { in: 3, out: 15 },
-  'bedrock:global.anthropic.claude-sonnet-4-6': { in: 3, out: 15 },
+  // Per-scope override: MATCH_MODEL=anthropic.claude-sonnet-4-6 (with MATCH_PROVIDER=bedrock)
+  'bedrock:anthropic.claude-sonnet-4-6': { in: 3, out: 15 },
 };
 
 export function computeCostUsd(
@@ -412,7 +408,7 @@ export function getModel(scope: string): string {
     case 'gemini':
       return process.env.AI_MODEL_GEMINI_DEFAULT ?? 'gemini-2.5-flash';
     case 'bedrock':
-      return process.env.BEDROCK_MODEL_ID ?? 'us.anthropic.claude-opus-4-7';
+      return process.env.BEDROCK_MODEL_ID ?? 'anthropic.claude-opus-4-7';
     case 'claude-cli':
       return 'claude-opus-4-7';
     case 'openai':


### PR DESCRIPTION
## Summary

- `us.anthropic.claude-*` cross-region inference profile IDs require explicit AWS opt-in per account/region — without it, Bedrock returns "not found" → 524 timeout on `/processing`
- Changed default Bedrock model in `getModel()` from `us.anthropic.claude-opus-4-7` → `anthropic.claude-opus-4-7` (direct inference, no cross-region prefix)
- Updated cost table keys to match direct inference IDs so billing audit still works
- Fixed `.env.local.example`: `BEDROCK_MODEL_ID` now shows correct non-prefixed IDs; corrected `MATCH_BEDROCK_MODEL` → `MATCH_MODEL` (env var name the code actually reads)
- Updated 4 test fixtures to use `anthropic.*` model IDs (cost computation tests + integration test)

## Test plan

- [x] `npx jest --testPathPatterns="ai-provider|parse-vessel"` — 131 passed, 0 failed
- [x] `grep "us.anthropic" lib/ app/` — 0 results in non-test TS files
- [x] ESLint — 0 errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)