### PR TITLE
test(api): coverage for 3 untested routes [code-only]

### DIFF
--- a/__tests__/api/auth-google.test.ts
+++ b/__tests__/api/auth-google.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for GET /api/auth/google
+ *
+ * OAuth callback: redirects to Google when no code, handles error param,
+ * exchanges code for session cookie, handles exchange failure.
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/google', () => ({
+  getAuthUrl: jest.fn(() => 'https://accounts.google.com/o/oauth2/auth?mock=1'),
+  exchangeCodeForToken: jest.fn(),
+  fetchGmailProfile: jest.fn(),
+}));
+
+jest.mock('@/lib/session', () => ({
+  createSession: jest.fn(() => 'sid-test'),
+  updateSession: jest.fn(),
+}));
+
+jest.mock('@/lib/csrf', () => ({
+  generateCsrfToken: jest.fn(() => 'csrf-test'),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+import { exchangeCodeForToken, fetchGmailProfile } from '@/lib/google';
+const mockExchangeCode = exchangeCodeForToken as jest.Mock;
+const mockFetchProfile = fetchGmailProfile as jest.Mock;
+
+describe('GET /api/auth/google', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...origEnv, NEXT_PUBLIC_APP_URL: 'http://localhost:3000' };
+    mockExchangeCode.mockResolvedValue('access-token-xyz');
+    mockFetchProfile.mockResolvedValue('user@example.com');
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('redirects to Google auth URL when no code param', async () => {
+    const { GET } = await import('@/app/api/auth/google/route');
+    const req = new NextRequest('http://localhost/api/auth/google');
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('accounts.google.com');
+  });
+
+  it('redirects to /?error=access_denied when error param is present', async () => {
+    const { GET } = await import('@/app/api/auth/google/route');
+    const req = new NextRequest('http://localhost/api/auth/google?error=access_denied');
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('error=access_denied');
+  });
+
+  it('sets session_id cookie and redirects to /processing on valid code', async () => {
+    const { GET } = await import('@/app/api/auth/google/route');
+    const req = new NextRequest('http://localhost/api/auth/google?code=valid-code');
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('/processing');
+    const cookie = res.headers.get('set-cookie') ?? '';
+    expect(cookie).toContain('session_id=sid-test');
+  });
+
+  it('redirects to /?error=auth_failed when code exchange throws', async () => {
+    mockExchangeCode.mockRejectedValueOnce(new Error('OAuth error'));
+    const { GET } = await import('@/app/api/auth/google/route');
+    const req = new NextRequest('http://localhost/api/auth/google?code=bad-code');
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('error=auth_failed');
+  });
+});

--- a/__tests__/api/extension-draft.test.ts
+++ b/__tests__/api/extension-draft.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for POST /api/extension/draft
+ *
+ * Auth gate (requireSession → 401), missing fields → 400,
+ * happy-path returns draftText, length cap enforcement (subject/body).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+jest.mock('@/extensions/gmail/inserts/sanitize', () => ({
+  sanitizeForCompose: jest.fn((html: string) => html),
+}));
+
+import { requireSession } from '@/lib/session';
+const mockRequireSession = requireSession as jest.Mock;
+
+const validCargo = {
+  emailId: 'msg-1',
+  itemIndex: 0,
+  originPort: 'Rotterdam',
+  destinationPort: 'Singapore',
+  cargoDescription: 'Iron ore',
+};
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/extension/draft', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/extension/draft', () => {
+  beforeEach(() => {
+    mockRequireSession.mockReturnValue({
+      sessionId: 'sid-test',
+      session: {},
+    });
+  });
+
+  it('returns 401 when requireSession returns a 401 response', async () => {
+    mockRequireSession.mockReturnValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+    const { POST } = await import('@/app/api/extension/draft/route');
+    const res = await POST(makeReq({ parsedCargo: validCargo, vesselId: 'v1', brokerName: 'Acme' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const { POST } = await import('@/app/api/extension/draft/route');
+    const res = await POST(makeReq({ parsedCargo: validCargo }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/required/i);
+  });
+
+  it('returns 200 with draftText on valid payload', async () => {
+    const { POST } = await import('@/app/api/extension/draft/route');
+    const res = await POST(
+      makeReq({ parsedCargo: validCargo, vesselId: 'v1', brokerName: 'Acme Shipping' }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.draftText).toBe('string');
+    expect(json.draftText).toContain('Acme Shipping');
+  });
+
+  it('returns 400 when subject exceeds 200 chars', async () => {
+    const { POST } = await import('@/app/api/extension/draft/route');
+    const res = await POST(
+      makeReq({
+        parsedCargo: validCargo,
+        vesselId: 'v1',
+        brokerName: 'Acme',
+        subject: 'x'.repeat(201),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/subject too long/i);
+  });
+
+  it('returns 400 when email body exceeds 50 000 chars', async () => {
+    const { POST } = await import('@/app/api/extension/draft/route');
+    const res = await POST(
+      makeReq({
+        parsedCargo: validCargo,
+        vesselId: 'v1',
+        brokerName: 'Acme',
+        body: 'x'.repeat(50_001),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/body too long/i);
+  });
+});

--- a/__tests__/api/whatsapp-ingest.test.ts
+++ b/__tests__/api/whatsapp-ingest.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for POST /api/whatsapp/ingest
+ *
+ * Internal-token auth gate → 401, missing fields → 400,
+ * unconfigured client → 503, happy-path → 200.
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/whatsapp/client', () => ({
+  getWhatsAppClient: jest.fn(),
+}));
+
+jest.mock('@/lib/whatsapp/forward-parser', () => ({
+  parseForwardedMessage: jest.fn(),
+}));
+
+const VALID_TOKEN = 'test-internal-token';
+
+function makeReq(body: unknown, token?: string): NextRequest {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== undefined) headers['x-quantika-internal'] = token;
+  return new NextRequest('http://localhost/api/whatsapp/ingest', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+const validBody = {
+  phone: '+1234567890',
+  messageId: 'msg-001',
+  type: 'text',
+  content: 'Looking for bulk carrier Rotterdam→Singapore',
+};
+
+describe('POST /api/whatsapp/ingest', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv, QUANTIKA_INTERNAL_TOKEN: VALID_TOKEN };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('returns 401 when x-quantika-internal header is missing', async () => {
+    const { POST } = await import('@/app/api/whatsapp/ingest/route');
+    const res = await POST(makeReq(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when x-quantika-internal token is wrong', async () => {
+    const { POST } = await import('@/app/api/whatsapp/ingest/route');
+    const res = await POST(makeReq(validBody, 'wrong-token'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const { POST } = await import('@/app/api/whatsapp/ingest/route');
+    const res = await POST(makeReq({ phone: '+1234567890' }, VALID_TOKEN));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when WhatsApp client is not configured', async () => {
+    const { getWhatsAppClient } = jest.requireMock('@/lib/whatsapp/client');
+    getWhatsAppClient.mockReturnValue(null);
+    const { POST } = await import('@/app/api/whatsapp/ingest/route');
+    const res = await POST(makeReq(validBody, VALID_TOKEN));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 200 with parsed result when client is configured and payload is valid', async () => {
+    const { getWhatsAppClient } = jest.requireMock('@/lib/whatsapp/client');
+    const { parseForwardedMessage } = jest.requireMock('@/lib/whatsapp/forward-parser');
+    getWhatsAppClient.mockReturnValue({ sendText: jest.fn() });
+    parseForwardedMessage.mockResolvedValue({
+      parsedCargo: { cargoDescription: 'bulk cargo' },
+      parsedVessel: null,
+      confidence: 'high',
+      missingFields: [],
+      rawText: 'Looking for bulk carrier Rotterdam→Singapore',
+    });
+    const { POST } = await import('@/app/api/whatsapp/ingest/route');
+    const res = await POST(makeReq(validBody, VALID_TOKEN));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.confidence).toBe('high');
+    expect(Array.isArray(json.missingFields)).toBe(true);
+  });
+});

--- a/__tests__/api/whatsapp-webhook.test.ts
+++ b/__tests__/api/whatsapp-webhook.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for GET+POST /api/whatsapp/webhook
+ *
+ * GET: Meta hub verification — valid token returns challenge, wrong token → 403.
+ * POST: empty body → 400, invalid HMAC → 401, valid HMAC → 200 OK.
+ */
+import { createHmac } from 'crypto';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/whatsapp/client', () => ({
+  getWhatsAppClient: jest.fn(() => null),
+}));
+
+jest.mock('@/lib/whatsapp/router', () => ({
+  routeIncomingMessage: jest.fn(),
+}));
+
+const VERIFY_TOKEN = 'whatsapp-verify-secret';
+const APP_SECRET = 'whatsapp-app-secret';
+
+function computeSig(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body, 'utf8').digest('hex')}`;
+}
+
+function makePostReq(body: string, sig?: string): NextRequest {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (sig !== undefined) headers['x-hub-signature-256'] = sig;
+  return new NextRequest('http://localhost/api/whatsapp/webhook', {
+    method: 'POST',
+    body,
+    headers,
+  });
+}
+
+const minimalPayload = JSON.stringify({
+  object: 'whatsapp_business_account',
+  entry: [{ id: 'e1', changes: [{ value: { messaging_product: 'whatsapp', metadata: { display_phone_number: '15551234', phone_number_id: 'pid' }, messages: [] }, field: 'messages' }] }],
+});
+
+describe('GET /api/whatsapp/webhook — hub verification', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv, WHATSAPP_VERIFY_TOKEN: VERIFY_TOKEN, WHATSAPP_APP_SECRET: APP_SECRET };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('returns the challenge when mode=subscribe and token matches', async () => {
+    const { GET } = await import('@/app/api/whatsapp/webhook/route');
+    const req = new NextRequest(
+      `http://localhost/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=${VERIFY_TOKEN}&hub.challenge=abc123`,
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('abc123');
+  });
+
+  it('returns 403 when verify_token does not match', async () => {
+    const { GET } = await import('@/app/api/whatsapp/webhook/route');
+    const req = new NextRequest(
+      'http://localhost/api/whatsapp/webhook?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=abc123',
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/whatsapp/webhook — message delivery', () => {
+  const origEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv, WHATSAPP_VERIFY_TOKEN: VERIFY_TOKEN, WHATSAPP_APP_SECRET: APP_SECRET };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('returns 400 when body is empty', async () => {
+    const { POST } = await import('@/app/api/whatsapp/webhook/route');
+    const req = new NextRequest('http://localhost/api/whatsapp/webhook', {
+      method: 'POST',
+      body: '',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when HMAC signature is missing', async () => {
+    const { POST } = await import('@/app/api/whatsapp/webhook/route');
+    const res = await POST(makePostReq(minimalPayload));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when HMAC signature is wrong', async () => {
+    const { POST } = await import('@/app/api/whatsapp/webhook/route');
+    const res = await POST(makePostReq(minimalPayload, 'sha256=badhash'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 OK when HMAC signature is valid', async () => {
+    const { POST } = await import('@/app/api/whatsapp/webhook/route');
+    const sig = computeSig(minimalPayload, APP_SECRET);
+    const res = await POST(makePostReq(minimalPayload, sig));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #336 follow-up — adds smoke/auth/happy-path tests for previously untested API routes.

**Coverage:** 50/53 → 53/53 (100%).

**Files (tests only, no production code):**
- `__tests__/api/auth-google.test.ts` — 4 tests
- `__tests__/api/extension-draft.test.ts` — 5 tests  
- `__tests__/api/whatsapp-ingest.test.ts` — 5 tests
- `__tests__/api/whatsapp-webhook.test.ts` — 6 tests (incl. HMAC signature)

**Tests:** 20/20 green. PI3: 0 existing expectations modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)