### PR TITLE
feat(parsers): add freight_rate_usd field to parse-cargo (A2) [code-only]

### DIFF
--- a/lib/parsing/parse-cargo-ai.ts
+++ b/lib/parsing/parse-cargo-ai.ts
@@ -24,6 +24,7 @@ export interface RawCargoItem {
   discharge_rate?: string | null;
   commission_percent?: number | string | null;
   commission_terms?: string | null;
+  freight_rate_usd?: number | null;
   special_requirements?: string | null;
   stowage_factor?: string | null;
   missing_info?: string[];
@@ -112,6 +113,7 @@ export function parseCargoAIResponse(raw: string, emailId: string): ParsedCargo[
       dischargeRate: extractStr(item.discharge_rate),
       commissionPercent: extractNum(item.commission_percent),
       commissionTerms: extractStr(item.commission_terms),
+      freightRateUsd: extractNum(item.freight_rate_usd),
       specialRequirements: extractStr(item.special_requirements),
       stowageFactor: extractStr(item.stowage_factor),
       missingInfo: Array.isArray(item.missing_info) ? item.missing_info : [],

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -365,6 +365,15 @@ Extract per inquiry item:
 - discharge_terms: laytime cost-allocation and dispatch regime qualifiers, same rule as loading_terms.
 - commission_percent: broker commission if mentioned
 - commission_terms: e.g. "TTL BENDS", "address commission", "ADDCOMPUS", "pus"
+- freight_rate_usd: freight rate in USD per metric ton if EXPLICITLY stated in the email.
+  RULES:
+  - Extract ONLY when a specific dollar amount per MT/ton is written (e.g. "$18/MT", "USD 22 pmt", "18.50 usd/mt", "frt usd 20/mt").
+  - Return as a plain NUMBER (the numeric value only, e.g. 18.5).
+  - Do NOT infer or calculate from other fields. Null if not explicitly stated.
+  - Do NOT confuse with loading_rate (MT/day) or commission_percent.
+  - Example: "cargo 5000mt grain, frt usd 18/mt fio" → freight_rate_usd: 18
+  - Example: "5500mt salt $22 pmt shinc" → freight_rate_usd: 22
+  - Example: "cement 10000mt, no freight indicated" → freight_rate_usd: null
 - special_requirements: temperature, hazmat class, fumigation, vessel constraints (LOA max, beam max), etc. Do NOT put laytime cost terms (FIO, CQD, SHINC, SHEX) here — those go in loading_terms / discharge_terms. ALWAYS include NOR tendering conditions if present (WIPON, WIBON, WIFPON, WICCON or any combination) as a special_requirements entry — these are contractually critical laytime/demurrage terms that belong here. Include vessel size constraints (e.g. "LOA max 124m, beam max 18m") here.
 - stowage_factor: if mentioned — MUST be a STRING with original units (see STOWAGE FACTOR RULES)
 - missing_info: array of plain English strings (see missing_info RULES — never return objects or field names)

--- a/lib/schemas/__tests__/parse-cargo.test.ts
+++ b/lib/schemas/__tests__/parse-cargo.test.ts
@@ -41,3 +41,16 @@ describe('PARSE_CARGO_SCHEMA multi-port fields', () => {
     expect(itemProps.weight_per_port.nullable).toBe(true);
   });
 });
+
+describe('PARSE_CARGO_SCHEMA freight_rate_usd field', () => {
+  const itemProps = (PARSE_CARGO_SCHEMA as any).properties.items.items.properties;
+
+  it('includes freight_rate_usd as NUMBER', () => {
+    expect(itemProps.freight_rate_usd).toBeDefined();
+    expect(itemProps.freight_rate_usd.type).toBe('NUMBER');
+  });
+
+  it('freight_rate_usd is nullable', () => {
+    expect(itemProps.freight_rate_usd.nullable).toBe(true);
+  });
+});

--- a/lib/schemas/parse-cargo.ts
+++ b/lib/schemas/parse-cargo.ts
@@ -58,6 +58,7 @@ const cargoItemSchema = {
     discharge_terms: { type: Type.STRING, nullable: true },
     commission_percent: { type: Type.NUMBER, nullable: true },
     commission_terms: { type: Type.STRING, nullable: true },
+    freight_rate_usd: { type: Type.NUMBER, nullable: true },
     special_requirements: { type: Type.STRING, nullable: true },
     stowage_factor: { type: Type.STRING, nullable: true },
     missing_info: { type: Type.ARRAY, items: { type: Type.STRING } },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -176,6 +176,7 @@ export interface ParsedCargo {
   dischargeRate: string | null;
   commissionPercent: number | null;
   commissionTerms: string | null;
+  freightRateUsd?: number | null;
   specialRequirements: string | null;
   stowageFactor: string | null;
   missingInfo: string[];


### PR DESCRIPTION
## Summary

- Adds `freight_rate_usd` field to parse-cargo: extracts explicitly stated USD/MT freight rate (e.g. `$18/MT`, `USD 22 pmt`, `18.50 usd/mt`)
- Field is `null` when not written — never inferred or calculated from other fields
- Updated 5 files: prompt rules, Gemini schema, TypeScript type, AI response mapper, schema tests

## Test plan

- [x] `lib/schemas/__tests__/parse-cargo.test.ts` — 8 tests pass (2 new: type=NUMBER, nullable=true)
- [x] ESLint clean on changed files
- [x] `grep freight_rate_usd` confirms field in prompt, schema, and mapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)