### PR TITLE
[deploy-affects] feat(ops): post-deploy verify script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,3 +64,27 @@ jobs:
       # Seed logic must live inside /root/deploy-quantika-demo.sh on the VPS (after the
       # health check, before exit). See docs/runbooks/post-deploy-seed.md for manual run
       # instructions and the VPS integration note.
+      #
+      # Post-deploy verify: DB checks (schema migrations, fx_rates, env vars) also run
+      # inside /root/deploy-quantika-demo.sh via scripts/ops/verify-deploy.sh.
+      # HTTP checks (4-5) run here from CI against the public URL.
+      - name: Post-deploy verify (HTTP health)
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          BASE_URL="https://demo.quantika.org"
+          echo "[verify] GET ${BASE_URL}/api/health"
+          curl -fsS --max-time 15 "${BASE_URL}/api/health" \
+            || { echo "[verify] FAIL: /api/health did not return 200 — check VPS: pm2 status quantika-demo"; exit 1; }
+          echo "[verify] /api/health OK"
+
+          if [[ -n "${ADMIN_TOKEN:-}" ]]; then
+            echo "[verify] GET ${BASE_URL}/api/admin/knowledge-status"
+            curl -fsS --max-time 15 \
+              -H "X-Admin-Token: ${ADMIN_TOKEN}" \
+              "${BASE_URL}/api/admin/knowledge-status" \
+              || { echo "[verify] FAIL: /api/admin/knowledge-status — check ADMIN_TOKEN secret or app status"; exit 1; }
+            echo "[verify] /api/admin/knowledge-status OK"
+          else
+            echo "[verify] SKIP: ADMIN_TOKEN secret not configured in GitHub Actions"
+          fi

--- a/scripts/ops/verify-deploy.sh
+++ b/scripts/ops/verify-deploy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# verify-deploy.sh
+#
+# Post-deploy health check for quantika-demo.
+# Runs on the VPS after deploy + restart; called from /root/deploy-quantika-demo.sh.
+#
+# Exit 0 = healthy. Exit 1 + clear message = broken.
+#
+# Usage (on VPS):
+#   bash /root/quantika-demo/scripts/ops/verify-deploy.sh
+#
+# Env overrides (all optional):
+#   APP_DIR     — default /root/quantika-demo
+#   DB_PATH     — default $APP_DIR/data/sessions.db
+#   ENV_FILE    — default $APP_DIR/.env.local
+#   BASE_URL    — default http://localhost:3000
+#   ADMIN_TOKEN — read from ENV_FILE if not set in environment
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/root/quantika-demo}"
+DB_PATH="${DB_PATH:-${APP_DIR}/data/sessions.db}"
+ENV_FILE="${ENV_FILE:-${APP_DIR}/.env.local}"
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+
+log()  { echo "[verify-deploy] $*"; }
+fail() { echo "[verify-deploy] FAIL: $*" >&2; exit 1; }
+
+# ── Read ADMIN_TOKEN from .env.local if not in environment ────────────────────
+if [[ -z "${ADMIN_TOKEN:-}" && -f "$ENV_FILE" ]]; then
+  ADMIN_TOKEN="$(grep -E '^ADMIN_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ' || echo '')"
+fi
+
+# ── Check 1: Schema migrations ────────────────────────────────────────────────
+log "Check 1: schema migrations..."
+
+MIGRATION_COUNT="$(set +o pipefail; find "${APP_DIR}/lib/migrations/" -maxdepth 1 -name '[0-9][0-9][0-9]-*.ts' 2>/dev/null | wc -l | tr -d ' ')"
+if [[ -z "$MIGRATION_COUNT" || "$MIGRATION_COUNT" -eq 0 ]]; then
+  fail "Could not count migration files in ${APP_DIR}/lib/migrations/ — repo may not be checked out"
+fi
+
+MAX_VERSION="$(sqlite3 "${DB_PATH}" 'SELECT MAX(version) FROM schema_migrations;' 2>/dev/null || echo '')"
+if [[ -z "$MAX_VERSION" ]]; then
+  fail "Cannot query schema_migrations — DB may be missing or schema not initialised (path: ${DB_PATH})"
+fi
+
+if [[ "$MAX_VERSION" != "$MIGRATION_COUNT" ]]; then
+  fail "Migration mismatch: DB MAX(version)=${MAX_VERSION}, migration files=${MIGRATION_COUNT}. Run migrations or check for failed apply. (path: ${DB_PATH})"
+fi
+log "  schema_migrations MAX(version)=${MAX_VERSION} matches ${MIGRATION_COUNT} migration files"
+
+# ── Check 2: fx_rates seed ────────────────────────────────────────────────────
+log "Check 2: fx_rates seed..."
+FX_COUNT="$(sqlite3 "${DB_PATH}" 'SELECT COUNT(*) FROM fx_rates;' 2>/dev/null || echo '')"
+if [[ -z "$FX_COUNT" ]]; then
+  fail "Cannot query fx_rates table (path: ${DB_PATH}) — check if DB initialised"
+fi
+if [[ "$FX_COUNT" -le 0 ]]; then
+  fail "fx_rates table is empty — run: bash ${APP_DIR}/scripts/ops/post-deploy-seed.sh"
+fi
+log "  fx_rates has ${FX_COUNT} rows"
+
+# ── Check 3: Required env vars ────────────────────────────────────────────────
+log "Check 3: required env vars..."
+check_env_var() {
+  local var="$1"
+  local val="${!var:-}"
+
+  if [[ -z "$val" && -f "$ENV_FILE" ]]; then
+    val="$(grep -E "^${var}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | sed "s/^[\"']//;s/[\"']\$//" | cut -d'#' -f1 | tr -d ' ' || echo '')"
+  fi
+
+  if ! test -n "$val"; then
+    fail "Required env var ${var} is not set — check ${ENV_FILE}"
+  fi
+  log "  ${var} is set"
+}
+
+check_env_var DATABASE_URL
+check_env_var AI_PROVIDER
+check_env_var AUTH_SECRET
+
+# ── Check 4: /api/health ──────────────────────────────────────────────────────
+log "Check 4: GET ${BASE_URL}/api/health..."
+HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${BASE_URL}/api/health" 2>/dev/null || true)"
+HTTP_CODE="${HTTP_CODE:-000}"
+if [[ "$HTTP_CODE" != "200" ]]; then
+  fail "/api/health returned HTTP ${HTTP_CODE} (expected 200) — check: pm2 status, pm2 logs quantika-demo"
+fi
+log "  /api/health -> HTTP 200"
+
+# ── Check 5: /api/admin/knowledge-status ─────────────────────────────────────
+log "Check 5: GET ${BASE_URL}/api/admin/knowledge-status..."
+if [[ -z "${ADMIN_TOKEN:-}" ]]; then
+  log "  SKIP: ADMIN_TOKEN not set — skipping knowledge-status check"
+else
+  HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+    -H "X-Admin-Token: ${ADMIN_TOKEN}" \
+    "${BASE_URL}/api/admin/knowledge-status" 2>/dev/null || true)"
+  HTTP_CODE="${HTTP_CODE:-000}"
+  if [[ "$HTTP_CODE" != "200" ]]; then
+    fail "/api/admin/knowledge-status returned HTTP ${HTTP_CODE} (expected 200) — check ADMIN_TOKEN in ${ENV_FILE}"
+  fi
+  log "  /api/admin/knowledge-status -> HTTP 200"
+fi
+
+log "All checks passed — deploy is healthy."


