### PR TITLE
feat(matches): PDF export — /api/matches/export/pdf + Export PDF button

### DIFF
--- a/.pipeline/phase_1_scope_pdf_export.md
+++ b/.pipeline/phase_1_scope_pdf_export.md
@@ -1,0 +1,43 @@
+# Phase 1 — Scope: PDF Export of Match Results
+
+## Assumptions
+
+Понимаю задачу как: добавить кнопку на /matches, генерирующую PDF со всеми
+видимыми матчами (с учётом текущих фильтров), и скачивать его через браузер.
+
+Альтернатива: клиентская генерация (jspdf). Не иду по ней, потому что pdfkit
+уже в зависимостях как server-side библиотека, а server-side удобнее для
+контроля форматирования и не раскрывает raw data клиенту.
+
+## Affected Files
+
+| Файл                                     | Тип                 | Действие                                                                |
+| ---------------------------------------- | ------------------- | ----------------------------------------------------------------------- |
+| app/api/matches/export/pdf/route.ts      | New production      | GET endpoint: auth, feature flag, listMatches, pdfkit → binary Response |
+| app/matches/MatchesClient.tsx            | Modified production | +1 кнопка "Export PDF" + handler window.open()                          |
+| **tests**/api/matches-export-pdf.test.ts | New test            | Behavioral tests (Class 9): 401/503/200/PDF-magic-bytes/filters         |
+
+## Rule B Check
+
+- URL/path/HTML: Нет. Q1-chain не применяется.
+- LLM endpoint: Нет. AbortController не нужен.
+- Auth code: используем существующий requireSession pass-through.
+
+## Rule D (Feature-flag wiring)
+
+Нет нового feature flag. Endpoint гейтируется существующим MATCHES_ENABLED.
+
+## Rule F (Admin endpoint whitelist)
+
+/api/matches/export/pdf — НЕ под /api/admin/ → middleware whitelist не нужен.
+Endpoint требует session cookie (requireSession), как все остальные /api/matches/\*.
+
+## Rule G Trigger
+
+- 2 production файла (< 3) → не триггерит.
+- Domain: не parser, не auth code, не payments, не regex normalizer.
+- Decision: single-agent TDD.
+
+## Security Note (Phase 3: Security-Auditor)
+
+Новый endpoint принимает query params от user → нужна проверка Phase 3.

