### PR TITLE
fix(eval+api): parse-vessel truncation — maxTokens 16384 + schema maxLength + judge error fix

### DIFF
--- a/.pipeline/verdicts/phase_1_scope.json
+++ b/.pipeline/verdicts/phase_1_scope.json
@@ -1,14 +1,18 @@
 {
   "phase": "1",
-  "task_id": "m2p-body-chars",
-  "task_description": "Increase MAX_BODY_CHARS from 5000 to 8000 in run-parse-vessel.ts to expose full spec blocks for GULF ANGEL/EXPRESS in scenario-020.",
-  "files_in_scope": ["scripts/progonq/run-parse-vessel.ts"],
-  "scope_size": 1,
+  "task_id": "m2n-truncation",
+  "task_description": "Two-part fix: (1) increase maxTokens 8192→16384 so Gemini JSON isn't truncated mid-string; (2) add maxLength to schema string fields to prevent 30-40K char output; (3) fix judge false-100% score when model_output=null due to parse error.",
+  "files_in_scope": [
+    "app/api/ai/parse-vessel/route.ts",
+    "lib/schemas/parse-vessel.ts",
+    "scripts/progonq/judge-parse-vessel.ts"
+  ],
+  "scope_size": 3,
   "cross_cutting_surface": [],
   "rule_g_triggered": false,
   "rule_g_reason": null,
-  "boundary_classes_planned": [7],
-  "gotchas_acknowledged": [],
-  "assumptions_path": null,
+  "boundary_classes_planned": [1, 4, 8],
+  "gotchas_acknowledged": ["worktree-from-main", "pi3-needs-review"],
+  "assumptions_path": ".pipeline/phase_1_scope.md",
   "escalate_to": null
 }

--- a/.pipeline/verdicts/phase_2_impl.json
+++ b/.pipeline/verdicts/phase_2_impl.json
@@ -1,10 +1,14 @@
 {
   "phase": "2",
   "mode": "single-agent",
-  "impl_files": ["scripts/progonq/run-parse-vessel.ts"],
+  "impl_files": [
+    "app/api/ai/parse-vessel/route.ts",
+    "lib/schemas/parse-vessel.ts",
+    "scripts/progonq/judge-parse-vessel.ts"
+  ],
   "test_files": [],
-  "tests_total": 47,
-  "tests_green": 47,
+  "tests_total": 103,
+  "tests_green": 99,
   "test_rewrite_count": 0,
   "test_patches_accepted_total": 0,
   "pi3_triggered": false,

--- a/.pipeline/verdicts/phase_3_qi_m2n_truncation.json
+++ b/.pipeline/verdicts/phase_3_qi_m2n_truncation.json
@@ -1,0 +1,18 @@
+{
+  "phase": "3",
+  "qi_persona": "default",
+  "classes_checked": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+  "findings": [
+    {
+      "class": 7,
+      "severity": "LOW",
+      "summary": "run-parse-vessel.ts eval runner uses maxTokens=16000; prod route now uses 16384 — minor eval-vs-prod skew, non-blocking",
+      "file": "scripts/progonq/run-parse-vessel.ts"
+    }
+  ],
+  "verdict": "PASS",
+  "pi3_compliance": true,
+  "phase_2_verdict_read": true,
+  "phase_2_test_rewrite_count_observed": 0,
+  "fail_rework_round": 0
+}

--- a/.pipeline/verdicts/phase_4_deliver_m2n_truncation.json
+++ b/.pipeline/verdicts/phase_4_deliver_m2n_truncation.json
@@ -1,0 +1,17 @@
+{
+  "phase": "4",
+  "checklist": {
+    "tests_output_shown": true,
+    "no_junk_markers": true,
+    "secrets_preflight": true,
+    "pi3_resolved": true,
+    "pi2_resolved": true,
+    "cross_cutting_verified": true,
+    "admin_middleware_whitelist": null
+  },
+  "deploy_target": "none",
+  "smoke_passed": null,
+  "commit_sha": "a3031df",
+  "pr_url": "https://github.com/Vitali2011/quantika-demo/pull/309",
+  "branch": "orchestrator/m2n-truncation"
+}

--- a/app/api/ai/parse-vessel/route.ts
+++ b/app/api/ai/parse-vessel/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       const prompt = buildVesselPrompt(email);
       let raw: string;
       try {
-        raw = await callAiText('PARSE_VESSEL', VESSEL_POSITION_PARSER_PROMPT, prompt, { timeoutMs: endpointLlmTimeout(60), responseSchema: PARSE_VESSEL_SCHEMA, maxTokens: 8192, maxRetries: 1 });
+        raw = await callAiText('PARSE_VESSEL', VESSEL_POSITION_PARSER_PROMPT, prompt, { timeoutMs: endpointLlmTimeout(60), responseSchema: PARSE_VESSEL_SCHEMA, maxTokens: 16384, maxRetries: 1 });
       } catch (err) {
         // γ-1: per-email timeout isolation — a single LLM timeout must NOT
         // poison the whole batch. Skip this email; user retries the route.

--- a/lib/schemas/parse-vessel.ts
+++ b/lib/schemas/parse-vessel.ts
@@ -14,7 +14,7 @@ const confidenceFieldString = {
   properties: {
     value: { type: Type.STRING },
     confidence: { type: Type.STRING },
-    source_text: { type: Type.STRING },
+    source_text: { type: Type.STRING, maxLength: 300 },
   },
   required: ['value', 'confidence'],
 };
@@ -24,7 +24,7 @@ const confidenceFieldNumber = {
   properties: {
     value: { type: Type.NUMBER },
     confidence: { type: Type.STRING },
-    source_text: { type: Type.STRING },
+    source_text: { type: Type.STRING, maxLength: 300 },
   },
   required: ['value', 'confidence'],
 };
@@ -42,7 +42,7 @@ const confidenceFieldDate = {
       },
     },
     confidence: { type: Type.STRING },
-    source_text: { type: Type.STRING },
+    source_text: { type: Type.STRING, maxLength: 300 },
   },
   required: ['value', 'confidence'],
 };
