### PR TITLE
fix(matching): populate M3 fields in demo seed match (#393) [code-only]

### DIFF
--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,30 +1,15 @@
 import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
-import type Database from 'better-sqlite3';
 import { getSession } from '@/lib/session';
 import { getStore } from '@/lib/session-store';
-import { listMatches, createMatch } from '@/lib/matching/matches-repository';
-import type { Match } from '@/lib/types';
+import { listMatches } from '@/lib/matching/matches-repository';
+import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
 import MatchesClient from './MatchesClient';
 
 export const metadata: Metadata = {
   title: 'Your Recent Matches — Quantika',
 };
-
-function persistSessionMatches(db: Database.Database, sessionId: string, sessionMatches: Match[]): void {
-  for (const m of sessionMatches) {
-    createMatch(db, {
-      cargo_id: m.cargoEmailId,
-      vessel_id: m.vesselEmailId,
-      score: Math.max(0, Math.min(100, Math.round(m.score))),
-      reason: m.matchReasons[0] ?? '',
-      status: 'shortlist',
-      user_id: sessionId,
-      reason_structured: m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
-    });
-  }
-}
 
 export default async function MatchesPage() {
   const cookieStore = await cookies();
@@ -38,7 +23,7 @@ export default async function MatchesPage() {
   const db = getStore().getDatabase();
 
   if (session.matches.length > 0) {
-    persistSessionMatches(db, sessionId, session.matches);
+    persistSessionMatches(db, sessionId, session.matches, session.parsedCargos, session.parsedVessels);
   }
   const matches = listMatches(db, { user_id: sessionId, sortBy: 'score', sortDir: 'desc' });
 

--- a/lib/matching/__tests__/persist-session-matches-m3.test.ts
+++ b/lib/matching/__tests__/persist-session-matches-m3.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Behavioral tests — persistSessionMatches M3 field write-through (demo match)
+ *
+ * PI2: real DB + real function call. Verifies that the guaranteed demo match
+ * injected by /api/sample is persisted with non-null M3 fields when the
+ * session carries parsed cargo/vessel data.
+ *
+ * Regression guard for #393 (demo match had NULL cargo_type/ports/laycan/dwt).
+ */
+import Database from 'better-sqlite3';
+import migration032 from '@/lib/migrations/032-matches';
+import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
+import { listMatches } from '@/lib/matching/matches-repository';
+import { resolveSyntheticCargo, resolveSyntheticVessel } from '@/lib/sample-data/synthetic-economics';
+import type { Match } from '@/lib/types';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  migration033.up(db);
+  migration034.up(db);
+  return db;
+}
+
+const DEMO_MATCH: Match = {
+  cargoEmailId: 'demo-cargo-economics',
+  cargoItemIndex: 0,
+  vesselEmailId: 'demo-vessel-economics',
+  vesselItemIndex: 0,
+  score: 92,
+  matchLevel: 'good',
+  matchReasons: ['Guaranteed demo match for EconomicsTab'],
+  issues: [],
+};
+
+describe('persistSessionMatches — M3 field write-through (demo match, #393)', () => {
+  const now = new Date();
+  const demoCargo = resolveSyntheticCargo(now);
+  const demoVessel = resolveSyntheticVessel(now);
+
+  it('persists cargo_type, load_port, discharge_port, laycan_start, laycan_end, vessel_dwt as non-null', () => {
+    const db = freshDb();
+    persistSessionMatches(db, 'session-demo-1', [DEMO_MATCH], [demoCargo], [demoVessel]);
+
+    const [match] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+    expect(match).toBeDefined();
+
+    expect(match.cargo_type).toBe('BULK');
+    expect(match.load_port).toBe('CNSHA');
+    expect(match.discharge_port).toBe('NLRTM');
+    expect(match.laycan_start).not.toBeNull();
+    expect(match.laycan_end).not.toBeNull();
+    expect(match.vessel_dwt).toBe(58000);
+  });
+
+  it('laycan_start < laycan_end (valid date range)', () => {
+    const db = freshDb();
+    persistSessionMatches(db, 'session-demo-2', [DEMO_MATCH], [demoCargo], [demoVessel]);
+
+    const [match] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+    expect(match.laycan_start!).toBeLessThan(match.laycan_end!);
+  });
+
+  it('reason field is "Guaranteed demo match for EconomicsTab"', () => {
+    const db = freshDb();
+    persistSessionMatches(db, 'session-demo-3', [DEMO_MATCH], [demoCargo], [demoVessel]);
+
+    const [match] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+    expect(match.reason).toBe('Guaranteed demo match for EconomicsTab');
+  });
+
+  it('null-safe: no parsed cargo/vessel → M3 fields stored as null (no crash)', () => {
+    const db = freshDb();
+    persistSessionMatches(db, 'session-demo-4', [DEMO_MATCH], [], []);
+
+    const [match] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+    expect(match).toBeDefined();
+    expect(match.cargo_type).toBeNull();
+    expect(match.load_port).toBeNull();
+    expect(match.discharge_port).toBeNull();
+    expect(match.laycan_start).toBeNull();
+    expect(match.laycan_end).toBeNull();
+    expect(match.vessel_dwt).toBeNull();
+  });
+});

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -1,0 +1,38 @@
+import type Database from 'better-sqlite3';
+import { cfValue } from '@/lib/types';
+import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+import { createMatch } from '@/lib/matching/matches-repository';
+import { parseLaycan } from '@/lib/sailing/date-parsing';
+
+export function persistSessionMatches(
+  db: Database.Database,
+  sessionId: string,
+  sessionMatches: Match[],
+  parsedCargos: ParsedCargo[],
+  parsedVessels: ParsedVessel[],
+): void {
+  const cargoMap = new Map(parsedCargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
+  const vesselMap = new Map(parsedVessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
+
+  for (const m of sessionMatches) {
+    const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);
+    const vessel = vesselMap.get(`${m.vesselEmailId}|${m.vesselItemIndex}`);
+    const laycan = cargo ? parseLaycan(cargo.laycan) : null;
+
+    createMatch(db, {
+      cargo_id: m.cargoEmailId,
+      vessel_id: m.vesselEmailId,
+      score: Math.max(0, Math.min(100, Math.round(m.score))),
+      reason: m.matchReasons[0] ?? '',
+      status: 'shortlist',
+      user_id: sessionId,
+      reason_structured: m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
+      cargo_type: cargo ? cargo.cargoType : null,
+      load_port: cargo ? cfValue(cargo.originPort) : null,
+      discharge_port: cargo ? cfValue(cargo.destinationPort) : null,
+      laycan_start: laycan ? laycan.start.getTime() : null,
+      laycan_end: laycan ? laycan.end.getTime() : null,
+      vessel_dwt: vessel ? cfValue(vessel.dwtSummer) : null,
+    });
+  }
+}

--- a/lib/sailing/date-parsing.ts
+++ b/lib/sailing/date-parsing.ts
@@ -176,8 +176,8 @@ export function parseLaycan(
   const s = raw.trim();
   if (!s) return null;
 
-  // ISO range "2025-09-15 to 2025-09-25" / "2025-09-15 - 2025-09-25"
-  const isoRange = s.match(/(\d{4})-(\d{1,2})-(\d{1,2})\s*(?:to|[-–])\s*(\d{4})-(\d{1,2})-(\d{1,2})/);
+  // ISO range "2025-09-15 to 2025-09-25" / "2025-09-15 - 2025-09-25" / "2025-09-15 .. 2025-09-25"
+  const isoRange = s.match(/(\d{4})-(\d{1,2})-(\d{1,2})\s*(?:to|[-–]|\.\.)\s*(\d{4})-(\d{1,2})-(\d{1,2})/);
   if (isoRange) {
     return {
       start: mkUtc(Number(isoRange[1]), Number(isoRange[2]) - 1, Number(isoRange[3])),


### PR DESCRIPTION
Closes #393.

Re-test после #383 нашёл что fix покрыл runtime computeAndPersistMatches, но 'Guaranteed demo match for EconomicsTab' seed creator писал hardcoded row с NULL'ами. Этот PR извлекает helper `persist-session-matches.ts` (same pattern как #383), seed теперь populates cargo_type='BULK', load_port='CNSHA', discharge_port='NLRTM', vessel_dwt=58000 + valid laycan.

**Bonus:** `parseLaycan` теперь принимает `..` separator (synthetic cargo использует `YYYY-MM-DD .. YYYY-MM-DD`).

**Tests:** 4 new PI2 + 155/155 matching suites green.

**Cold-QA /test-skill:** PASS — 123/123 matching + 28/28 date-parsing. 0 CRIT / 0 HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)