### PR TITLE
fix(emails): stable /api/emails/fetch on 2nd run + logout cleanup (#376) [code-only]

### DIFF
--- a/app/api/auth/__tests__/logout.test.ts
+++ b/app/api/auth/__tests__/logout.test.ts
@@ -2,6 +2,7 @@
  * Tests for app/api/auth/logout/route.ts
  * POST /api/auth/logout
  */
+import { NextRequest } from 'next/server';
 
 describe('POST /api/auth/logout', () => {
   beforeEach(() => {
@@ -22,5 +23,38 @@ describe('POST /api/auth/logout', () => {
     const cookie = res.headers.get('set-cookie');
     expect(cookie).toContain('demo_auth=');
     expect(cookie).toContain('Max-Age=0');
+  });
+
+  // PI2 — (b): logout clears session_id and csrf_token cookies
+  it('clears session_id and csrf_token cookies in Set-Cookie response', async () => {
+    const POST = await getHandler();
+    const req = new Request('http://localhost/api/auth/logout', { method: 'POST' });
+    const res = await POST(req as Parameters<typeof POST>[0]);
+    const allCookies = res.headers.get('set-cookie') ?? '';
+    expect(allCookies).toContain('session_id=');
+    expect(allCookies).toContain('csrf_token=');
+  });
+
+  // PI2 — (b): logout deletes the OAuth session from the store
+  it('deletes the OAuth session from the session store', async () => {
+    const mockDelete = jest.fn();
+    jest.doMock('@/lib/session', () => ({ deleteSession: mockDelete }));
+    const { POST } = await import('../logout/route');
+    const req = new NextRequest('http://localhost/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: 'session_id=test-session-id' },
+    });
+    await POST(req);
+    expect(mockDelete).toHaveBeenCalledWith('test-session-id');
+  });
+
+  // PI2 — (c): double-logout is idempotent (no session_id cookie → no error)
+  it('double-logout without session cookie is idempotent', async () => {
+    const POST = await getHandler();
+    const makeReq = () => new Request('http://localhost/api/auth/logout', { method: 'POST' });
+    const res1 = await POST(makeReq() as Parameters<typeof POST>[0]);
+    expect(res1.status).toBe(303);
+    const res2 = await POST(makeReq() as Parameters<typeof POST>[0]);
+    expect(res2.status).toBe(303);
   });
 });

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,8 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
 import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
+import { deleteSession } from '@/lib/session';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Delete the OAuth session so re-login always starts with a fresh access token.
+  // Without this, a stale session_id cookie survives logout and the expired token
+  // causes /api/emails/fetch to 500 on the next pipeline run.
+  const sessionId = request.cookies?.get?.('session_id')?.value;
+  if (sessionId) {
+    deleteSession(sessionId);
+  }
+
   const response = NextResponse.redirect(new URL('/login', getRequestBaseUrl(request)), { status: 303 });
 
   // Clear the auth cookie by setting Max-Age=0
@@ -10,6 +19,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     'Set-Cookie',
     `${AUTH_COOKIE_NAME}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`,
   );
+  // Clear OAuth session cookies so the browser cannot reuse the deleted session.
+  response.headers.append('Set-Cookie', 'session_id=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax');
+  response.headers.append('Set-Cookie', 'csrf_token=; Path=/; Max-Age=0; SameSite=Strict');
 
   return response;
 }

--- a/app/api/emails/__tests__/fetch-persists.test.ts
+++ b/app/api/emails/__tests__/fetch-persists.test.ts
@@ -11,12 +11,88 @@ jest.mock("@/lib/session", () => ({
   updateSession: jest.fn().mockReturnValue(true),
 }));
 
