### PR TITLE
fix(eca): parser polygon_geojson + data-integrity audit [code-only]

### DIFF
--- a/__tests__/lib/knowledge/eca/parser-adversarial.test.ts
+++ b/__tests__/lib/knowledge/eca/parser-adversarial.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Adversarial QA for lib/knowledge/eca/parser.ts
+ *
+ * Cold-start independent review — focus: polygon_geojson string path (PR #338 fix).
+ * Uses test.failing() to document bugs without breaking the suite.
+ *
+ * BUG-1 (Medium): coordinates non-array passes silently
+ *   Line 97 in parser.ts: the guard only fires for null/undefined or empty array.
+ *   Non-array truthy values (object `{}`, number `42`, string `"foo"`) bypass
+ *   the check and produce an EcaZone with corrupt polygon_geojson. The DB insert
+ *   succeeds; isPortInEca then silently skips the zone (adapter line 36: checks
+ *   `polygon.coordinates.length > 0` which is undefined for {}) → false negative
+ *   in ECA detection for the affected zone.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseMarpolEcaZones } from '@/lib/knowledge/eca/parser';
+import { isPortInEca, calculateEcaFuelPortion } from '@/lib/knowledge/eca/adapter';
+import type { EcaZone } from '@/lib/knowledge/eca/parser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function zoneYaml(overrides: {
+  name?: string;
+  region?: string;
+  fuel?: number;
+  from?: string;
+  polygon_geojson?: string;
+  polygon?: string;
+}): string {
+  const {
+    name = 'Test ECA',
+    region = 'test',
+    fuel = 0.10,
+    from = '2015-01-01',
+    polygon_geojson,
+    polygon,
+  } = overrides;
+
+  const polygonLine = polygon_geojson !== undefined
+    ? `    polygon_geojson: |\n      ${polygon_geojson}`
+    : polygon !== undefined
+    ? `    polygon:\n${polygon}`
+    : '';
+
+  return `zones:
+  - name: "${name}"
+    region: "${region}"
+    fuel_sulphur_max_pct: ${fuel}
+    effective_from: "${from}"
+${polygonLine}
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: polygon_geojson path — invalid JSON
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — polygon_geojson invalid JSON', () => {
+  it('throws on whitespace-only polygon_geojson (quoted YAML string, truthy but not JSON)', () => {
+    // Note: block literal `|` with whitespace-only content → YAML parses as ""
+    // Use quoted string to ensure the parser receives a non-empty whitespace string.
+    const yaml = `zones:
+  - name: "Test ECA"
+    region: "test"
+    fuel_sulphur_max_pct: 0.10
+    effective_from: "2015-01-01"
+    polygon_geojson: "   "
+`;
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/polygon_geojson is not valid JSON/i);
+  });
+
+  it('throws on arbitrary non-JSON string in polygon_geojson', () => {
+    const yaml = zoneYaml({ polygon_geojson: 'not-json-at-all' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/polygon_geojson is not valid JSON/i);
+  });
+
+  it('throws on truncated JSON in polygon_geojson', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":[[' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/polygon_geojson is not valid JSON/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: polygon_geojson path — missing / empty coordinates
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — polygon_geojson missing or empty coordinates', () => {
+  it('throws when polygon_geojson has no coordinates key', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon"}' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/empty or missing coordinates/i);
+  });
+
+  it('throws when polygon_geojson has coordinates: null', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":null}' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/empty or missing coordinates/i);
+  });
+
+  it('throws when polygon_geojson has coordinates: [] (empty outer ring)', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":[]}' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/empty or missing coordinates/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 3: BUG-1 — coordinates is non-array truthy value
+//
+// These tests encode the CORRECT expected behavior (parser should reject).
+// They are marked test.failing() because the current impl silently accepts
+// non-array coordinates — a confirmed bug.
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — BUG-1: non-array coordinates silently accepted', () => {
+  // BUG-1a: coordinates is an object {}
+  it('BUG-1a: throws when polygon_geojson has coordinates: {} (object not array)', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":{}}' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/coordinates/i);
+  });
+
+  // BUG-1b: coordinates is a number
+  it('BUG-1b: throws when polygon_geojson has coordinates: 42 (number not array)', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":42}' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/coordinates/i);
+  });
+
+  // BUG-1c: coordinates is a string "bad"
+  it('BUG-1c: throws when polygon_geojson has coordinates: "bad" (string not array)', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":"bad"}' });
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/coordinates/i);
+  });
+
+  // BUG-1d: after fix — parser now throws at parse time, preventing silent adapter failure
+  it('BUG-1d (fixed): zone with coordinates:{} throws at parse time (silent adapter failure prevented)', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":{}}' });
+    // Fixed: Array.isArray guard now rejects non-array coordinates immediately
+    expect(() => parseMarpolEcaZones(yaml)).toThrow(/coordinates/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 4: polygon_geojson — edge case: empty inner ring [[]]
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — polygon_geojson edge cases', () => {
+  // coordinates: [[]] — outer array has 1 element (empty inner ring).
+  // Array.isArray([[]]]) = true, [[]]].length = 1 (not 0) → no throw.
+  // Accepted. Adapter: ring = [], pointInPolygon with empty ring → always false.
+  it('accepts polygon_geojson with empty inner ring [[]] (no throw, but zone is functionally useless)', () => {
+    const yaml = zoneYaml({ polygon_geojson: '{"type":"Polygon","coordinates":[[]]}' });
+    // Current behavior: no throw (questionable but not a blocking bug)
+    const zones = parseMarpolEcaZones(yaml);
+    expect(zones).toHaveLength(1);
+    // Adapter: silently returns false for any port (ring is empty)
+    const port = { lat: 50, lon: 5 };
+    expect(isPortInEca(port, zones)).toBe(false);
+  });
+
+  it('accepts polygon_geojson with out-of-range coordinates (no range validation)', () => {
+    // Coordinates with lon=200 (invalid GeoJSON) pass through parser unchecked.
+    const yaml = zoneYaml({
+      polygon_geojson: '{"type":"Polygon","coordinates":[[[200,200],[210,200],[210,210],[200,210],[200,200]]]}',
+    });
+    // Parser does NOT validate coordinate ranges — this documents the gap.
+    expect(() => parseMarpolEcaZones(yaml)).not.toThrow();
+    const zones = parseMarpolEcaZones(yaml);
+    expect(zones).toHaveLength(1);
+  });
+
+  it('accepts polygon_geojson with wrong type field (no type validation)', () => {
+    // type: "Point" is accepted by parser (no type check).
+    // Adapter skips it silently (checks type === 'Polygon').
+    const yaml = zoneYaml({
+      polygon_geojson: '{"type":"MultiPolygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}',
+    });
+    expect(() => parseMarpolEcaZones(yaml)).not.toThrow();
+    const zones = parseMarpolEcaZones(yaml);
+    // Adapter: type !== 'Polygon' → skips zone → false for any port
+    const port = { lat: 0.5, lon: 0.5 };
+    expect(isPortInEca(port, zones)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 5: Both polygon AND polygon_geojson present
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — both polygon and polygon_geojson present', () => {
+  it('polygon_geojson wins over polygon when both are present', () => {
+    // Encode both keys. polygon_geojson should take precedence (line 89).
+    const yaml = `zones:
+  - name: "Dual Format Zone"
+    region: "test"
+    fuel_sulphur_max_pct: 0.10
+    effective_from: "2015-01-01"
+    polygon_geojson: |
+      {"type":"Polygon","coordinates":[[[0,50],[10,50],[10,60],[0,60],[0,50]]]}
+    polygon:
+      type: "Polygon"
+      coordinates:
+        - [[100, 10], [110, 10], [110, 20], [100, 10]]
+`;
+    const zones = parseMarpolEcaZones(yaml);
+    expect(zones).toHaveLength(1);
+    const parsed = JSON.parse(zones[0].polygon_geojson);
+    // polygon_geojson wins — first coordinate should be [0, 50] not [100, 10]
+    expect(parsed.coordinates[0][0]).toEqual([0, 50]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 6: Duplicate zone names
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — duplicate zone names', () => {
+  it('parser returns both zones when duplicate names present (no dedup at parse level)', () => {
+    const yaml = `zones:
+  - name: "North Sea ECA"
+    region: "north-sea"
+    fuel_sulphur_max_pct: 0.10
+    effective_from: "2015-01-01"
+    polygon_geojson: |
+      {"type":"Polygon","coordinates":[[[0,55],[10,55],[10,60],[0,60],[0,55]]]}
+  - name: "North Sea ECA"
+    region: "north-sea-dupe"
+    fuel_sulphur_max_pct: 0.10
+    effective_from: "2015-01-01"
+    polygon_geojson: |
+      {"type":"Polygon","coordinates":[[[0,55],[10,55],[10,60],[0,60],[0,55]]]}
+`;
+    const zones = parseMarpolEcaZones(yaml);
+    // Parser returns both — DB unique constraint will catch this at seed time
+    expect(zones).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 7: Giant GeoJSON (no crash test)
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — giant polygon_geojson', () => {
+  it('handles a polygon_geojson with 1000 coordinate pairs without crashing', () => {
+    // Generate a large ring (closed polygon around lon=0..1 zigzag)
+    const coords: [number, number][] = Array.from({ length: 999 }, (_, i) => [
+      i % 2 === 0 ? 0 : 1,
+      50 + (i / 999) * 10,
+    ]);
+    coords.push(coords[0]); // close ring
+    const json = JSON.stringify({ type: 'Polygon', coordinates: [coords] });
+    const yaml = zoneYaml({ polygon_geojson: json });
+    expect(() => parseMarpolEcaZones(yaml)).not.toThrow();
+    const zones = parseMarpolEcaZones(yaml);
+    expect(zones).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 8: End-to-end with real YAML file — verify audit claims
+// ---------------------------------------------------------------------------
+
+describe('parser adversarial — end-to-end with real marpol-annex-vi.yaml', () => {
+  const yamlPath = path.join(process.cwd(), 'data/knowledge/eca/marpol-annex-vi.yaml');
+
+  it('real YAML parses to exactly 4 zones (audit claim: eca_zones 0→4)', () => {
+    const raw = fs.readFileSync(yamlPath, 'utf-8');
+    const zones = parseMarpolEcaZones(raw);
+    expect(zones).toHaveLength(4);
+  });
+
+  it('all 4 zones have valid polygon_geojson (Polygon type, non-empty coordinates)', () => {
+    const raw = fs.readFileSync(yamlPath, 'utf-8');
+    const zones = parseMarpolEcaZones(raw);
+    for (const zone of zones) {
+      const poly = JSON.parse(zone.polygon_geojson);
+      expect(poly.type).toBe('Polygon');
+      expect(Array.isArray(poly.coordinates)).toBe(true);
+      expect(poly.coordinates.length).toBeGreaterThan(0);
+      expect(poly.coordinates[0].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('audit claim: calculateEcaFuelPortion is NOT 0% for a Baltic Sea port (refutes silent 0% bug)', () => {
+    // The audit doc says: "calculateEcaFuelPortion() returns 0.0 when zones.length === 0"
+    // and the fix should give 4 zones so port in Baltic Sea returns 0.05, not 0.
+    const raw = fs.readFileSync(yamlPath, 'utf-8');
+    const zones = parseMarpolEcaZones(raw);
+    expect(zones.length).toBeGreaterThan(0);
+
+    // Stockholm is clearly inside Baltic Sea ECA
+    // Baltic polygon covers roughly lon=9..30, lat=54..66
+    const stockholm = { lat: 59.3, lon: 18.1 };
+    const portOutside = { lat: 1.3, lon: 103.8 }; // Singapore — outside all ECAs
+
+    const portion = calculateEcaFuelPortion(stockholm, portOutside, zones);
+    expect(portion).toBe(0.05); // NOT 0.0
+  });
+
+  it('calculateEcaFuelPortion returns 0.0 for two ports both outside all ECAs', () => {
+    const raw = fs.readFileSync(yamlPath, 'utf-8');
+    const zones = parseMarpolEcaZones(raw);
+
+    const singapore = { lat: 1.3, lon: 103.8 };
+    const dubai = { lat: 25.2, lon: 55.3 };
+
+    const portion = calculateEcaFuelPortion(singapore, dubai, zones);
+    expect(portion).toBe(0.0);
+  });
+
+  it('all 4 zones have expected zone names from audit', () => {
+    const raw = fs.readFileSync(yamlPath, 'utf-8');
+    const zones = parseMarpolEcaZones(raw);
+    const names = zones.map((z) => z.name);
+    expect(names).toContain('North Sea Emission Control Area');
+    expect(names).toContain('Baltic Sea Emission Control Area');
+    expect(names).toContain('North American Emission Control Area');
+    expect(names).toContain('Mediterranean Sea Emission Control Area for SOx and PM');
+  });
+
+  it('all 4 zones have fuel_sulphur_max_pct = 0.10', () => {
+    const raw = fs.readFileSync(yamlPath, 'utf-8');
+    const zones = parseMarpolEcaZones(raw);
+    for (const zone of zones) {
+      expect(zone.fuel_sulphur_max_pct).toBe(0.10);
+    }
+  });
+});

--- a/docs/audit/2026-05-22-data-integrity.md
+++ b/docs/audit/2026-05-22-data-integrity.md
@@ -1,0 +1,142 @@
+# Data Integrity Audit — 2026-05-22
+
+**Scope:** Broker-facing tables in `data/sessions.db` (dev) + `data/canal.db`
+**Auditor:** data-integrity-sweep worktree
+**Strategy:** Broker must TRUST real data, not stubs or silently-empty tables.
+
+---
+
+## Verdicts by Source
+
+| Source / Table | Rows (dev) | Freshest | Verdict | Broker Impact |
+|---|---|---|---|---|
+| `ofac_entities` | 19 042 | 2026-05-20 | ✅ REAL | OFAC sanctions screening OK |
+| `port_distances` | 17 985 | 2026-05-17 | ✅ REAL | Route distances OK |
+| `imsbc_fts` (RAG) | 49 | 2026-05-17 | ✅ REAL | Cargo RAG OK |
+| `igc_fts` (RAG) | 77 | 2026-05-17 | ✅ REAL | Grain code RAG OK |
+| `jwc_fts` (RAG) | 8 | 2026-05-17 | ✅ REAL | JWC bulletin RAG OK |
+| `bimco_fts` (RAG) | 7 | 2026-05-17 | ⚠️ REAL but 2 failures | Vertex PERMISSION_DENIED in knowledge_sources; FTS data OK |
+| `charterers` | 20 | 2026-05-17 | ✅ SEEDED-OK | Real company names (Cargill, ADM…), manual tier assignment |
+| `port_da_estimates` | 94 | 2026-05-17 | ⚠️ ESTIMATED | `source='manual'/'broker-research-2026-05'` — not port-authority data |
+| `psc_detention_history` | 16 | 2026-05-17 | ⚠️ SEEDED | 16-row fixture, not live PSC database |
+| `roi_metrics` | 18 | 2026-05-17 | ⚠️ SYNTHETIC | Demo data |
+| `fx_rates` | 200 | 2026-05-15 | ⚠️ STALE | 7 days old (C5 cron merged PR#323 — verify running on prod) |
+| `baltic_indices` | 5 | 2026-05-09 | ⚠️ STALE | 13 days (threshold=14) — borderline; only 5 entries |
+| `bunker_prices` | 10 | 2026-05-09 | 🔴 STALE | 14 days old, threshold=3 days |
+| `eua_prices` | 1 | 2026-05-04 | 🔴 STALE | 18 days old, threshold=7 days; only 1 row |
+| `canal_tariffs` (canal.db) | 22 | 2025-01-01 | ⚠️ STALE | 17 months old (Bosporus/Kiel/Panama/Suez); one-shot |
+| `market_indices` | 90 | 2026-05-17 | 🔴 HARDCODED-FALLBACK | `source='seed-synthetic'` — bhsi/drewry-bb/tmi are fake |
+| `eu_sanctions_entities` | 0 | — | 🔴 EMPTY | EU sanctions NOT screened; `KNOWLEDGE_SANCTIONS_REAL=true` active |
+| `eca_zones` | 0→4* | — | 🔴 FIXED (dev) | Parser bug fixed; 4 MARPOL zones seeded in dev. **Prod needs apply (#approve-9)** |
+| `war_risk_zones` | 0 | — | ✅ NOT CRITICAL | War risk is HARDCODED in `lib/economics/war-risk.ts`; `KNOWLEDGE_WAR_RISK_FROM_DB` flag exists in env but NO code reads it |
+| `port_master` (DB) | 0 | — | ✅ NOT CRITICAL | `port-master.ts` reads `data/ports/port-master.json` (7189 entries), NOT from DB table. DB table = UN/LOCODE directory (future) |
+| `matches` | 0 | — | ✅ NOT CRITICAL | Populated at runtime by broker sessions |
+
+*\* ECA zones 0→4: `lib/knowledge/eca/parser.ts` had format mismatch (expected structured `polygon`, YAML uses `polygon_geojson` string). Fixed in this PR. Seed ran: 4 MARPOL Annex VI zones in worktree dev DB.*
+
+---
+
+## 🔴 Critical Issues — Broker Sees Fake/Missing Data
+
+### 1. `eca_zones` — EMPTY (silently returns 0% ECA surcharge)
+**Impact:** `calculateEcaFuelPortion()` returns `0.0` when `zones.length === 0`.
+Every voyage through North Sea / Baltic / Mediterranean silently shows no ECA surcharge.
+Voyage P&L is understated for any EU/North Sea route.
+
+**Root cause:** `parser.ts` expected structured `polygon:` YAML key but `marpol-annex-vi.yaml` uses `polygon_geojson:` (raw JSON string). Never caught because seed was never run end-to-end.
+
+**Dev fix:** Parser fixed in this PR. Seed ran successfully: 4 zones inserted.
+
+**Prod fix (needs #approve-9):**
+```bash
+# On VPS after deploying this PR:
+cd /var/www/quantika-demo
+npx tsx scripts/knowledge/sources/eca.ts
+```
+
+---
+
+### 2. `eu_sanctions_entities` — EMPTY (EU list not screened)
+**Impact:** `KNOWLEDGE_SANCTIONS_REAL=true` in `.env.local`. `scanActiveDeals()` queries `sanction_corpus_view` which UNION-ALLs OFAC + EU. EU portion returns 0 rows → EU-sanctioned entities pass without a flag.
+OFAC (19 042 rows) is working correctly.
+
+**Root cause:** `EU_SANCTIONS_TOKEN=n00mo9i3` set in env but `knowledge_sources.eu-sanctions` status=`unknown` (never synced). Token likely invalid/expired.
+
+**Prod fix (needs #approve-9):**
+1. Rotate token at https://webgate.ec.europa.eu/fsd/fsf (free, institutional registration)
+2. Set `EU_SANCTIONS_TOKEN=<new-token>` in `.env.production`
+3. `npm run knowledge:refresh eu-sanctions`
+
+---
+
+### 3. `market_indices` — SYNTHETIC DATA
+**Impact:** `source='seed-synthetic'` for all 90 rows (indices: bhsi, drewry-bb, tmi).
+Broker sees fake Baltic/Drewry benchmarks in market comparison screens.
+
+**Root cause:** Real market data sources (Toepfer TMI, Baltic Exchange, Drewry) require API keys or scraping. Seeded synthetic data as placeholder.
+
+**Fix:** Either subscribe to a data provider (Toepfer, Baltic, Drewry) or label UI clearly as "Indicative / Not Live". Not a cheap dev-side fix.
+
+---
+
+## ⚠️ Stale Data (needs cron verification)
+
+### 4. `bunker_prices` — 14 days old (threshold: 3 days)
+Last: 2026-05-09. `bunker-usda` / `bunker-shipandbunker` status=`unknown`.
+**Prod fix:** `npx tsx scripts/knowledge/cron/refresh-bunker.ts`
+
+### 5. `eua_prices` — 18 days old (threshold: 7 days), only 1 row
+Last: 2026-05-04. `eua-eex` / `eua-icap` status=`unknown`.
+**Prod fix:** `npx tsx scripts/knowledge/cron/refresh-eua.ts`
+
+### 6. `fx_rates` — 7 days old
+Last: 2026-05-15. C5 cron PR#323 merged — verify it ran on prod.
+**Prod fix:** `npm run cron:fx-rates` (or verify PM2 cron schedule)
+
+### 7. `baltic_indices` — 13 days old (threshold: 14 days)
+Borderline. Only 5 rows. `baltic-indices` status=`unknown`.
+**Prod fix:** `npm run knowledge:refresh baltic-indices`
+
+---
+
+## Dev Cheap Fixes Applied
+
+| Fix | File | Status |
+|---|---|---|
+| ECA parser: accept `polygon_geojson` string from YAML | `lib/knowledge/eca/parser.ts` | ✅ Applied + tested |
+| ECA zones seed (4 MARPOL zones) | worktree `data/sessions.db` | ✅ Seeded |
+
+---
+
+## Prod Fixes Requiring Approve (#approve-9)
+
+```bash
+# 1. ECA zones (after PR merge)
+npx tsx scripts/knowledge/sources/eca.ts
+
+# 2. EU sanctions token rotation
+# → rotate at webgate.ec.europa.eu/fsd/fsf
+# → set EU_SANCTIONS_TOKEN=<new> in .env.production
+npm run knowledge:refresh eu-sanctions
+
+# 3. Bunker prices refresh
+npx tsx scripts/knowledge/cron/refresh-bunker.ts
+
+# 4. EUA prices refresh
+npx tsx scripts/knowledge/cron/refresh-eua.ts
+
+# 5. FX rates — verify C5 cron is running
+pm2 status | grep quantika
+# or manual: npm run cron:fx-rates
+
+# 6. Baltic indices
+npm run knowledge:refresh baltic-indices
+```
+
+---
+
+## Env/Flag Notes
+
+- `KNOWLEDGE_WAR_RISK_FROM_DB=true` in `.env.local` — **has no effect**: no code in `app/` or `lib/` reads this flag. War risk is always hardcoded (`JWC_HRA_ZONES` in `lib/economics/war-risk.ts`). Flag is planned but unimplemented.
+- `KNOWLEDGE_SANCTIONS_REAL=true` + `eu_sanctions_entities=0` = **silent EU gap** (see issue #2 above).
+- `bimco` knowledge_sources shows 2 consecutive failures: `PERMISSION_DENIED on resource project quantika-demo-2026` — Vertex AI permission issue, not affecting SQLite RAG path.

--- a/lib/knowledge/eca/parser.ts
+++ b/lib/knowledge/eca/parser.ts
@@ -21,6 +21,8 @@ interface YamlZone {
   effective_from?: string;
   effective_to?: string | null;
   polygon?: YamlPolygon;
+  /** Alternative format used in marpol-annex-vi.yaml — raw GeoJSON string */
+  polygon_geojson?: string;
 }
 
 interface YamlRoot {
@@ -69,7 +71,7 @@ export function parseMarpolEcaZones(yamlContent: string): EcaZone[] {
     if (!zone.effective_from || typeof zone.effective_from !== 'string') {
       throw new Error(`Zone "${zone.name}": missing required field "effective_from"`);
     }
-    if (!zone.polygon) {
+    if (!zone.polygon && !zone.polygon_geojson) {
       throw new Error(`Zone "${zone.name}": missing required field "polygon"`);
     }
 
@@ -82,16 +84,31 @@ export function parseMarpolEcaZones(yamlContent: string): EcaZone[] {
       throw new Error(`Zone "${zone.name}": fuel_sulphur_max_pct must be between 0 and 1 (got ${fuelPct})`);
     }
 
-    // Validate polygon
-    if (!zone.polygon.coordinates || (Array.isArray(zone.polygon.coordinates) && zone.polygon.coordinates.length === 0)) {
-      throw new Error(`Zone "${zone.name}": polygon has empty or missing coordinates`);
+    // Build polygon GeoJSON string — accept either structured object or raw JSON string
+    let polygonGeoJson: string;
+    if (zone.polygon_geojson) {
+      // YAML stores raw GeoJSON string (e.g. marpol-annex-vi.yaml)
+      let parsed: YamlPolygon;
+      try {
+        parsed = JSON.parse(zone.polygon_geojson);
+      } catch {
+        throw new Error(`Zone "${zone.name}": polygon_geojson is not valid JSON`);
+      }
+      if (!parsed.coordinates || (Array.isArray(parsed.coordinates) && (parsed.coordinates as unknown[]).length === 0)) {
+        throw new Error(`Zone "${zone.name}": polygon has empty or missing coordinates`);
+      }
+      polygonGeoJson = zone.polygon_geojson.trim();
+    } else {
+      // Structured polygon object format
+      const poly = zone.polygon!;
+      if (!poly.coordinates || (Array.isArray(poly.coordinates) && (poly.coordinates as unknown[]).length === 0)) {
+        throw new Error(`Zone "${zone.name}": polygon has empty or missing coordinates`);
+      }
+      polygonGeoJson = JSON.stringify({
+        type: poly.type,
+        coordinates: poly.coordinates,
+      });
     }
-
-    // Convert polygon to GeoJSON string
-    const polygonGeoJson = JSON.stringify({
-      type: zone.polygon.type,
-      coordinates: zone.polygon.coordinates,
-    });
 
     result.push({
       name: zone.name,

--- a/lib/knowledge/eca/parser.ts
+++ b/lib/knowledge/eca/parser.ts
@@ -94,7 +94,7 @@ export function parseMarpolEcaZones(yamlContent: string): EcaZone[] {
       } catch {
         throw new Error(`Zone "${zone.name}": polygon_geojson is not valid JSON`);
       }
-      if (!parsed.coordinates || (Array.isArray(parsed.coordinates) && (parsed.coordinates as unknown[]).length === 0)) {
+      if (!Array.isArray(parsed.coordinates) || (parsed.coordinates as unknown[]).length === 0) {
         throw new Error(`Zone "${zone.name}": polygon has empty or missing coordinates`);
       }
       polygonGeoJson = zone.polygon_geojson.trim();


### PR DESCRIPTION
Data integrity audit of 21 broker-facing tables + ECA parser fix.
**🔴 Critical:** `eu_sanctions_entities=0` (EU not screened); `eca_zones=0` (parser bug FIXED here); `market_indices` synthetic; war_risk always hardcoded. STALE: bunker 14d, eua 18d, fx 7d, baltic 13d.
**DRAFT / HOLD:** touches parser code → pending /test-skill QA. Prod fixes need separate approve (#9). Report: `docs/audit/2026-05-22-data-integrity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)