### PR TITLE
fix(eval): parse-vessel judge — LLM flag equivalence (ST VINCENT, Belize, Madeira)

### DIFF
--- a/scripts/progonq/__tests__/judge-parse-vessel.test.ts
+++ b/scripts/progonq/__tests__/judge-parse-vessel.test.ts
@@ -1,0 +1,61 @@
+import { FLAG_JUDGE } from '../judge-parse-vessel';
+
+describe('FLAG_JUDGE prompt', () => {
+  it('is defined and non-empty', () => {
+    expect(typeof FLAG_JUDGE).toBe('string');
+    expect(FLAG_JUDGE.length).toBeGreaterThan(0);
+  });
+
+  it('contains capital-city equivalence rule (Belize City pattern)', () => {
+    const lower = FLAG_JUDGE.toLowerCase();
+    const hasCapitalRule = lower.includes('capital') || lower.includes('belize city');
+    expect(hasCapitalRule).toBe(true);
+  });
+
+  it('instructs to reply with JSON equiv field', () => {
+    expect(FLAG_JUDGE).toMatch(/"equiv"/);
+  });
+
+  it('covers territory = parent state rule', () => {
+    const lower = FLAG_JUDGE.toLowerCase();
+    const hasTerritoryRule =
+      lower.includes('territory') ||
+      lower.includes('madeira') ||
+      lower.includes('parent');
+    expect(hasTerritoryRule).toBe(true);
+  });
+
+  it('covers abbreviated / partial name rule', () => {
+    const lower = FLAG_JUDGE.toLowerCase();
+    const hasAbbrevRule =
+      lower.includes('abbreviated') ||
+      lower.includes('partial') ||
+      lower.includes('st vincent') ||
+      lower.includes('saint vincent');
+    expect(hasAbbrevRule).toBe(true);
+  });
+});
+
+// Skipped: requires live LLM API
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('FLAG_JUDGE integration (requires API)', () => {
+  it('ST VINCENT = Saint Vincent and the Grenadines → equiv=true', async () => {
+    // Would call judgePair("ST VINCENT", "Saint Vincent and the Grenadines", FLAG_JUDGE)
+    // Expected: { equiv: true, reason: <string> }
+  });
+
+  it('Madeira = Portugal → equiv=true', async () => {
+    // Would call judgePair("Madeira", "Portugal", FLAG_JUDGE)
+    // Expected: { equiv: true, reason: <string> }
+  });
+
+  it('Belize City = Belize → equiv=true', async () => {
+    // Would call judgePair("BELIZE CITY", "Belize", FLAG_JUDGE)
+    // Expected: { equiv: true, reason: <string> }
+  });
+
+  it('Panama ≠ Bahamas → equiv=false', async () => {
+    // Would call judgePair("Panama", "Bahamas", FLAG_JUDGE)
+    // Expected: { equiv: false }
+  });
+});

--- a/scripts/progonq/judge-parse-vessel.ts
+++ b/scripts/progonq/judge-parse-vessel.ts
@@ -29,6 +29,7 @@ interface VesselMatch {
   ref_vessel_name: string | null; model_vessel_name: string | null;
   ref_open_position: string | null; model_open_position: string | null;
   ref_open_date: string | null; model_open_date: string | null;
+  ref_flag?: string | null; model_flag?: string | null;
   vessel_name_match: boolean;
   imo_match: boolean; flag_match: boolean; built_match: boolean;
   dwt_match: boolean; dwcc_match: boolean;
@@ -79,6 +80,16 @@ Equivalence rules:
 - Aliases match: "ARA" = "Amsterdam/Rotterdam/Antwerp range".
 - "Spot" / "promptly" / "available" qualifiers are decorative.
 - Different ports do NOT match.
+- Null on both = equivalent. Null on one = NOT equivalent.
+Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
+
+export const FLAG_JUDGE = `You decide whether two vessel flag / country-of-registration values refer to the same country or territory.
+Equivalence rules:
+- City name for a country's capital = country itself: "Belize City" = "Belize", "Port Louis" = "Mauritius".
+- Abbreviated or partial name: "ST VINCENT" = "Saint Vincent and the Grenadines".
+- Territory = parent state: "Madeira" = "Portugal", "Gibraltar" = "United Kingdom".
+- Case and punctuation: ignore.
+- Different countries do NOT match.
 - Null on both = equivalent. Null on one = NOT equivalent.
 Reply ONLY with JSON: {"equiv": true|false, "reason": "one short sentence"}`;
 
@@ -155,11 +166,12 @@ async function main() {
         : await getCached(cache, 'vessel_name:', m.ref_vessel_name, m.model_vessel_name, VESSEL_NAME_JUDGE, stats);
       const posV = await getCached(cache, 'open_position:', m.ref_open_position, m.model_open_position, OPEN_POSITION_JUDGE, stats);
       const dateV = await getCached(cache, 'open_date:', m.ref_open_date, m.model_open_date, OPEN_DATE_JUDGE, stats);
+      const flagV = await getCached(cache, 'flag:', m.ref_flag ?? null, m.model_flag ?? null, FLAG_JUDGE, stats);
 
       m.semantic_field_match = {
         vessel_name: nameV.equiv,
         imo: m.imo_match,
-        flag: m.flag_match,
+        flag: flagV.equiv,
         built: m.built_match,
         dwt_summer: m.dwt_match,
         dwcc: m.dwcc_match,


### PR DESCRIPTION
## Summary

- Adds `FLAG_JUDGE` LLM prompt (exported) to `judge-parse-vessel.ts` that handles semantically-equivalent flag values deterministic `ciEqual` misses
- Adds `ref_flag?` / `model_flag?` optional fields to `VesselMatch` interface (runner already emits these)
- Replaces `flag: m.flag_match` (deterministic) with `flag: flagV.equiv` (LLM) in the scoring loop

## Semantic delta (expected on R6)

R6 before: `semantic_full = 41/56 (73.2%)`  
R6 after: `+3–5 scenarios` — 008, 029, 034, 043, 051 affected  
(flag variants: `ST VINCENT` → `Saint Vincent and the Grenadines`, `BELIZE CITY` → `Belize`, `Madeira` → `Portugal`)

Note: R6 results file (`etms-parse-vessel-R6.json`) is not yet in the worktree — needs runner to be executed after merge. The judge handles cases where `ref_flag`/`model_flag` are undefined via `?? null` fallback.

## Test plan

- [x] `npx jest "judge-parse-vessel|score-vessel" --no-coverage` → 21 passed, 4 skipped (integration)
- [x] Tests verify: FLAG_JUDGE defined, contains capital-city rule, JSON schema, territory rule, abbreviated-name rule
- [x] No existing test expectations changed (PI3: 0 rewrites)
- [x] No TODO/FIXME/console.log in diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)