-function req(): NextRequest {
+function req(sessionId = "s1"): NextRequest {
   return new NextRequest("http://x/api/emails/fetch", {
     method: "POST",
-    headers: { cookie: "session_id=s1" },
+    headers: { cookie: `session_id=${sessionId}` },
   });
 }
+
+// PI2 — stale-state guard + relogin regression tests (closes #376)
+describe("emails/fetch stale-state guard", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // PI2 (a): first fetch returns 200
+  it("(a) first fetch returns 200 with valid session", async () => {
+    (session.getSession as jest.Mock).mockReturnValue({
+      id: "s1",
+      isSampleData: false,
+      accessToken: "tok",
+      emails: [],
+    });
+    jest.spyOn(google, "fetchGmailEmails").mockResolvedValue([]);
+    const res = await POST(req());
+    expect(res.status).toBe(200);
+  });
+
+  // PI2 (b): after logout (session deleted) + re-login (new session), fetch returns 200
+  it("(b) fetch succeeds with fresh session after old session is deleted", async () => {
+    // Old session (pre-logout): deleted → returns null
+    // New session (post-relogin): returns valid data
+    (session.getSession as jest.Mock).mockImplementation((id: string) => {
+      if (id === "s2") return { id: "s2", isSampleData: false, accessToken: "new-tok", emails: [] };
+      return null; // s1 was deleted on logout
+    });
+    jest.spyOn(google, "fetchGmailEmails").mockResolvedValue([]);
+    const res = await POST(req("s2"));
+    expect(res.status).toBe(200);
+  });
+
+  // PI2 stale-state guard: Google 401 → route returns 401 (not 500)
+  it("returns 401 when Gmail API returns 401 (expired token)", async () => {
+    (session.getSession as jest.Mock).mockReturnValue({
+      id: "s1",
+      isSampleData: false,
+      accessToken: "expired",
+      emails: [],
+    });
+    const authErr = Object.assign(new Error("401 Unauthorized"), {
+      response: { status: 401 },
+    });
+    jest.spyOn(google, "fetchGmailEmails").mockRejectedValue(authErr);
+    const res = await POST(req());
+    expect(res.status).toBe(401);
+  });
+
+  // PI2 stale-state guard: Google 403 → route returns 401 (not 500)
+  it("returns 401 when Gmail API returns 403 (revoked token)", async () => {
+    (session.getSession as jest.Mock).mockReturnValue({
+      id: "s1",
+      isSampleData: false,
+      accessToken: "revoked",
+      emails: [],
+    });
+    const authErr = Object.assign(new Error("403 Forbidden"), {
+      response: { status: 403 },
+    });
+    jest.spyOn(google, "fetchGmailEmails").mockRejectedValue(authErr);
+    const res = await POST(req());
+    expect(res.status).toBe(401);
+  });
+
+  // PI2 (c): non-auth errors still return 500
+  it("returns 500 for non-auth Gmail errors", async () => {
+    (session.getSession as jest.Mock).mockReturnValue({
+      id: "s1",
+      isSampleData: false,
+      accessToken: "tok",
+      emails: [],
+    });
+    jest.spyOn(google, "fetchGmailEmails").mockRejectedValue(new Error("network error"));
+    const res = await POST(req());
+    expect(res.status).toBe(500);
+  });
+});
 
 describe("emails/fetch persists raw emails", () => {
   beforeEach(() => jest.clearAllMocks());

--- a/app/api/emails/fetch/route.ts
+++ b/app/api/emails/fetch/route.ts
@@ -54,6 +54,16 @@ export async function POST(request: NextRequest) {
       message: `Loaded ${truncatedEmails.length} emails`,
     });
   } catch (err) {
+    // Google API 401/403 means the OAuth token is expired or revoked; surface as
+    // 401 so the client can redirect to re-auth instead of showing a generic 500.
+    const googleStatus =
+      typeof err === 'object' && err !== null
+        ? ((err as { response?: { status?: number } }).response?.status ??
+           (err as { status?: number }).status)
+        : undefined;
+    if (googleStatus === 401 || googleStatus === 403) {
+      return NextResponse.json({ error: 'Gmail auth expired, please reconnect' }, { status: 401 });
+    }
     logger.error({ err }, 'Email fetch error');
     return NextResponse.json({ error: 'Failed to fetch emails' }, { status: 500 });
   }


### PR DESCRIPTION
Closes #376.

Root cause: /api/auth/logout не очищал stale Gmail OAuth state → 2-й fetch падал на cached client. Add session/cookie cleanup + stale-state 401/403 guard в fetch handler.

**Fix:**
- `app/api/auth/logout/route.ts` — clears all cookies, deletes session, idempotent.
- `app/api/emails/fetch/route.ts` — stale-state guard: `err.response.status === 401|403` → HTTP 401 (вместо 500).

**Tests:** 8 PI2 (3 logout idempotent + 5 fetch stale-state). 43/43 green. /test-skill cold-QA не нужен — изолированный route fix с TDD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)