--- a/__tests__/api/matches-export-pdf.test.ts
+++ b/__tests__/api/matches-export-pdf.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests — GET /api/matches/export/pdf
+ *
+ * Covers (Class 9 — E2E behavioral via NextRequest/Response route import):
+ *   - Auth: no session → 401
+ *   - Feature flag MATCHES_ENABLED=false → 503
+ *   - Happy path (empty matches) → 200, Content-Type: application/pdf
+ *   - Happy path (with matches) → response body starts with PDF magic bytes %PDF
+ *   - Content-Disposition header present with attachment filename
+ *   - Filter: ?status=saved → only saved matches in PDF (verified via Content-Length delta)
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest, NextResponse } from 'next/server';
+import migration032 from '@/lib/migrations/032-matches';
+import { createMatch } from '@/lib/matching/matches-repository';
+import { requireSession } from '@/lib/session';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+
+const AUTHENTICATED_SESSION = {
+  session: { id: 'sess-1', parsedCargos: [], parsedVessels: [] },
+  sessionId: 'test-sid',
+};
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+describe('GET /api/matches/export/pdf', () => {
+  let db: Database.Database;
+  const originalEnv = process.env.MATCHES_ENABLED;
+  // Import once — no resetModules needed; listMatches reads db at call time
+  let GET: (req: NextRequest) => Promise<Response | NextResponse>;
+
+  beforeAll(async () => {
+    const mod = await import('@/app/api/matches/export/pdf/route');
+    GET = mod.GET;
+  });
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration032.up(db);
+    testDb = db;
+    process.env.MATCHES_ENABLED = 'true';
+    mockRequireSession.mockReturnValue(AUTHENTICATED_SESSION);
+  });
+
+  afterEach(() => {
+    process.env.MATCHES_ENABLED = originalEnv;
+    db.close();
+  });
+
+  it('returns 401 when no session', async () => {
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'No session' }, { status: 401 })
+    );
+    const res = await GET(makeRequest('/api/matches/export/pdf'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when MATCHES_ENABLED=false', async () => {
+    process.env.MATCHES_ENABLED = 'false';
+    const res = await GET(makeRequest('/api/matches/export/pdf'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it('returns 200 with application/pdf content-type on empty match list', async () => {
+    const res = await GET(makeRequest('/api/matches/export/pdf'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+  });
+
+  it('returns PDF magic bytes (%PDF) in response body', async () => {
+    createMatch(db, {
+      cargo_id: 'CARGO-001',
+      vessel_id: 'VESSEL-001',
+      score: 85,
+      reason: 'Good geographic fit',
+      user_id: 'test-sid',
+    });
+
+    const res = await GET(makeRequest('/api/matches/export/pdf'));
+    expect(res.status).toBe(200);
+
+    const bytes = Buffer.from(await res.arrayBuffer());
+    expect(bytes.slice(0, 4).toString('ascii')).toBe('%PDF');
+  });
+
+  it('returns content-disposition header with attachment filename', async () => {
+    const res = await GET(makeRequest('/api/matches/export/pdf'));
+    const disposition = res.headers.get('content-disposition');
+    expect(disposition).toMatch(/^attachment; filename="quantika-matches-/);
+    expect(disposition).toMatch(/\.pdf"$/);
+  });
+
+  it('returns larger PDF body when matches present vs empty list', async () => {
+    const emptyRes = await GET(makeRequest('/api/matches/export/pdf'));
+    const emptySize = (await emptyRes.arrayBuffer()).byteLength;
+
+    for (let i = 0; i < 3; i++) {
+      createMatch(db, {
+        cargo_id: `CARGO-${i}`,
+        vessel_id: `VESSEL-${i}`,
+        score: 70 + i * 5,
+        reason: `Reason ${i}`,
+        user_id: 'test-sid',
+        load_port: 'NLRTM',
+        discharge_port: 'CNSHA',
+        cargo_type: 'grain',
+        vessel_dwt: 50000 + i * 5000,
+      });
+    }
+
+    const fullRes = await GET(makeRequest('/api/matches/export/pdf'));
+    const fullSize = (await fullRes.arrayBuffer()).byteLength;
+
+    expect(fullSize).toBeGreaterThan(emptySize);
+  });
+
+  it('filters by status param — filtered PDF smaller than unfiltered', async () => {
+    createMatch(db, {
+      cargo_id: 'CARGO-SAVED',
+      vessel_id: 'VESSEL-SAVED',
+      score: 90,
+      reason: '',
+      status: 'saved',
+      user_id: 'test-sid',
+    });
+    createMatch(db, {
+      cargo_id: 'CARGO-SHORTLIST',
+      vessel_id: 'VESSEL-SHORTLIST',
+      score: 60,
+      reason: '',
+      status: 'shortlist',
+      user_id: 'test-sid',
+    });
+
+    const filteredRes = await GET(makeRequest('/api/matches/export/pdf?status=saved'));
+    expect(filteredRes.status).toBe(200);
+    const filteredSize = (await filteredRes.arrayBuffer()).byteLength;
+
+    const allRes = await GET(makeRequest('/api/matches/export/pdf'));
+    expect(allRes.status).toBe(200);
+    const allSize = (await allRes.arrayBuffer()).byteLength;
+
+    // 1-match PDF should be smaller than 2-match PDF
+    expect(filteredSize).toBeLessThan(allSize);
+  });
+});

--- a/app/api/matches/export/pdf/route.ts
+++ b/app/api/matches/export/pdf/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getStore } from '@/lib/session-store';
+import { requireSession } from '@/lib/session';
+import { listMatches } from '@/lib/matching/matches-repository';
+import type { MatchStatus, StoredMatch } from '@/lib/matching/matches-repository';
+import PDFDocument from 'pdfkit';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_STATUSES: MatchStatus[] = ['shortlist', 'saved', 'dismissed', 'archived'];
+
+function isFeatureEnabled(): boolean {
+  return process.env.MATCHES_ENABLED === 'true';
+}
+
+function formatDate(ts: number | null): string {
+  if (!ts) return '—';
+  return new Date(ts).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+async function buildPdf(matches: StoredMatch[]): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 40, size: 'A4' });
+    const chunks: Buffer[] = [];
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    doc
+      .fontSize(18)
+      .font('Helvetica-Bold')
+      .fillColor('#111827')
+      .text('Quantika — Match Results Export');
+    doc
+      .fontSize(9)
+      .font('Helvetica')
+      .fillColor('#6b7280')
+      .text(`Generated: ${new Date().toUTCString()}  ·  Matches: ${matches.length}`);
+    doc.moveDown(1);
+
+    if (matches.length === 0) {
+      doc.fontSize(11).fillColor('#374151').text('No matches found with the current filters.');
+    } else {
+      matches.forEach((m, i) => {
+        if (doc.y > 730) doc.addPage();
+
+        doc
+          .fontSize(11)
+          .font('Helvetica-Bold')
+          .fillColor('#1d4ed8')
+          .text(`#${i + 1}  Score: ${m.score}%`, { continued: true });
+        doc
+          .fontSize(9)
+          .font('Helvetica')
+          .fillColor('#6b7280')
+          .text(`   [${m.status}]`);
+
+        doc.fontSize(9).fillColor('#111827');
+        doc.font('Helvetica-Bold').text('Cargo: ', { continued: true });
+        doc.font('Helvetica').text(m.cargo_id);
+        doc.font('Helvetica-Bold').text('Vessel: ', { continued: true });
+        doc.font('Helvetica').text(m.vessel_id);
+
+        if (m.cargo_type) {
+          doc.font('Helvetica-Bold').text('Cargo type: ', { continued: true });
+          doc.font('Helvetica').text(m.cargo_type);
+        }
+
+        if (m.load_port || m.discharge_port) {
+          doc.font('Helvetica-Bold').text('Route: ', { continued: true });
+          doc.font('Helvetica').text(`${m.load_port ?? '?'} → ${m.discharge_port ?? '?'}`);
+        }
+
+        if (m.laycan_start || m.laycan_end) {
+          doc.font('Helvetica-Bold').text('Laycan: ', { continued: true });
+          doc.font('Helvetica').text(`${formatDate(m.laycan_start)} – ${formatDate(m.laycan_end)}`);
+        }
+
+        if (m.vessel_dwt) {
+          doc.font('Helvetica-Bold').text('DWT: ', { continued: true });
+          doc.font('Helvetica').text(m.vessel_dwt.toLocaleString());
+        }
+
+        if (m.reason) {
+          doc.fontSize(8).fillColor('#6b7280').font('Helvetica').text(m.reason, { lineGap: 1 });
+        }
+
+        doc.moveDown(0.5);
+        if (i < matches.length - 1) {
+          doc
+            .moveTo(40, doc.y)
+            .lineTo(555, doc.y)
+            .strokeColor('#e5e7eb')
+            .lineWidth(0.5)
+            .stroke();
+          doc.moveDown(0.5);
+        }
+      });
+    }
+
+    doc.end();
+  });
+}
+
+export async function GET(request: NextRequest): Promise<Response | NextResponse> {
+  const authResult = requireSession(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { sessionId } = authResult;
+
+  if (!isFeatureEnabled()) {
+    return NextResponse.json({ error: 'Feature disabled' }, { status: 503 });
+  }
+
+  const db = getStore().getDatabase();
+  const sp = request.nextUrl.searchParams;
+
+  const statusParam = sp.get('status');
+  const status =
+    statusParam && VALID_STATUSES.includes(statusParam as MatchStatus)
+      ? (statusParam as MatchStatus)
+      : undefined;
+
+  const cargoTypes = sp.getAll('cargo_type');
+  const route = sp.get('route') ?? undefined;
+
+  const parseMs = (raw: string | null): number | undefined => {
+    if (!raw) return undefined;
+    const t = new Date(raw).getTime();
+    return isNaN(t) ? undefined : t;
+  };
+  const parseNum = (raw: string | null): number | undefined => {
+    if (!raw) return undefined;
+    const n = Number(raw);
+    return isNaN(n) ? undefined : n;
+  };
+
+  const matches = listMatches(db, {
+    user_id: sessionId,
+    status,
+    sortBy: 'score',
+    sortDir: 'desc',
+    cargo_type: cargoTypes.length > 0 ? cargoTypes : undefined,
+    route,
+    laycan_from: parseMs(sp.get('laycan_from')),
+    laycan_to: parseMs(sp.get('laycan_to')),
+    score_min: parseNum(sp.get('score_min')),
+    dwt_min: parseNum(sp.get('dwt_min')),
+    dwt_max: parseNum(sp.get('dwt_max')),
+  });
+
+  try {
+    const pdfBuffer = await buildPdf(matches);
+    const filename = `quantika-matches-${new Date().toISOString().slice(0, 10)}.pdf`;
+    // TypeScript 6 tightened ArrayBufferView generics; copy into a fresh ArrayBuffer
+    // to satisfy BodyInit (which requires ArrayBuffer, not ArrayBufferLike).
+    const arrayBuffer = new ArrayBuffer(pdfBuffer.byteLength);
+    new Uint8Array(arrayBuffer).set(pdfBuffer);
+    return new Response(arrayBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Length': String(pdfBuffer.byteLength),
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'PDF generation failed' }, { status: 500 });
+  }
+}

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -90,6 +90,21 @@ export default function MatchesClient({ initialMatches }: Props) {
     }
   }, [router]);
 
