### PR TITLE
feat(cron): C5 fx_rates daily refresh from frankfurter.app [deploy-affects]

### DIFF
--- a/ops/systemd/quantika-fx-rates-refresh.service
+++ b/ops/systemd/quantika-fx-rates-refresh.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Quantika FX rates daily refresh from frankfurter.app
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=quantika
+Group=quantika
+WorkingDirectory=/opt/quantika
+ExecStart=/usr/bin/node /opt/quantika/scripts/knowledge/cron/refresh-fx-rates.js
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=quantika-fx-rates
+TimeoutStartSec=5min
+EnvironmentFile=/opt/quantika/.env.production
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/quantika
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/quantika-fx-rates-refresh.timer
+++ b/ops/systemd/quantika-fx-rates-refresh.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily Quantika FX rates refresh
+Requires=quantika-fx-rates-refresh.service
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+RandomizedDelaySec=5min
+Persistent=true
+Unit=quantika-fx-rates-refresh.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Add systemd timer + service for daily fx_rates refresh (03:00 UTC, RandomizedDelaySec=5min)
- Pulls EUR-base FX rates from frankfurter.app (ECB) and upserts into fx_rates table
- Closes C5 gap: fx_rates=0 on prod while MULTI_CURRENCY_V2_ENABLED=true
- Reuses existing infra: fx-rates slug already in KNOWN_SLUGS, refresh-fx-rates.ts already present

## Files
- ops/systemd/quantika-fx-rates-refresh.timer (OnCalendar=03:00:00 UTC)
- ops/systemd/quantika-fx-rates-refresh.service (User=quantika, security hardening from sanctions service)

## Test plan
- [x] Unit tests 4/4 green (refresh-fx-rates.test.ts)
- [ ] Post-deploy on outreach-vps: systemctl enable --now quantika-fx-rates-refresh.timer
- [ ] Verify fx_rates row count > 0 after first cron tick

Dispatched by orchestrator-day (disp-20260521-215907-34a246)