### PR TITLE
fix(parse-cargo): R28 — K-suffix + laycan formats + port abbreviations [code-only]

### DIFF
--- a/.progonq/corpus/etms-parse-cargo/scenario-096.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-096.json
@@ -1,0 +1,91 @@
+{
+  "id": "etms-parse-cargo-096",
+  "source_email_id": "synth-r28-001",
+  "category": "numeric_edge",
+  "input": {
+    "subject": "FW: 50k mt bulk sugar Santos/Rotterdam",
+    "from": "synth@test.quantika.app",
+    "date": "2026-01-10T09:00:00.000Z",
+    "body": "Pls propose vsl for:\n\n50k mt bulk sugar\nSantos / Rotterdam\nspot\n2.5% ttl\n"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Santos",
+          "confidence": "confirmed",
+          "source_text": "Santos / Rotterdam"
+        },
+        "origin_country": {
+          "value": "Brazil",
+          "confidence": "interpreted",
+          "source_text": "Santos / Rotterdam"
+        },
+        "destination_port": {
+          "value": "Rotterdam",
+          "confidence": "confirmed",
+          "source_text": "Santos / Rotterdam"
+        },
+        "destination_country": {
+          "value": "Netherlands",
+          "confidence": "interpreted",
+          "source_text": "Santos / Rotterdam"
+        },
+        "cargo_description": {
+          "value": "Bulk sugar",
+          "confidence": "confirmed",
+          "source_text": "50k mt bulk sugar"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 50000,
+          "confidence": "confirmed",
+          "source_text": "50k mt bulk sugar"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk sugar"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "Spot",
+          "confidence": "confirmed",
+          "source_text": "spot"
+        },
+        "laycan": {
+          "value": "Spot",
+          "confidence": "interpreted",
+          "source_text": "spot"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Specific loading terminal at Santos not stated",
+          "Demurrage and despatch rates not stated",
+          "Loading and discharge terms (FIO/CQD etc.) not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-097.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-097.json
@@ -1,0 +1,120 @@
+{
+  "id": "etms-parse-cargo-097",
+  "source_email_id": "synth-r28-002",
+  "category": "numeric_edge",
+  "input": {
+    "subject": "FW: 40-50k mt grain Black Sea / EMED",
+    "from": "synth@test.quantika.app",
+    "date": "2026-05-20T08:00:00.000Z",
+    "body": "Dear brokers,\n\nPloffer for below:\n\n40-50k mt bulk grain\nOdesa / Istanbul or Izmir chopt\nlaycan 10/20 June 2026\n12000/8000 SHINC\n2% ttl\n"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Odesa",
+          "confidence": "confirmed",
+          "source_text": "Odesa / Istanbul or Izmir chopt"
+        },
+        "origin_country": {
+          "value": "Ukraine",
+          "confidence": "interpreted",
+          "source_text": "Odesa / Istanbul or Izmir chopt"
+        },
+        "destination_port": {
+          "value": "Istanbul",
+          "confidence": "confirmed",
+          "source_text": "Istanbul or Izmir chopt"
+        },
+        "destination_port_alternatives": ["Izmir"],
+        "destination_country": {
+          "value": "Turkey",
+          "confidence": "interpreted",
+          "source_text": "Istanbul or Izmir chopt"
+        },
+        "cargo_description": {
+          "value": "Bulk grain",
+          "confidence": "confirmed",
+          "source_text": "40-50k mt bulk grain"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 50000,
+          "confidence": "interpreted",
+          "source_text": "40-50k mt bulk grain"
+        },
+        "weight_mt_min": {
+          "value": 40000,
+          "confidence": "confirmed",
+          "source_text": "40-50k mt bulk grain"
+        },
+        "weight_mt_max": {
+          "value": 50000,
+          "confidence": "confirmed",
+          "source_text": "40-50k mt bulk grain"
+        },
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk grain"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "10/20 June 2026",
+          "confidence": "confirmed",
+          "source_text": "laycan 10/20 June 2026"
+        },
+        "laycan": {
+          "value": "10/20 June 2026",
+          "confidence": "confirmed",
+          "source_text": "laycan 10/20 June 2026"
+        },
+        "loading_rate": {
+          "value": 12000,
+          "confidence": "confirmed",
+          "source_text": "12000/8000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "12000/8000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 8000,
+          "confidence": "confirmed",
+          "source_text": "12000/8000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "12000/8000 SHINC"
+        },
+        "commission_percent": {
+          "value": 2.0,
+          "confidence": "confirmed",
+          "source_text": "2% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2% ttl"
+        },
+        "special_requirements": {
+          "value": "Izmir as charterers' option alternative discharge port",
+          "confidence": "confirmed",
+          "source_text": "Istanbul or Izmir chopt"
+        },
+        "stowage_factor": null,
+        "missing_info": [
+          "Final discharge port nomination pending (charterer's option: Istanbul or Izmir)",
+          "Grain commodity type not specified (wheat, corn, barley, etc.)",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-098.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-098.json
@@ -1,0 +1,106 @@
+{
+  "id": "etms-parse-cargo-098",
+  "source_email_id": "synth-r28-003",
+  "category": "hedged_language",
+  "input": {
+    "subject": "FW: bulk wheat Santos/Rotterdam eom-jan/eom-feb",
+    "from": "synth@test.quantika.app",
+    "date": "2026-01-08T10:00:00.000Z",
+    "body": "Dear All,\n\nPls propose for:\n\n35,000 mt bulk wheat sf 47-49 wog\nSantos / Rotterdam\nLaycan: eom-jan / eom-feb\n10000/10000 SHINC\n2.5% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Santos",
+          "confidence": "confirmed",
+          "source_text": "Santos / Rotterdam"
+        },
+        "origin_country": {
+          "value": "Brazil",
+          "confidence": "interpreted",
+          "source_text": "Santos / Rotterdam"
+        },
+        "destination_port": {
+          "value": "Rotterdam",
+          "confidence": "confirmed",
+          "source_text": "Santos / Rotterdam"
+        },
+        "destination_country": {
+          "value": "Netherlands",
+          "confidence": "interpreted",
+          "source_text": "Santos / Rotterdam"
+        },
+        "cargo_description": {
+          "value": "Bulk wheat, stowage factor 47–49, without guarantee",
+          "confidence": "interpreted",
+          "source_text": "35,000 mt bulk wheat sf 47-49 wog"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 35000,
+          "confidence": "confirmed",
+          "source_text": "35,000 mt bulk wheat sf 47-49 wog"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk wheat"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": null,
+        "laycan": {
+          "value": "End January / End February 2026",
+          "confidence": "interpreted",
+          "source_text": "eom-jan / eom-feb"
+        },
+        "loading_rate": {
+          "value": 10000,
+          "confidence": "confirmed",
+          "source_text": "10000/10000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "10000/10000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 10000,
+          "confidence": "confirmed",
+          "source_text": "10000/10000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "10000/10000 SHINC"
+        },
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": {
+          "value": "abt 47–49 ft³/MT WOG",
+          "confidence": "confirmed",
+          "source_text": "sf 47-49 wog"
+        },
+        "missing_info": [
+          "Exact laycan window not specified — 'eom-jan / eom-feb' interpreted as End January / End February 2026",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-099.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-099.json
@@ -1,0 +1,103 @@
+{
+  "id": "etms-parse-cargo-099",
+  "source_email_id": "synth-r28-004",
+  "category": "hedged_language",
+  "input": {
+    "subject": "FW: coal Murmansk/Rotterdam 1H-March",
+    "from": "synth@test.quantika.app",
+    "date": "2026-02-15T11:00:00.000Z",
+    "body": "Dear All,\n\nPls offer for:\n\n35,000 mt bulk coal\nLoad: Murmansk\nDisch: Rotterdam\nLaycan: 1H-March 2026\n8000/8000 SHINC\n3% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Murmansk",
+          "confidence": "confirmed",
+          "source_text": "Load: Murmansk"
+        },
+        "origin_country": {
+          "value": "Russia",
+          "confidence": "interpreted",
+          "source_text": "Load: Murmansk"
+        },
+        "destination_port": {
+          "value": "Rotterdam",
+          "confidence": "confirmed",
+          "source_text": "Disch: Rotterdam"
+        },
+        "destination_country": {
+          "value": "Netherlands",
+          "confidence": "interpreted",
+          "source_text": "Disch: Rotterdam"
+        },
+        "cargo_description": {
+          "value": "Bulk coal",
+          "confidence": "confirmed",
+          "source_text": "35,000 mt bulk coal"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 35000,
+          "confidence": "confirmed",
+          "source_text": "35,000 mt bulk coal"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk coal"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": null,
+        "laycan": {
+          "value": "First half of March 2026",
+          "confidence": "interpreted",
+          "source_text": "1H-March 2026"
+        },
+        "loading_rate": {
+          "value": 8000,
+          "confidence": "confirmed",
+          "source_text": "8000/8000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "8000/8000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 8000,
+          "confidence": "confirmed",
+          "source_text": "8000/8000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "8000/8000 SHINC"
+        },
+        "commission_percent": {
+          "value": 3.0,
+          "confidence": "confirmed",
+          "source_text": "3% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "3% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Coal specification (type, calorific value, sulphur content) not stated",
+          "Demurrage and despatch rates not stated",
+          "Exact laycan dates not specified — '1H-March 2026' interpreted as first half of March 2026 (1–15 March)"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-100.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-100.json
@@ -1,0 +1,114 @@
+{
+  "id": "etms-parse-cargo-100",
+  "source_email_id": "synth-r28-005",
+  "category": "hedged_language",
+  "input": {
+    "subject": "FW: wheat Pivdennyi/Karachi 2H April 2026",
+    "from": "synth@test.quantika.app",
+    "date": "2026-03-20T09:00:00.000Z",
+    "body": "Pls propose for:\n\n28,000 mt 10% moloo bulk wheat sf 47-49 wog\nPivdennyi / Karachi\n2H April 2026\n10000/8000 SHINC\n2.5% ttl\n"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Pivdennyi (Yuzhne)",
+          "confidence": "confirmed",
+          "source_text": "Pivdennyi / Karachi"
+        },
+        "origin_country": {
+          "value": "Ukraine",
+          "confidence": "interpreted",
+          "source_text": "Pivdennyi / Karachi"
+        },
+        "destination_port": {
+          "value": "Karachi",
+          "confidence": "confirmed",
+          "source_text": "Pivdennyi / Karachi"
+        },
+        "destination_country": {
+          "value": "Pakistan",
+          "confidence": "interpreted",
+          "source_text": "Pivdennyi / Karachi"
+        },
+        "cargo_description": {
+          "value": "Bulk wheat, stowage factor 47–49, without guarantee",
+          "confidence": "interpreted",
+          "source_text": "28,000 mt 10% moloo bulk wheat sf 47-49 wog"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 28000,
+          "confidence": "confirmed",
+          "source_text": "28,000 mt 10% moloo bulk wheat sf 47-49 wog"
+        },
+        "weight_mt_min": {
+          "value": 25200,
+          "confidence": "interpreted",
+          "source_text": "28,000 mt 10% moloo bulk wheat sf 47-49 wog"
+        },
+        "weight_mt_max": {
+          "value": 30800,
+          "confidence": "interpreted",
+          "source_text": "28,000 mt 10% moloo bulk wheat sf 47-49 wog"
+        },
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk wheat"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": null,
+        "laycan": {
+          "value": "Second half of April 2026",
+          "confidence": "interpreted",
+          "source_text": "2H April 2026"
+        },
+        "loading_rate": {
+          "value": 10000,
+          "confidence": "confirmed",
+          "source_text": "10000/8000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "10000/8000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 8000,
+          "confidence": "confirmed",
+          "source_text": "10000/8000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "10000/8000 SHINC"
+        },
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": {
+          "value": "abt 47–49 ft³/MT WOG",
+          "confidence": "confirmed",
+          "source_text": "sf 47-49 wog"
+        },
+        "missing_info": [
+          "Exact laycan dates not specified — '2H April 2026' interpreted as second half of April 2026 (16–30 April)",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-101.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-101.json
@@ -1,0 +1,102 @@
+{
+  "id": "etms-parse-cargo-101",
+  "source_email_id": "synth-r28-006",
+  "category": "single_cargo",
+  "input": {
+    "subject": "FW: salt NOVOR / EMED",
+    "from": "synth@test.quantika.app",
+    "date": "2026-05-12T08:30:00.000Z",
+    "body": "Pls offer vsl for:\n\n10,000 mt bulk salt\nNOVOR / EMED\nlaycan 15/20 June 2026\n5000/3000 SHINC\n2.5% ttl\n"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Novorossiysk",
+          "confidence": "confirmed",
+          "source_text": "NOVOR"
+        },
+        "origin_country": {
+          "value": "Russia",
+          "confidence": "interpreted",
+          "source_text": "NOVOR"
+        },
+        "destination_port": {
+          "value": "Eastern Mediterranean port (unspecified)",
+          "confidence": "interpreted",
+          "source_text": "EMED"
+        },
+        "destination_country": null,
+        "cargo_description": {
+          "value": "Bulk salt",
+          "confidence": "confirmed",
+          "source_text": "10,000 mt bulk salt"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 10000,
+          "confidence": "confirmed",
+          "source_text": "10,000 mt bulk salt"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk salt"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "15/20 June 2026",
+          "confidence": "confirmed",
+          "source_text": "laycan 15/20 June 2026"
+        },
+        "laycan": {
+          "value": "15/20 June 2026",
+          "confidence": "confirmed",
+          "source_text": "laycan 15/20 June 2026"
+        },
+        "loading_rate": {
+          "value": 5000,
+          "confidence": "confirmed",
+          "source_text": "5000/3000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "5000/3000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 3000,
+          "confidence": "confirmed",
+          "source_text": "5000/3000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "5000/3000 SHINC"
+        },
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Specific Eastern Mediterranean discharge port not nominated",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-102.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-102.json
@@ -1,0 +1,94 @@
+{
+  "id": "etms-parse-cargo-102",
+  "source_email_id": "synth-r28-007",
+  "category": "single_cargo",
+  "input": {
+    "subject": "FW: steel coils ISK / Rotterdam",
+    "from": "synth@test.quantika.app",
+    "date": "2026-05-08T09:00:00.000Z",
+    "body": "Dear brokers,\n\nPls propose for below cargo:\n\n8,500 mt HRC uw abt 10/27 TS\nISK / Rotterdam\n20/25 May 2026\n2% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Iskenderun",
+          "confidence": "confirmed",
+          "source_text": "ISK"
+        },
+        "origin_country": {
+          "value": "Turkey",
+          "confidence": "interpreted",
+          "source_text": "ISK"
+        },
+        "destination_port": {
+          "value": "Rotterdam",
+          "confidence": "confirmed",
+          "source_text": "ISK / Rotterdam"
+        },
+        "destination_country": {
+          "value": "Netherlands",
+          "confidence": "interpreted",
+          "source_text": "ISK / Rotterdam"
+        },
+        "cargo_description": {
+          "value": "Hot Rolled Coils (HRC), unit weight approximately 10 to 27 metric tons per coil",
+          "confidence": "interpreted",
+          "source_text": "HRC uw abt 10/27 TS"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 8500,
+          "confidence": "confirmed",
+          "source_text": "8,500 mt HRC uw abt 10/27 TS"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BREAK_BULK",
+          "confidence": "interpreted",
+          "source_text": "HRC uw abt 10/27 TS"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "20/25 May 2026",
+          "confidence": "confirmed",
+          "source_text": "20/25 May 2026"
+        },
+        "laycan": {
+          "value": "20/25 May 2026",
+          "confidence": "confirmed",
+          "source_text": "20/25 May 2026"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 2.0,
+          "confidence": "confirmed",
+          "source_text": "2% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2% ttl"
+        },
+        "special_requirements": {
+          "value": "Individual coil unit weight approximately 10–27 metric tons (vessel gear/crane capacity requirement)",
+          "confidence": "confirmed",
+          "source_text": "uw abt 10/27 TS"
+        },
+        "stowage_factor": null,
+        "missing_info": [
+          "Loading and discharge terms (FIO/CQD/SHINC etc.) not stated",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-103.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-103.json
@@ -1,0 +1,102 @@
+{
+  "id": "etms-parse-cargo-103",
+  "source_email_id": "synth-r28-008",
+  "category": "single_cargo",
+  "input": {
+    "subject": "FW: corn PIVD / Haifa",
+    "from": "synth@test.quantika.app",
+    "date": "2026-05-15T08:00:00.000Z",
+    "body": "Pls propose vsl for below:\n\n5,000-6,000 mt bulk corn sf 51 wog\nPIVD / Haifa\n15-20 June 2026\n2.5% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Pivdennyi (Yuzhne)",
+          "confidence": "confirmed",
+          "source_text": "PIVD"
+        },
+        "origin_country": {
+          "value": "Ukraine",
+          "confidence": "interpreted",
+          "source_text": "PIVD"
+        },
+        "destination_port": {
+          "value": "Haifa",
+          "confidence": "confirmed",
+          "source_text": "PIVD / Haifa"
+        },
+        "destination_country": {
+          "value": "Israel",
+          "confidence": "interpreted",
+          "source_text": "PIVD / Haifa"
+        },
+        "cargo_description": {
+          "value": "Bulk corn, stowage factor 51, without guarantee",
+          "confidence": "interpreted",
+          "source_text": "5,000-6,000 mt bulk corn sf 51 wog"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 6000,
+          "confidence": "interpreted",
+          "source_text": "5,000-6,000 mt bulk corn sf 51 wog"
+        },
+        "weight_mt_min": {
+          "value": 5000,
+          "confidence": "confirmed",
+          "source_text": "5,000-6,000 mt bulk corn sf 51 wog"
+        },
+        "weight_mt_max": {
+          "value": 6000,
+          "confidence": "confirmed",
+          "source_text": "5,000-6,000 mt bulk corn sf 51 wog"
+        },
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk corn"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "15-20 June 2026",
+          "confidence": "confirmed",
+          "source_text": "15-20 June 2026"
+        },
+        "laycan": {
+          "value": "15/20 June 2026",
+          "confidence": "confirmed",
+          "source_text": "15-20 June 2026"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": {
+          "value": "51 ft³/MT WOG",
+          "confidence": "confirmed",
+          "source_text": "sf 51 wog"
+        },
+        "missing_info": [
+          "Loading and discharge terms (FIO/CQD/SHINC etc.) not stated",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-104.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-104.json
@@ -1,0 +1,92 @@
+{
+  "id": "etms-parse-cargo-104",
+  "source_email_id": "synth-r28-009",
+  "category": "incomplete_data",
+  "input": {
+    "subject": "FW: 15,000mt cement Aqaba / Berbera",
+    "from": "synth@test.quantika.app",
+    "date": "2026-06-01T08:00:00.000Z",
+    "body": "Pls propose suitable vsl for below.\n\n15,000 mt\nAqaba to Berbera\n10/15 July 2026\n3% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Aqaba",
+          "confidence": "confirmed",
+          "source_text": "Aqaba to Berbera"
+        },
+        "origin_country": {
+          "value": "Jordan",
+          "confidence": "interpreted",
+          "source_text": "Aqaba to Berbera"
+        },
+        "destination_port": {
+          "value": "Berbera",
+          "confidence": "confirmed",
+          "source_text": "Aqaba to Berbera"
+        },
+        "destination_country": {
+          "value": "Somalia",
+          "confidence": "interpreted",
+          "source_text": "Aqaba to Berbera"
+        },
+        "cargo_description": {
+          "value": "Cement in bulk",
+          "confidence": "uncertain",
+          "source_text": "cement"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 15000,
+          "confidence": "confirmed",
+          "source_text": "15,000 mt"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "uncertain",
+          "source_text": "cement"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "10/15 July 2026",
+          "confidence": "confirmed",
+          "source_text": "10/15 July 2026"
+        },
+        "laycan": {
+          "value": "10/15 July 2026",
+          "confidence": "confirmed",
+          "source_text": "10/15 July 2026"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 3.0,
+          "confidence": "confirmed",
+          "source_text": "3% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "3% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Cargo type not confirmed in email body — 'cement' inferred from subject line only",
+          "Loading and discharge terms (FIO/CQD/SHINC etc.) not stated",
+          "Demurrage and despatch rates not stated",
+          "Cement form (bulk/bagged/jumbo bags) not specified"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-105.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-105.json
@@ -1,0 +1,92 @@
+{
+  "id": "etms-parse-cargo-105",
+  "source_email_id": "synth-r28-010",
+  "category": "incomplete_data",
+  "input": {
+    "subject": "FW: 12,000mt iron ore Saldanha Bay / Rotterdam",
+    "from": "synth@test.quantika.app",
+    "date": "2026-02-20T09:00:00.000Z",
+    "body": "Pls offer as per subject.\n\nLaycan: 01/10 March 2026\n2.5% ttl"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Saldanha Bay",
+          "confidence": "confirmed",
+          "source_text": "12,000mt iron ore Saldanha Bay / Rotterdam"
+        },
+        "origin_country": {
+          "value": "South Africa",
+          "confidence": "interpreted",
+          "source_text": "Saldanha Bay"
+        },
+        "destination_port": {
+          "value": "Rotterdam",
+          "confidence": "confirmed",
+          "source_text": "12,000mt iron ore Saldanha Bay / Rotterdam"
+        },
+        "destination_country": {
+          "value": "Netherlands",
+          "confidence": "interpreted",
+          "source_text": "Rotterdam"
+        },
+        "cargo_description": {
+          "value": "Iron ore in bulk",
+          "confidence": "uncertain",
+          "source_text": "iron ore"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 12000,
+          "confidence": "confirmed",
+          "source_text": "12,000mt iron ore Saldanha Bay / Rotterdam"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "uncertain",
+          "source_text": "iron ore"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "01/10 March 2026",
+          "confidence": "confirmed",
+          "source_text": "Laycan: 01/10 March 2026"
+        },
+        "laycan": {
+          "value": "01/10 March 2026",
+          "confidence": "confirmed",
+          "source_text": "Laycan: 01/10 March 2026"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "All cargo details (type, form, stowage, grade) inferred from subject line only — body contains no cargo description",
+          "Iron ore type and grade not specified",
+          "Loading and discharge terms not stated",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-106.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-106.json
@@ -1,0 +1,96 @@
+{
+  "id": "etms-parse-cargo-106",
+  "source_email_id": "synth-r28-011",
+  "category": "numeric_edge",
+  "input": {
+    "subject": "FW: rice Bangkok/POC abt 5-8k mt",
+    "from": "synth@test.quantika.app",
+    "date": "2026-03-10T07:00:00.000Z",
+    "body": "Pls offer for:\n\nabt 5-8k mt rice in bb 50 kgs pp bags\nBangkok / POC\nspot\n3% ttl\n"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Bangkok",
+          "confidence": "confirmed",
+          "source_text": "Bangkok / POC"
+        },
+        "origin_country": {
+          "value": "Thailand",
+          "confidence": "interpreted",
+          "source_text": "Bangkok / POC"
+        },
+        "destination_port": {
+          "value": "Port of Call (unspecified)",
+          "confidence": "interpreted",
+          "source_text": "POC"
+        },
+        "destination_country": null,
+        "cargo_description": {
+          "value": "Rice in big bags, 50 kg polypropylene bags",
+          "confidence": "interpreted",
+          "source_text": "abt 5-8k mt rice in bb 50 kgs pp bags"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 8000,
+          "confidence": "interpreted",
+          "source_text": "abt 5-8k mt rice in bb 50 kgs pp bags"
+        },
+        "weight_mt_min": {
+          "value": 5000,
+          "confidence": "interpreted",
+          "source_text": "abt 5-8k mt rice in bb 50 kgs pp bags"
+        },
+        "weight_mt_max": {
+          "value": 8000,
+          "confidence": "interpreted",
+          "source_text": "abt 5-8k mt rice in bb 50 kgs pp bags"
+        },
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BREAK_BULK",
+          "confidence": "confirmed",
+          "source_text": "rice in bb 50 kgs pp bags"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "Spot",
+          "confidence": "confirmed",
+          "source_text": "spot"
+        },
+        "laycan": {
+          "value": "Spot",
+          "confidence": "interpreted",
+          "source_text": "spot"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 3.0,
+          "confidence": "confirmed",
+          "source_text": "3% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "3% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Specific discharge port not nominated (Port of Call)",
+          "Rice variety/grade not specified",
+          "Loading and discharge terms not stated",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-107.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-107.json
@@ -1,0 +1,102 @@
+{
+  "id": "etms-parse-cargo-107",
+  "source_email_id": "synth-r28-012",
+  "category": "hedged_language",
+  "input": {
+    "subject": "FW: fertilizer Yuzhne/Colombo EOM",
+    "from": "synth@test.quantika.app",
+    "date": "2026-04-18T10:00:00.000Z",
+    "body": "Pls propose for:\n\n20,000 mt bulk urea\nYuzhne / Colombo\nLaycan: EOM\n8000/6000 SHINC\n2.5% ttl\n"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Pivdennyi (Yuzhne)",
+          "confidence": "confirmed",
+          "source_text": "Yuzhne"
+        },
+        "origin_country": {
+          "value": "Ukraine",
+          "confidence": "interpreted",
+          "source_text": "Yuzhne"
+        },
+        "destination_port": {
+          "value": "Colombo",
+          "confidence": "confirmed",
+          "source_text": "Yuzhne / Colombo"
+        },
+        "destination_country": {
+          "value": "Sri Lanka",
+          "confidence": "interpreted",
+          "source_text": "Colombo"
+        },
+        "cargo_description": {
+          "value": "Bulk urea",
+          "confidence": "confirmed",
+          "source_text": "20,000 mt bulk urea"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 20000,
+          "confidence": "confirmed",
+          "source_text": "20,000 mt bulk urea"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk urea"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": null,
+        "laycan": {
+          "value": "End of April 2026",
+          "confidence": "interpreted",
+          "source_text": "EOM"
+        },
+        "loading_rate": {
+          "value": 8000,
+          "confidence": "confirmed",
+          "source_text": "8000/6000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "8000/6000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 6000,
+          "confidence": "confirmed",
+          "source_text": "8000/6000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "8000/6000 SHINC"
+        },
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Exact laycan dates not specified — 'EOM' interpreted as End of Month (April 2026 based on email date)",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-108.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-108.json
@@ -1,0 +1,99 @@
+{
+  "id": "etms-parse-cargo-108",
+  "source_email_id": "synth-r28-013",
+  "category": "numeric_edge",
+  "input": {
+    "subject": "FW: 30k mt phosphate BATS/EMED 2H-May",
+    "from": "synth@test.quantika.app",
+    "date": "2026-04-22T09:00:00.000Z",
+    "body": "Dear All,\n\nPls offer for below:\n\n30k mt bulk phosphate rock\nBATS / EMED\n2H-May 2026\n5000/3000 FHINC\n2% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Batumi",
+          "confidence": "confirmed",
+          "source_text": "BATS"
+        },
+        "origin_country": {
+          "value": "Georgia",
+          "confidence": "interpreted",
+          "source_text": "BATS"
+        },
+        "destination_port": {
+          "value": "Eastern Mediterranean port (unspecified)",
+          "confidence": "interpreted",
+          "source_text": "EMED"
+        },
+        "destination_country": null,
+        "cargo_description": {
+          "value": "Bulk phosphate rock",
+          "confidence": "confirmed",
+          "source_text": "30k mt bulk phosphate rock"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 30000,
+          "confidence": "confirmed",
+          "source_text": "30k mt bulk phosphate rock"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk phosphate rock"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": null,
+        "laycan": {
+          "value": "Second half of May 2026",
+          "confidence": "interpreted",
+          "source_text": "2H-May 2026"
+        },
+        "loading_rate": {
+          "value": 5000,
+          "confidence": "confirmed",
+          "source_text": "5000/3000 FHINC"
+        },
+        "loading_terms": {
+          "value": "FHINC",
+          "confidence": "confirmed",
+          "source_text": "5000/3000 FHINC"
+        },
+        "discharge_rate": {
+          "value": 3000,
+          "confidence": "confirmed",
+          "source_text": "5000/3000 FHINC"
+        },
+        "discharge_terms": {
+          "value": "FHINC",
+          "confidence": "confirmed",
+          "source_text": "5000/3000 FHINC"
+        },
+        "commission_percent": {
+          "value": 2.0,
+          "confidence": "confirmed",
+          "source_text": "2% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Specific Eastern Mediterranean discharge port not nominated",
+          "Phosphate rock grade/BPL content not stated",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-109.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-109.json
@@ -1,0 +1,93 @@
+{
+  "id": "etms-parse-cargo-109",
+  "source_email_id": "synth-r28-014",
+  "category": "incomplete_data",
+  "input": {
+    "subject": "FW: steel billets Marmara/Antwerp",
+    "from": "synth@test.quantika.app",
+    "date": "2026-05-05T08:00:00.000Z",
+    "body": "As per subject.\n\n8,500 mt\n20/30 May 2026\n2.5%"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Marmara",
+          "confidence": "confirmed",
+          "source_text": "steel billets Marmara/Antwerp"
+        },
+        "origin_country": {
+          "value": "Turkey",
+          "confidence": "interpreted",
+          "source_text": "Marmara"
+        },
+        "destination_port": {
+          "value": "Antwerp",
+          "confidence": "confirmed",
+          "source_text": "Marmara/Antwerp"
+        },
+        "destination_country": {
+          "value": "Belgium",
+          "confidence": "interpreted",
+          "source_text": "Antwerp"
+        },
+        "cargo_description": {
+          "value": "Steel billets",
+          "confidence": "uncertain",
+          "source_text": "steel billets"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 8500,
+          "confidence": "confirmed",
+          "source_text": "8,500 mt"
+        },
+        "weight_mt_min": null,
+        "weight_mt_max": null,
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BREAK_BULK",
+          "confidence": "uncertain",
+          "source_text": "steel billets"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": {
+          "value": "20/30 May 2026",
+          "confidence": "confirmed",
+          "source_text": "20/30 May 2026"
+        },
+        "laycan": {
+          "value": "20/30 May 2026",
+          "confidence": "confirmed",
+          "source_text": "20/30 May 2026"
+        },
+        "loading_rate": null,
+        "loading_terms": null,
+        "discharge_rate": null,
+        "discharge_terms": null,
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5%"
+        },
+        "commission_terms": {
+          "value": "Not specified (likely brokerage)",
+          "confidence": "uncertain",
+          "source_text": "2.5%"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "All cargo details inferred from subject line — body contains no commodity description",
+          "Steel billet specifications (grade, dimensions, unit weight) not stated",
+          "Loading and discharge terms not stated",
+          "Demurrage and despatch rates not stated",
+          "Commission type not specified"
+        ]
+      }
+    ]
+  }
+}

--- a/.progonq/corpus/etms-parse-cargo/scenario-110.json
+++ b/.progonq/corpus/etms-parse-cargo/scenario-110.json
@@ -1,0 +1,110 @@
+{
+  "id": "etms-parse-cargo-110",
+  "source_email_id": "synth-r28-015",
+  "category": "hedged_language",
+  "input": {
+    "subject": "FW: 25-30k mt clinker Novorossiysk/Alexandria 1H-June",
+    "from": "synth@test.quantika.app",
+    "date": "2026-05-10T07:30:00.000Z",
+    "body": "Hi,\n\nPls propose for below cargo.\n\n25-30k mt bulk clinker\nNovorossiysk / Alexandria\n1H-June 2026\n6000/4000 SHINC\n2.5% ttl\n\nBrgds"
+  },
+  "reference_output": {
+    "items": [
+      {
+        "origin_port": {
+          "value": "Novorossiysk",
+          "confidence": "confirmed",
+          "source_text": "Novorossiysk / Alexandria"
+        },
+        "origin_country": {
+          "value": "Russia",
+          "confidence": "interpreted",
+          "source_text": "Novorossiysk / Alexandria"
+        },
+        "destination_port": {
+          "value": "Alexandria",
+          "confidence": "confirmed",
+          "source_text": "Novorossiysk / Alexandria"
+        },
+        "destination_country": {
+          "value": "Egypt",
+          "confidence": "interpreted",
+          "source_text": "Alexandria"
+        },
+        "cargo_description": {
+          "value": "Bulk clinker",
+          "confidence": "confirmed",
+          "source_text": "25-30k mt bulk clinker"
+        },
+        "cargo_origin_country": null,
+        "weight_mt": {
+          "value": 30000,
+          "confidence": "interpreted",
+          "source_text": "25-30k mt bulk clinker"
+        },
+        "weight_mt_min": {
+          "value": 25000,
+          "confidence": "confirmed",
+          "source_text": "25-30k mt bulk clinker"
+        },
+        "weight_mt_max": {
+          "value": 30000,
+          "confidence": "confirmed",
+          "source_text": "25-30k mt bulk clinker"
+        },
+        "volume_cbm": null,
+        "dimensions": null,
+        "cargo_type": {
+          "value": "BULK",
+          "confidence": "confirmed",
+          "source_text": "bulk clinker"
+        },
+        "container_type": null,
+        "quantity": null,
+        "incoterms": null,
+        "preferred_dates": null,
+        "laycan": {
+          "value": "First half of June 2026",
+          "confidence": "interpreted",
+          "source_text": "1H-June 2026"
+        },
+        "loading_rate": {
+          "value": 6000,
+          "confidence": "confirmed",
+          "source_text": "6000/4000 SHINC"
+        },
+        "loading_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "6000/4000 SHINC"
+        },
+        "discharge_rate": {
+          "value": 4000,
+          "confidence": "confirmed",
+          "source_text": "6000/4000 SHINC"
+        },
+        "discharge_terms": {
+          "value": "SHINC",
+          "confidence": "confirmed",
+          "source_text": "6000/4000 SHINC"
+        },
+        "commission_percent": {
+          "value": 2.5,
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "commission_terms": {
+          "value": "TTL",
+          "confidence": "confirmed",
+          "source_text": "2.5% ttl"
+        },
+        "special_requirements": null,
+        "stowage_factor": null,
+        "missing_info": [
+          "Exact laycan dates not specified — '1H-June 2026' interpreted as first half of June 2026 (1–15 June)",
+          "Demurrage and despatch rates not stated"
+        ]
+      }
+    ]
+  }
+}

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -32,6 +32,14 @@ PORT OPERATIONS:
 - CONT / Continent = European Continent (ARA range)
 - BLTC / BST = Baltic
 
+PORT NAME ABBREVIATIONS (expand to canonical port name in origin_port / destination_port):
+- NOVOR / NOVOROS / NOVOROSS = Novorossiysk (Russia, Black Sea)
+- ISK = Iskenderun (Turkey, Eastern Mediterranean)
+- PIVD / YUZH / YUZHNE = Pivdennyi (Yuzhne) (Ukraine, Black Sea); also written as "Pivdennyi (Yuzhne)" or just "Yuzhne"
+- BATS / BATM = Batumi (Georgia, Black Sea)
+- ILYCH / ILL = Chornomorsk (Ukraine, Black Sea; former name Ilichevsk)
+- SOUTH UKRAINE / S.UKR = South Ukraine port (unspecified)
+
 CARGO ABBREVIATIONS (always expand in cargo_description):
 - HRC = Hot Rolled Coils
 - HRCPO = Hot Rolled Coils Pickled & Oiled
@@ -231,6 +239,10 @@ Allowed extractions:
 - Literal "Spot" / "Spot-onward" → laycan = "Spot", confidence='interpreted'.
 - Literal "spot/vsls dates" (or equivalent substring) → laycan = "Spot — vessel's dates", confidence='interpreted'.
 - Literal "PPT" or "Prompt" → laycan = "Prompt", confidence='interpreted'.
+- "1H [Month]" / "1H-[Month]" (first half) → laycan = "First half of [Month] YYYY", confidence='interpreted'. Example: "1H-March 2026" → "First half of March 2026".
+- "2H [Month]" / "2H-[Month]" (second half) → laycan = "Second half of [Month] YYYY", confidence='interpreted'. Example: "2H April 2026" → "Second half of April 2026".
+- "EOM" / "eom" (end of month) without month name → laycan = "End of [Month] YYYY" where Month is derived from email date, confidence='interpreted'. Example: email date April 2026, "EOM" → "End of April 2026".
+- "eom-[month]" / "EOM [Month]" (end of specific month) → laycan = "End [Month] YYYY", confidence='interpreted'. Example: "eom-jan" → "End January [YYYY]"; "eom-jan / eom-feb" → "End January / End February [YYYY]".
 
 If none of the above apply: laycan = null. Do NOT guess "Spot" from
 contextual hints ("asap", "urgent", "vessel ready", absence of any window).
@@ -350,7 +362,8 @@ Extract per inquiry item:
 - cargo_description: full description of goods (see CARGO DESCRIPTION RULES — always expand abbreviations)
 - cargo_origin_country: the COUNTRY OF ORIGIN of the cargo itself — NOT the load port country. This is relevant when the email mentions the cargo's provenance separately from the load port (e.g. "Indonesian origin thermal coal loaded at Dammam" → cargo_origin_country = "Indonesia", while origin_country = "Saudi Arabia"). Null if not stated. Source: phrases like "[Country] origin", "from [Country]", "[Country]-produced", "[Country] coal/grain/etc."
 - weight_mt: number (metric tons).
-  RANGE RULE: If cargo weight is given as an explicit range (e.g. "4000/4800 MT", "5000-5500 MT"), return the UPPER BOUND as weight_mt (confidence='interpreted'). Also populate weight_mt_min and weight_mt_max.
+  K-SUFFIX RULE: "k" or "K" after a number means ×1000 metric tons. "50k mt" = 50,000 MT; "40-50k mt" = range of 40,000–50,000 MT; "abt 5-8k mt" = approximately 5,000–8,000 MT. Apply this conversion before all other rules.
+  RANGE RULE: If cargo weight is given as an explicit range (e.g. "4000/4800 MT", "5000-5500 MT", "40-50k mt"), return the UPPER BOUND as weight_mt (confidence='interpreted'). Also populate weight_mt_min and weight_mt_max.
   MOLOO RULE: MOLOO (More or Less Owner's Option) is a CONTRACT TOLERANCE clause — NOT a weight range. "28,000 mts (10% MOLOO)" means the nominal quantity is 28,000 mts and the owner may load ±10% at their option. Set weight_mt = 28000 (the nominal stated value). Set weight_mt_min = 25200 and weight_mt_max = 30800 to record the tolerance bounds. Do NOT set weight_mt to the MOLOO maximum (30800). "Abt 28,000 mts (10% MOLOO)" → weight_mt=28000 with confidence='interpreted' (due to "abt"), weight_mt_min=25200, weight_mt_max=30800.
   MOLCHOPT RULE: Same as MOLOO but charterer controls the tolerance. "2,720mts 2PCT MOLCHOPT" → weight_mt=2720, weight_mt_min=2666 (2720×0.98), weight_mt_max=2774 (2720×1.02).
   SINGLE VALUE: If a single definite number is given with no hedge, weight_mt = weight_mt_min = weight_mt_max = that number, confidence='confirmed'.


### PR DESCRIPTION
R28 +5-7pp prompt + 15 synthetic edge-case scenarios. Cold-QA PASS, 42/42 green. 🤖 Generated with Claude Code