### PR TITLE
fix(eval): parse-vessel runner — M/V normalization + ex-name strip + null ref tolerance

### DIFF
--- a/scripts/progonq/__tests__/score-vessel.test.ts
+++ b/scripts/progonq/__tests__/score-vessel.test.ts
@@ -1,4 +1,4 @@
-import { scoreVesselItems, withinTolerance } from '../run-parse-vessel';
+import { scoreVesselItems, withinTolerance, normalizeVesselName } from '../run-parse-vessel';
 
 function field<T>(value: T | null): { value: T; confidence: string } | null {
   return value === null ? null : { value, confidence: 'confirmed' };
@@ -18,15 +18,20 @@ function makeRef(overrides: Record<string, unknown> = {}) {
   };
 }
 
+describe('normalizeVesselName', () => {
+  it('strips M/V prefix with slash', () => expect(normalizeVesselName('M/V GOYNUK')).toBe('GOYNUK'));
+  it('strips ex-name in parentheses', () => expect(normalizeVesselName('MV LADY ZEHMA (EX CASSIOPEIA STAR)')).toBe('LADY ZEHMA'));
+  it('strips quoted ex-name', () => expect(normalizeVesselName("MV ALI (EX-STAR)")).toBe('ALI'));
+});
+
 describe('withinTolerance (numeric ±5%)', () => {
   it('exact match → true', () => expect(withinTolerance(3000, 3000)).toBe(true));
   it('within 5% → true', () => expect(withinTolerance(3000, 3140)).toBe(true));
   it('outside 5% → false', () => expect(withinTolerance(3000, 3200)).toBe(false));
   it('both null → true', () => expect(withinTolerance(null, null)).toBe(true));
-  it('one null → false', () => {
-    expect(withinTolerance(null, 100)).toBe(false);
-    expect(withinTolerance(100, null)).toBe(false);
-  });
+  it('ref null (unannotated) → true', () => expect(withinTolerance(null, 4000)).toBe(true));
+  it('ref has value, model null → false', () => expect(withinTolerance(3858, null)).toBe(false));
+  it('model null, ref not null → false', () => expect(withinTolerance(100, null)).toBe(false));
 });
 
 describe('scoreVesselItems', () => {

--- a/scripts/progonq/run-parse-vessel.ts
+++ b/scripts/progonq/run-parse-vessel.ts
@@ -154,8 +154,8 @@ function asNumber(v: unknown): number | null {
 }
 
 export function withinTolerance(ref: number | null, model: number | null, tolerance = 0.05): boolean {
-  if (ref === null && model === null) return true;
-  if (ref === null || model === null) return false;
+  if (ref === null) return true;   // unannotated ref — don't penalize model
+  if (model === null) return false;
   if (ref === 0) return model === 0;
   return Math.abs(ref - model) / Math.abs(ref) <= tolerance;
 }
@@ -166,11 +166,13 @@ function ciEqual(a: string | null, b: string | null): boolean {
   return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
 
-function normalizeVesselName(s: string | null): string | null {
+export function normalizeVesselName(s: string | null): string | null {
   if (!s) return s;
   return s
     .toUpperCase()
-    .replace(/^(M[\s.]*V[.\s]*|MS[.\s]*|SS[.\s]*|MT[.\s]*)/i, '')
+    .replace(/^(M[\s./]*V[.\s/]*|MS[.\s]*|SS[.\s]*|MT[.\s]*)/i, '')
+    .replace(/\s*\(EX[\s-][^)]+\)/gi, '')
+    .replace(/\s*['"]{1,2}\s*EX\s+[^'"]+['"]{1,2}/gi, '')
     .replace(/[^A-Z0-9 ]/g, '')
     .replace(/\s+/g, ' ')
     .trim();
@@ -182,6 +184,8 @@ function normalizeImo(s: string | null): string | null {
   return m ? m[0] : null;
 }
 
+// TODO: replace positional pairing with greedy best-match by normalized vessel_name
+// to handle multi-vessel scenarios where model returns vessels in different order (affects ~2 scenarios).
 export function scoreVesselItems(refItems: VesselItem[], modelItems: VesselItem[]): VesselMatchResult[] {
   const results: VesselMatchResult[] = [];
   const maxLen = Math.max(refItems.length, modelItems.length);
@@ -209,13 +213,13 @@ export function scoreVesselItems(refItems: VesselItem[], modelItems: VesselItem[
 
     const vesselNameMatch = ciEqual(normalizeVesselName(refName), normalizeVesselName(modelName));
     const imoMatch =
-      refImo === null && modelImo === null
+      refImo === null
         ? true
-        : refImo === null || modelImo === null
+        : modelImo === null
           ? false
           : normalizeImo(refImo) === normalizeImo(modelImo);
-    const flagMatch = ciEqual(refFlag, modelFlag);
-    const builtMatch = refBuilt === modelBuilt;
+    const flagMatch = refFlag === null ? true : ciEqual(refFlag, modelFlag);
+    const builtMatch = refBuilt === null ? true : refBuilt === modelBuilt;
     const dwtMatch = withinTolerance(refDwt, modelDwt);
     const dwccMatch = withinTolerance(refDwcc, modelDwcc);
 


### PR DESCRIPTION
## Summary

Analysis of R5 failures (26/56 failing scenarios) revealed the model was correct in many cases but the runner gave false-negatives due to three scoring bugs:

### Fix 1 — M/V prefix with slash not stripped
`normalizeVesselName` regex `M[\s.]*V[.\s]*` didn't match `M/V` format.  
Added `/` to both character classes: `M[\s./]*V[.\s/]*`  
Affects: scenarios 028, 037 (~5 vessels with `M/V NAME` format)

### Fix 2 — Ex-name annotations not stripped
Model correctly included `(EX CASSIOPEIA STAR)` or `'' EX ALI AYKIN''` from email context, but reference has clean names. Added two strip passes before the non-alphanum filter:
- `\s*\(EX[\s-][^)]+\)` → strips `(EX NAME)` and `(EX-NAME)` 
- `\s*['"]{1,2}\s*EX\s+[^'"]+['"]{1,2}` → strips `'' EX OLD NAME''`  

Affects: scenarios 027, 029, 034

### Fix 3 — Unannotated ref fields penalized
`withinTolerance(null, value)` returned `false`. When corpus ref is `null` (field not annotated), model should not be penalized for extracting a value. Changed: `ref === null → return true`.

Same logic applied to `builtMatch`, `flagMatch`, `imoMatch`.  
Affected fields: `dwt` (15 cases), `built` (13 cases), `flag`, `imo`

### Fix 4 — Multi-vessel best-match pairing (deferred)
Positional pairing fails when model returns 2 vessels in different order than reference. Added TODO comment in `scoreVesselItems`. Affects ~2 scenarios — deferred as it requires a non-trivial refactor.

## PI3 Log (test expectation changes)
1. `withinTolerance(null, 100)` — changed `false → true` (old test removed, replaced with split tests clarifying semantics)  
   New tests added: `withinTolerance(null, 4000) → true`, `withinTolerance(3858, null) → false`

## Tests
16 tests passing (was 11; +5 new tests for normalizeVesselName and withinTolerance null-ref behavior).

## R6 Eval Results
_(running — will be posted in comment once complete)_

## Files changed
- `scripts/progonq/run-parse-vessel.ts` — normalizeVesselName, withinTolerance, imoMatch, flagMatch, builtMatch
- `scripts/progonq/__tests__/score-vessel.test.ts` — 3 normalizeVesselName tests + 2 withinTolerance null-ref tests