### PR DESCRIPTION
## Summary

- **`scripts/ops/verify-deploy.sh`** (new, exec'able) — 5-check post-deploy health script for VPS, called from `/root/deploy-quantika-demo.sh` after pm2 restart:
  1. `schema_migrations MAX(version)` matches `lib/migrations/[0-9][0-9][0-9]-*.ts` file count
  2. `fx_rates COUNT(*) > 0` (seed guard — directs to `post-deploy-seed.sh` on failure)
  3. `DATABASE_URL`, `AI_PROVIDER`, `AUTH_SECRET` present (checked via `test -n`, values never printed)
  4. `GET /api/health → 200`
  5. `GET /api/admin/knowledge-status` with `X-Admin-Token → 200` (skipped if `ADMIN_TOKEN` unset)
- **`.github/workflows/deploy.yml`** — adds `Post-deploy verify (HTTP health)` step that runs checks 4-5 from CI against `https://demo.quantika.org` using `secrets.ADMIN_TOKEN`. DB/env checks (1-3) cannot run from CI due to forced-command SSH constraint (documented in comment matching existing seed-guard pattern).

## Test plan

- [ ] `bash -n scripts/ops/verify-deploy.sh` passes (verified locally)
- [ ] Dry-run with fake DB/env: all 5 failure paths produce correct messages and exit 1
- [ ] Dry-run with real migrations dir + test SQLite: checks 1-2 pass, check 3 fails on missing env vars correctly
- [ ] VPS integration: add `bash ${APP_DIR}/scripts/ops/verify-deploy.sh` call to `/root/deploy-quantika-demo.sh` after pm2 restart step
- [ ] Add `ADMIN_TOKEN` as GitHub Actions secret if not already present (for check 5 in CI step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)