### PR TITLE
fix(dashboard): replace static-seed BHSI/TOEPFER with live market_indices query

### DIFF
--- a/__tests__/api/market/benchmark-route.test.ts
+++ b/__tests__/api/market/benchmark-route.test.ts
@@ -2,17 +2,19 @@
  * Integration tests for GET /api/market/benchmark route (spec-01).
  *
  * Route logic:
- * 1. DB-first: getLatestBalticIndex(db, indicator) for BHSI and TOEPFER_TMI
+ * 1. DB-first: getLatestIndex(db, indexName) from market_indices for BHSI and TOEPFER_TMI
  * 2. Fallback: getCurrentBenchmark(indicator) (scraper for TMI)
  * 3. 404 if no data (not 503)
+ * 4. stale=true if index_date is >7 days old
  *
  * Requirements:
- * - ?indicator=BHSI → 200 with value: 650 (from DB)
- * - ?indicator=TOEPFER_TMI → 200 with value: 12683 (from DB)
+ * - ?indicator=BHSI → 200 with value from market_indices
+ * - ?indicator=TOEPFER_TMI → 200 with value from market_indices
+ * - stale row (>7 days) → 200 with stale=true
+ * - missing row → fallback to scraper or 404
  * - ?indicator=DREWRY_BREAKBULK → 404 (no data)
  * - no indicator → 400
  * - invalid indicator → 400
- * - missing data → 404 (not 503)
  */
 
 import { GET } from '@/app/api/market/benchmark/route';
@@ -24,11 +26,11 @@ jest.mock('@/lib/session-store', () => ({
   getStore: jest.fn(() => ({ getDatabase: mockGetDatabase })),
 }));
 
-// ─── Mock baltic-repository ───────────────────────────────────────────────────
+// ─── Mock market-indices-repository ───────────────────────────────────────────
 
