### PR TITLE
fix(ux): W2 mobile UX polish — H-2/H-3/H-4/H-5 from audit (4 HIGH)

### DIFF
--- a/__tests__/matches-touch-target.test.tsx
+++ b/__tests__/matches-touch-target.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * H-2 touch-target audit — MatchesClient.tsx
+ * H-3 bulk-footer BottomNav clearance
+ *
+ * Static source analysis (testEnvironment: 'node').
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const clientPath = path.join(ROOT, 'app/matches/MatchesClient.tsx');
+
+function readSource(): string {
+  return fs.readFileSync(clientPath, 'utf8');
+}
+
+describe('H-2 — status chips ≥44px', () => {
+  it('All chip uses py-2.5 (not py-1)', () => {
+    const src = readSource();
+    // py-1 was 30px; py-2.5 gives ≥44px with line-height
+    expect(src).toMatch(/py-2\.5.*rounded-full.*text-sm.*border.*bg-blue-600/);
+  });
+
+  it('status filter chips use py-2.5', () => {
+    const src = readSource();
+    // ALL_STATUSES map uses py-2.5
+    expect(src).toMatch(/py-2\.5.*rounded-full.*text-sm.*border.*capitalize/);
+  });
+
+  it('Advanced Filters chip uses py-2.5', () => {
+    const src = readSource();
+    // className and text are on separate lines in JSX — check both exist
+    expect(src).toMatch(/Advanced Filters/);
+    expect(src).toMatch(/py-2\.5.*rounded-full.*text-sm.*border.*bg-white/);
+  });
+
+  it('status chips have min-h-[44px]', () => {
+    const src = readSource();
+    // Confirm min-height guard exists on chips
+    expect(src).toMatch(/min-h-\[44px\].*rounded-full|rounded-full.*min-h-\[44px\]/);
+  });
+});
+
+describe('H-2 — action buttons ≥44px', () => {
+  it('Save action button uses py-3', () => {
+    const src = readSource();
+    expect(src).toMatch(/py-3.*text-xs.*rounded.*bg-green-100.*text-green-700/);
+  });
+
+  it('Dismiss action button uses py-3', () => {
+    const src = readSource();
+    expect(src).toMatch(/py-3.*text-xs.*rounded.*bg-red-100.*text-red-700/);
+  });
+
+  it('Archive action button uses py-3', () => {
+    const src = readSource();
+    expect(src).toMatch(/py-3.*text-xs.*rounded.*bg-gray-100.*text-gray-600/);
+  });
+
+  it('Restore action button uses py-3', () => {
+    const src = readSource();
+    expect(src).toMatch(/py-3.*text-xs.*rounded.*bg-blue-100.*text-blue-700/);
+  });
+
+  it('action buttons have min-h-[44px]', () => {
+    const src = readSource();
+    expect(src).toMatch(/py-3.*text-xs.*rounded.*min-h-\[44px\]|min-h-\[44px\].*text-xs.*rounded/);
+  });
+});
+
+describe('H-3 — bulk footer clears BottomNav', () => {
+  it('bulk footer div has pb calc with 56px BottomNav height', () => {
+    const src = readSource();
+    expect(src).toMatch(/pb-\[calc\(56px\+env\(safe-area-inset-bottom,0px\)\)\]/);
+  });
+
+  it('bulk footer is fixed bottom-0 z-50', () => {
+    const src = readSource();
+    expect(src).toMatch(/fixed.*bottom-0.*z-50|fixed bottom-0[\s\S]{0,100}z-50/);
+  });
+
+  it('bulk action buttons in footer use py-3 min-h-[44px]', () => {
+    const src = readSource();
+    // Bulk footer buttons must also be ≥44px
+    expect(src).toMatch(/py-3.*text-sm.*rounded.*bg-blue-100.*min-h-\[44px\]|py-3.*min-h-\[44px\].*bg-blue-100/);
+  });
+});

