### PR TITLE
fix(ops): C5 fx-rates service — User=root + npx tsx pattern to match prod [deploy-affects]

### DIFF
--- a/ops/systemd/quantika-fx-rates-refresh.service
+++ b/ops/systemd/quantika-fx-rates-refresh.service
@@ -5,21 +5,13 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=quantika
-Group=quantika
-WorkingDirectory=/opt/quantika
-ExecStart=/usr/bin/node /opt/quantika/scripts/knowledge/cron/refresh-fx-rates.js
+User=root
+WorkingDirectory=/root/quantika-demo
+ExecStart=/usr/bin/npx tsx --env-file=.env.local scripts/knowledge/cron/refresh-fx-rates.ts
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=quantika-fx-rates
 TimeoutStartSec=5min
-EnvironmentFile=/opt/quantika/.env.production
-
-NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/opt/quantika
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- `User=quantika` → `User=root` (no `quantika` user on outreach-vps)
- `WorkingDirectory=/opt/quantika` → `/root/quantika-demo`
- `ExecStart` changed from `node .js` to `npx tsx --env-file=.env.local .ts` — matches bunker/sanctions prod pattern
- Removed `EnvironmentFile`, `Group=quantika`, and systemd hardening directives (`NoNewPrivileges`, `PrivateTmp`, `ProtectSystem`, `ProtectHome`, `ReadWritePaths`) — incompatible with root + this deploy pattern
- Timer `OnCalendar=*-*-* 03:00:00 UTC` unchanged — correct for daily FX rates refresh

## Test plan
- [ ] After deploy: `systemctl status quantika-fx-rates-refresh.service` shows no errors
- [ ] `journalctl -u quantika-fx-rates-refresh.service` shows successful run at 03:00 UTC
- [ ] `grep "User=root" /etc/systemd/system/quantika-fx-rates-refresh.service` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)