### PR TITLE
fix(market): TMI outlier marker + EN labels (#354 #353) [code-only]

### DIFF
--- a/__tests__/components/market/MarketBenchmarkChart.test.tsx
+++ b/__tests__/components/market/MarketBenchmarkChart.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ *
+ * PI2 behavioral tests for MarketBenchmarkChart:
+ * - #353: labels render in English (not Russian)
+ * - #354: values >3x median get an outlier warning marker
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MarketBenchmarkChart } from '@/components/market/MarketBenchmarkChart';
+
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_MARKET_BENCHMARK_FULL_ENABLED = 'true';
+});
+
+afterAll(() => {
+  delete process.env.NEXT_PUBLIC_MARKET_BENCHMARK_FULL_ENABLED;
+});
+
+const normalData = [
+  { date: '2026-05-01', value: 1100 },
+  { date: '2026-05-02', value: 1150 },
+  { date: '2026-05-03', value: 1200 },
+  { date: '2026-05-04', value: 1180 },
+  { date: '2026-05-05', value: 1210 },
+];
+
+describe('MarketBenchmarkChart — #353 EN labels', () => {
+  it('renders "as of" (not Russian "по состоянию на") for asOfDate', () => {
+    render(
+      React.createElement(MarketBenchmarkChart, {
+        indexName: 'tmi',
+        data: normalData,
+        asOfDate: '2026-05-05',
+        unit: 'USD/day',
+      }),
+    );
+
+    expect(screen.getByText(/as of 2026-05-05/i)).toBeInTheDocument();
+    expect(screen.queryByText(/по состоянию на/i)).not.toBeInTheDocument();
+  });
+
+  it('renders "Source" (not Russian "источник") for source prop', () => {
+    render(
+      React.createElement(MarketBenchmarkChart, {
+        indexName: 'tmi',
+        data: normalData,
+        source: 'https://example.com',
+        unit: 'USD/day',
+      }),
+    );
+
+    expect(screen.getByText(/Source/i)).toBeInTheDocument();
+    expect(screen.queryByText(/источник/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('MarketBenchmarkChart — #354 outlier marker', () => {
+  it('marks a value >3x median with outlier-marker', () => {
+    // median of [1100, 1150, 1200, 1180, 12841] sorted = [1100, 1150, 1180, 1200, 12841]
+    // median = 1180; threshold = 3540; 12841 > 3540 → outlier
+    const spikeData = [
+      { date: '2026-05-10', value: 1100 },
+      { date: '2026-05-11', value: 1150 },
+      { date: '2026-05-12', value: 1180 },
+      { date: '2026-05-13', value: 1200 },
+      { date: '2026-05-14', value: 12841 },
+    ];
+
+    render(
+      React.createElement(MarketBenchmarkChart, {
+        indexName: 'tmi',
+        data: spikeData,
+        unit: 'USD/day',
+      }),
+    );
+
+    const markers = screen.getAllByTestId('outlier-marker');
+    expect(markers.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does NOT mark normal values as outliers', () => {
+    render(
+      React.createElement(MarketBenchmarkChart, {
+        indexName: 'tmi',
+        data: normalData,
+        unit: 'USD/day',
+      }),
+    );
+
+    expect(screen.queryByTestId('outlier-marker')).not.toBeInTheDocument();
+  });
+
+  it('outlier marker has descriptive title attribute for accessibility', () => {
+    const spikeData = [
+      { date: '2026-05-10', value: 1000 },
+      { date: '2026-05-11', value: 1000 },
+      { date: '2026-05-12', value: 1000 },
+      { date: '2026-05-14', value: 9000 },
+    ];
+
+    render(
+      React.createElement(MarketBenchmarkChart, {
+        indexName: 'tmi',
+        data: spikeData,
+        unit: 'USD/day',
+      }),
+    );
+
+    const marker = screen.getByTestId('outlier-marker');
+    expect(marker).toHaveAttribute('title');
+    expect(marker.getAttribute('title')).toMatch(/3x.*median|median.*3x/i);
+  });
+});

--- a/components/market/MarketBenchmarkChart.tsx
+++ b/components/market/MarketBenchmarkChart.tsx
@@ -59,6 +59,12 @@ export function MarketBenchmarkChart({ indexName, data, asOfDate, source, unit }
   const maxValue = Math.max(...validData.map((d) => d.value));
   const minValue = Math.min(...validData.map((d) => d.value));
 
+  const sorted = validData.map((d) => d.value).slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  const outlierThreshold = median * 3;
+
   return (
     <div className="rounded border border-gray-200 p-4">
       <h3 className="mb-1 text-lg font-semibold">{indexName.toUpperCase()}</h3>
@@ -67,12 +73,12 @@ export function MarketBenchmarkChart({ indexName, data, asOfDate, source, unit }
           {unit && <span>{unit}</span>}
           {asOfDate && (
             <span>
-              {unit ? ' · ' : ''}по состоянию на {asOfDate}
+              {unit ? ' · ' : ''}as of {asOfDate}
             </span>
           )}
           {source && (
             <span title={source}>
-              {(unit || asOfDate) ? ' · ' : ''}источник
+              {(unit || asOfDate) ? ' · ' : ''}Source
             </span>
           )}
         </p>
@@ -108,10 +114,22 @@ export function MarketBenchmarkChart({ indexName, data, asOfDate, source, unit }
               .reverse()
               .map((item, idx) => {
                 const pct = ((item.value - minValue) / (maxValue - minValue || 1)) * 100;
+                const isOutlier = median > 0 && item.value > outlierThreshold;
                 return (
                   <tr key={idx} className="border-t border-gray-100">
                     <td className="px-2 py-1 text-gray-600">{item.date}</td>
-                    <td className="px-2 py-1 text-right font-mono">{item.value.toFixed(2)}</td>
+                    <td className="px-2 py-1 text-right font-mono">
+                      {item.value.toFixed(2)}
+                      {isOutlier && (
+                        <span
+                          className="ml-1 text-amber-500"
+                          title="Value is more than 3x the median — possible data anomaly"
+                          data-testid="outlier-marker"
+                        >
+                          &#9888;
+                        </span>
+                      )}
+                    </td>
                     <td className="px-2 py-1">
                       <div className="h-2 w-full rounded bg-gray-100">
                         <div


### PR DESCRIPTION
Closes #354. Closes #353.

- **#354** /market TMI spike 2026-05-14 = 12,841 (10x median ~1,180). Investigation: source CSV empty, spike is real/uploaded data, not parser bug. Added UI-level outlier marker (`>3× median` → ⚠ warning) без изменения source.
- **#353** RU labels: `по состоянию на → as of`, `источник → Source` в `MarketBenchmarkChart.tsx`.

**Tests:** 5 new PI2 + 22/22 existing market tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)