### PR TITLE
fix(eval): parse-vessel runner — normalizeFlag (&→and, St→Saint) for annotation variance

### DIFF
--- a/scripts/progonq/__tests__/score-vessel.test.ts
+++ b/scripts/progonq/__tests__/score-vessel.test.ts
@@ -1,4 +1,4 @@
-import { scoreVesselItems, withinTolerance, normalizeVesselName } from '../run-parse-vessel';
+import { scoreVesselItems, withinTolerance, normalizeVesselName, normalizeFlag } from '../run-parse-vessel';
 
 function field<T>(value: T | null): { value: T; confidence: string } | null {
   return value === null ? null : { value, confidence: 'confirmed' };
@@ -156,6 +156,33 @@ describe('scoreVesselItems', () => {
     expect(results).toHaveLength(2);
     expect(results[0].vessel_name_match).toBe(true);
     expect(results[1].vessel_name_match).toBe(false);
+  });
+});
+
+describe('normalizeFlag', () => {
+  it('& → and: Antigua & Barbuda equals Antigua and Barbuda', () =>
+    expect(normalizeFlag('Antigua & Barbuda')).toBe(normalizeFlag('Antigua and Barbuda')));
+
+  it('St + & → Saint + and: St Kitts & Nevis equals Saint Kitts and Nevis', () =>
+    expect(normalizeFlag('St Kitts & Nevis')).toBe(normalizeFlag('Saint Kitts and Nevis')));
+
+  it('St. + & → Saint + and: St. Kitts & Nevis equals Saint Kitts and Nevis', () =>
+    expect(normalizeFlag('St. Kitts & Nevis')).toBe(normalizeFlag('Saint Kitts and Nevis')));
+
+  it('case insensitive: Panama equals panama', () =>
+    expect(normalizeFlag('Panama')).toBe(normalizeFlag('panama')));
+
+  it('null → empty string', () =>
+    expect(normalizeFlag(null)).toBe(''));
+
+  it('idempotent: normalizeFlag(normalizeFlag(s)) === normalizeFlag(s) for sample inputs', () => {
+    const samples = [
+      'Antigua & Barbuda', 'St Kitts & Nevis', 'St. Vincent & Grenadines',
+      'Panama', 'Saint Kitts and Nevis', 'Marshall Islands', '', 'Belize',
+    ];
+    for (const s of samples) {
+      expect(normalizeFlag(normalizeFlag(s))).toBe(normalizeFlag(s));
+    }
   });
 });
 

--- a/scripts/progonq/run-parse-vessel.ts
+++ b/scripts/progonq/run-parse-vessel.ts
@@ -178,6 +178,16 @@ export function normalizeVesselName(s: string | null): string | null {
     .trim();
 }
 
+export function normalizeFlag(s: string | null): string {
+  if (!s) return '';
+  return s
+    .toLowerCase()
+    .replace(/\bst\.?\s+/g, 'saint ')   // St. / St → Saint
+    .replace(/\s*&\s*/g, ' and ')        // & → and
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function normalizeImo(s: string | null): string | null {
   if (!s) return s;
   const m = s.match(/\d+/);
@@ -240,7 +250,7 @@ export function scoreVesselItems(refItems: VesselItem[], modelItems: VesselItem[
         : modelImo === null
           ? false
           : normalizeImo(refImo) === normalizeImo(modelImo);
-    const flagMatch = refFlag === null ? true : ciEqual(refFlag, modelFlag);
+    const flagMatch = refFlag === null ? true : normalizeFlag(refFlag) === normalizeFlag(modelFlag);
     const builtMatch = refBuilt === null ? true : refBuilt === modelBuilt;
     const dwtMatch = withinTolerance(refDwt, modelDwt);
     const dwccMatch = withinTolerance(refDwcc, modelDwcc);


### PR DESCRIPTION
## Summary

Runner `ciEqual` did exact string match on the `flag` field, penalizing the model for correct outputs that used different canonical forms in reference annotations. This fixes 4 failing scenarios in R9 (78.6% = 44/56):

| Scenario | ref flag | model flag | Old result |
|----------|----------|------------|------------|
| scenario-019 | `Antigua & Barbuda` | `Antigua and Barbuda` | ❌ |
| scenario-020 | `Antigua & Barbuda` | `Antigua and Barbuda` | ❌ |
| scenario-037 | `St Kitts & Nevis` | `Saint Kitts and Nevis` | ❌ |
| scenario-051 | `St. Kitts & Nevis` | `Saint Kitts and Nevis` | ❌ |

**Model was correct in all 4 cases** — reference annotations are inconsistent.

## Changes

- **`scripts/progonq/run-parse-vessel.ts`**: adds `export function normalizeFlag()` (lowercases, `St./St →` Saint, `&` → `and`, collapses whitespace); updates `flagMatch` to compare `normalizeFlag(refFlag) === normalizeFlag(modelFlag)` instead of `ciEqual`
- **`scripts/progonq/__tests__/score-vessel.test.ts`**: adds `normalizeFlag` import + 6 new tests (5 spec cases + idempotence property test)

## Expected delta

R9 → R10: +4 full-match scenarios, **78.6% → ~85.7%** (48/56)

## Test plan

- [x] `npx jest --testPathPatterns="score-vessel"` — 53/53 pass
- [x] Full suite — 544 suites, 6397 tests, all green
- [ ] Run R10 eval to confirm match_rate=1.0 on all 4 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)