-const mockGetLatestBalticIndex = jest.fn();
-jest.mock('@/lib/market/baltic-repository', () => ({
-  getLatestBalticIndex: (...args: unknown[]) => mockGetLatestBalticIndex(...args),
+const mockGetLatestIndex = jest.fn();
+jest.mock('@/lib/market/market-indices-repository', () => ({
+  getLatestIndex: (...args: unknown[]) => mockGetLatestIndex(...args),
 }));
 
 // ─── Mock getCurrentBenchmark (scraper fallback) ──────────────────────────────
@@ -47,8 +49,11 @@ function makeRequest(indicator?: string): Request {
   return new Request(url);
 }
 
-const BHSI_ROW = { index_code: 'BHSI', value: 650, price_date: '2026-05-09', source: 'static-seed' };
-const TMI_ROW = { index_code: 'TOEPFER_TMI', value: 12683, price_date: '2026-05-09', source: 'static-seed' };
+const TODAY = new Date().toISOString().slice(0, 10);
+const STALE_DATE = '2020-01-01';
+
+const BHSI_ROW = { id: 'bhsi-2026-05-09', index_name: 'bhsi', index_date: '2026-05-09', value: 650, unit: 'USD/day', source: 'https://www.handybulk.com/', fetched_at: '2026-05-09T10:00:00.000Z' };
+const TMI_ROW = { id: 'tmi-2026-05-09', index_name: 'tmi', index_date: '2026-05-09', value: 12683, unit: 'USD/day', source: 'static-seed', fetched_at: '2026-05-09T10:00:00.000Z' };
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -58,8 +63,8 @@ beforeEach(() => {
 });
 
 describe('GET /api/market/benchmark — DB path', () => {
-  it('R-1: ?indicator=BHSI → 200 with value=650 from DB', async () => {
-    mockGetLatestBalticIndex.mockReturnValue(BHSI_ROW);
+  it('R-1: ?indicator=BHSI → 200 with value=650 from market_indices', async () => {
+    mockGetLatestIndex.mockReturnValue(BHSI_ROW);
 
     const res = await GET(makeRequest('BHSI'));
     const json = await res.json();
@@ -70,8 +75,8 @@ describe('GET /api/market/benchmark — DB path', () => {
     expect(json.unit).toBe('index');
   });
 
-  it('R-2: ?indicator=TOEPFER_TMI → 200 with value=12683 from DB', async () => {
-    mockGetLatestBalticIndex.mockReturnValue(TMI_ROW);
+  it('R-2: ?indicator=TOEPFER_TMI → 200 with value=12683 from market_indices', async () => {
+    mockGetLatestIndex.mockReturnValue(TMI_ROW);
 
     const res = await GET(makeRequest('TOEPFER_TMI'));
     const json = await res.json();
@@ -84,8 +89,8 @@ describe('GET /api/market/benchmark — DB path', () => {
     expect(mockGetCurrentBenchmark).not.toHaveBeenCalled();
   });
 
-  it('R-3: TOEPFER_TMI falls back to scraper when DB has no row', async () => {
-    mockGetLatestBalticIndex.mockReturnValue(null);
+  it('R-3: TOEPFER_TMI falls back to scraper when market_indices has no row', async () => {
+    mockGetLatestIndex.mockReturnValue(null);
     const scraperBenchmark = {
       indicator: 'TOEPFER_TMI' as const,
       value: 13000,
@@ -103,6 +108,28 @@ describe('GET /api/market/benchmark — DB path', () => {
     expect(json.value).toBe(13000);
     expect(mockGetCurrentBenchmark).toHaveBeenCalledTimes(1);
   });
+
+  it('R-9: recent row (today) → stale=false', async () => {
+    mockGetLatestIndex.mockReturnValue({ ...BHSI_ROW, index_date: TODAY });
+
+    const res = await GET(makeRequest('BHSI'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.stale).toBe(false);
+    expect(json.value).toBe(650);
+  });
+
+  it('R-10: stale row (>7 days) → stale=true, value still present', async () => {
+    mockGetLatestIndex.mockReturnValue({ ...BHSI_ROW, index_date: STALE_DATE });
+
+    const res = await GET(makeRequest('BHSI'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.stale).toBe(true);
+    expect(json.value).toBe(650);
+  });
 });
 
 describe('GET /api/market/benchmark — null / error paths', () => {
@@ -116,8 +143,8 @@ describe('GET /api/market/benchmark — null / error paths', () => {
     expect(json.error).toMatch(/DREWRY_BREAKBULK/);
   });
 
-  it('R-5: BHSI with no DB row → 404 (no scraper fallback for BHSI)', async () => {
-    mockGetLatestBalticIndex.mockReturnValue(null);
+  it('R-5: BHSI with no market_indices row → 404 (no scraper fallback for BHSI)', async () => {
+    mockGetLatestIndex.mockReturnValue(null);
     mockGetCurrentBenchmark.mockResolvedValue(null);
 
     const res = await GET(makeRequest('BHSI'));
@@ -126,7 +153,7 @@ describe('GET /api/market/benchmark — null / error paths', () => {
   });
 
   it('R-6: 404 response has descriptive error message', async () => {
-    mockGetLatestBalticIndex.mockReturnValue(null);
+    mockGetLatestIndex.mockReturnValue(null);
     mockGetCurrentBenchmark.mockResolvedValue(null);
 
     const res = await GET(makeRequest('BHSI'));
@@ -134,6 +161,14 @@ describe('GET /api/market/benchmark — null / error paths', () => {
 
     expect(typeof json.error).toBe('string');
     expect(json.error.length).toBeGreaterThan(0);
+  });
+
+  it('R-11: missing market_indices row (TOEPFER_TMI) → 404 when scraper also null', async () => {
+    mockGetLatestIndex.mockReturnValue(null);
+    mockGetCurrentBenchmark.mockResolvedValue(null);
+
+    const res = await GET(makeRequest('TOEPFER_TMI'));
+    expect(res.status).toBe(404);
   });
 });
 

--- a/app/api/market/benchmark/route.ts
+++ b/app/api/market/benchmark/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { MarketBenchmark, MarketIndicator } from '@/lib/types';
 import { getCurrentBenchmark } from '@/lib/market/benchmark';
-import { getLatestBalticIndex } from '@/lib/market/baltic-repository';
+import { getLatestIndex } from '@/lib/market/market-indices-repository';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { getStore } from '@/lib/session-store';
@@ -14,22 +14,16 @@ const VALID_INDICATORS: ReadonlySet<string> = new Set<MarketIndicator>([
   'EUA',
 ]);
 
-/** Indicators sourced from the baltic_indices DB table (static seed). */
+/** Indicators sourced from the market_indices DB table (live data). */
 const DB_INDICATORS = new Set<MarketIndicator>(['BHSI', 'TOEPFER_TMI']);
 
-function rowToMarketBenchmark(
-  row: { value: number; price_date: string; source: string },
-  indicator: MarketIndicator,
-): MarketBenchmark {
-  return {
-    indicator,
-    value: row.value,
-    unit: indicator === 'TOEPFER_TMI' ? 'USD/day' : 'index',
-    period: row.price_date,
-    sourceUrl: row.source,
-    fetchedAt: new Date().toISOString(),
-  };
-}
+/** Maps API indicator name to market_indices.index_name. */
+const MARKET_INDEX_NAME: Partial<Record<MarketIndicator, string>> = {
+  BHSI: 'bhsi',
+  TOEPFER_TMI: 'tmi',
+};
+
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Intentionally public endpoint — returns only public commodity data (no PII).
@@ -49,12 +43,24 @@ export async function GET(request: Request): Promise<NextResponse> {
   const typedIndicator = indicator as MarketIndicator;
   let benchmark: MarketBenchmark | null = null;
 
-  // DB-first lookup for BHSI and TOEPFER_TMI (server-only, uses better-sqlite3)
+  // DB-first lookup for BHSI and TOEPFER_TMI from market_indices (live data)
   if (DB_INDICATORS.has(typedIndicator)) {
     const db = getStore().getDatabase();
-    const row = getLatestBalticIndex(db, typedIndicator);
-    if (row) {
-      benchmark = rowToMarketBenchmark(row, typedIndicator);
+    const indexName = MARKET_INDEX_NAME[typedIndicator];
+    if (indexName) {
+      const row = getLatestIndex(db, indexName);
+      if (row) {
+        const ageMs = Date.now() - new Date(row.index_date).getTime();
+        benchmark = {
+          indicator: typedIndicator,
+          value: row.value,
+          unit: typedIndicator === 'TOEPFER_TMI' ? 'USD/day' : 'index',
+          period: row.index_date,
+          sourceUrl: row.source,
+          fetchedAt: new Date().toISOString(),
+          stale: ageMs > STALE_THRESHOLD_MS,
+        };
+      }
     }
   } else if (typedIndicator === 'BUNKER_ROTTERDAM') {
     const db = getStore().getDatabase();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -92,6 +92,7 @@ export interface MarketBenchmark {
   period: string;                      // 'Apr 2026' | 'W17 2026'
   sourceUrl: string;                   // canonical URL where it was scraped
   fetchedAt: string;                   // ISO 8601
+  stale?: boolean;                     // true if index_date is >7 days old
 }
 
 // Helper to extract value from ConfidenceField


### PR DESCRIPTION
## Summary
- Closes #377
- Switch `/api/market/benchmark` for BHSI and TOEPFER_TMI from `baltic_indices` (hardcoded static-seed 2026-05-09) to `market_indices` (populated by live scrapers)
- Add `stale: boolean` field to `MarketBenchmark` — true when `index_date` is >7 days old
- Graceful 404 preserved when no row exists (KpiCard already renders "Unavailable")

## Files changed
- `app/api/market/benchmark/route.ts` — swap `getLatestBalticIndex` → `getLatestIndex` + staleness check
- `lib/types.ts` — add `stale?: boolean` to `MarketBenchmark`
- `__tests__/api/market/benchmark-route.test.ts` — update mocks + add R-9/R-10/R-11 (PI2)

## Test plan
- [x] 16/16 tests green (`benchmark-route` suite)
- [x] R-9: recent row (today) → `stale=false`
- [x] R-10: stale row (`2020-01-01`) → `stale=true`, value still present
- [x] R-11: missing market_indices row + null scraper → 404
- [x] Pre-existing failures (`data-integrity-check`, `compare-routes-perf`) confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)