### PR TITLE
fix(market): BHSI Current — ORDER BY DESC (#402) [code-only]

### DIFF
--- a/__tests__/components/market/MarketBenchmarkChart.test.tsx
+++ b/__tests__/components/market/MarketBenchmarkChart.test.tsx
@@ -56,6 +56,32 @@ describe('MarketBenchmarkChart — #353 EN labels', () => {
   });
 });
 
+describe('MarketBenchmarkChart — #402 Current value = newest (DESC data from API)', () => {
+  it('shows the first array element as Current when data is DESC-ordered (newest first)', () => {
+    // getIndexHistory returns ORDER BY index_date DESC — newest row is [0]
+    const descData = [
+      { date: '2026-05-10', value: 851 }, // newest — must show as Current
+      { date: '2026-05-09', value: 720 },
+      { date: '2026-05-08', value: 650 },
+      { date: '2026-05-07', value: 327 }, // oldest — must NOT show as Current
+    ];
+
+    render(
+      React.createElement(MarketBenchmarkChart, {
+        indexName: 'bhsi',
+        data: descData,
+        unit: 'index',
+      }),
+    );
+
+    const currentLabel = screen.getByText('Current:');
+    const currentRow = currentLabel.closest('div')!;
+    // 851 is the newest; 327 is the oldest — component must display 851.00
+    expect(within(currentRow).getByText('851.00')).toBeInTheDocument();
+    expect(within(currentRow).queryByText('327.00')).not.toBeInTheDocument();
+  });
+});
+
 describe('MarketBenchmarkChart — #354 outlier marker', () => {
   it('marks a value >3x median with outlier-marker', () => {
     // median of [1100, 1150, 1200, 1180, 12841] sorted = [1100, 1150, 1180, 1200, 12841]

--- a/components/market/MarketBenchmarkChart.tsx
+++ b/components/market/MarketBenchmarkChart.tsx
@@ -87,7 +87,7 @@ export function MarketBenchmarkChart({ indexName, data, asOfDate, source, unit }
       <div className="mb-4 flex gap-4 text-sm">
         <div>
           <span className="text-gray-500">Current: </span>
-          <strong>{validData[validData.length - 1].value.toFixed(2)}</strong>
+          <strong>{validData[0].value.toFixed(2)}</strong>
         </div>
         <div>
           <span className="text-gray-500">Min: </span>


### PR DESCRIPTION
Closes #402. /api/market/benchmark возвращал oldest вместо newest. 113/113 green. 🤖 Generated with Claude Code