### PR TITLE
feat(matching): TCE freight rate estimation + manual override [code-only]

### DIFF
--- a/__tests__/api/freight-rate-override.test.ts
+++ b/__tests__/api/freight-rate-override.test.ts
@@ -1,0 +1,160 @@
+/**
+ * PI2 behavioral tests — PATCH /api/matches/[id] freight rate override.
+ *
+ * Covers:
+ *   - PATCH with valid freight_rate_usd_per_mt recalculates TCE and stores it
+ *   - PATCH with invalid rate (0, negative, non-numeric) returns 400
+ *   - PATCH returns 404 for non-existent match id
+ *   - PATCH returns 404 when match belongs to a different session (isolation)
+ *   - PATCH returns 401 when unauthenticated
+ *   - PATCH returns 503 when feature disabled
+ *   - Manual override sets freight_rate_source='manual'
+ *   - Recalculated tce_usd_per_day is a finite number
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest, NextResponse } from 'next/server';
+import migration032 from '@/lib/migrations/032-matches';
+import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import migration035 from '@/lib/migrations/035-matches-tce-distance';
+import migration036 from '@/lib/migrations/036-matches-freight-rate';
+import { createMatch } from '@/lib/matching/matches-repository';
+import { requireSession } from '@/lib/session';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+
+const SESSION_ID = 'test-session-freight';
+const OTHER_SESSION_ID = 'other-session';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  migration033.up(db);
+  migration034.up(db);
+  migration035.up(db);
+  migration036.up(db);
+  return db;
+}
+
+function seedMatch(db: Database.Database, sessionId = SESSION_ID, extra: Record<string, unknown> = {}) {
+  return createMatch(db, {
+    cargo_id: 'cargo-test',
+    vessel_id: 'vessel-test',
+    score: 80,
+    reason: 'test match',
+    user_id: sessionId,
+    distance_nm: 3000,
+    vessel_dwt: 50000,
+    cargo_type: 'BULK',
+    ...extra,
+  });
+}
+
+beforeEach(() => {
+  testDb = freshDb();
+  process.env.MATCHES_ENABLED = 'true';
+  mockRequireSession.mockReturnValue({
+    session: { id: SESSION_ID },
+    sessionId: SESSION_ID,
+  });
+});
+
+afterEach(() => {
+  testDb.close();
+});
+
+describe('PATCH /api/matches/[id] — freight rate override', () => {
+  let PATCH: (req: NextRequest, ctx: { params: Promise<{ id: string }> }) => Promise<NextResponse>;
+
+  beforeAll(async () => {
+    ({ PATCH } = await import('@/app/api/matches/[id]/route'));
+  });
+
+  function doPatch(id: number, body: unknown) {
+    return PATCH(
+      new NextRequest(`http://localhost/api/matches/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+      { params: Promise.resolve({ id: String(id) }) },
+    );
+  }
+
+  it('recalculates TCE and stores freight_rate_source=manual', async () => {
+    const match = seedMatch(testDb);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 25 });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.freight_rate_usd_per_mt).toBe(25);
+    expect(json.freight_rate_source).toBe('manual');
+    expect(Number.isFinite(json.tce_usd_per_day)).toBe(true);
+  });
+
+  it('tce_usd_per_day is a finite number after override', async () => {
+    const match = seedMatch(testDb);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 30 });
+    const json = await res.json();
+    expect(typeof json.tce_usd_per_day).toBe('number');
+    expect(Number.isFinite(json.tce_usd_per_day)).toBe(true);
+  });
+
+  it('returns 400 for rate=0', async () => {
+    const match = seedMatch(testDb);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for negative rate', async () => {
+    const match = seedMatch(testDb);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: -5 });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-numeric rate', async () => {
+    const match = seedMatch(testDb);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for non-existent match id', async () => {
+    const res = await doPatch(99999, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when match belongs to different session (isolation)', async () => {
+    const match = seedMatch(testDb, OTHER_SESSION_ID);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const match = seedMatch(testDb);
+    mockRequireSession.mockReturnValueOnce(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    );
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when feature disabled', async () => {
+    process.env.MATCHES_ENABLED = 'false';
+    const match = seedMatch(testDb);
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(503);
+  });
+});

--- a/app/api/matches/[id]/route.ts
+++ b/app/api/matches/[id]/route.ts
@@ -4,8 +4,10 @@ import { requireSession } from '@/lib/session';
 import {
   getMatch,
   updateMatchStatus,
+  updateMatchFreightRate,
 } from '@/lib/matching/matches-repository';
 import type { MatchStatus } from '@/lib/matching/matches-repository';
+import { estimateFreightRate, computeEstimatedTce } from '@/lib/matching/tce-calculator';
 
 export const dynamic = 'force-dynamic';
 
@@ -54,6 +56,7 @@ export async function PATCH(
 ): Promise<NextResponse> {
   const authResult = requireSession(request);
   if (authResult instanceof NextResponse) return authResult;
+  const { sessionId } = authResult;
 
   if (!isFeatureEnabled()) {
     return NextResponse.json(
@@ -73,22 +76,43 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { status } = body;
+    const { status, freight_rate_usd_per_mt } = body;
 
+    const db = getStore().getDatabase();
+    const existing = getMatch(db, id);
+
+    if (!existing || existing.user_id !== sessionId) {
+      return NextResponse.json(
+        { error: `Match not found: ${id}` },
+        { status: 404 }
+      );
+    }
+
+    // Freight rate override path
+    if (freight_rate_usd_per_mt !== undefined) {
+      const rate = Number(freight_rate_usd_per_mt);
+      if (!Number.isFinite(rate) || rate <= 0) {
+        return NextResponse.json(
+          { error: 'freight_rate_usd_per_mt must be a positive number' },
+          { status: 400 }
+        );
+      }
+      const freightEst = { rate, source: 'manual' as const, confidence: 1.0 };
+      const tceEst = computeEstimatedTce(
+        freightEst,
+        existing.distance_nm ?? 0,
+        existing.vessel_dwt ?? 0,
+        0,
+      );
+      const updated = updateMatchFreightRate(db, id, rate, tceEst.tce_usd_per_day, 'manual');
+      return NextResponse.json(updated, { status: 200 });
+    }
+
+    // Status update path
     if (!status || typeof status !== 'string' || !VALID_STATUSES.includes(status as MatchStatus)) {
       return NextResponse.json(
         { error: 'Field "status" is required and must be one of: shortlist, saved, dismissed, archived' },
         { status: 400 }
-      );
-    }
-
-    const db = getStore().getDatabase();
-
-    const existing = getMatch(db, id);
-    if (!existing) {
-      return NextResponse.json(
-        { error: `Match not found: ${id}` },
-        { status: 404 }
       );
     }
 

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -162,6 +162,9 @@ export default async function MatchDetailPage({ params }: Props) {
               vessel={vessel}
               cargo={cargo}
               cargoEmailId={cargoEmail?.id}
+              matchDbId={storedMatch.id}
+              storedFreightRate={storedMatch.freight_rate_usd_per_mt}
+              freightRateSource={storedMatch.freight_rate_source}
             />
 
             {cargo && cargoEmail && (

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -446,8 +446,11 @@ export default function MatchesClient({ initialMatches, isComputing = false }: P
                             </div>
                           )}
                           {match.tce_usd_per_day != null && (
-                            <div className="text-xs font-medium text-emerald-700">
+                            <div className="text-xs font-medium text-emerald-700 flex items-center gap-1">
                               TCE: ${match.tce_usd_per_day.toLocaleString()}/day
+                              {match.freight_rate_source === 'estimated' && (
+                                <span className="text-xs bg-amber-100 text-amber-700 px-1 rounded" title="Estimated freight rate">est</span>
+                              )}
                             </div>
                           )}
                         </div>

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import type { ParsedVessel, ParsedCargo } from '@/lib/types';
 import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
 import { calculateFuelEu } from '@/lib/economics/fueleu';
@@ -16,6 +16,9 @@ interface EconomicsTabProps {
    * (shows "Voyage distance n/a") instead of using a hardcoded constant.
    */
   routeDistanceNm?: number | null;
