### PR TITLE
docs(roadmap): qa-walker 4 waves complete — 21 issues closed [code-only]

### DIFF
--- a/docs/ROADMAP-CURRENT-STATE.md
+++ b/docs/ROADMAP-CURRENT-STATE.md
@@ -1,7 +1,7 @@
 # Quantika Demo — ROADMAP (Текущее состояние)
 
 **Последний полный аудит:** 2026-05-17 (5-поточный код-аудит) + 2026-05-19 UI audit (Playwright+Chrome MCP) + **2026-05-19 ROADMAP reality audit** (claim vs prod sweep)
-**Последнее обновление:** 2026-05-23 (утро→день) — 3-параллельных PR закрывают roadmap items #3-#5 — 4-волновой план: 7 PR merged (#365-#371), 4 GH issues closed (#359 #361 #364 + #360 #362 #363), mobile UX audit findings закрыты (1 CRIT через rebuild + 4 HIGH + 3 LOW)
+**Последнее обновление:** 2026-05-23 (вечер) — qa-walker 4-волновой план: 21 issue закрыт за день, 7 PR merged — 4-волновой план: 7 PR merged (#365-#371), 4 GH issues closed (#359 #361 #364 + #360 #362 #363), mobile UX audit findings закрыты (1 CRIT через rebuild + 4 HIGH + 3 LOW)
 **Текущая версия:** prod HEAD после auto-deploy LIVE (#259, systemd quantika-demo.service на outreach-vps)
 **Статус:** 🟢 Основные потоки работают; parse-vessel в активной итерации (R8 baseline после revert); pre-merge-guard LIVE
 
@@ -126,6 +126,14 @@ Quantika Demo прошла **Wave α → β → βf×3 → γ (Scale + Vertex + 
 - ✅ **W2**: #370 `fix(ux): mobile polish — H-2/H-3/H-4/H-5` — 8 touch-targets /matches на ≥44px, bulk-footer clearance BottomNav, /upgrade в /more nav, /more populated (Upgrade/Dashboard/Help/Logout). H-1 prod build-gap закрылся auto-deploy'ем W0/W1
 - ✅ **W3**: #371 `fix(cleanup): LOW mass-cleanup` closes **#360** (benchmark link 404 → http:// guard) + **#362** (SANCTIONS badge mistag → pair-analyzer primary-cause filter) + **#363** (sitemap.xml 404 → public/robots.txt + sitemap.xml) + audit LOW L-1/L-2/L-3 (RU empty-state, design tokens на /upgrade, safe-area на /more)
 - 📋 **Autonomous wave-driver**: 4 волны выполнены через cron-loop (CronCreate каждые 15м → dispatch.sh → tmux fire-and-forget → done-watcher → wake), zero-touch после первой команды. Конфликт на /more/page.tsx между W2 (nav links) и W3 (safe-area) резолвлен оркестратором inline.
+
+**Что изменилось за 2026-05-23 (вечер — qa-walker 4 waves, ~4ч автономно):**
+
+- ✅ **Wave A (CRITICAL):** #383 (#378 matches NULL fields — root cause: 6 columns миграции 033 не передавались в createMatch) + #384 (#376 /api/emails/fetch 500 на 2-м запуске — stale Gmail OAuth state, logout cleanup). Оба /test-skill PASS.
+- ✅ **Wave B (HIGH /matches UI):** #385 — 5 issues одной веткой (#375 overflow, #374 bulk toolbar, #373 filter dup, #350 sort, #348 clickable cards) + bonus #349 cargo/route/dwt display из #378 fields. 168/168 green.
+- ✅ **Wave C (HIGH data/security):** #386 (#377 BHSI/TOEPFER live из market_indices + stale marker) + #387 (#354 TMI outlier marker + #353 RU→EN labels) + #388 (#355 server-side XSS sanitization, /test-skill 29 adversarial vectors 0 VULN).
+- ✅ **Wave D (LOW polish + verify-close):** #389 — 4 fixes (#357 hydration, #356 email dup, #351 Quote draft generator, #352 logout verified) + 6 verified-close (#294 #291 #292 #293 #362 #352). 21 qa-walker issue из 22 закрыто.
+- 📋 **Q001 остался:** #363 sitemap.xml — файл существует в public/ но middleware блокирует. 1-line patch для следующей сессии (AUTH_BYPASS_PATHS += '/sitemap.xml').
 
 **Что изменилось за 2026-05-23 (день — 3-параллельных, ~1.5ч):**
 


### PR DESCRIPTION
Closes qa-walker work for 2026-05-23. 4 waves merged: #383 #384 #385 #386 #387 #388 #389. Q001 #363 sitemap middleware patch deferred to next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)