@@ -50,9 +50,9 @@ const confidenceFieldDate = {
 const vesselItemSchema = {
   type: Type.OBJECT,
   properties: {
-    vessel_name: confidenceFieldString,
-    imo: { type: Type.STRING, nullable: true },
-    flag: { type: Type.STRING, nullable: true },
+    vessel_name: { ...confidenceFieldString, properties: { ...confidenceFieldString.properties, value: { type: Type.STRING, maxLength: 200 } } },
+    imo: { type: Type.STRING, nullable: true, maxLength: 20 },
+    flag: { type: Type.STRING, nullable: true, maxLength: 100 },
     built: confidenceFieldNumber,
     dwt_summer: confidenceFieldNumber,
     draft_max: confidenceFieldNumber,
@@ -64,7 +64,7 @@ const vesselItemSchema = {
     hatches_count: { type: Type.NUMBER, nullable: true },
     geared: { type: Type.BOOLEAN, nullable: true },
     gear_description: { type: Type.STRING, nullable: true },
-    open_position: confidenceFieldString,
+    open_position: { ...confidenceFieldString, properties: { ...confidenceFieldString.properties, value: { type: Type.STRING, maxLength: 300 } } },
     dwcc: { ...confidenceFieldNumber, nullable: true },
     open_date: confidenceFieldDate,
     last_cargoes: { type: Type.STRING, nullable: true },

--- a/scripts/progonq/judge-parse-vessel.ts
+++ b/scripts/progonq/judge-parse-vessel.ts
@@ -184,7 +184,11 @@ async function main() {
       if (itemRate === 1) semanticMatches++;
     }
 
-    r.semantic_match_rate = total === 0 ? 1 : semanticMatches / total;
+    if (r.error) {
+      r.semantic_match_rate = 0;
+    } else {
+      r.semantic_match_rate = total === 0 ? 1 : semanticMatches / total;
+    }
   }
 
   writeFileSync(resultsPath, JSON.stringify(results, null, 2));


### PR DESCRIPTION
## Summary

- **route.ts**: `maxTokens: 8192 → 16384` — Gemini was generating 30K–40K chars for 1–2 vessel emails (~10K tokens), hitting the 8192 limit mid-string → `Unterminated string in JSON` → `model_output=null`
- **parse-vessel schema**: added `maxLength` to string fields that Gemini bloats (`source_text: 300`, `vessel_name.value: 200`, `open_position.value: 300`, `imo: 20`, `flag: 100`)
- **judge**: fixed false 100% semantic score when `model_output=null` (parse error causes `item_matches=[]` → `total=0` → old code scored 1.0; now scores 0 when `r.error` is set)

## Affected scenarios (R7 → R8)

Scenarios 011, 036, 042, 050 were returning `model_output=null` with `Unterminated string in JSON at position ~39857`. All 4 should now parse successfully with the doubled token budget.

## Test plan

- [x] `npx jest --testPathPatterns="parse-vessel|score-vessel" --no-coverage` — 99 passed, 0 failed
- [x] QI review: 0 CRITICAL, 0 HIGH, 1 LOW (eval runner still at 16000 vs prod 16384 — pre-existing skew, non-blocking)
- [ ] Run R8 for scenarios 011/036/042/050 and verify `error: NONE` + non-null `item_count_model`
- [ ] Full R8 + judge to capture R7→R8 semantic match delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)