### PR TITLE
fix(match): Phase B advanced — 25→39 evals 100% [code-only]

### DIFF
--- a/docs/superpowers/plans/2026-05-23-match-phase-b-advanced.md
+++ b/docs/superpowers/plans/2026-05-23-match-phase-b-advanced.md
@@ -1,0 +1,44 @@
+# Plan: Match Phase B Advanced — Extended Corridors + Fuzzy + Idle Calibration
+Date: 2026-05-23
+
+## Цель
+Расширить eval corpus с 25 → 39 сценариев и обеспечить >=95% PASS за счёт трёх улучшений.
+
+## Baseline
+25/25 PASS (100%) до расширения. Все новые тесты должны пройти с 0 регрессий.
+
+## Файлы
+- `lib/sailing/port-distances.ts` — DISTANCES_NM + PORT_ALIASES
+- `evals/match/runner.test.ts` — +14 новых сценариев (SC-26..SC-39)
+
+## Шаги
+
+1. **Marghera↔Black Sea (9 пар в DISTANCES_NM)** — все эти пары отсутствуют в searoute JSON.
+   Источник: Ravenna-baseline + 10nm offset (Marghera|Piraeus=710 vs Ravenna|Piraeus=700).
+   Пары: Marghera↔Novorossiysk/Varna/Burgas/Constanta/Karasu/Izmail/Taman/Tuapse/Yuzhny.
+
+2. **intra-MENA + Far East feeders (6 пар)** — Tier 1 promotion из searoute JSON для документирования
+   ключевых коридоров: Alexandria|Jeddah, Mersin|Tartus, Piraeus|Tartus, Bangkok|Songkhla,
+   Singapore|Songkhla, Kakinada|Chennai.
+
+3. **PORT_ALIASES (+2)** — 'konstantsa'→Constanta (руском/болгарская транслитерация),
+   'novorossisk'→Novorossiysk (распространённая опечатка). Fuzzy fallback уже работает
+   для этих вариантов, но explicit alias гарантирует детерминизм.
+
+4. **eval runner.test.ts (+14 сценариев)**:
+   - Group I (SC-26..SC-31): idle penalty boundary — gapDays 0/7/14/15/30/31
+   - Group J (SC-32..SC-36): extended corridors — Mersin|Tartus, Alexandria|Jeddah,
+     Trieste|Novorossiysk, Marghera|Novorossiysk, Bangkok|Songkhla
+   - Group K (SC-37..SC-39): fuzzy matching — Konstantsa, Novorossisk, Porto Marghera
+
+## Acceptance
+- 39/39 PASS (или >=38/39 = >=97%)
+- PI3: ни одно существующее ожидание не переписывается
+- PI2: Group J/K используют реальные вызовы `calculateReadinessGap`; Group I — `idleScorePenalty`
+
+## Out of scope
+- LLM prompt в match API
+- UI /matches (другая ветка)
+- parse-vessel / parse-cargo runtime
+- Readiness scoring FuelEU/MED-01
+- Tier 3 (on-the-fly searoute) — только Tier 1/2

--- a/evals/match/runner.test.ts
+++ b/evals/match/runner.test.ts
@@ -1,5 +1,5 @@
 /**
- * evals/match/runner.test.ts — 25-scenario eval for the match scoring layer.
+ * evals/match/runner.test.ts — 39-scenario eval for the match scoring layer.
  *
  * Tests three distinct behaviors in a single suite:
  *   A. Port-pair resolution  — 6 pairs that were returning readiness=unknown due to
@@ -8,11 +8,14 @@
  *      -35 severe-idle penalty; shorter idles must stay 'possible'.
  *   C. Vague-region detection — sea names / country-only inputs must trigger the
  *      -20 vagueRegionAdjustment and return readiness=unknown.
+ *   I. Idle penalty boundary conditions — exact breakpoints at gapDays 14 and 30.
+ *   J. Extended corridors — Adriatic↔Black Sea, intra-MENA, Far East feeders.
+ *   K. Fuzzy port matching — typos, transliterations, alias resolution.
  *
  * Run: npx jest evals/match/runner
  */
 import { calculateReadinessGap } from '@/lib/sailing/readiness-gap';
-import { computeScoreBreakdown, deriveMatchLevel } from '@/lib/sailing/match-scoring';
+import { computeScoreBreakdown, deriveMatchLevel, idleScorePenalty } from '@/lib/sailing/match-scoring';
 import type { Match, MatchReadiness, ParsedCargo, ParsedVessel } from '@/lib/types';
 
 // Fixed reference date — all laycans in these scenarios are in Jun/Jul/Aug 2026.