--- a/__tests__/more-nav-links.test.tsx
+++ b/__tests__/more-nav-links.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * H-4 — /upgrade discoverable from /more
+ * H-5 — /more page has minimum set of links
+ *
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import MorePage from '@/app/more/page';
+
+describe('/more page — H-4 upgrade link', () => {
+  beforeEach(() => {
+    render(React.createElement(MorePage));
+  });
+
+  it('renders a link to /upgrade', () => {
+    const link = screen.getByRole('link', { name: /upgrade/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/upgrade');
+  });
+});
+
+describe('/more page — H-5 navigation links', () => {
+  beforeEach(() => {
+    render(React.createElement(MorePage));
+  });
+
+  it('renders a nav landmark', () => {
+    expect(screen.getByRole('navigation', { name: /more navigation/i })).toBeInTheDocument();
+  });
+
+  it('renders a link to /dashboard', () => {
+    const link = screen.getByRole('link', { name: /dashboard/i });
+    expect(link).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('renders a log out button', () => {
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();
+  });
+
+  it('logout button is inside a form POSTing to /api/auth/logout', () => {
+    const button = screen.getByRole('button', { name: /log out/i });
+    const form = button.closest('form');
+    expect(form).not.toBeNull();
+    expect(form).toHaveAttribute('method', 'POST');
+    expect(form).toHaveAttribute('action', '/api/auth/logout');
+  });
+
+  it('Help & FAQ entry is present', () => {
+    expect(screen.getByText(/Help.*FAQ|FAQ.*Help/i)).toBeInTheDocument();
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -202,7 +202,7 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
       <div className="flex gap-2 flex-wrap">
         <button
           onClick={() => applyStatusFilter(null)}
-          className={`px-3 py-1 rounded-full text-sm border ${!filterStatus ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-700 border-gray-300'}`}
+          className={`px-3 py-2.5 rounded-full text-sm border min-h-[44px] ${!filterStatus ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-700 border-gray-300'}`}
         >
           All
         </button>
@@ -210,14 +210,14 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
           <button
             key={s}
             onClick={() => applyStatusFilter(s)}
-            className={`px-3 py-1 rounded-full text-sm border capitalize ${filterStatus === s ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-700 border-gray-300'}`}
+            className={`px-3 py-2.5 rounded-full text-sm border capitalize min-h-[44px] ${filterStatus === s ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-700 border-gray-300'}`}
           >
             {s}
           </button>
         ))}
         <button
           onClick={() => setFiltersOpen((o) => !o)}
-          className="px-3 py-1 rounded-full text-sm border bg-white text-gray-700 border-gray-300 ml-2"
+          className="px-3 py-2.5 rounded-full text-sm border bg-white text-gray-700 border-gray-300 ml-2 min-h-[44px]"
         >
           Advanced Filters
         </button>
@@ -499,7 +499,7 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
                       {match.status !== 'saved' && match.status !== 'archived' && (
                         <button
                           onClick={() => handleAction(match.id, 'saved')}
-                          className="px-3 py-1 text-xs rounded bg-green-100 text-green-700 hover:bg-green-200"
+                          className="px-3 py-3 text-xs rounded bg-green-100 text-green-700 hover:bg-green-200 min-h-[44px]"
                         >
                           Save
                         </button>
@@ -507,7 +507,7 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
                       {match.status !== 'dismissed' && match.status !== 'archived' && (
                         <button
                           onClick={() => handleAction(match.id, 'dismissed')}
-                          className="px-3 py-1 text-xs rounded bg-red-100 text-red-700 hover:bg-red-200"
+                          className="px-3 py-3 text-xs rounded bg-red-100 text-red-700 hover:bg-red-200 min-h-[44px]"
                         >
                           Dismiss
                         </button>
@@ -515,7 +515,7 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
                       {match.status !== 'archived' && (
                         <button
                           onClick={() => handleAction(match.id, 'archived')}
-                          className="px-3 py-1 text-xs rounded bg-gray-100 text-gray-600 hover:bg-gray-200"
+                          className="px-3 py-3 text-xs rounded bg-gray-100 text-gray-600 hover:bg-gray-200 min-h-[44px]"
                         >
                           Archive
                         </button>
@@ -523,7 +523,7 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
                       {match.status === 'archived' && (
                         <button
                           onClick={() => handleAction(match.id, 'saved')}
-                          className="px-3 py-1 text-xs rounded bg-blue-100 text-blue-700 hover:bg-blue-200"
+                          className="px-3 py-3 text-xs rounded bg-blue-100 text-blue-700 hover:bg-blue-200 min-h-[44px]"
                         >
                           Restore
                         </button>
@@ -539,7 +539,7 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
 
       {/* Sticky footer for bulk actions */}
       {selectedIds.size > 0 && (
-        <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg px-4 py-3 flex items-center gap-3 z-50 sticky-bulk-footer">
+        <div className="fixed bottom-0 left-0 right-0 bg-white border-t shadow-lg px-4 py-3 pb-[calc(56px+env(safe-area-inset-bottom,0px))] flex items-center gap-3 z-50 sticky-bulk-footer">
           <span className="text-sm font-medium text-gray-700">
             Selected {selectedIds.size} {selectedIds.size === 1 ? 'match' : 'matches'}
           </span>
@@ -549,19 +549,19 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
           <div className="flex gap-2 ml-auto">
             <button
               onClick={handleExportCsv}
-              className="px-3 py-1.5 text-sm rounded bg-blue-100 text-blue-700 hover:bg-blue-200"
+              className="px-3 py-3 text-sm rounded bg-blue-100 text-blue-700 hover:bg-blue-200 min-h-[44px]"
             >
               Export CSV
             </button>
             <button
               onClick={() => handleBulkAction('saved')}
-              className="px-3 py-1.5 text-sm rounded bg-green-100 text-green-700 hover:bg-green-200"
+              className="px-3 py-3 text-sm rounded bg-green-100 text-green-700 hover:bg-green-200 min-h-[44px]"
             >
               Save All
             </button>
             <button
               onClick={() => handleBulkAction('dismissed')}
-              className="px-3 py-1.5 text-sm rounded bg-red-100 text-red-700 hover:bg-red-200"
+              className="px-3 py-3 text-sm rounded bg-red-100 text-red-700 hover:bg-red-200 min-h-[44px]"
             >
               Dismiss All
             </button>
@@ -573,13 +573,13 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
                   handleBulkAction('archived');
                 }
               }}
-              className="px-3 py-1.5 text-sm rounded bg-gray-100 text-gray-700 hover:bg-gray-200"
+              className="px-3 py-3 text-sm rounded bg-gray-100 text-gray-700 hover:bg-gray-200 min-h-[44px]"
             >
               Archive All
             </button>
             <button
               onClick={() => setShowModal({ action: 'delete', count: selectedIds.size })}
-              className="px-3 py-1.5 text-sm rounded bg-red-600 text-white hover:bg-red-700"
+              className="px-3 py-3 text-sm rounded bg-red-600 text-white hover:bg-red-700 min-h-[44px]"
             >
               Delete (admin)
             </button>

--- a/app/more/page.tsx
+++ b/app/more/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'More — Quantika',
@@ -6,15 +7,46 @@ export const metadata: Metadata = {
 
 export default function MorePage() {
   return (
-    <div className="flex min-h-[calc(100vh-56px)] flex-col items-center justify-center p-6">
-      <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 shadow-sm">
-        <h1 className="mb-1 text-xl font-semibold">More</h1>
-        <p className="mb-6 text-sm text-muted-foreground">Quantika Demo</p>
+    <div className="flex min-h-[calc(100vh-56px)] flex-col p-6">
+      <div className="w-full max-w-sm mx-auto rounded-xl border border-border bg-card p-8 shadow-sm space-y-6">
+        <div>
+          <h1 className="mb-1 text-xl font-semibold">More</h1>
+          <p className="text-sm text-muted-foreground">Quantika Demo</p>
+        </div>
+
+        <nav aria-label="More navigation">
+          <ul className="space-y-1">
+            <li>
+              <Link
+                href="/upgrade"
+                className="flex items-center justify-between w-full rounded-lg px-4 py-3 text-sm font-medium text-foreground hover:bg-muted min-h-[44px]"
+              >
+                Upgrade to Pro
+                <span className="text-muted-foreground text-xs">→</span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/dashboard"
+                className="flex items-center justify-between w-full rounded-lg px-4 py-3 text-sm font-medium text-foreground hover:bg-muted min-h-[44px]"
+              >
+                Dashboard
+                <span className="text-muted-foreground text-xs">→</span>
+              </Link>
+            </li>
+            <li>
+              <span className="flex items-center justify-between w-full rounded-lg px-4 py-3 text-sm font-medium text-muted-foreground min-h-[44px]">
+                Help &amp; FAQ
+                <span className="text-xs">Coming soon</span>
+              </span>
+            </li>
+          </ul>
+        </nav>
 
         <form method="POST" action="/api/auth/logout">
           <button
             type="submit"
-            className="w-full rounded-lg border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+            className="w-full rounded-lg border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted min-h-[44px]"
             aria-label="Log out of Quantika"
           >
             Log out


### PR DESCRIPTION
Closes 4 HIGH from `docs/audits/mobile-ux-2026-05-22.md`. H-1 prod build-gap auto-closed by W1 deploy.

**Changes:**
- **H-2** /matches touch targets: 8 chips/buttons → ≥44px (`py-1→py-2.5/3 + min-h-[44px]`)
- **H-3** Bulk-action footer clears BottomNav: `pb-[calc(56px+env(safe-area-inset-bottom,0px))]`
- **H-4** /upgrade discoverable from `/more`
- **H-5** /more populated: Upgrade / Dashboard / Help&FAQ stub / Logout

**Files:** `app/matches/MatchesClient.tsx`, `app/more/page.tsx`, `__tests__/matches-touch-target.test.tsx` (new), `__tests__/more-nav-links.test.tsx` (new)

**Tests:** 18 new + 6603 existing green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>