+  // Export current visible matches as PDF download
+  function handleExportPdf() {
+    const params = new URLSearchParams();
+    for (const ct of cargoTypes) params.append('cargo_type', ct);
+    if (route) params.set('route', route);
+    if (laycan_from) params.set('laycan_from', laycan_from);
+    if (laycan_to) params.set('laycan_to', laycan_to);
+    if (score_min) params.set('score_min', score_min);
+    if (dwt_min) params.set('dwt_min', dwt_min);
+    if (dwt_max) params.set('dwt_max', dwt_max);
+    if (filterStatus) params.set('status', filterStatus);
+    const qs = params.toString();
+    window.open(qs ? `/api/matches/export/pdf?${qs}` : '/api/matches/export/pdf', '_blank');
+  }
+
   // Single match action
   async function handleAction(id: number, status: MatchStatus) {
     const res = await fetch(`/api/matches/${id}`, {
@@ -177,6 +192,13 @@ export default function MatchesClient({ initialMatches }: Props) {
           className="px-3 py-1 rounded-full text-sm border bg-white text-gray-700 border-gray-300 ml-2"
         >
           Advanced Filters
+        </button>
+        <button
+          onClick={handleExportPdf}
+          className="px-3 py-1 rounded-full text-sm border bg-white text-gray-700 border-gray-300 ml-auto"
+          title="Export current matches as PDF"
+        >
+          Export PDF
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

- New `GET /api/matches/export/pdf` endpoint — server-side PDF generation via `pdfkit` (already a dependency)
- Auth-gated via `requireSession` + `MATCHES_ENABLED` flag (consistent with other matches endpoints)
- Accepts the same filter query params as `GET /api/matches` (status, cargo_type, route, laycan_from/to, score_min, dwt_min/max)
- Export PDF button added to /matches filter bar (top-right, `ml-auto`); respects all active filters via `window.open()`

## Test plan

- [x] 7 behavioral tests in `__tests__/api/matches-export-pdf.test.ts`: 401, 503, 200, PDF magic bytes `%PDF`, content-disposition header, size-delta with/without matches, status filter
- [x] TypeScript clean (0 new errors; pre-existing `searoute-ts` error fixed by `npm install`)
- [x] Pre-commit hook passed (ESLint + Prettier + tsc)
- [x] No regressions in existing matches tests (failures only in stale `.worktrees/`)

## Security

- User isolation: `listMatches` scoped to `sessionId` from verified session, not from query params
- All query params validated/sanitized (status whitelist, numeric NaN-guard, SQL via parameterized queries)
- Filename is static date only — no user input in headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)