### PR TITLE
fix(fueleu): correct compliance badge — WtW > target is non-compliant (#359)

### DIFF
--- a/__tests__/components/match/EconomicsTab-fueleu.test.tsx
+++ b/__tests__/components/match/EconomicsTab-fueleu.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { EconomicsTab } from '@/components/match/EconomicsTab';
 
 describe('EconomicsTab FuelEU tile', () => {
@@ -38,14 +38,14 @@ describe('EconomicsTab FuelEU tile', () => {
     expect(fuelSelect).toHaveValue('hfo'); // default
   });
 
-  test('FuelEU tile shows compliance badge when compliant', () => {
+  test('FuelEU tile shows non-compliant badge for HFO (91.27 > target 91.16)', () => {
     process.env.NEXT_PUBLIC_FUELEU_ENABLED = 'true';
 
     render(<EconomicsTab />);
 
-    // Default: HFO is non-compliant (91.27 > 91.16)
-    // But without voyage data, totalEnergy=0, so it should be compliant
-    expect(screen.getByText(/Compliant/i)).toBeInTheDocument();
+    // HFO WtW GHG intensity (91.27) exceeds target (91.16) → non-compliant
+    expect(screen.getByTestId('fueleu-noncompliant')).toBeInTheDocument();
+    expect(screen.queryByTestId('fueleu-compliant')).not.toBeInTheDocument();
   });
 
   test('FuelEU tile shows penalty when non-compliant with voyage data', () => {
@@ -106,5 +106,55 @@ describe('EconomicsTab FuelEU tile', () => {
     render(<EconomicsTab />);
 
     expect(screen.getByText(/GHG intensity/i)).toBeInTheDocument();
+  });
+});
+
+describe('FuelEU badge — compliance inversion fix (PI2 behavioral)', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_FUELEU_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_FUELEU_ENABLED;
+  });
+
+  test('WtW > target: HFO (91.27 g/MJ) above 91.16 target → non-compliant badge, no compliant badge', () => {
+    render(<EconomicsTab />);
+
+    expect(screen.getByTestId('fueleu-noncompliant')).toBeInTheDocument();
+    expect(screen.queryByTestId('fueleu-compliant')).not.toBeInTheDocument();
+  });
+
+  test('WtW < target: LNG (75.21 g/MJ) below 91.16 target → compliant badge', () => {
+    render(<EconomicsTab />);
+    fireEvent.change(screen.getByLabelText('Fuel type'), { target: { value: 'lng' } });
+
+    expect(screen.getByTestId('fueleu-compliant')).toBeInTheDocument();
+    expect(screen.queryByTestId('fueleu-noncompliant')).not.toBeInTheDocument();
+  });
+
+  test('WtW > target + voyage data: HFO with routeDistanceNm → penalty badge (not bare non-compliant)', () => {
+    const vessel = {
+      emailId: '1',
+      itemIndex: 0,
+      vesselName: { value: 'MV Test', confidence: 'confirmed' as const },
+      dwtSummer: { value: 50000, confidence: 'confirmed' as const },
+      speedLaden: '14 kts',
+      consumption: '30 mt/day',
+      openPosition: null,
+      openDate: null,
+      restrictions: [],
+      specialFeatures: [],
+    };
+
+    render(
+      <EconomicsTab
+        vessel={vessel as unknown as import('@/lib/types').ParsedVessel}
+        routeDistanceNm={5000}
+      />
+    );
+
+    expect(screen.getByTestId('fueleu-penalty')).toBeInTheDocument();
+    expect(screen.queryByTestId('fueleu-compliant')).not.toBeInTheDocument();
   });
 });

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -253,13 +253,13 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
               </div>
 
               <div className="mt-2 pt-2 border-t border-blue-200">
-                {fuelEuResult.isCompliant ? (
-                  <div className="flex items-center gap-1.5 text-green-700">
+                {fuelEuResult.ghgIntensityActual <= fuelEuResult.ghgIntensityTarget ? (
+                  <div data-testid="fueleu-compliant" className="flex items-center gap-1.5 text-green-700">
                     <span className="text-base">✓</span>
                     <span className="font-medium">Compliant</span>
                   </div>
-                ) : (
-                  <div className="space-y-1">
+                ) : fuelEuResult.totalEnergyMj > 0 ? (
+                  <div data-testid="fueleu-penalty" className="space-y-1">
                     <div className="flex items-center gap-1.5 text-orange-700">
                       <span className="text-base">⚠</span>
                       <span className="font-medium">
@@ -269,6 +269,11 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
                     <div className="text-gray-500">
                       ≈ ${fuelEuResult.penaltyUsd.toLocaleString('en-US', { maximumFractionDigits: 0 })}
                     </div>
+                  </div>
+                ) : (
+                  <div data-testid="fueleu-noncompliant" className="flex items-center gap-1.5 text-orange-700">
+                    <span className="text-base">⚠</span>
+                    <span className="font-medium">Non-compliant fuel type</span>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
Closes #359.

**Root cause:** `EconomicsTab.tsx` used `fuelEuResult.isCompliant` for the badge, but that field returns `true` when `totalEnergyMj === 0` (no voyage data yet), so HFO (91.27 g/MJ > target 91.16) showed ✅ Compliant.

**Fix:** badge uses `ghgIntensityActual <= ghgIntensityTarget` directly + 3 display states: **Compliant** / **Penalty** (voyage data, exceeds target) / **Non-compliant fuel type** (no voyage data, fuel itself exceeds).

**Files:**
- `components/match/EconomicsTab.tsx` — badge condition + 3 `data-testid` attributes
- `__tests__/components/match/EconomicsTab-fueleu.test.tsx` — 1 existing test fixed (had a comment literally documenting the bug); 3 new PI2 behavioral tests added

**Tests:** 38/38 green (EconomicsTab-fueleu + RC-fueleu-flag + fueleu unit suite). 6 pre-existing `data-integrity-check` failures unrelated.

**PI3:** only 1 existing test expectation changed (the one with bug-doc comment). Zero `fueleu.ts` test changes — fix is at UI layer.

**Independent QA:** `/test-skill` cold-QA = **PASS, 0 CRITICAL / 0 HIGH** (logic-risk #5 satisfied). 4 LOW findings non-blocking — recommend merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>