### PR TITLE
fix(eval): parse-vessel runner — normalizeFlag prefix match for island state abbreviations

### DIFF
--- a/scripts/progonq/__tests__/score-vessel.test.ts
+++ b/scripts/progonq/__tests__/score-vessel.test.ts
@@ -186,6 +186,29 @@ describe('normalizeFlag', () => {
   });
 });
 
+describe('flagMatch prefix logic (via scoreVesselItems)', () => {
+  it('Saint Vincent is prefix of Saint Vincent and the Grenadines → flag_match true', () => {
+    const ref = [makeRef({ flag: field('Saint Vincent') })];
+    const model = [makeRef({ flag: field('Saint Vincent and the Grenadines') })];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.flag_match).toBe(true);
+  });
+
+  it('Panama vs Panama → flag_match true (exact)', () => {
+    const ref = [makeRef({ flag: field('Panama') })];
+    const model = [makeRef({ flag: field('Panama') })];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.flag_match).toBe(true);
+  });
+
+  it('Panama vs Portugal → flag_match false (no prefix)', () => {
+    const ref = [makeRef({ flag: field('Panama') })];
+    const model = [makeRef({ flag: field('Portugal') })];
+    const [r] = scoreVesselItems(ref, model);
+    expect(r.flag_match).toBe(false);
+  });
+});
+
 describe('scoreVesselItems — vessel ordering', () => {
   const mkVessel = (name: string) => ({
     vessel_name: { value: name, confidence: 'confirmed' },

--- a/scripts/progonq/run-parse-vessel.ts
+++ b/scripts/progonq/run-parse-vessel.ts
@@ -250,7 +250,12 @@ export function scoreVesselItems(refItems: VesselItem[], modelItems: VesselItem[
         : modelImo === null
           ? false
           : normalizeImo(refImo) === normalizeImo(modelImo);
-    const flagMatch = refFlag === null ? true : normalizeFlag(refFlag) === normalizeFlag(modelFlag);
+    const nRef = normalizeFlag(refFlag);
+    const nModel = normalizeFlag(modelFlag);
+    const flagMatch = refFlag === null ? true :
+      nRef === nModel ||
+      (nRef.length > 4 && nModel.startsWith(nRef)) ||
+      (nModel.length > 4 && nRef.startsWith(nModel));
     const builtMatch = refBuilt === null ? true : refBuilt === modelBuilt;
     const dwtMatch = withinTolerance(refDwt, modelDwt);
     const dwccMatch = withinTolerance(refDwcc, modelDwcc);


### PR DESCRIPTION
## Summary

- Adds prefix/substring check to `flagMatch` in `scripts/progonq/run-parse-vessel.ts`
- `'Saint Vincent'` now matches `'Saint Vincent and the Grenadines'` after normalization (prefix check)
- `length > 4` guard prevents false positives on short strings (e.g. `"us"` would not match `"ussr"`)
- Fixes scenarios 029 and 043 (R10 87.5% → R11 89.3%)

## Test plan

- [x] 3 new tests added: prefix match, exact match, no-match cases
- [x] All 56 tests green (`npx jest score-vessel --no-coverage`)
- [x] RED→GREEN verified (1 RED before impl, 56 GREEN after)
- [x] R10 data confirmed: `ref='Saint Vincent'` / `model='Saint Vincent and the Grenadines'` → now `flag_match=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)