### PR TITLE
fix(eval): parse-vessel runner — best-match vessel pairing (fix swapped order)

### DIFF
--- a/scripts/progonq/__tests__/score-vessel.test.ts
+++ b/scripts/progonq/__tests__/score-vessel.test.ts
@@ -80,4 +80,25 @@ describe('scoreVesselItems', () => {
   it('both 0-items → empty list (caller handles)', () => {
     expect(scoreVesselItems([], [])).toEqual([]);
   });
+
+  it('best-match: swapped vessel order → both match by name', () => {
+    const refA = makeRef({ vessel_name: field('MV ALPHA') });
+    const refB = makeRef({ vessel_name: field('MV BETA') });
+    const modelB = makeRef({ vessel_name: field('MV BETA') });
+    const modelA = makeRef({ vessel_name: field('MV ALPHA') });
+    const results = scoreVesselItems([refA, refB], [modelB, modelA]);
+    expect(results).toHaveLength(2);
+    expect(results[0].vessel_name_match).toBe(true);
+    expect(results[1].vessel_name_match).toBe(true);
+  });
+
+  it('best-match: model missing one vessel → matched vessel scores, unmatched gets null model', () => {
+    const refA = makeRef({ vessel_name: field('MV ALPHA') });
+    const refB = makeRef({ vessel_name: field('MV BETA') });
+    const modelA = makeRef({ vessel_name: field('MV ALPHA') });
+    const results = scoreVesselItems([refA, refB], [modelA]);
+    expect(results).toHaveLength(2);
+    expect(results[0].vessel_name_match).toBe(true);
+    expect(results[1].vessel_name_match).toBe(false);
+  });
 });

--- a/scripts/progonq/run-parse-vessel.ts
+++ b/scripts/progonq/run-parse-vessel.ts
@@ -184,15 +184,37 @@ function normalizeImo(s: string | null): string | null {
   return m ? m[0] : null;
 }
 
-// TODO: replace positional pairing with greedy best-match by normalized vessel_name
-// to handle multi-vessel scenarios where model returns vessels in different order (affects ~2 scenarios).
 export function scoreVesselItems(refItems: VesselItem[], modelItems: VesselItem[]): VesselMatchResult[] {
   const results: VesselMatchResult[] = [];
+  const used = new Set<number>();
+
+  function findBestMatch(refName: string, items: VesselItem[]): number {
+    for (let j = 0; j < items.length; j++) {
+      if (used.has(j)) continue;
+      const mName = normalizeVesselName(asString(getFieldValue(items[j]?.vessel_name)));
+      if (refName && mName && refName === mName) return j;
+    }
+    for (let j = 0; j < items.length; j++) {
+      if (!used.has(j)) return j;
+    }
+    return -1;
+  }
+
   const maxLen = Math.max(refItems.length, modelItems.length);
 
   for (let i = 0; i < maxLen; i++) {
     const ref = refItems[i] ?? null;
-    const model = modelItems[i] ?? null;
+    let model: VesselItem | null = null;
+
+    if (ref !== null) {
+      const refName = normalizeVesselName(asString(getFieldValue(ref?.vessel_name))) ?? '';
+      const bestIdx = findBestMatch(refName, modelItems);
+      if (bestIdx !== -1) { model = modelItems[bestIdx]; used.add(bestIdx); }
+    } else {
+      for (let j = 0; j < modelItems.length; j++) {
+        if (!used.has(j)) { model = modelItems[j]; used.add(j); break; }
+      }
+    }
 
     const refName = asString(getFieldValue(ref?.vessel_name));
     const modelName = asString(getFieldValue(model?.vessel_name));


### PR DESCRIPTION
## Summary

- Replaces positional index pairing in `scoreVesselItems` with greedy best-match by `normalizeVesselName`
- Fixes multi-vessel scenarios where model returns vessels in different order than reference
- Removes TODO comment that was already in the code

## Eval delta (R7 — scenarios 020 + 038)

| Scenario | Before | After | Note |
|----------|--------|-------|------|
| etms-parse-vessel-038 | ~0% (swapped order) | **100%** | 9/9 vessels correctly paired |
| etms-parse-vessel-020 | ~0% (swapped order) | **79.2%** | model returned 7/8 ref vessels |

`string_full` improvement: **+1** confirmed (scenario-038), scenario-020 improved but model missing 1 vessel.

## Changes

- `scripts/progonq/run-parse-vessel.ts`: replaced positional loop with `findBestMatch` helper (greedy exact-name match → first-unused fallback), ~28 LOC
- `scripts/progonq/__tests__/score-vessel.test.ts`: +2 tests — swapped-order best-match and partial-model coverage

## Test plan

- [x] `npx jest --testPathPatterns="score-vessel" --no-coverage` — 18/18 passed
- [x] Existing 16 tests unchanged (PI3: 0 rewrites)
- [x] Re-ran scenarios 020 + 038 via runner + judge

🤖 Generated with [Claude Code](https://claude.com/claude-code)