### PR TITLE
test(coverage): broker-trust tests for 13 untested routes [code-only]

### DIFF
--- a/__tests__/api/agent-execute.test.ts
+++ b/__tests__/api/agent-execute.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for POST /api/agent/execute
+ *
+ * Tests session guard, planId mismatch validation, empty approvedStepIds,
+ * and idempotency: same planId+approved set returns cached result.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+import { requireSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+
+function makePlan(planId: string) {
+  return {
+    planId,
+    goal: 'test goal',
+    steps: [],
+    estimated_actions: 0,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/agent/execute', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/agent/execute', () => {
+  beforeEach(() => {
+    mockRequireSession.mockReset();
+    mockRequireSession.mockReturnValue({ session: {}, sessionId: 'sid' });
+  });
+
+  it('returns 401 when no session', async () => {
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const planId = randomUUID();
+    const res = await POST(makeReq({ planId, plan: makePlan(planId), approvedStepIds: [] }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/agent/execute', {
+      method: 'POST',
+      body: 'not json',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when planId does not match plan.planId', async () => {
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const res = await POST(makeReq({
+      planId: 'plan-A',
+      plan: makePlan('plan-B'),
+      approvedStepIds: [],
+    }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('planId_mismatch');
+  });
+
+  it('returns 200 with ExecutionResult for valid empty plan', async () => {
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const planId = randomUUID();
+    const res = await POST(makeReq({
+      planId,
+      plan: makePlan(planId),
+      approvedStepIds: [],
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.planId).toBe(planId);
+    expect(Array.isArray(json.stepResults)).toBe(true);
+    expect(typeof json.completedAt).toBe('string');
+  });
+
+  it('returns same cached result for identical planId + approvedStepIds (idempotency)', async () => {
+    const { POST } = await import('@/app/api/agent/execute/route');
+    const planId = randomUUID();
+    const body = { planId, plan: makePlan(planId), approvedStepIds: [] };
+    const res1 = await POST(makeReq(body));
+    const res2 = await POST(makeReq(body));
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    const json1 = await res1.json();
+    const json2 = await res2.json();
+    expect(json1.completedAt).toBe(json2.completedAt);
+  });
+});

--- a/__tests__/api/agent-plan.test.ts
+++ b/__tests__/api/agent-plan.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for POST /api/agent/plan
+ *
+ * Validates session guard, goal validation, and plan shape from
+ * the deterministic rule-based planner (AGENT_PLANNER_PROVIDER=regex).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+import { requireSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/agent/plan', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/agent/plan', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...origEnv, AGENT_PLANNER_PROVIDER: 'regex' };
+    mockRequireSession.mockReset();
+    mockRequireSession.mockReturnValue({ session: {}, sessionId: 'sid' });
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('returns 401 when no session', async () => {
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const res = await POST(makeReq({ goal: 'send email' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/agent/plan', {
+      method: 'POST',
+      body: 'not json',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for empty goal string', async () => {
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const res = await POST(makeReq({ goal: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when goal field is missing', async () => {
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const res = await POST(makeReq({ context: {} }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with plan containing planId, goal, steps array', async () => {
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const res = await POST(makeReq({ goal: 'send shipping quote' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.planId).toBe('string');
+    expect(json.goal).toBe('send shipping quote');
+    expect(Array.isArray(json.steps)).toBe(true);
+    expect(typeof json.estimated_actions).toBe('number');
+    expect(typeof json.createdAt).toBe('string');
+  });
+
+  it('plan steps each have required fields (id, kind, description)', async () => {
+    const { POST } = await import('@/app/api/agent/plan/route');
+    const res = await POST(makeReq({ goal: 'check sanctions and send quote' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    for (const step of json.steps) {
+      expect(typeof step.id).toBe('string');
+      expect(typeof step.kind).toBe('string');
+      expect(typeof step.description).toBe('string');
+      expect(typeof step.requires_approval).toBe('boolean');
+    }
+  });
+});

--- a/__tests__/api/auth-login.test.ts
+++ b/__tests__/api/auth-login.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for POST /api/auth/login
+ *
+ * Timing-safe credential check, redirect on success/failure.
+ * Tests verify behavioral contract without touching the cookie-signing internals.
+ */
+import { NextRequest } from 'next/server';
+
+describe('POST /api/auth/login', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...origEnv,
+      DEMO_AUTH_USER: 'testuser',
+      DEMO_AUTH_PASSWORD: 'testpass',
+      DEMO_AUTH_SECRET: 'testsecret1234567890',
+      DEMO_AUTH_COOKIE_DAYS: '7',
+      NODE_ENV: 'test',
+    };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  function makeJsonReq(body: Record<string, string>): NextRequest {
+    return new NextRequest('http://localhost/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  function makeFormReq(body: Record<string, string>): NextRequest {
+    return new NextRequest('http://localhost/api/auth/login', {
+      method: 'POST',
+      body: new URLSearchParams(body).toString(),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+  }
+
+  it('redirects to /login?error=1 on wrong password (JSON)', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeJsonReq({ user: 'testuser', password: 'wrong' }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toMatch(/\/login\?error=1/);
+  });
+
+  it('redirects to /login?error=1 on wrong user (JSON)', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeJsonReq({ user: 'wronguser', password: 'testpass' }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toMatch(/\/login\?error=1/);
+  });
+
+  it('redirects to /login?error=1 when password is empty', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeJsonReq({ user: 'testuser', password: '' }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toMatch(/\/login\?error=1/);
+  });
+
+  it('redirects to / and sets demo_auth cookie on correct credentials (JSON)', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeJsonReq({ user: 'testuser', password: 'testpass' }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toMatch(/\/$|^http:\/\/localhost\/$/);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('demo_auth=');
+    expect(setCookie).toContain('HttpOnly');
+  });
+
+  it('accepts form-encoded body and sets cookie on correct credentials', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeFormReq({ user: 'testuser', password: 'testpass' }));
+    expect(res.status).toBe(303);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('demo_auth=');
+  });
+
+  it('redirects to /login?error=1 on form body with wrong creds', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeFormReq({ user: 'testuser', password: 'bad' }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toMatch(/\/login\?error=1/);
+  });
+});

--- a/__tests__/api/counterparty.test.ts
+++ b/__tests__/api/counterparty.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for POST /api/ai/counterparty
+ *
+ * Groups session emails by sender domain using real groupByCounterparty logic.
+ * Verifies the route produces real groupings from session data, not hardcoded values.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+  updateSession: jest.fn(),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn(() => true),
+}));
+
+import { requireSession, updateSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+const mockUpdateSession = updateSession as jest.Mock;
+
+function makeReq(): NextRequest {
+  return new NextRequest('http://localhost/api/ai/counterparty', { method: 'POST' });
+}
+
+describe('POST /api/ai/counterparty', () => {
+  beforeEach(() => {
+    mockRequireSession.mockReset();
+    mockUpdateSession.mockReset();
+  });
+
+  it('returns 401 when no session', async () => {
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/ai/counterparty/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when CSRF fails', async () => {
+    const { validateCsrf } = await import('@/lib/csrf');
+    (validateCsrf as jest.Mock).mockReturnValueOnce(false);
+    mockRequireSession.mockReturnValue({ session: { emails: [], classifications: [] }, sessionId: 'sid' });
+    const { POST } = await import('@/app/api/ai/counterparty/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 with count 0 for empty session', async () => {
+    mockRequireSession.mockReturnValue({
+      sessionId: 'sid',
+      session: { emails: [], classifications: [] },
+    });
+    const { POST } = await import('@/app/api/ai/counterparty/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.count).toBe(0);
+  });
+
+  it('groups emails by domain and returns correct count', async () => {
+    const emails = [
+      { id: 'e1', from: 'alice@acme.com', fromName: 'Alice', fromEmail: 'alice@acme.com', snippet: '', body: '', subject: '', date: '' },
+      { id: 'e2', from: 'bob@acme.com', fromName: 'Bob', fromEmail: 'bob@acme.com', snippet: '', body: '', subject: '', date: '' },
+      { id: 'e3', from: 'carol@beta.org', fromName: 'Carol', fromEmail: 'carol@beta.org', snippet: '', body: '', subject: '', date: '' },
+    ];
+    mockRequireSession.mockReturnValue({
+      sessionId: 'sid',
+      session: { emails, classifications: [] },
+    });
+    const { POST } = await import('@/app/api/ai/counterparty/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // 3 emails from 2 domains → 2 counterparties
+    expect(json.count).toBe(2);
+    // updateSession was called with the counterparties
+    expect(mockUpdateSession).toHaveBeenCalledWith('sid', expect.objectContaining({
+      counterparties: expect.arrayContaining([
+        expect.objectContaining({ emailDomain: 'acme.com', emailCount: 2 }),
+        expect.objectContaining({ emailDomain: 'beta.org', emailCount: 1 }),
+      ]),
+    }));
+  });
+});

--- a/__tests__/api/draft-reply.test.ts
+++ b/__tests__/api/draft-reply.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for POST /api/ai/draft-reply
+ *
+ * Two union shapes: emailId (missing info follow-up) and pendingItems.
+ * LLM call mocked. Tests verify routing, CSRF, session guard, and
+ * validation without touching prod logic.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn(() => true),
+}));
+
+jest.mock('@/lib/ai-provider', () => ({
+  callAiText: jest.fn(async () => 'Dear Client,\n\nPlease provide missing details.\n\nBest regards'),
+}));
+
+import { requireSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+
+const MOCK_SESSION = {
+  emails: [
+    {
+      id: 'e1',
+      from: 'alice@acme.com',
+      fromName: 'Alice',
+      fromEmail: 'alice@acme.com',
+      subject: 'Cargo inquiry',
+      body: '',
+      snippet: '',
+      date: '2026-05-01',
+    },
+  ],
+  parsedCargos: [
+    {
+      emailId: 'e1',
+      itemIndex: 0,
+      missingInfo: ['weight', 'laycan'],
+    },
+  ],
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/ai/draft-reply', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/ai/draft-reply', () => {
+  beforeEach(() => {
+    mockRequireSession.mockReset();
+    mockRequireSession.mockReturnValue({ session: MOCK_SESSION, sessionId: 'sid' });
+  });
+
+  it('returns 403 when CSRF fails', async () => {
+    const { validateCsrf } = await import('@/lib/csrf');
+    (validateCsrf as jest.Mock).mockReturnValueOnce(false);
+    const { POST } = await import('@/app/api/ai/draft-reply/route');
+    const res = await POST(makeReq({ emailId: 'e1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no session', async () => {
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/ai/draft-reply/route');
+    const res = await POST(makeReq({ emailId: 'e1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for empty body (neither emailId nor pendingItems)', async () => {
+    const { POST } = await import('@/app/api/ai/draft-reply/route');
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with draft text when emailId is provided', async () => {
+    const { POST } = await import('@/app/api/ai/draft-reply/route');
+    const res = await POST(makeReq({ emailId: 'e1' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.draft).toBe('string');
+    expect(json.draft.length).toBeGreaterThan(0);
+  });
+
+  it('returns 200 with draft text when pendingItems is provided', async () => {
+    const { POST } = await import('@/app/api/ai/draft-reply/route');
+    const res = await POST(makeReq({
+      pendingItems: [
+        { field: 'freight_rate', status: 'pending' },
+        { field: 'laycan', status: 'pending' },
+      ],
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.draft).toBe('string');
+  });
+});

--- a/__tests__/api/emails-fetch.test.ts
+++ b/__tests__/api/emails-fetch.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for POST /api/emails/fetch
+ *
+ * Broker trust focus: verifies the sample-data bypass returns the
+ * pre-loaded emails without hitting Gmail API, and that missing/expired
+ * sessions are properly rejected.
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  getSession: jest.fn(),
+  updateSession: jest.fn(),
+}));
+
+jest.mock('@/lib/email-cache', () => ({
+  upsertEmails: jest.fn(),
+}));
+
+jest.mock('@/lib/google', () => ({
+  fetchGmailEmails: jest.fn(async () => []),
+}));
+
+import { getSession, updateSession } from '@/lib/session';
+const mockGetSession = getSession as jest.Mock;
+const mockUpdateSession = updateSession as jest.Mock;
+
+function makeReq(sessionId?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (sessionId) headers['cookie'] = `session_id=${sessionId}`;
+  return new NextRequest('http://localhost/api/emails/fetch', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('POST /api/emails/fetch', () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+    mockUpdateSession.mockReset();
+  });
+
+  it('returns 401 when no session_id cookie', async () => {
+    const { POST } = await import('@/app/api/emails/fetch/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe('No session');
+  });
+
+  it('returns 401 when session is expired (getSession returns null)', async () => {
+    mockGetSession.mockReturnValue(null);
+    const { POST } = await import('@/app/api/emails/fetch/route');
+    const res = await POST(makeReq('expired-sid'));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe('Session expired');
+  });
+
+  it('returns 200 with email count for sample data session (bypasses Gmail)', async () => {
+    const sampleEmails = [
+      { id: 'e1', from: 'test@test.com', subject: 'Test', body: '', snippet: '', date: '' },
+      { id: 'e2', from: 'test2@test.com', subject: 'Test2', body: '', snippet: '', date: '' },
+    ];
+    mockGetSession.mockReturnValue({
+      isSampleData: true,
+      emails: sampleEmails,
+      accessToken: 'token',
+      accountId: null,
+    });
+    const { POST } = await import('@/app/api/emails/fetch/route');
+    const res = await POST(makeReq('sample-sid'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.count).toBe(2);
+    expect(json.message).toMatch(/Sample data/i);
+    // Gmail fetch must NOT be called for sample sessions
+    const { fetchGmailEmails } = await import('@/lib/google');
+    expect(fetchGmailEmails).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/explain-deal.test.ts
+++ b/__tests__/api/explain-deal.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for POST /api/ai/explain-deal
+ *
+ * Feature flag EXPLAIN_DEAL_ENABLED. Tests: flag off → 403,
+ * missing session → 401, invalid body → 400, match not found → 404.
+ * The LLM call is mocked so tests stay hermetic.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn(() => true),
+}));
+
+jest.mock('@/lib/ai-provider', () => ({
+  callAiText: jest.fn(async () =>
+    'Market Context\nSolid demand.\nDeal Rationale\nGood fit.\nKey Risks\nNone.\nRecommended Next Steps\nProceed.',
+  ),
+}));
+
+import { requireSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+
+const MOCK_SESSION = {
+  matches: [
+    {
+      cargoEmailId: 'e1',
+      cargoItemIndex: 0,
+      vesselEmailId: 'v1',
+      vesselItemIndex: 0,
+      score: 85,
+      matchLevel: 'good',
+      matchReasons: ['size ok'],
+      issues: [],
+      economics: null,
+      scoreBreakdown: null,
+    },
+  ],
+  parsedCargos: [],
+  parsedVessels: [],
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/ai/explain-deal', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/ai/explain-deal', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...origEnv, EXPLAIN_DEAL_ENABLED: 'false' };
+    mockRequireSession.mockReset();
+    mockRequireSession.mockReturnValue({ session: MOCK_SESSION, sessionId: 'sid' });
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('returns 403 (feature_disabled) when flag is off', async () => {
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ matchIndex: 0, language: 'en' }));
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe('feature_disabled');
+  });
+
+  it('returns 403 when CSRF fails', async () => {
+    const { validateCsrf } = await import('@/lib/csrf');
+    (validateCsrf as jest.Mock).mockReturnValueOnce(false);
+    process.env.EXPLAIN_DEAL_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ matchIndex: 0, language: 'en' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no session', async () => {
+    process.env.EXPLAIN_DEAL_ENABLED = 'true';
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ matchIndex: 0, language: 'en' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid request body (missing matchIndex)', async () => {
+    process.env.EXPLAIN_DEAL_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ language: 'en' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid language value', async () => {
+    process.env.EXPLAIN_DEAL_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ matchIndex: 0, language: 'fr' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when matchIndex out of range', async () => {
+    process.env.EXPLAIN_DEAL_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ matchIndex: 99, language: 'en' }));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe('Match not found');
+  });
+
+  it('returns 200 with 4-section narrative when flag is enabled and match exists', async () => {
+    process.env.EXPLAIN_DEAL_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/explain-deal/route');
+    const res = await POST(makeReq({ matchIndex: 0, language: 'en' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.language).toBe('en');
+    expect(Array.isArray(json.sections)).toBe(true);
+    expect(json.sections).toHaveLength(4);
+    expect(json.sections[0].heading).toBe('Market Context');
+    expect(typeof json.sections[0].content).toBe('string');
+  });
+});

--- a/__tests__/api/generate-route-map.test.ts
+++ b/__tests__/api/generate-route-map.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for POST /api/ai/generate-route-map
+ *
+ * Feature flag guarded. Tests: flag off → 404, input validation (422),
+ * rate limit enforcement (SQLite, real DB logic), and port name injection guard.
+ */
+import Database from 'better-sqlite3';
+import { NextRequest, NextResponse } from 'next/server';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn(() => true),
+}));
+
+import { requireSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/ai/generate-route-map', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const VALID_BODY = {
+  matchId: 'match-001',
+  loading_port: 'Rotterdam',
+  discharge_port: 'Singapore',
+};
+
+describe('POST /api/ai/generate-route-map', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...origEnv, ROUTE_MAP_ENABLED: 'false' };
+    testDb = new Database(':memory:');
+    mockRequireSession.mockReset();
+    mockRequireSession.mockReturnValue({
+      sessionId: 'sess-123',
+      session: {},
+    });
+  });
+
+  afterEach(() => {
+    testDb.close();
+    process.env = origEnv;
+  });
+
+  it('returns 403 when CSRF fails', async () => {
+    const { validateCsrf } = await import('@/lib/csrf');
+    (validateCsrf as jest.Mock).mockReturnValueOnce(false);
+    const { POST } = await import('@/app/api/ai/generate-route-map/route');
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when session is missing', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/ai/generate-route-map/route');
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when feature flag is off', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'false';
+    const { POST } = await import('@/app/api/ai/generate-route-map/route');
+    const res = await POST(makeReq(VALID_BODY));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/disabled/i);
+  });
+
+  it('returns 422 for invalid port name (special chars)', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/generate-route-map/route');
+    const res = await POST(makeReq({
+      ...VALID_BODY,
+      loading_port: '<script>alert(1)</script>',
+    }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid request');
+    expect(Array.isArray(json.fields)).toBe(true);
+  });
+
+  it('returns 422 for port name that exceeds 50 chars', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/generate-route-map/route');
+    const res = await POST(makeReq({
+      ...VALID_BODY,
+      loading_port: 'A'.repeat(51),
+    }));
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for missing required field loading_port', async () => {
+    process.env.ROUTE_MAP_ENABLED = 'true';
+    const { POST } = await import('@/app/api/ai/generate-route-map/route');
+    const { loading_port: _, ...bodyWithoutPort } = VALID_BODY;
+    const res = await POST(makeReq(bodyWithoutPort));
+    expect(res.status).toBe(422);
+  });
+
+  it('checkRateLimit returns true (allow) when no prior entry in DB', async () => {
+    const { checkRateLimit } = await import('@/app/api/ai/generate-route-map/route');
+    expect(checkRateLimit('sess-x:match-new')).toBe(true);
+  });
+
+  it('checkRateLimit returns false (deny) after rate limit is recorded', async () => {
+    const { checkRateLimit, recordRateLimit } = await import('@/app/api/ai/generate-route-map/route');
+    const key = 'sess-y:match-rate';
+    expect(checkRateLimit(key)).toBe(true);
+    recordRateLimit(key);
+    expect(checkRateLimit(key)).toBe(false);
+  });
+
+  it('buildRouteMapPrompt includes port names in output', async () => {
+    const { buildRouteMapPrompt } = await import('@/app/api/ai/generate-route-map/route');
+    const prompt = buildRouteMapPrompt({
+      matchId: 'test',
+      loading_port: 'Hamburg',
+      discharge_port: 'Piraeus',
+    });
+    expect(prompt).toContain('Hamburg');
+    expect(prompt).toContain('Piraeus');
+  });
+});

--- a/__tests__/api/parse-recap.test.ts
+++ b/__tests__/api/parse-recap.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for POST /api/ai/parse-recap
+ *
+ * Session-scoped fixture recap parser. Tests: CSRF, session guard,
+ * and the early-return when no fixture recaps exist in session.
+ * LLM call is mocked — focus is on route plumbing, not LLM output.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+  updateSession: jest.fn(),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn(() => true),
+}));
+
+jest.mock('@/lib/ai-provider', () => ({
+  callAiText: jest.fn(async () => '[]'),
+}));
+
+jest.mock('@/lib/email-cache', () => ({
+  getCachedParses: jest.fn(() => new Map()),
+  saveParsedResults: jest.fn(),
+  hashParserVersion: jest.fn(() => 'v1'),
+}));
+
+import { requireSession, updateSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+const mockUpdateSession = updateSession as jest.Mock;
+
+function makeReq(): NextRequest {
+  return new NextRequest('http://localhost/api/ai/parse-recap', { method: 'POST' });
+}
+
+describe('POST /api/ai/parse-recap', () => {
+  beforeEach(() => {
+    mockRequireSession.mockReset();
+    mockUpdateSession.mockReset();
+    mockRequireSession.mockReturnValue({
+      sessionId: 'sid',
+      session: {
+        emails: [],
+        classifications: [],
+        accountId: null,
+      },
+    });
+  });
+
+  it('returns 403 when CSRF fails', async () => {
+    const { validateCsrf } = await import('@/lib/csrf');
+    (validateCsrf as jest.Mock).mockReturnValueOnce(false);
+    const { POST } = await import('@/app/api/ai/parse-recap/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no session', async () => {
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/ai/parse-recap/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with count=0 when no FIXTURE_RECAP emails in session', async () => {
+    // No classifications → no fixture recaps to parse
+    mockRequireSession.mockReturnValue({
+      sessionId: 'sid',
+      session: {
+        emails: [{ id: 'e1', from: 'test@test.com', subject: 'hi', body: '', snippet: '', date: '' }],
+        classifications: [{ emailId: 'e1', category: 'CARGO_INQUIRY' }],
+        accountId: null,
+      },
+    });
+    const { POST } = await import('@/app/api/ai/parse-recap/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.count).toBe(0);
+    // Must update session even when empty
+    expect(mockUpdateSession).toHaveBeenCalledWith('sid', expect.objectContaining({
+      parsedFixtureRecaps: [],
+      commissionSummary: null,
+    }));
+  });
+});

--- a/__tests__/api/pipedrive-oauth.test.ts
+++ b/__tests__/api/pipedrive-oauth.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for GET /api/integrations/pipedrive/oauth
+ *
+ * Two flows: ?action=init (redirect to Pipedrive) and callback (?code=...&state=...).
+ * CSRF state cookie must match query param on callback.
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/integrations/pipedrive/tokens', () => ({
+  saveTokens: jest.fn(),
+}));
+
+function makeReq(searchParams: Record<string, string>, cookieState?: string): NextRequest {
+  const url = new URL('http://localhost/api/integrations/pipedrive/oauth');
+  for (const [k, v] of Object.entries(searchParams)) {
+    url.searchParams.set(k, v);
+  }
+  const headers: Record<string, string> = {};
+  if (cookieState) {
+    headers['cookie'] = `pipedrive_oauth_state=${cookieState}`;
+  }
+  return new NextRequest(url.toString(), { headers });
+}
+
+describe('GET /api/integrations/pipedrive/oauth', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...origEnv,
+      PIPEDRIVE_CLIENT_ID: 'test-client-id',
+      PIPEDRIVE_CLIENT_SECRET: 'test-client-secret',
+      PIPEDRIVE_REDIRECT_URI: 'http://localhost/api/integrations/pipedrive/oauth',
+    };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+    jest.clearAllMocks();
+  });
+
+  it('returns 500 when PIPEDRIVE_CLIENT_ID is not configured on init', async () => {
+    delete process.env.PIPEDRIVE_CLIENT_ID;
+    const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+    const res = await GET(makeReq({ action: 'init' }));
+    expect(res.status).toBe(500);
+  });
+
+  it('redirects to Pipedrive OAuth URL on action=init', async () => {
+    const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+    const res = await GET(makeReq({ action: 'init' }));
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain('oauth.pipedrive.com');
+    expect(location).toContain('client_id=test-client-id');
+  });
+
+  it('sets pipedrive_oauth_state cookie on init', async () => {
+    const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+    const res = await GET(makeReq({ action: 'init' }));
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('pipedrive_oauth_state=');
+    expect(setCookie).toContain('HttpOnly');
+  });
+
+  it('returns 400 when callback state does not match cookie', async () => {
+    const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+    const res = await GET(makeReq(
+      { code: 'auth-code', state: 'wrong-state' },
+      'correct-state',
+    ));
+    expect(res.status).toBe(400);
+    const json = JSON.parse(await res.text());
+    expect(json.error).toMatch(/CSRF/i);
+  });
+
+  it('returns 400 when callback has no state cookie', async () => {
+    const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+    const res = await GET(makeReq({ code: 'auth-code', state: 'some-state' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for request with no params', async () => {
+    const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+    const res = await GET(makeReq({}));
+    // No action, no code, no state → falls through to ?action=init path or invalid
+    // The implementation redirects to Pipedrive on missing code+state, treat as redirect or 500
+    // Either is acceptable — just not 200 with empty body
+    expect([302, 400, 500]).toContain(res.status);
+  });
+});

--- a/__tests__/api/pipedrive-webhook.test.ts
+++ b/__tests__/api/pipedrive-webhook.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for POST /api/integrations/pipedrive/webhook
+ *
+ * HMAC-SHA256 signature verification. Tests verify real security logic:
+ * missing secret → 500, empty body → 400, missing/wrong sig → 401,
+ * valid HMAC → 200 OK.
+ */
+import Database from 'better-sqlite3';
+import { createHmac } from 'crypto';
+import { NextRequest } from 'next/server';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+jest.mock('@/lib/notifications', () => ({
+  writeNotification: jest.fn(),
+}));
+
+function computeSig(body: string, secret: string): string {
+  return createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+}
+
+function makeReq(body: string, sig?: string): NextRequest {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (sig !== undefined) headers['x-pipedrive-signature'] = sig;
+  return new NextRequest('http://localhost/api/integrations/pipedrive/webhook', {
+    method: 'POST',
+    body,
+    headers,
+  });
+}
+
+describe('POST /api/integrations/pipedrive/webhook', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv, PIPEDRIVE_WEBHOOK_SECRET: 'test-secret' };
+    testDb = new Database(':memory:');
+    // Ensure notifications table exists
+    testDb.exec(`CREATE TABLE IF NOT EXISTS notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT,
+      event TEXT,
+      payload TEXT,
+      created_at INTEGER DEFAULT (strftime('%s','now'))
+    )`);
+  });
+
+  afterEach(() => {
+    testDb.close();
+    process.env = origEnv;
+  });
+
+  it('returns 500 when PIPEDRIVE_WEBHOOK_SECRET is not set', async () => {
+    delete process.env.PIPEDRIVE_WEBHOOK_SECRET;
+    const { POST } = await import('@/app/api/integrations/pipedrive/webhook/route');
+    const body = JSON.stringify({ event: 'deal.added' });
+    const res = await POST(makeReq(body));
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 400 for empty body', async () => {
+    const { POST } = await import('@/app/api/integrations/pipedrive/webhook/route');
+    const res = await POST(makeReq(''));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when signature header is missing', async () => {
+    const { POST } = await import('@/app/api/integrations/pipedrive/webhook/route');
+    const body = JSON.stringify({ event: 'deal.added' });
+    const res = await POST(makeReq(body)); // no sig
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for wrong HMAC signature', async () => {
+    const { POST } = await import('@/app/api/integrations/pipedrive/webhook/route');
+    const body = JSON.stringify({ event: 'deal.added' });
+    const res = await POST(makeReq(body, 'deadbeef'.repeat(8)));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 for valid HMAC signature', async () => {
+    const { POST } = await import('@/app/api/integrations/pipedrive/webhook/route');
+    const body = JSON.stringify({ event: 'deal.added', meta: { action: 'added', object: 'deal' } });
+    const sig = computeSig(body, 'test-secret');
+    const res = await POST(makeReq(body, sig));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 even when JSON is malformed (acknowledge receipt to stop retries)', async () => {
+    const { POST } = await import('@/app/api/integrations/pipedrive/webhook/route');
+    const body = 'not-json';
+    const sig = computeSig(body, 'test-secret');
+    const res = await POST(makeReq(body, sig));
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/sample-route.test.ts
+++ b/__tests__/api/sample-route.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for POST /api/sample
+ *
+ * Broker trust focus: verifies the sample route loads REAL sample data
+ * (not empty stubs) into the session, so a demo user sees actual cargo,
+ * vessel, and classification data immediately.
+ */
+import { NextRequest } from 'next/server';
+import { getSession } from '@/lib/session';
+
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: jest.fn(() => true),
+  generateCsrfToken: jest.fn(() => 'a'.repeat(64)),
+}));
+
+function makeReq(): NextRequest {
+  return new NextRequest('http://localhost/api/sample', { method: 'POST' });
+}
+
+describe('POST /api/sample', () => {
+
+  it('returns 403 when CSRF fails', async () => {
+    const { validateCsrf } = await import('@/lib/csrf');
+    (validateCsrf as jest.Mock).mockReturnValueOnce(false);
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    expect(res.status).toBe(403);
+  });
+
+  it('creates a session and redirects to /processing', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    // 303 redirect
+    expect(res.status).toBe(303);
+    const location = res.headers.get('location');
+    expect(location).toMatch(/\/processing$/);
+  });
+
+  it('sets session_id and csrf_token cookies', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const all = cookies.join('; ');
+    expect(all).toContain('session_id=');
+    expect(all).toContain('csrf_token=');
+  });
+
+  it('session contains real sample emails (not empty)', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    // Extract session id from Set-Cookie header
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const sessionCookie = cookies.find((c: string) => c.includes('session_id='));
+    const sessionId = sessionCookie?.match(/session_id=([^;]+)/)?.[1];
+    expect(sessionId).toBeTruthy();
+
+    const session = getSession(sessionId!);
+    expect(session).not.toBeNull();
+    expect(session!.emails.length).toBeGreaterThan(0);
+    expect(session!.parsedCargos.length).toBeGreaterThan(0);
+  });
+
+  it('session is marked isSampleData=true', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const sessionCookie = cookies.find((c: string) => c.includes('session_id='));
+    const sessionId = sessionCookie?.match(/session_id=([^;]+)/)?.[1];
+    const session = getSession(sessionId!);
+    expect(session!.isSampleData).toBe(true);
+  });
+
+  it('session contains at least one guaranteed demo match', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const sessionCookie = cookies.find((c: string) => c.includes('session_id='));
+    const sessionId = sessionCookie?.match(/session_id=([^;]+)/)?.[1];
+    const session = getSession(sessionId!);
+    expect(session!.matches.length).toBeGreaterThan(0);
+    // Must have the guaranteed economics match
+    const hasEconomicsMatch = session!.matches.some(
+      (m) => m.cargoEmailId === 'demo-cargo-economics',
+    );
+    expect(hasEconomicsMatch).toBe(true);
+  });
+});

--- a/__tests__/api/vessel-imo.test.ts
+++ b/__tests__/api/vessel-imo.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for GET /api/vessel/[imo]
+ *
+ * Data source: vessel registry built from lib/sample-data/vessel-positions.json
+ * and lib/sample-data/imo/cii.json. Tests verify real data lookup, not hardcoded
+ * responses — broker trust focus.
+ */
+import { NextRequest } from 'next/server';
+
+function makeReq(imo: string): NextRequest {
+  return new NextRequest(`http://localhost/api/vessel/${imo}`);
+}
+
+describe('GET /api/vessel/[imo]', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns 400 for non-7-digit IMO', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    const res = await GET(makeReq('123'), { params: Promise.resolve({ imo: '123' }) });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/7 digits|invalid IMO/i);
+  });
+
+  it('returns 400 for alphabetic IMO', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    const res = await GET(makeReq('ABCDEFG'), { params: Promise.resolve({ imo: 'ABCDEFG' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown 7-digit IMO', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    const res = await GET(makeReq('0000000'), { params: Promise.resolve({ imo: '0000000' }) });
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/not found/i);
+  });
+
+  it('returns 200 with real vessel shape for known IMO from CII dataset', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    // 9200648 is in cii.json with rating A
+    const imo = '9200648';
+    const res = await GET(makeReq(imo), { params: Promise.resolve({ imo }) });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.imo).toBe(imo);
+    expect(typeof json.name).toBe('string');
+    expect(typeof json.chartering_policy_reject).toBe('boolean');
+  });
+
+  it('returns chartering_policy_reject=true for CII D-rated vessel', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    // 9322180 is in cii.json with rating D → must reject
+    const imo = '9322180';
+    const res = await GET(makeReq(imo), { params: Promise.resolve({ imo }) });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cii_rating).toBe('D');
+    expect(json.chartering_policy_reject).toBe(true);
+  });
+
+  it('returns chartering_policy_reject=false for CII A-rated vessel', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    // 9200648 is in cii.json with rating A → accept
+    const imo = '9200648';
+    const res = await GET(makeReq(imo), { params: Promise.resolve({ imo }) });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cii_rating).toBe('A');
+    expect(json.chartering_policy_reject).toBe(false);
+  });
+
+  it('returns chartering_policy_reject=true for CII E-rated vessel', async () => {
+    const { GET } = await import('@/app/api/vessel/[imo]/route');
+    // 9478999 is in cii.json with rating E → must reject
+    const imo = '9478999';
+    const res = await GET(makeReq(imo), { params: Promise.resolve({ imo }) });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cii_rating).toBe('E');
+    expect(json.chartering_policy_reject).toBe(true);
+  });
+});


### PR DESCRIPTION
73 behavioral tests across 13 new files in `__tests__/api/` (broker-trust focus: routes serve REAL data, not stubs).
- 73/73 green; full suite 6504 passing (2 pre-existing flaky in refresh-sanctions, pass in isolation)
- Data integrity: no bugs — all audited routes return real data
- Tests-only, additive. No prod code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)