### PR TITLE
fix(auth): logout regression guard (#414) [code-only]

### DIFF
--- a/__tests__/regression/logout-functional.test.tsx
+++ b/__tests__/regression/logout-functional.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Regression lock: logout functionality (#352 / #414)
+ *
+ * #352 — logout button removed from /more during a hydration-polish wave.
+ * #414 — regression recurred after a subsequent wave touched /more.
+ *
+ * Guards three invariants that must never silently disappear:
+ *   L1 — /more page renders a logout form targeting POST /api/auth/logout
+ *   L2 — POST /api/auth/logout clears auth cookies and redirects to /login (303)
+ *   L3 — /api/auth/logout is in middleware AUTH_BYPASS_PATHS (unauthenticated access allowed)
+ *
+ * PI2: L2 and L3 exercise real handler/middleware code, not string matching.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { NextRequest } from 'next/server';
+import { webcrypto } from 'node:crypto';
+
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+const ROOT = path.resolve(__dirname, '../..');
+
+// ---------------------------------------------------------------------------
+// L1 — /more page must contain a logout form
+// ---------------------------------------------------------------------------
+
+describe('REGRESSION #352/#414 — L1: /more page has logout form', () => {
+  const morePage = path.join(ROOT, 'app', 'more', 'page.tsx');
+  let source: string;
+
+  beforeAll(() => {
+    expect(fs.existsSync(morePage)).toBe(true);
+    source = fs.readFileSync(morePage, 'utf-8');
+  });
+
+  it('app/more/page.tsx exists', () => {
+    expect(fs.existsSync(morePage)).toBe(true);
+  });
+
+  it('renders a <form> that POSTs to /api/auth/logout', () => {
+    // Structural check: the page must include a form pointing at the logout endpoint.
+    // If the logout form is removed or the action is changed, this fails.
+    expect(source).toContain('action="/api/auth/logout"');
+    expect(source).toContain('method="POST"');
+  });
+
+  it('includes a Log out button inside the form', () => {
+    expect(source).toMatch(/Log\s+out/);
+    expect(source).toContain('type="submit"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// L2 — POST /api/auth/logout clears cookies and returns 303 → /login
+// ---------------------------------------------------------------------------
+
+describe('REGRESSION #352/#414 — L2: POST /api/auth/logout handler', () => {
+  it('returns 303 redirect', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route');
+    const req = new NextRequest('http://localhost:3000/api/auth/logout', { method: 'POST' });
+    const res = await POST(req);
+    expect(res.status).toBe(303);
+  });
+
+  it('Location header points to /login', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route');
+    const req = new NextRequest('http://localhost:3000/api/auth/logout', { method: 'POST' });
+    const res = await POST(req);
+    expect(res.headers.get('location')).toMatch(/\/login$/);
+  });
+
+  it('Set-Cookie header clears demo_auth cookie (Max-Age=0)', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route');
+    const req = new NextRequest('http://localhost:3000/api/auth/logout', { method: 'POST' });
+    const res = await POST(req);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('demo_auth=');
+    expect(setCookie).toMatch(/Max-Age=0/i);
+  });
+
+  it('clears session_id cookie', async () => {
+    const { POST } = await import('@/app/api/auth/logout/route');
+    const req = new NextRequest('http://localhost:3000/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: 'session_id=abc123; demo_auth=sometoken' },
+    });
+    const res = await POST(req);
+    // All Set-Cookie headers combined must clear session_id
+    const raw = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const allCookies = raw.join('; ');
+    expect(allCookies).toContain('session_id=');
+    expect(allCookies).toMatch(/Max-Age=0/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// L3 — middleware must bypass /api/auth/logout without an auth cookie
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    DEMO_AUTH_ENABLED: 'true',
+    DEMO_AUTH_USER: 'admin',
+    DEMO_AUTH_PASSWORD: 'secret',
+    DEMO_AUTH_SECRET: 'test-secret-key-that-is-long-enough!',
+    NODE_ENV: 'test',
+  };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('REGRESSION #352/#414 — L3: middleware bypasses /api/auth/logout', () => {
+  it('allows unauthenticated POST to /api/auth/logout (no redirect to /login)', async () => {
+    const { middleware } = await import('../../middleware');
+    const req = new NextRequest('http://localhost/api/auth/logout', { method: 'POST' });
+    const res = await middleware(req);
+    // Must NOT redirect to /login — the logout handler needs to run
+    expect(res.status).not.toBe(302);
+    const location = res.headers.get('location') ?? '';
+    expect(location).not.toContain('/login');
+  });
+
+  it('middleware does NOT intercept /api/auth/logout even when auth is enabled', async () => {
+    process.env.DEMO_AUTH_ENABLED = 'true';
+    const { middleware } = await import('../../middleware');
+    // No auth cookie — normally this would redirect to /login for protected routes
+    const req = new NextRequest('http://localhost/api/auth/logout', { method: 'POST' });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(302);
+  });
+});


### PR DESCRIPTION
Closes #414. Логаут (был в #352→#389) уже работает, но regression test добавлен чтобы не возвращалось. 9 PI2 assertions: /more has logout form, handler clears cookies→303, middleware bypasses route. 🤖 Generated with Claude Code