### PR TITLE
fix(ci): auto-merge via AUTO_REBASE_PAT to restore deploy trigger [code-only]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -41,4 +41,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_REBASE_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Root cause: auto-merge.yml enabled auto-merge via GITHUB_TOKEN. GitHub suppresses workflow triggers on GITHUB_TOKEN pushes (anti-recursion), so the merge-push to main never fired deploy.yml. Result: #336/#337/#338 merged but prod stayed at #334 (deployed manually). Fix: use AUTO_REBASE_PAT (already used by auto-rebase-prs.yml for the same reason; repo+workflow scope, secret exists) — 1-line. After merge, auto-merged PRs trigger deploy.yml again.