### PR TITLE
fix(schema): parse-vessel dwcc nullable — allow null when not explicitly stated

### DIFF
--- a/lib/schemas/__tests__/parse-vessel-schema.test.ts
+++ b/lib/schemas/__tests__/parse-vessel-schema.test.ts
@@ -32,4 +32,12 @@ describe('PARSE_VESSEL_SCHEMA — vesselItemSchema required fields', () => {
       expect(itemSchema.properties[field]).toBeDefined();
     }
   });
+
+  it('dwcc is not in required (optional/nullable)', () => {
+    expect(itemSchema.required).not.toContain('dwcc');
+  });
+
+  it('dwcc field allows null (nullable: true)', () => {
+    expect(itemSchema.properties.dwcc.nullable).toBe(true);
+  });
 });

--- a/lib/schemas/parse-vessel.ts
+++ b/lib/schemas/parse-vessel.ts
@@ -65,7 +65,7 @@ const vesselItemSchema = {
     geared: { type: Type.BOOLEAN, nullable: true },
     gear_description: { type: Type.STRING, nullable: true },
     open_position: confidenceFieldString,
-    dwcc: confidenceFieldNumber,
+    dwcc: { ...confidenceFieldNumber, nullable: true },
     open_date: confidenceFieldDate,
     last_cargoes: { type: Type.STRING, nullable: true },
     vessel_type: { type: Type.STRING, nullable: true },


### PR DESCRIPTION
## Summary

- `dwcc` field in `vesselItemSchema` was `confidenceFieldNumber` (required `value`+`confidence`), making it impossible for Gemini to return `null`
- When DWCC was not mentioned in an email, Gemini defaulted to copying the `dwt_summer` value — causing 29 failing scenarios in R3
- Fix: spread `confidenceFieldNumber` with `nullable: true` so Gemini can return `null` for `dwcc` when absent from the email

## Eval history

| Round | Result | Notes |
|-------|--------|-------|
| R0 | baseline | — |
| R1 | — | — |
| R2 | — | — |
| R3 | 16/56 (28.6%) | Root cause identified: dwcc non-nullable |
| **R4** | **29/56 (51.8%) string_full** | dwcc fix applied |

**R4 per-field accuracy (56 scenarios, 115 vessel slots):**
- dwcc: **110/115 (95.7%)** — was copying dwt_summer before fix
- imo: 111/115 (96.5%)
- flag: 101/115 (87.8%)
- dwt_summer: 95/115 (82.6%)
- vessel_name: 96/115 (83.5%)
- built: 94/115 (81.7%)
- open_position: 78/115 (67.8%)
- open_date: 70/115 (60.9%)

Hallucination: 0 (dwcc no longer copies dwt_summer value)

## Changes

- `lib/schemas/parse-vessel.ts`: `dwcc: { ...confidenceFieldNumber, nullable: true }` (1-line change)
- `lib/schemas/__tests__/parse-vessel-schema.test.ts`: +2 tests verifying `dwcc` nullable and not-required

## PI3

0 existing test expectations changed. 2 new tests added. No test rewrites.

## Test plan

- [x] `npx jest "parse-vessel" --no-coverage` → 47/47 pass
- [x] R4 eval 56 scenarios complete
- [x] dwcc field accuracy 95.7% (110/115)
- [x] `nullable: true` does not affect other `confidenceFieldNumber` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)