### PR TITLE
fix(matching): align applyReadinessScoring → deriveMatchLevel (MED-01)

### DIFF
--- a/app/api/ai/__tests__/match-readiness.test.ts
+++ b/app/api/ai/__tests__/match-readiness.test.ts
@@ -109,3 +109,58 @@ describe('applyReadinessScoring', () => {
     expect(applyReadinessScoring(baseMatch({ score: 40 }), readinessOf('idle', 8)).matchLevel).toBe('weak');
   });
 });
+
+// MED-01: boundary alignment — applyReadinessScoring must use deriveMatchLevel thresholds (>=, not >)
+describe('applyReadinessScoring boundary alignment with deriveMatchLevel', () => {
+  // These boundary tests pin the CORRECT behavior after the MED-01 fix.
+  // Before the fix, the inline formula used > 70 and > 40 (exclusive),
+  // while deriveMatchLevel uses >= 70 and >= 40 (inclusive).
+
+  it('score exactly 70 + tight: matchLevel must be good (>= threshold)', () => {
+    const m = applyReadinessScoring(baseMatch({ score: 70 }), readinessOf('tight', 0));
+    expect(m.score).toBe(70);
+    expect(m.matchLevel).toBe('good');
+  });
+
+  it('score exactly 40 + tight: matchLevel must be possible (>= threshold)', () => {
+    const m = applyReadinessScoring(baseMatch({ score: 40 }), readinessOf('tight', 0));
+    expect(m.score).toBe(40);
+    expect(m.matchLevel).toBe('possible');
+  });
+
+  it('score 30 + ideal (+10 = 40): matchLevel must be possible (>= 40)', () => {
+    const m = applyReadinessScoring(baseMatch({ score: 30 }), readinessOf('ideal', 2));
+    expect(m.score).toBe(40);
+    expect(m.matchLevel).toBe('possible');
+  });
+
+  it('score 60 + ideal (+10 = 70): matchLevel must be good (>= 70)', () => {
+    const m = applyReadinessScoring(baseMatch({ score: 60 }), readinessOf('ideal', 2));
+    expect(m.score).toBe(70);
+    expect(m.matchLevel).toBe('good');
+  });
+
+  it('score 69 + tight: matchLevel must be possible (below 70)', () => {
+    const m = applyReadinessScoring(baseMatch({ score: 69 }), readinessOf('tight', 0));
+    expect(m.score).toBe(69);
+    expect(m.matchLevel).toBe('possible');
+  });
+
+  it('score 39 + tight: matchLevel must be weak (below 40)', () => {
+    const m = applyReadinessScoring(baseMatch({ score: 39 }), readinessOf('tight', 0));
+    expect(m.score).toBe(39);
+    expect(m.matchLevel).toBe('weak');
+  });
+
+  it('matchLevel from applyReadinessScoring matches deriveMatchLevel at score boundaries', () => {
+    const { deriveMatchLevel } = require('@/lib/sailing/match-scoring');
+    const verdicts = ['tight', 'unknown'] as const;
+    const boundaryScores = [0, 39, 40, 41, 69, 70, 71, 100];
+    for (const verdict of verdicts) {
+      for (const score of boundaryScores) {
+        const m = applyReadinessScoring(baseMatch({ score }), readinessOf(verdict, 0));
+        expect(m.matchLevel).toBe(deriveMatchLevel(score));
+      }
+    }
+  });
+});

--- a/lib/sailing/match-scoring.ts
+++ b/lib/sailing/match-scoring.ts
@@ -261,8 +261,7 @@ export function applyReadinessScoring(
         break;
     }
 
-    // Recalculate matchLevel from adjusted score
-    updated.matchLevel = (updated.score > 70 ? 'good' : updated.score > 40 ? 'possible' : 'weak') as MatchLevel;
+    updated.matchLevel = deriveMatchLevel(updated.score);
   }
 
   // DWCC overload hard guard — must run after score/level adjustment so it


### PR DESCRIPTION
## Summary

- `applyReadinessScoring` had an inline `> 70` / `> 40` formula (strict), while `deriveMatchLevel` uses `>= 70` / `>= 40` (inclusive). At score exactly 70 or 40, they returned different tiers.
- Replaced the inline ternary on line 265 of `match-scoring.ts` with a single `deriveMatchLevel(updated.score)` call — one source of truth.
- `pair-analyzer.ts` already overrides matchLevel with `deriveMatchLevel` after calling `applyReadinessScoring` (lines 449/490), so the pipeline's net output was masked — standalone callers of `applyReadinessScoring` saw the wrong tier.

## Test plan

- [x] 7 new boundary tests in `match-readiness.test.ts` — 5 were red before the fix
- [x] All 18 tests in `match-readiness.test.ts` green
- [x] Full suite (match-readiness, pair-analyzer, overload-guard, pipeline-score-integrity): **101/101 green**
- [x] `git status --porcelain` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)