### PR TITLE
fix(seo): allow /sitemap.xml + /robots.txt through middleware (#363) [code-only]

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,6 +25,9 @@ const AUTH_BYPASS_PATHS = new Set([
   // Admin knowledge endpoints have their own X-Admin-Token check (requireAdmin)
   '/api/admin/knowledge/refresh',
   '/api/admin/knowledge-status',
+  // Public SEO files
+  '/sitemap.xml',
+  '/robots.txt',
 ]);
 
 const AUTH_BYPASS_PREFIXES = ['/_next/static', '/_next/image', '/_next/webpack'];


### PR DESCRIPTION
Closes #363.

3-line patch — adds `/sitemap.xml` and `/robots.txt` to `AUTH_BYPASS_PATHS` in `middleware.ts`. The files were created in #371 but middleware redirected unauthenticated requests to /login → 404 effectively for search engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)