### PR TITLE
fix(prompt): parse-vessel R2 — vessel-seeking-cargo extraction rule

### DIFF
--- a/lib/prompts/parse-vessel.ts
+++ b/lib/prompts/parse-vessel.ts
@@ -31,6 +31,18 @@ NOW the four types:
    - Sender perspective: SHIPOWNER or BROKER offering a vessel.
    - Signals: a specific vessel name + "open [port]", "available", "promptly", "spot", "ETA", explicit DWT/IMO/Built/Flag, fleet positions, vessel particulars, L/C history.
    - Example phrases: "MV NORTH BRIT open Antwerp 15-20 May", "Fleet positions:", "Vessel offered:", explicit vessel specs.
+   - VESSEL-SEEKING-CARGO language (also extract): When a broker/owner lists FULL VESSEL SPECS and asks recipients to propose cargo/freight — this is vessel OFFERING, not cargo inquiry. The vessel is available; the owner wants cargo proposals. EXTRACT all vessel particulars.
+   - Example phrases that trigger extraction: "Please propose suitable cargo for below vessel", "Please offer cargo/rates for MV X", "We are looking for cargo for the following vessel", "Kindly offer freight for below vessel", "Please advise suitable cargo for".
+
+   EXAMPLE — vessel seeking cargo (EXTRACT, not cargo inquiry):
+   "Dear Sirs, Please propose suitable cargo for below open vessel:
+    MV DELTA STAR, 28,500 DWT, Built 2004, Flag: Panama, IMO 9123456
+    Open: Rotterdam spot / ETA ARA 20-22 May
+    Geared 3x30T, grain cap 35,000 cbm"
+   → items=[{vessel_name: "MV DELTA STAR", dwt_summer: 28500, built: 2004, flag: "Panama", imo: 9123456, open_position: "Rotterdam", geared: true, ...}]
+   Rationale: full vessel specs are listed BY THE OWNER/BROKER — this is a vessel position. The
+   "please propose cargo" phrasing means the owner WANTS cargo, making the vessel available.
+   This is functionally identical to "MV DELTA STAR open Rotterdam spot."
 
 3. **FIXTURE RECAP** (extract vessel — same as type 1):
    - Sender perspective: OWNER's broker confirming a fixed deal between owner and charterer
@@ -60,7 +72,8 @@ Laycan: 15-20 May 2026  Freight: USD 32/mt FIO"
 DECISION RULE:
 - Is the email a certificate/administrative document (P&I Blue Card, class cert, etc.)? → return items=[] (HIGHEST PRIORITY — check this first even if vessel particulars are listed).
 - Does the email name a specific vessel that is being offered for charter or that has been fixed? → extract.
-- Does the email request a vessel (any vessel matching specs) for a cargo? → return items=[].
+- Does the email list FULL VESSEL SPECS (name + DWT + built + flag + open position) while asking recipients to "propose cargo", "offer freight", or "advise suitable cargo"? → this is vessel OFFERING (owner/broker is seeking cargo for an available vessel) — EXTRACT. Do NOT classify as cargo inquiry.
+- Does the email request a vessel (any vessel matching specs) for a cargo, WITHOUT naming a specific vessel? → return items=[].
 - If mixed or unclear → err on items=[] (returning empty is SAFER than fabricating).
 
 CRITICAL ANTI-PATTERN — NEVER map cargo-side fields to vessel fields:


### PR DESCRIPTION
## Summary

- Add VESSEL-SEEKING-CARGO sub-rule to VESSEL POSITION CIRCULAR section with concrete example
- Add clarifying DECISION RULE bullet: full specs + "propose cargo" = extract (vessel offering)
- Fixes primary failure mode: Gemini classifying vessel position circulars as cargo inquiries

## Eval results

| Metric | R0 | R2 | Delta |
|---|---|---|---|
| semantic_full | 16.1% (9/56) | 30.4% (17/56) | **+14.3pp** |
| items=[] vessel misses | unknown | **0** | fixed |
| Errors | 0 | 0 | — |
| Truncation errors | 0 | 0 | — |
| Hallucinations | 0 | 0 | — |

## Scenario clusters improved

- All vessel-seeking-cargo emails now correctly extracted (`items=[] miss rate = 0`)
- `full_specs`, `single_vessel`, `multi_vessel` clusters all improved

## Remaining failures (R3 needed)

30-50% range → need R3. Top failure modes:

1. **open_date format (12.5% field accuracy)**: Model correctly returns structured ISO objects `{"open":"2025-10-01","close":"2025-10-05","display":"..."}` but reference corpus stores raw strings ("SPOT", "01-05 October"). String comparison always fails. Root cause: reference data format mismatch, not model error. R3 fix: normalize reference data or improve judge date equivalence.

2. **dwcc over-extraction (23 dwcc_edge failures, 75% field accuracy)**: Model returns dwcc=DWT when email doesn't explicitly state DWCC; reference has dwcc=null in these cases. R3 fix: prompt rule "extract dwcc only when explicitly stated in email; do NOT infer dwcc=dwt_summer". Note: NOT the same as the R1 regression rule — this is specifically about null-when-not-stated, not about derivation from cargo.

3. **Flag casing minor (~3-5 failures)**: Model returns "BELIZE CITY" vs "Belize", or wrong case. Low-priority.

## Decision

R2 = 30.4% → **NEED R3** (30-50% range per decision tree)