@@ -387,5 +390,133 @@ describe('H — graceful degradation', () => {
       OPTS,
     );
     expect(r.verdict).toBe('unknown');
+  });
+});
+
+// ── I. Idle penalty boundary conditions ──────────────────────────────────────
+// Verifies the breakpoints in idleScorePenalty: >14d → -25; >30d → -35.
+// W3-W5 edge cases: exactly at boundary values must use the LOWER (less punishing) tier.
+
+describe('I — idle penalty boundary conditions', () => {
+  it('SC-26 gapDays=0 — penalty -15 (0d idle: floor tier, not > 14)', () => {
+    expect(idleScorePenalty(0)).toBe(-15);
+  });
+
+  it('SC-27 gapDays=7 — penalty -15 (short idle ≤ 14d threshold)', () => {
+    expect(idleScorePenalty(7)).toBe(-15);
+  });
+
+  it('SC-28 gapDays=14 — penalty -15 (exact boundary: 14 is NOT > 14)', () => {
+    expect(idleScorePenalty(14)).toBe(-15);
+  });
+
+  it('SC-29 gapDays=15 — penalty -25 (15 crosses >14d threshold)', () => {
+    expect(idleScorePenalty(15)).toBe(-25);
+  });
+
+  it('SC-30 gapDays=30 — penalty -25 (exact boundary: 30 is NOT > 30)', () => {
+    expect(idleScorePenalty(30)).toBe(-25);
+  });
+
+  it('SC-31 gapDays=31 — penalty -35 (31 crosses >30d severe threshold)', () => {
+    expect(idleScorePenalty(31)).toBe(-35);
+  });
+});
+
+// ── J. Extended corridors ─────────────────────────────────────────────────────
+// New distance pairs: Adriatic↔Black Sea (Marghera), intra-MENA, Far East feeders.
+
+describe('J — extended corridors', () => {
+  it('SC-32 Mersin→Tartus (~150nm, Tier 2) — verdict not unknown, short coastal', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Mersin', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-06-05', originPort: 'Tartus' },
+      OPTS,
+    );
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBeGreaterThan(100);
+    expect(r.distanceNm).toBeLessThan(300);
+  });
+
+  it('SC-33 Alexandria→Jeddah (~910nm, via Suez) — verdict not unknown', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Alexandria', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-06-15', originPort: 'Jeddah' },
+      OPTS,
+    );
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBeGreaterThan(700);
+    expect(r.distanceNm).toBeLessThan(1100);
+  });
+
+  it('SC-34 Trieste→Novorossiysk (~1519nm, Tier 2) — long Adriatic↔Black Sea ballast', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Trieste', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-07-10', originPort: 'Novorossiysk' },
+      OPTS,
+    );
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBeGreaterThan(1400);
+  });
+
+  it('SC-35 Marghera→Novorossiysk (1540nm, Tier 1 hand-curated) — exact distance', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Marghera', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-07-10', originPort: 'Novorossiysk' },
+      OPTS,
+    );
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBe(1540);
+  });
+
+  it('SC-36 Bangkok→Songkhla (~345nm, Tier 1) — Far East feeder, verdict not unknown', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Bangkok', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-06-04', originPort: 'Songkhla' },
+      OPTS,
+    );
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBeGreaterThan(200);
+    expect(r.distanceNm).toBeLessThan(500);
+  });
+});
+
+// ── K. Fuzzy port matching ────────────────────────────────────────────────────
+// Typos, transliterations, and alias variants that appear in real broker emails.
+
+describe('K — fuzzy port matching', () => {
+  it('SC-37 "Konstantsa" → resolves to Constanta, distance to Piraeus computed', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Konstantsa', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-06-12', originPort: 'Piraeus' },
+      OPTS,
+    );
+    // Konstantsa resolves to Constanta; Constanta|Piraeus=790nm in matrix
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBeGreaterThan(600);
+    expect(r.distanceNm).toBeLessThan(950);
+  });
+
+  it('SC-38 "Novorossisk" (common typo) → resolves to Novorossiysk, distance computed', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Novorossisk', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-06-15', originPort: 'Piraeus' },
+      OPTS,
+    );
+    // Novorossisk → Novorossiysk; Novorossiysk|Piraeus=895nm
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBeGreaterThan(700);
+    expect(r.distanceNm).toBeLessThan(1100);
+  });
+
+  it('SC-39 "Porto Marghera" → resolves to Marghera, uses new Tier 1 pair for Novorossiysk', () => {
+    const r = calculateReadinessGap(
+      { openDate: '2026-06-01', openPosition: 'Porto Marghera', speedLaden: null, dwtSummer: null },
+      { laycan: '2026-07-10', originPort: 'Novorossiysk' },
+      OPTS,
+    );
+    // Porto Marghera → Marghera alias (already in PORT_ALIASES); Marghera|Novorossiysk=1540
+    expect(r.verdict).not.toBe('unknown');
+    expect(r.distanceNm).toBe(1540);
   });
 });

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -96,11 +96,13 @@ const PORT_ALIASES: Record<string, KnownPort> = {
   'constanta': 'Constanta',
   'constantza': 'Constanta',
   'konstanta': 'Constanta',
+  'konstantsa': 'Constanta',     // Russian/Bulgarian transliteration variant
   'varna': 'Varna',
   'burgas': 'Burgas',
   'bourgas': 'Burgas',
   'novorossiysk': 'Novorossiysk',
   'novorossiisk': 'Novorossiysk',
+  'novorossisk': 'Novorossiysk', // common typo — missing 'iy'
   'taman': 'Taman',
   'tuapse': 'Tuapse',
   'izmail': 'Izmail',
@@ -1056,6 +1058,32 @@ const DISTANCES_NM: Record<string, number> = {
   'Marmara|Ravenna': 980,          // Marmara→Dardanelles→Aegean→Adriatic→Ravenna; Istanbul|Ravenna=1050, Marmara 70nm closer to exit
   'Izmail|Piraeus': 840,           // Izmail→Black Sea coastal→Bosphorus(300nm)→Aegean→Piraeus(430nm) + routing factor
   'Aliaga|Izmail': 580,            // Aliaga→Aegean→Bosphorus(275nm)→Black Sea→Izmail(300nm) + routing
+
+  // ── Phase B advanced: Marghera↔Black Sea (all missing from searoute JSON) ──
+  // Marghera (Porto Marghera/Venice) is 90nm north of Ravenna in the north Adriatic.
+  // Marghera|Piraeus=710 vs Ravenna|Piraeus=700 (+10nm offset). All values derived
+  // from Ravenna baseline +10nm; verified against Marghera|Odesa=1430 already in matrix.
+  'Marghera|Novorossiysk': 1540,   // Novorossiysk|Ravenna=1530 +10nm Marghera offset
+  'Burgas|Marghera': 1210,         // Burgas|Ravenna=1200 +10nm
+  'Marghera|Varna': 1170,          // Ravenna|Varna=1160 +10nm
+  'Constanta|Marghera': 1260,      // Constanta|Ravenna=1250 +10nm
+  'Karasu|Marghera': 1155,         // Karasu|Ravenna=1145 +10nm
+  'Izmail|Marghera': 1220,         // Izmail|Ravenna=1210 +10nm
+  'Marghera|Taman': 1580,          // Marghera|Novorossiysk=1540 + Novorossiysk|Taman=40
+  'Marghera|Tuapse': 1620,         // Marghera|Novorossiysk=1540 + Novorossiysk|Tuapse=80
+  'Marghera|Yuzhny': 1460,         // Marghera|Odesa=1430 + ~30nm for Yuzhny (east of Odessa)
+
+  // ── Phase B advanced: intra-MENA corridors (Tier 1 promotion from searoute JSON) ──
+  // Red Sea/East Med pairs requiring Suez Canal transit — haversine cuts through Sinai.
+  'Alexandria|Jeddah': 910,        // via Suez Canal: Alexandria|Suez=200 + Suez|Jeddah=700 + ~10nm
+  'Mersin|Tartus': 150,            // direct Eastern Med coastal: Mersin(TR)→Tartus(SY)
+  'Piraeus|Tartus': 655,           // Aegean→Eastern Med: Piraeus→(Rhodes area)→Tartus
+
+  // ── Phase B advanced: Far East feeder corridors (Tier 1 promotion) ──
+  // Short SE Asian feeder routes — open-ocean, haversine reliable but promoting for clarity.
+  'Bangkok|Songkhla': 345,         // Gulf of Thailand: Bangkok→Songkhla (southern Thailand)
+  'Singapore|Songkhla': 575,       // Malacca Strait→Gulf of Thailand: Singapore→Songkhla
+  'Kakinada|Chennai': 190,         // Bay of Bengal coast: Kakinada→Chennai (India east coast)
 
 };
 


### PR DESCRIPTION
Closes Match Phase B advanced roadmap item.

- +15 distance pairs (9 Marghera↔Black Sea, 3 intra-MENA, 3 Far East)
- +2 PORT_ALIASES (konstantsa→Constanta, novorossisk→Novorossiysk)
- +14 PI2 scenarios (groups I idle boundaries, J extended corridors, K fuzzy matching)
- Corpus 25→39 = 100% PASS
- 350/350 sailing+matching suites green

**Cold-QA /test-skill:** PASS — 0 CRIT / 0 HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)