### PR TITLE
feat(nav): add Market link on home page [code-only]

### DIFF
--- a/__tests__/pages/dashboard-market-link.test.ts
+++ b/__tests__/pages/dashboard-market-link.test.ts
@@ -1,0 +1,34 @@
+/**
+ * RC test (PI4) for Market dashboard link.
+ *
+ * Verifies that app/dashboard/page.tsx contains a Link to /market
+ * so brokers can navigate to the market indices screen from home.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const dashboardPath = path.join(process.cwd(), 'app/dashboard/page.tsx');
+
+describe('Dashboard Market link (RC test)', () => {
+  it('dashboard page file exists', () => {
+    expect(fs.existsSync(dashboardPath)).toBe(true);
+  });
+
+  it('dashboard contains a link to /market', () => {
+    const source = fs.readFileSync(dashboardPath, 'utf8');
+    expect(source).toMatch(/href="\/market"/);
+  });
+
+  it('market link is in the Market Intelligence section', () => {
+    const source = fs.readFileSync(dashboardPath, 'utf8');
+    const marketIntelIdx = source.indexOf('Market Intelligence');
+    const linkIdx = source.indexOf('href="/market"');
+    expect(marketIntelIdx).toBeGreaterThan(-1);
+    expect(linkIdx).toBeGreaterThan(-1);
+    // Link must appear after the Market Intelligence section header
+    expect(linkIdx).toBeGreaterThan(marketIntelIdx);
+    // And within a reasonable proximity (same section)
+    expect(linkIdx - marketIntelIdx).toBeLessThan(500);
+  });
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -213,9 +213,17 @@ export default async function DashboardPage() {
 
         {/* ── Market Intelligence ────────────────────────────────── */}
         <section>
-          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
-            Market Intelligence
-          </h2>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">
+              Market Intelligence
+            </h2>
+            <Link
+              href="/market"
+              className="text-xs text-gray-500 hover:text-gray-900 transition-colors"
+            >
+              View all →
+            </Link>
+          </div>
           <MarketIntelligence noActiveDeals={noActiveDeals} />
         </section>
 

--- a/components/nav/BottomNav.tsx
+++ b/components/nav/BottomNav.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Home as HomeIcon, Layers, TrendingUp, Menu } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 function isHomeActive(pathname: string): boolean {
   return (
@@ -37,7 +38,10 @@ export default function BottomNav() {
       <Link
         href="/dashboard"
         aria-current={homeActive ? 'page' : undefined}
-        className="flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs"
+        className={cn(
+          'flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs',
+          homeActive ? 'text-foreground' : 'text-muted-foreground',
+        )}
       >
         <HomeIcon className="size-5" aria-hidden="true" />
         <span>Home</span>
@@ -45,7 +49,10 @@ export default function BottomNav() {
       <Link
         href="/matches"
         aria-current={matchesActive ? 'page' : undefined}
-        className="flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs"
+        className={cn(
+          'flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs',
+          matchesActive ? 'text-foreground' : 'text-muted-foreground',
+        )}
       >
         <Layers className="size-5" aria-hidden="true" />
         <span>Matches</span>
@@ -53,7 +60,10 @@ export default function BottomNav() {
       <Link
         href="/market"
         aria-current={marketActive ? 'page' : undefined}
-        className="flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs"
+        className={cn(
+          'flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs',
+          marketActive ? 'text-foreground' : 'text-muted-foreground',
+        )}
       >
         <TrendingUp className="size-5" aria-hidden="true" />
         <span>Market</span>
@@ -61,7 +71,7 @@ export default function BottomNav() {
       <Link
         href="/more"
         aria-current={undefined}
-        className="flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs"
+        className="flex flex-col items-center justify-center gap-0.5 flex-1 h-full text-xs text-muted-foreground"
       >
         <Menu className="size-5" aria-hidden="true" />
         <span>More</span>


### PR DESCRIPTION
## Summary

- **`app/dashboard/page.tsx`**: Market Intelligence section header now has a \"View all →\" link to `/market` — this is the main fix. On desktop the BottomNav is `md:hidden` (mobile-only), so there was literally no way to reach `/market` from the home page on desktop.
- **`components/nav/BottomNav.tsx`**: added `text-foreground` / `text-muted-foreground` active state styling so the Market tab in the mobile bottom nav is visually distinct when active (previously all tabs looked identical).
- **`__tests__/pages/dashboard-market-link.test.ts`**: RC test verifying the `/market` link is present in the Market Intelligence section of the dashboard (3 assertions).

## Where the button appears

`app/dashboard/page.tsx` — Market Intelligence section:

    <div className="flex items-center justify-between mb-3">
      <h2 ...>Market Intelligence</h2>
      <Link href="/market" ...>View all →</Link>
    </div>

## Test plan
- [x] dashboard-market-link.test.ts — 3/3 green
- [x] BottomNav.test.tsx — 5/5 green (no regression)
- [x] dashboard-market-intelligence.test.tsx — green
- [x] git status --porcelain — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)