+  matchDbId?: number | null;
+  storedFreightRate?: number | null;
+  freightRateSource?: string | null;
 }
 
 function parseLeadingNumber(s: string | null | undefined): number {
@@ -48,9 +51,13 @@ const DISPLAY_RATES: Record<DisplayCurrency, number> = {
   USD: 1, EUR: 0.926, GBP: 0.787, NOK: 10.87, AED: 3.67,
 };
 
-export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm }: EconomicsTabProps) {
+export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm, matchDbId, storedFreightRate, freightRateSource }: EconomicsTabProps) {
   const [open, setOpen] = useState(false);
   const [bunkerPriceUsdPerMt, setBunkerPriceUsdPerMt] = useState('');
+  const [overrideRate, setOverrideRate] = useState(storedFreightRate != null ? String(storedFreightRate) : '');
+  const [overrideTce, setOverrideTce] = useState<number | null>(null);
+  const [overrideSaving, setOverrideSaving] = useState(false);
+  const [overrideError, setOverrideError] = useState<string | null>(null);
   const [bunkerPort, setBunkerPort] = useState<BunkerPort>('SGSIN');
   const [bunkerGrade, setBunkerGrade] = useState<BunkerGrade>('VLSFO');
   const [displayCurrency, setDisplayCurrency] = useState<DisplayCurrency>('USD');
@@ -74,6 +81,35 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
       .catch(() => { if (!cancelled) setEuaPhase('unavailable'); });
     return () => { cancelled = true; };
   }, []);
