### PR TITLE
fix(auth): F7 /processing 403 → 200 for demo_auth-only users [code-only]

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -142,4 +142,26 @@ describe('middleware auth guard', () => {
       expect(res.headers.get('location')).toContain('/login');
     });
   });
+
+  describe('/processing guard — csrf_token required', () => {
+    it('redirects demo_auth user to / when no csrf_token cookie', async () => {
+      const cookie = await makeValidCookie();
+      const req = makeReq('/processing', cookie);
+      const res = await runMiddleware(req);
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toBe('http://localhost/');
+    });
+
+    it('passes /processing when demo_auth and csrf_token are both present', async () => {
+      const cookie = await makeValidCookie();
+      const csrfToken = 'a'.repeat(64);
+      const req = new NextRequest('http://localhost/processing', {
+        headers: { cookie: `demo_auth=${cookie}; csrf_token=${csrfToken}` },
+      });
+      const res = await runMiddleware(req);
+      expect(res.status).not.toBe(302);
+      expect(res.status).not.toBe(403);
+    });
+  });
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -72,6 +72,13 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
       const loginUrl = new URL('/login', getRequestBaseUrl(request));
       return NextResponse.redirect(loginUrl, { status: 302 });
     }
+
+    // /processing requires a csrf_token cookie (set by Google OAuth or /api/sample).
+    // Demo-auth-only users navigating here directly have no session or CSRF token,
+    // so the pipeline would immediately 403 on all API calls. Redirect to upload CTA instead.
+    if (pathname === '/processing' && !request.cookies.get('csrf_token')?.value) {
+      return NextResponse.redirect(new URL('/', getRequestBaseUrl(request)), { status: 302 });
+    }
   }
 
   // ── CSRF + Rate-limit guard (existing logic, untouched) ───────────────────


### PR DESCRIPTION
## Summary

- Demo users logging in via password get only `demo_auth` cookie (no `session_id` or `csrf_token`)
- Navigating directly to `/processing` caused middleware CSRF check to 403 every pipeline API call (`/api/emails/fetch`, `/api/ai/*`)
- Fix: add guard in middleware — if `/processing` requested with valid `demo_auth` but no `csrf_token`, redirect 302 → `/` (shows `EmailUploadCTA`)
- Users then click \"Try with Sample Data\" → `/api/sample` sets `session_id` + `csrf_token` → redirects back to `/processing` — pipeline works

## curl before / after

**Before** (403 on pipeline API call):
\`\`\`bash
# Login to get demo_auth cookie
curl -c cookies.txt -X POST http://localhost:3000/api/auth/login \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'user=admin&password=secret'

# POST to first pipeline step — CSRF check fails
curl -b cookies.txt -X POST http://localhost:3000/api/emails/fetch -i
# → HTTP/1.1 403  {"error":"Invalid or missing CSRF token"}
\`\`\`

**After** (302 redirect to upload CTA instead of 403):
\`\`\`bash
# GET /processing with demo_auth but no csrf_token
curl -b cookies.txt -L -i http://localhost:3000/processing
# → HTTP/1.1 302  Location: http://localhost:3000/
# → User sees EmailUploadCTA with "Try with Sample Data" button
\`\`\`

## Files changed

- `middleware.ts` — add `/processing` guard inside `authConfig.enabled` block
- `__tests__/middleware-auth.test.ts` — 2 new behavioral tests for `/processing guard`

## Test plan

- [x] `npm test -- --testPathPatterns=middleware-auth` → 24/24 green (was 22)
- [x] Full test suite → 6433/6460 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)