### PR TITLE
fix(middleware): return 401 JSON for /api/* instead of 302 redirect (#364)

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -79,15 +79,30 @@ describe('middleware auth guard', () => {
     }
   });
 
-  describe('protected routes without auth cookie', () => {
-    const protectedPaths = ['/', '/dashboard', '/api/ai/match', '/api/emails/parse'];
+  describe('page routes without auth cookie redirect to /login', () => {
+    const pagePaths = ['/', '/dashboard', '/matches', '/market'];
 
-    for (const path of protectedPaths) {
+    for (const path of pagePaths) {
       it(`redirects to /login for ${path} without cookie`, async () => {
         const req = makeReq(path);
         const res = await runMiddleware(req);
         expect(res.status).toBe(302);
         expect(res.headers.get('location')).toContain('/login');
+      });
+    }
+  });
+
+  describe('API routes without auth cookie return 401 JSON', () => {
+    const apiPaths = ['/api/ai/match', '/api/emails/parse', '/api/matches', '/api/vessels'];
+
+    for (const path of apiPaths) {
+      it(`returns 401 JSON for ${path} without cookie`, async () => {
+        const req = makeReq(path);
+        const res = await runMiddleware(req);
+        expect(res.status).toBe(401);
+        expect(res.headers.get('content-type')).toContain('application/json');
+        const body = await res.json();
+        expect(body).toEqual({ error: 'Unauthorized' });
       });
     }
   });

--- a/middleware.ts
+++ b/middleware.ts
@@ -67,6 +67,9 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
       : null;
 
     if (!payload) {
+      if (pathname.startsWith('/api/')) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
       // Redirect to /login preserving the original URL as `next` param is intentionally omitted
       // (simple demo — no deep-link restoration needed)
       const loginUrl = new URL('/login', getRequestBaseUrl(request));


### PR DESCRIPTION
Closes #364.

**Changes:**
- `middleware.ts` (+3 lines): branch `if (!payload && pathname.startsWith('/api/')) return NextResponse.json({error:'Unauthorized'},{status:401})` BEFORE existing redirect. Bypass paths checked first (unaffected).
- `__tests__/middleware-auth.test.ts`: renamed describe to 'page routes' for protectedPaths; added 'API routes without auth cookie return 401 JSON' block (4 paths × full JSON body + Content-Type assertions).

**Tests:** 28/28 green. 6 pre-existing failures in `data-integrity-check.test.ts` confirmed unrelated.

**Independent QA:** `/test-skill` cold-QA = **PASS, 0 CRITICAL / 0 HIGH** (auth-risk #5 satisfied). F1 'no trailing slash' note non-blocking — `/api` без слеша не валидный Next.js endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>