+
+  const handleOverrideSubmit = useCallback(async () => {
+    if (!matchDbId) return;
+    const rate = parseFloat(overrideRate);
+    if (!Number.isFinite(rate) || rate <= 0) {
+      setOverrideError('Enter a positive rate (USD/mt)');
+      return;
+    }
+    setOverrideSaving(true);
+    setOverrideError(null);
+    try {
+      const res = await fetch(`/api/matches/${matchDbId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ freight_rate_usd_per_mt: rate }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setOverrideError((data as { error?: string }).error ?? `Error ${res.status}`);
+      } else {
+        const updated = await res.json();
+        setOverrideTce(updated.tce_usd_per_day ?? null);
+      }
+    } catch {
+      setOverrideError('Network error');
+    } finally {
+      setOverrideSaving(false);
+    }
+  }, [matchDbId, overrideRate]);
 
   const compareInputs = useMemo(() => {
     const origin = cargo?.originPort?.value ?? '';
@@ -145,6 +181,52 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
 
   return (
     <div data-testid="tab-economics" className="space-y-4 text-sm">
+      {/* Freight rate override */}
+      {matchDbId != null && (
+        <div data-testid="freight-rate-override" className="rounded border border-blue-200 bg-blue-50 p-3 space-y-2">
+          <h3 className="text-xs font-semibold text-blue-900">Freight Rate Override</h3>
+          {storedFreightRate != null && (
+            <p className="text-xs text-gray-600">
+              Current: <span className="font-medium">${storedFreightRate}/mt</span>
+              {freightRateSource === 'estimated' && (
+                <span className="ml-1 text-amber-700 bg-amber-100 px-1 rounded">est</span>
+              )}
+            </p>
+          )}
+          {overrideTce != null && (
+            <p data-testid="override-tce-result" className="text-xs font-medium text-emerald-700">
+              Recalculated TCE: ${overrideTce.toLocaleString()}/day
+            </p>
+          )}
+          <div className="flex gap-2 items-end">
+            <div className="flex-1">
+              <label className="text-xs text-gray-600 block mb-0.5">Rate (USD/mt)</label>
+              <input
+                data-testid="freight-rate-input"
+                type="number"
+                value={overrideRate}
+                onChange={(e) => { setOverrideRate(e.target.value); setOverrideTce(null); setOverrideError(null); }}
+                placeholder="e.g. 28"
+                min={0}
+                step={0.1}
+                className="w-full border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:border-blue-400"
+              />
+            </div>
+            <button
+              data-testid="freight-rate-submit"
+              onClick={handleOverrideSubmit}
+              disabled={overrideSaving || !overrideRate}
+              className="px-3 py-1.5 text-xs rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {overrideSaving ? '…' : 'Recalculate'}
+            </button>
+          </div>
+          {overrideError && (
+            <p data-testid="freight-rate-error" className="text-xs text-red-600">{overrideError}</p>
+          )}
+        </div>
+      )}
+
       {commissionPercent != null && (
         <div>
           <span className="text-gray-500">Commission</span>

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -22,9 +22,12 @@ interface MatchTabsProps {
   vessel?: ParsedVessel;
   cargo?: ParsedCargo;
   cargoEmailId?: string;
+  matchDbId?: number;
+  storedFreightRate?: number | null;
+  freightRateSource?: string | null;
 }
 
-export function MatchTabs({ match, vessel, cargo, cargoEmailId }: MatchTabsProps) {
+export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, storedFreightRate, freightRateSource }: MatchTabsProps) {
   const [activeTab, setActiveTab] = useState<TabId>('vessels');
   const uid = useId();
 
@@ -71,6 +74,9 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId }: MatchTabsProps
             vessel={vessel}
             cargo={cargo}
             routeDistanceNm={match.readiness?.distanceNm ?? null}
+            matchDbId={matchDbId}
+            storedFreightRate={storedFreightRate}
+            freightRateSource={freightRateSource}
           />
         )}
         {activeTab === 'passport' && (

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests — tce-calculator.ts
+ *
+ * Covers:
+ *   estimateFreightRate:
+ *     - known cargo types return their expected base rate range
+ *     - unknown cargo type falls back to median rate
+ *     - distance factor applied (short vs long voyage)
+ *     - DWT factor applied (small vs large vessel)
+ *     - null cargo_type → median fallback
+ *     - confidence: 0.6 for known, 0.3 for unknown
+ *     - source is always 'estimated'
+ *     - rate is always >= 1
+ *   computeEstimatedTce:
+ *     - returns a number (not NaN, not null)
+ *     - with manual override source='manual' passes through
+ *     - zero distance returns tce from 10-day fallback
+ *     - negative distance treated as 0
+ *   parseLeadingNumber:
+ *     - parses "12.5 knots" → 12.5
+ *     - parses "25 mt/day" → 25
+ *     - empty string → 0
+ *     - null → 0
+ */
+
+import {
+  estimateFreightRate,
+  computeEstimatedTce,
+  parseLeadingNumber,
+} from '@/lib/matching/tce-calculator';
+
+describe('parseLeadingNumber', () => {
+  it('parses "12.5 knots"', () => {
+    expect(parseLeadingNumber('12.5 knots')).toBe(12.5);
+  });
+
+  it('parses "25 mt/day"', () => {
+    expect(parseLeadingNumber('25 mt/day')).toBe(25);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseLeadingNumber('')).toBe(0);
+  });
+
+  it('returns 0 for null', () => {
+    expect(parseLeadingNumber(null)).toBe(0);
+  });
+
+  it('returns 0 for undefined', () => {
+    expect(parseLeadingNumber(undefined)).toBe(0);
+  });
+});
+
+describe('estimateFreightRate', () => {
+  it('returns source="estimated" always', () => {
+    const result = estimateFreightRate('BULK', 3000, 50000);
+    expect(result.source).toBe('estimated');
+  });
+
+  it('confidence=0.6 for known cargo type', () => {
+    const result = estimateFreightRate('COAL', 3000, 50000);
+    expect(result.confidence).toBe(0.6);
+  });
+
+  it('confidence=0.3 for unknown cargo type', () => {
+    const result = estimateFreightRate('UNKNOWN_TYPE', 3000, 50000);
+    expect(result.confidence).toBe(0.3);
+  });
+
+  it('null cargo_type falls back to median rate (confidence=0.3)', () => {
+    const result = estimateFreightRate(null, 3000, 50000);
+    expect(result.confidence).toBe(0.3);
+    expect(result.rate).toBeGreaterThan(0);
+  });
+
+  it('GRAIN has lower rate than BREAK_BULK at same distance/dwt', () => {
+    const grain = estimateFreightRate('GRAIN', 3000, 50000);
+    const breakBulk = estimateFreightRate('BREAK_BULK', 3000, 50000);
+    expect(grain.rate).toBeLessThan(breakBulk.rate);
+  });
+
+  it('long voyage (>6000nm) produces higher rate than short voyage (<1000nm)', () => {
+    const short = estimateFreightRate('BULK', 500, 50000);
+    const long = estimateFreightRate('BULK', 8000, 50000);
+    expect(long.rate).toBeGreaterThan(short.rate);
+  });
+
+  it('small vessel (<20000 DWT) produces higher rate than capesize (>120000 DWT)', () => {
+    const small = estimateFreightRate('BULK', 3000, 15000);
+    const cape = estimateFreightRate('BULK', 3000, 150000);
+    expect(small.rate).toBeGreaterThan(cape.rate);
+  });
+
+  it('rate is always >= 1', () => {
+    const result = estimateFreightRate('IRON_ORE', 100, 200000);
+    expect(result.rate).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles case-insensitive cargo type', () => {
+    const upper = estimateFreightRate('COAL', 3000, 50000);
+    const lower = estimateFreightRate('coal', 3000, 50000);
+    expect(upper.rate).toBe(lower.rate);
+  });
+
+  it('handles cargo type with spaces (IRON ORE)', () => {
+    const result = estimateFreightRate('IRON ORE', 3000, 50000);
+    expect(result.confidence).toBe(0.6);
+  });
+});
+
+describe('computeEstimatedTce', () => {
+  it('returns a finite tce_usd_per_day', () => {
+    const est = estimateFreightRate('BULK', 3000, 50000);
+    const result = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25);
+    expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
+  });
+
+  it('passes through manual source', () => {
+    const manual = { rate: 30, source: 'manual' as const, confidence: 1.0 };
+    const result = computeEstimatedTce(manual, 3000, 50000, 45000);
+    expect(result.freight_rate_source).toBe('manual');
+    expect(result.freight_rate_usd_per_mt).toBe(30);
+  });
+
+  it('zero distance uses 10-day fallback and still returns finite TCE', () => {
+    const est = estimateFreightRate('BULK', 0, 50000);
+    const result = computeEstimatedTce(est, 0, 50000, 45000);
+    expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
+  });
+
+  it('zero quantity uses dwt*0.9 fallback', () => {
+    const est = estimateFreightRate('BULK', 3000, 50000);
+    const withQty = computeEstimatedTce(est, 3000, 50000, 45000);
+    const withZeroQty = computeEstimatedTce(est, 3000, 50000, 0);
+    // Both should be finite, zero-qty result uses 50000*0.9=45000 so should be similar
+    expect(Number.isFinite(withZeroQty.tce_usd_per_day)).toBe(true);
+    expect(withZeroQty.tce_usd_per_day).toBeCloseTo(withQty.tce_usd_per_day, -3);
+  });
+
+  it('higher freight rate → higher TCE', () => {
+    const low = { rate: 10, source: 'estimated' as const, confidence: 0.6 };
+    const high = { rate: 40, source: 'estimated' as const, confidence: 0.6 };
+    const tce_low = computeEstimatedTce(low, 3000, 50000, 45000).tce_usd_per_day;
+    const tce_high = computeEstimatedTce(high, 3000, 50000, 45000).tce_usd_per_day;
+    expect(tce_high).toBeGreaterThan(tce_low);
+  });
+});

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -8,6 +8,7 @@ import { MATCH_PROMPT } from '@/lib/prompts';
 import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
+import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
 
 /**
  * Compute matches for a session and persist them to the DB.
@@ -58,6 +59,23 @@ export async function computeAndPersistMatches(
     const dischargePort = cargo ? cfValue(cargo.destinationPort) : null;
     const distanceResult = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
 
+    const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? 0) : 0;
+    const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
+    const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
+    const consumptionMt = vessel ? parseLeadingNumber(vessel.consumption) : 0;
+
+    let tce_usd_per_day: number | null = null;
+    let freight_rate_usd_per_mt: number | null = null;
+    let freight_rate_source: string | null = null;
+
+    if (distanceResult && distanceResult.nm > 0) {
+      const freightEst = estimateFreightRate(cargoType, distanceResult.nm, vesselDwt);
+      const tceEst = computeEstimatedTce(freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt);
+      tce_usd_per_day = tceEst.tce_usd_per_day;
+      freight_rate_usd_per_mt = tceEst.freight_rate_usd_per_mt;
+      freight_rate_source = tceEst.freight_rate_source;
+    }
+
     createMatch(db, {
       cargo_id: m.cargoEmailId,
       vessel_id: m.vesselEmailId,
@@ -71,9 +89,11 @@ export async function computeAndPersistMatches(
       discharge_port: dischargePort,
       laycan_start: laycan ? laycan.start.getTime() : null,
       laycan_end: laycan ? laycan.end.getTime() : null,
-      vessel_dwt: vessel ? cfValue(vessel.dwtSummer) : null,
-      tce_usd_per_day: null,
+      vessel_dwt: vesselDwt || null,
+      tce_usd_per_day,
       distance_nm: distanceResult ? distanceResult.nm : null,
+      freight_rate_usd_per_mt,
+      freight_rate_source,
     });
   }
 

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -21,6 +21,8 @@ export interface StoredMatch {
   vessel_dwt: number | null;
   tce_usd_per_day: number | null;
   distance_nm: number | null;
+  freight_rate_usd_per_mt: number | null;
+  freight_rate_source: string | null;
 }
 
 export interface CreateMatchInput {
@@ -39,6 +41,8 @@ export interface CreateMatchInput {
   vessel_dwt?: number | null;
   tce_usd_per_day?: number | null;
   distance_nm?: number | null;
+  freight_rate_usd_per_mt?: number | null;
+  freight_rate_source?: string | null;
 }
 
 export interface ListMatchesOptions {
@@ -74,6 +78,11 @@ function hasTceColumns(db: Database.Database): boolean {
   return cols.some((c) => c.name === 'tce_usd_per_day');
 }
 
+function hasFreightRateColumns(db: Database.Database): boolean {
+  const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+  return cols.some((c) => c.name === 'freight_rate_usd_per_mt');
+}
+
 export function createMatch(db: Database.Database, input: CreateMatchInput): StoredMatch {
   const now = Date.now();
   const status: MatchStatus = input.status ?? 'shortlist';
@@ -81,7 +90,49 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
 
   let result: { lastInsertRowid: number | bigint; changes: number };
 
-  if (hasTceColumns(db)) {
+  if (hasFreightRateColumns(db)) {
+    const reason_structured = input.reason_structured ?? null;
+    const cargo_type = input.cargo_type ?? null;
+    const load_port = input.load_port ?? null;
+    const discharge_port = input.discharge_port ?? null;
+    const laycan_start = input.laycan_start ?? null;
+    const laycan_end = input.laycan_end ?? null;
+    const vessel_dwt = input.vessel_dwt ?? null;
+    const tce_usd_per_day = input.tce_usd_per_day ?? null;
+    const distance_nm = input.distance_nm ?? null;
+    const freight_rate_usd_per_mt = input.freight_rate_usd_per_mt ?? null;
+    const freight_rate_source = input.freight_rate_source ?? null;
+
+    const stmt = db.prepare(
+      `INSERT OR IGNORE INTO matches
+         (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+          reason_structured, cargo_type, load_port, discharge_port,
+          laycan_start, laycan_end, vessel_dwt, tce_usd_per_day, distance_nm,
+          freight_rate_usd_per_mt, freight_rate_source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    result = stmt.run(
+      input.cargo_id,
+      input.vessel_id,
+      input.score,
+      input.reason,
+      status,
+      user_id,
+      now,
+      now,
+      reason_structured,
+      cargo_type,
+      load_port,
+      discharge_port,
+      laycan_start,
+      laycan_end,
+      vessel_dwt,
+      tce_usd_per_day,
+      distance_nm,
+      freight_rate_usd_per_mt,
+      freight_rate_source,
+    );
+  } else if (hasTceColumns(db)) {
     const reason_structured = input.reason_structured ?? null;
     const cargo_type = input.cargo_type ?? null;
     const load_port = input.load_port ?? null;
@@ -273,6 +324,24 @@ export function listMatches(db: Database.Database, opts: ListMatchesOptions): St
   }
 
   return db.prepare(query).all(...params) as StoredMatch[];
+}
+
+export function updateMatchFreightRate(
+  db: Database.Database,
+  id: number,
+  freight_rate_usd_per_mt: number,
+  tce_usd_per_day: number,
+  source: 'manual' | 'estimated' = 'manual',
+): StoredMatch {
+  const existing = getMatch(db, id);
+  if (!existing) throw new Error(`Match not found: ${id}`);
+
+  const now = Date.now();
+  db.prepare(
+    `UPDATE matches SET freight_rate_usd_per_mt = ?, freight_rate_source = ?, tce_usd_per_day = ?, updated_at = ? WHERE id = ?`
+  ).run(freight_rate_usd_per_mt, source, tce_usd_per_day, now, id);
+
+  return getMatch(db, id) as StoredMatch;
 }
 
 export function updateMatchStatus(db: Database.Database, id: number, newStatus: MatchStatus): StoredMatch {

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -4,6 +4,7 @@ import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
 import { createMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
+import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
 
 export function persistSessionMatches(
   db: Database.Database,
@@ -24,6 +25,28 @@ export function persistSessionMatches(
     const dischargePort = cargo ? cfValue(cargo.destinationPort) : null;
     const distanceResult = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
 
+    const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? 0) : 0;
+    const cargoTypeStr = cargo
+      ? (typeof cargo.cargoType === 'object' && cargo.cargoType !== null && 'value' in cargo.cargoType
+          ? (cargo.cargoType as unknown as { value: string }).value
+          : cargo.cargoType as string)
+      : null;
+    const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
+    const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
+    const consumptionMt = vessel ? parseLeadingNumber(vessel.consumption) : 0;
+
+    let tce_usd_per_day: number | null = null;
+    let freight_rate_usd_per_mt: number | null = null;
+    let freight_rate_source: string | null = null;
+
+    if (distanceResult && distanceResult.nm > 0) {
+      const freightEst = estimateFreightRate(cargoTypeStr, distanceResult.nm, vesselDwt);
+      const tceEst = computeEstimatedTce(freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt);
+      tce_usd_per_day = tceEst.tce_usd_per_day;
+      freight_rate_usd_per_mt = tceEst.freight_rate_usd_per_mt;
+      freight_rate_source = tceEst.freight_rate_source;
+    }
+
     createMatch(db, {
       cargo_id: m.cargoEmailId,
       vessel_id: m.vesselEmailId,
@@ -32,14 +55,16 @@ export function persistSessionMatches(
       status: 'shortlist',
       user_id: sessionId,
       reason_structured: m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
-      cargo_type: cargo ? cargo.cargoType : null,
+      cargo_type: cargoTypeStr,
       load_port: loadPort,
       discharge_port: dischargePort,
       laycan_start: laycan ? laycan.start.getTime() : null,
       laycan_end: laycan ? laycan.end.getTime() : null,
-      vessel_dwt: vessel ? cfValue(vessel.dwtSummer) : null,
-      tce_usd_per_day: null,
+      vessel_dwt: vesselDwt || null,
+      tce_usd_per_day,
       distance_nm: distanceResult ? distanceResult.nm : null,
+      freight_rate_usd_per_mt,
+      freight_rate_source,
     });
   }
 }

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -1,0 +1,120 @@
+import { calculateTCE } from '@/lib/economics/voyage-calculator';
+
+// Ballpark base freight rates (USD/mt) per cargo class
+const BASE_RATES: Record<string, number> = {
+  BULK: 20,
+  GRAIN: 18,
+  COAL: 12,
+  IRON_ORE: 10,
+  FERTILIZER: 22,
+  STEEL: 28,
+  BREAK_BULK: 30,
+  GENERAL_CARGO: 26,
+  CONTAINER: 35,
+  LUMBER: 32,
+  CEMENT: 24,
+  SUGAR: 20,
+  SALT: 15,
+  SCRAP: 18,
+  CLINKER: 22,
+};
+
+const BASE_RATE_FALLBACK = 22;
+const DEFAULT_BUNKER_USD_PER_MT = 600;
+const DEFAULT_EUA_EUR = 65;
+const DEFAULT_SPEED_KTS = 12;
+const DEFAULT_CONSUMPTION_MT_PER_DAY = 25;
+const DEFAULT_VESSEL_VALUE_USD = 22_000_000;
+
+export interface FreightRateEstimate {
+  rate: number;
+  source: 'estimated' | 'manual';
+  confidence: number;
+}
+
+export interface TceEstimate {
+  tce_usd_per_day: number;
+  freight_rate_usd_per_mt: number;
+  freight_rate_source: 'estimated' | 'manual';
+}
+
+// Parse a leading number from strings like "12.5 knots", "25 mt/day"
+export function parseLeadingNumber(s: string | null | undefined): number {
+  if (!s) return 0;
+  const m = s.match(/(\d+(?:\.\d+)?)/);
+  return m ? Number(m[1]) : 0;
+}
+
+// Longer voyages warrant higher rates per mt
+function distanceFactor(nm: number): number {
+  if (nm <= 0) return 1.0;
+  if (nm < 1000) return 0.7;
+  if (nm < 3000) return 1.0;
+  if (nm < 6000) return 1.3;
+  return 1.6;
+}
+
+// Smaller vessels command higher rates per mt
+function dwtFactor(dwt: number): number {
+  if (dwt <= 0) return 1.0;
+  if (dwt < 20000) return 1.4;
+  if (dwt < 40000) return 1.2;
+  if (dwt < 65000) return 1.0;
+  if (dwt < 120000) return 0.9;
+  return 0.8;
+}
+
+export function estimateFreightRate(
+  cargo_type: string | null,
+  distance_nm: number,
+  vessel_dwt: number,
+): FreightRateEstimate {
+  const key = (cargo_type ?? '').toUpperCase().replace(/[\s-]+/g, '_').trim();
+  const base = BASE_RATES[key] ?? BASE_RATE_FALLBACK;
+  const confidence = BASE_RATES[key] !== undefined ? 0.6 : 0.3;
+  const rate = Math.max(1, Math.round(base * distanceFactor(distance_nm) * dwtFactor(vessel_dwt) * 100) / 100);
+  return { rate, source: 'estimated', confidence };
+}
+
+export function computeEstimatedTce(
+  freightRate: FreightRateEstimate,
+  distance_nm: number,
+  vessel_dwt: number,
+  quantity_mt: number,
+  speed_kts: number = DEFAULT_SPEED_KTS,
+  consumption_mt_per_day: number = DEFAULT_CONSUMPTION_MT_PER_DAY,
+): TceEstimate {
+  const safeDist = distance_nm > 0 ? distance_nm : 0;
+  const safeDwt = vessel_dwt > 0 ? vessel_dwt : 10000;
+  const safeQty = quantity_mt > 0 ? quantity_mt : safeDwt * 0.9;
+  const safeSpeed = speed_kts > 0 ? speed_kts : DEFAULT_SPEED_KTS;
+  const safeCons = consumption_mt_per_day > 0 ? consumption_mt_per_day : DEFAULT_CONSUMPTION_MT_PER_DAY;
+  const durationDays = safeDist > 0 ? safeDist / (safeSpeed * 24) : 10;
+
+  const result = calculateTCE({
+    vessel: {
+      dwt: safeDwt,
+      valueUsd: DEFAULT_VESSEL_VALUE_USD,
+      speedKts: safeSpeed,
+      consumptionMtPerDay: safeCons,
+    },
+    route: {
+      originPort: '',
+      destinationPort: '',
+      distanceNm: safeDist,
+    },
+    cargo: {
+      quantityMt: safeQty,
+      freightRateUsdPerMt: freightRate.rate,
+    },
+    bunkerPriceUsdPerMt: DEFAULT_BUNKER_USD_PER_MT,
+    euaPriceEur: DEFAULT_EUA_EUR,
+    durationDays,
+  });
+
+  return {
+    tce_usd_per_day: result.daily_tce_usd,
+    freight_rate_usd_per_mt: freightRate.rate,
+    freight_rate_source: freightRate.source,
+  };
+}

--- a/lib/migrations/036-matches-freight-rate.ts
+++ b/lib/migrations/036-matches-freight-rate.ts
@@ -1,0 +1,21 @@
+import type { Migration } from "./types";
+
+const migration036: Migration = {
+  version: 36,
+  name: "matches-freight-rate",
+  up(db) {
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    if (!names.has('freight_rate_usd_per_mt')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN freight_rate_usd_per_mt REAL`);
+    }
+    if (!names.has('freight_rate_source')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN freight_rate_source TEXT`);
+    }
+  },
+  down(db) {
+    void db;
+  },
+};
+
+export default migration036;

--- a/lib/migrations/__tests__/036-matches-freight-rate.test.ts
+++ b/lib/migrations/__tests__/036-matches-freight-rate.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests — migration 036 (freight_rate_usd_per_mt + freight_rate_source columns).
+ *
+ * Covers:
+ *   - up() adds both columns to matches table
+ *   - Both columns accept NULL
+ *   - Both columns accept non-null values
+ *   - up() is idempotent (re-run after already applied does not throw)
+ *   - Migration metadata (version, name)
+ */
+
+import Database from 'better-sqlite3';
+import migration032 from '../032-matches';
+import migration033 from '../033-matches-score-breakdown';
+import migration034 from '../034-matches-unique-constraint';
+import migration035 from '../035-matches-tce-distance';
+import migration036 from '../036-matches-freight-rate';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  migration033.up(db);
+  migration034.up(db);
+  migration035.up(db);
+  migration036.up(db);
+  return db;
+}
+
+function insertRow(
+  db: Database.Database,
+  extra: Record<string, unknown> = {},
+): void {
+  const base = {
+    cargo_id: 'cargo-1',
+    vessel_id: 'vessel-1',
+    score: 75,
+    reason: 'test',
+    status: 'shortlist',
+    user_id: 'user-1',
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+  const merged = { ...base, ...extra };
+  const cols = Object.keys(merged).join(', ');
+  const placeholders = Object.keys(merged).map(() => '?').join(', ');
+  db.prepare(`INSERT INTO matches (${cols}) VALUES (${placeholders})`).run(
+    ...Object.values(merged),
+  );
+}
+
+describe('migration 036 — freight rate columns', () => {
+  it('adds freight_rate_usd_per_mt column', () => {
+    const db = freshDb();
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'freight_rate_usd_per_mt')).toBe(true);
+  });
+
+  it('adds freight_rate_source column', () => {
+    const db = freshDb();
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'freight_rate_source')).toBe(true);
+  });
+
+  it('accepts NULL freight_rate_usd_per_mt', () => {
+    const db = freshDb();
+    insertRow(db, { freight_rate_usd_per_mt: null });
+    const row = db.prepare('SELECT freight_rate_usd_per_mt FROM matches LIMIT 1').get() as { freight_rate_usd_per_mt: number | null };
+    expect(row.freight_rate_usd_per_mt).toBeNull();
+  });
+
+  it('accepts NULL freight_rate_source', () => {
+    const db = freshDb();
+    insertRow(db, { freight_rate_source: null });
+    const row = db.prepare('SELECT freight_rate_source FROM matches LIMIT 1').get() as { freight_rate_source: string | null };
+    expect(row.freight_rate_source).toBeNull();
+  });
+
+  it('stores numeric freight_rate_usd_per_mt', () => {
+    const db = freshDb();
+    insertRow(db, { freight_rate_usd_per_mt: 28.5 });
+    const row = db.prepare('SELECT freight_rate_usd_per_mt FROM matches LIMIT 1').get() as { freight_rate_usd_per_mt: number | null };
+    expect(row.freight_rate_usd_per_mt).toBeCloseTo(28.5);
+  });
+
+  it('stores freight_rate_source text', () => {
+    const db = freshDb();
+    insertRow(db, { freight_rate_source: 'estimated' });
+    const row = db.prepare('SELECT freight_rate_source FROM matches LIMIT 1').get() as { freight_rate_source: string | null };
+    expect(row.freight_rate_source).toBe('estimated');
+  });
+
+  it('is idempotent — re-running up() does not throw', () => {
+    const db = new Database(':memory:');
+    migration032.up(db);
+    migration033.up(db);
+    migration034.up(db);
+    migration035.up(db);
+    migration036.up(db);
+    expect(() => migration036.up(db)).not.toThrow();
+  });
+
+  it('has version=36', () => {
+    expect(migration036.version).toBe(36);
+  });
+
+  it('has name="matches-freight-rate"', () => {
+    expect(migration036.name).toBe('matches-freight-rate');
+  });
+});

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -33,6 +33,7 @@ import migration032 from './032-matches';
 import migration033 from './033-matches-score-breakdown';
 import migration034 from './034-matches-unique-constraint';
 import migration035 from './035-matches-tce-distance';
+import migration036 from './036-matches-freight-rate';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036];


### PR DESCRIPTION
Closes TCE roadmap item. Match Economics теперь показывает non-NULL TCE для большинства matches.

**Что:**
- `lib/matching/tce-calculator.ts`: estimateFreightRate(cargo_type, distance_nm, vessel_dwt)
- Migration 036: matches + freight_rate_usd_per_mt + freight_rate_source ('estimated'|'manual')
- compute-matches.ts + persist-session-matches.ts: estimate→store→voyageCalculator→TCE non-NULL
- PATCH /api/matches/[id]: manual override (auth + session-isolation как #399)
- UI: MatchesClient card + /match/[id] Economics tab + freight rate input

**Tests:** 13 файлов изменено + 3 new test files (tce-calculator + freight-rate-override + migration 036).

**Cold-QA /test-skill PASS:** 0 CRIT / 0 HIGH (2 MED non-blocking: storedFreightRate badge UX + API-contract polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)