### PR TITLE
fix(hydration): SubsCountdownWidget non-deterministic render (#404) [code-only]

### DIFF
--- a/__tests__/regression/hydration-418.test.tsx
+++ b/__tests__/regression/hydration-418.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression suite: React hydration error #418.
+ *
+ * Guards three fixes:
+ *   #357 — CRLF normalization in EmailBodyViewer (PR #389)
+ *   #291 — aria-valuetext without space in Progress (PR #389)
+ *   #404 — SubsCountdownWidget Date.now() in render path → SSR mismatch
+ *
+ * PI2: each test exercises a real render or renderToString call, not string matching.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
+import '@testing-library/jest-dom';
+
+// ---------------------------------------------------------------------------
+// #357 — CRLF normalization in EmailBodyViewer
+// ---------------------------------------------------------------------------
+import { EmailBodyViewer } from '@/components/email-body-viewer';
+
+describe('EmailBodyViewer CRLF normalization (#357)', () => {
+  it('renders body with \\r\\n without carriage-return chars in output', () => {
+    render(
+      <EmailBodyViewer body={'line one\r\nline two\r\nline three'} highlights={[]} />,
+    );
+    const text = document.body.textContent ?? '';
+    expect(text).not.toContain('\r');
+    expect(text).toContain('line one');
+    expect(text).toContain('line two');
+  });
+
+  it('renders body with bare \\r without carriage-return chars in output', () => {
+    render(
+      <EmailBodyViewer body={'alpha\rbeta'} highlights={[]} />,
+    );
+    const text = document.body.textContent ?? '';
+    expect(text).not.toContain('\r');
+    expect(text).toContain('alpha');
+    expect(text).toContain('beta');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #291 — Progress aria-valuetext format (no space before %)
+// ---------------------------------------------------------------------------
+import { Progress } from '@/components/ui/progress';
+
+describe('Progress aria-valuetext format (#291)', () => {
+  it('aria-valuetext at value=50 is "50%" with no space', () => {
+    render(<Progress value={50} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar.getAttribute('aria-valuetext')).toBe('50%');
+  });
+
+  it('aria-valuetext matches /^\\d+%$/ — never "N %"', () => {
+    render(<Progress value={33} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar.getAttribute('aria-valuetext')).toMatch(/^\d+%$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #404 — SubsCountdownWidget must not call Date.now() during SSR render
+// ---------------------------------------------------------------------------
+import SubsCountdownWidget from '@/components/deals/SubsCountdownWidget';
+
+describe('SubsCountdownWidget SSR determinism (#404)', () => {
+  const originalFlag = process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_SUBS_TIMER_V2_ENABLED = originalFlag;
+  });
+
+  it('renders identical HTML across two consecutive SSR passes', () => {
+    const props = { dealId: 'd1', subsDeadline: '2026-12-31T12:00:00Z' };
+    const a = renderToString(<SubsCountdownWidget {...props} />);
+    const b = renderToString(<SubsCountdownWidget {...props} />);
+    expect(a).toBe(b);
+  });
+
+  it('SSR output uses placeholder "--", not a live countdown string', () => {
+    const html = renderToString(
+      <SubsCountdownWidget dealId="d1" subsDeadline="2026-12-31T12:00:00Z" />,
+    );
+    // Before fix: component rendered "X days Y hours remaining" from Date.now() in useMemo.
+    // After fix: null sentinel → placeholder "--" until useEffect.
+    expect(html).toContain('--');
+    expect(html).not.toMatch(/\d+ days/);
+    expect(html).not.toMatch(/\d+ hours/);
+  });
+});

--- a/components/deals/SubsCountdownWidget.tsx
+++ b/components/deals/SubsCountdownWidget.tsx
@@ -7,7 +7,7 @@
 
 'use client';
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { getChartererGraceDays, normalizeDeadline } from '@/lib/deadlines/subs-guardian';
 
 export interface SubsCountdownWidgetProps {
@@ -27,16 +27,24 @@ function SubsCountdownInner({
   subsDeadline,
   chartererTier,
 }: SubsCountdownWidgetProps) {
-  const [tick, setTick] = useState(0);
-  // tick is intentional: computeRemaining calls Date.now() internally, which is not a
-  // React dep but must re-run every interval. tick forces that recomputation.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const remaining = useMemo(() => computeRemaining(subsDeadline), [subsDeadline, tick]);
+  // Defer Date.now() to post-mount: SSR and first client paint must produce
+  // identical HTML, otherwise React #418 hydration mismatch fires (same fix
+  // pattern as SubsCountdown — null sentinel → placeholder until useEffect).
+  const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
-    const id = setInterval(() => setTick(n => n + 1), 60_000);
+    setRemaining(computeRemaining(subsDeadline));
+    const id = setInterval(() => setRemaining(computeRemaining(subsDeadline)), 60_000);
     return () => clearInterval(id);
   }, [subsDeadline]);
+
+  if (remaining === null) {
+    return (
+      <div data-testid={`subs-countdown-${dealId}`} suppressHydrationWarning>
+        --
+      </div>
+    );
+  }
 
   if (isNaN(remaining)) {
     return <div>Invalid deadline</div>;


### PR DESCRIPTION
Closes #404.

Regression от #357/#291 — но новый источник: SubsCountdownWidget использовал useMemo + tick-counter в render path → SSR/client mismatch на минутных границах. Заменено на useState<number|null>(null) + useEffect (паттерн из SubsCountdown.tsx).

**Files:** components/deals/SubsCountdownWidget.tsx + new __tests__/regression/hydration-418.test.tsx (6 regression tests).

**Tests:** 35/35 green. PI3 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)