### PR TITLE
fix(schema+prompt): parse-vessel R3 — open_date structured type + dwcc null rule

### DIFF
--- a/lib/prompts/parse-vessel.ts
+++ b/lib/prompts/parse-vessel.ts
@@ -169,6 +169,7 @@ Extract per vessel:
 - p_and_i: P&I club
 - dwt_summer: deadweight tonnage (summer)
 - dwcc: deadweight cargo capacity
+  DWCC EXTRACTION RULE: Extract dwcc ONLY when the email explicitly states a DWCC value (e.g. "DWCC 28,500 MT", "deadweight cargo capacity: 28,500"). Do NOT infer dwcc from dwt_summer when dwcc is not explicitly mentioned. When dwcc is not stated → set dwcc = null.
 - draft_max: maximum draft in meters. IMPORTANT: if the email gives draft only as part of the DWCC line (e.g. "DWCC 11,800 mts at 7.8m draft"), use that value as draft_max with confidence='interpreted' and note in source_text that it is the DWCC draft — the vessel's structural maximum draft may differ. Only use confidence='confirmed' if the email explicitly states "Max draft: X" or "Draft summer: X".
 - loa: length overall in meters
 - beam: beam in meters

--- a/lib/schemas/parse-vessel.ts
+++ b/lib/schemas/parse-vessel.ts
@@ -29,6 +29,24 @@ const confidenceFieldNumber = {
   required: ['value', 'confidence'],
 };
 
+const confidenceFieldDate = {
+  type: Type.OBJECT,
+  properties: {
+    value: {
+      type: Type.OBJECT,
+      nullable: true,
+      properties: {
+        open: { type: Type.STRING, nullable: true },
+        close: { type: Type.STRING, nullable: true },
+        display: { type: Type.STRING, nullable: true },
+      },
+    },
+    confidence: { type: Type.STRING },
+    source_text: { type: Type.STRING },
+  },
+  required: ['value', 'confidence'],
+};
+
 const vesselItemSchema = {
   type: Type.OBJECT,
   properties: {
@@ -48,7 +66,7 @@ const vesselItemSchema = {
     gear_description: { type: Type.STRING, nullable: true },
     open_position: confidenceFieldString,
     dwcc: confidenceFieldNumber,
-    open_date: confidenceFieldString,
+    open_date: confidenceFieldDate,
     last_cargoes: { type: Type.STRING, nullable: true },
     vessel_type: { type: Type.STRING, nullable: true },
     class_society: { type: Type.STRING, nullable: true },


### PR DESCRIPTION
## Summary

- Add `confidenceFieldDate` schema constant with `{open, close, display}` nested value structure; change `open_date` from `confidenceFieldString` to `confidenceFieldDate`
- Add scoped DWCC extraction rule to prompt: extract only when explicitly stated, do not infer from `dwt_summer`
- R3 eval: **28.6% (16/56)** — slight regression vs R2's 30.4% (17/56); decision tree: < 40% → STOP, escalate

## R3 Eval Results

| Round | Score | Full matches |
|---|---|---|
| R0 | 16.1% | 9/56 |
| R2 | 30.4% | 17/56 |
| **R3** | **28.6%** | **16/56** |

**Mean field rate**: 84.8% (fields individually mostly correct)
**Errors**: 1/56

### Per-field accuracy (R3)

| Field | Match rate |
|---|---|
| vessel_name | 98/110 (89.1%) |
| imo | 106/110 (96.4%) |
| flag | 97/110 (88.2%) |
| built | 89/110 (80.9%) |
| dwt_summer | 90/110 (81.8%) |
| dwcc | 78/110 (70.9%) |
| open_position | 85/110 (77.3%) |
| open_date | 71/110 (64.5%) |

## Root Cause Analysis

### Why open_date schema fix didn't move the needle

The deterministic `match_rate` metric counts only 6 fields: `[vessel_name, imo, flag, built, dwt_summer, dwcc]`. `open_date` and `open_position` are excluded — they're scored separately by the semantic judge. The schema fix is **architecturally correct** (Gemini now outputs proper `{open, close, display}` objects), and `open_date` accuracy improved to 64.5% in the semantic metric, but it has zero impact on the full-match count.

### Why DWCC rule had limited effect

DWCC over-extraction breakdown in R3:
- `ref=null & model=null` (correct): **27**
- `ref=null & model not null` (over-extract): **29** ← unchanged from R2 estimate
- `ref has value & matches`: **51**
- `ref has value & wrong`: **3** ← possible 1-scenario regression from rule

The prompt rule (`Do NOT infer dwcc from dwt_summer`) is being ignored by Gemini in 29 cases. Root cause hypothesis: the `dwcc` field uses `confidenceFieldNumber` with `required: ['value', 'confidence']` where `value: {type: NUMBER}` is non-nullable. Gemini may be unable to output `dwcc: null` at the field level (schema constraint forces a number once it decides to include the field). The 1 new regression suggests the rule may have caused one case where the model correctly identified DWCC to now return null.

## PI3 Compliance

No existing tests check `open_date.value` as a string. The schema test (`lib/schemas/__tests__/parse-vessel-schema.test.ts`) only verifies the `required` array — unchanged. **0 test expectations modified**.

## Next Step Recommendation (< 40% decision tree)

**STOP — escalate to Vitali.** Two targeted fixes did not achieve ≥ 40%.

Likely root cause: schema-level constraint on `dwcc` prevents Gemini from expressing null. Proposed next fix: make `dwcc` outer object `nullable: true` in schema, allowing the model to emit `dwcc: null` when not stated. This is a schema-only change, no prompt needed.

## Test plan

- [x] `npx jest --testPathPatterns="parse-vessel" --no-coverage` → 45/45 pass
- [x] R3 eval: 56 scenarios ran (1 error), results in `.progonq/results/etms-parse-vessel-R3.json`
- [x] Schema TypeScript compiles (pre-commit hook: `tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)