### PR TITLE
R2: AppShell + TopNav + BottomNav + ModeSwitcher

### DIFF
--- a/__tests__/api/me.test.ts
+++ b/__tests__/api/me.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests — GET/PATCH /api/me (preferred_mode persist).
+ *
+ * Covers:
+ *   - GET returns { id, email, preferred_mode: 'charterer' } for new user
+ *   - PATCH preferred_mode='owner' persists and is returned
+ *   - PATCH with invalid mode returns 400
+ *   - Unauthenticated request (no cookie payload) returns 401
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import migration037 from '@/lib/migrations/037-add-user-preferred-mode';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: () => testDb })),
+}));
+
+jest.mock('@/lib/auth/config', () => ({
+  getAuthConfig: jest.fn().mockReturnValue({
+    enabled: true,
+    secret: 'test-secret',
+    user: 'testuser',
+    password: 'pw',
+    cookieDays: 7,
+  }),
+}));
+
+const mockVerifyAuthCookie = jest.fn();
+jest.mock('@/lib/auth/cookie', () => ({
+  AUTH_COOKIE_NAME: 'demo_auth',
+  verifyAuthCookie: (...args: unknown[]) => mockVerifyAuthCookie(...args),
+}));
+
+beforeEach(() => {
+  testDb = new Database(':memory:');
+  migration037.up(testDb);
+  mockVerifyAuthCookie.mockResolvedValue({ user: 'alice', exp: Date.now() + 3_600_000 });
+});
+
+function makeReq(method: string, cookie = 'demo_auth=valid-token'): NextRequest {
+  return new NextRequest('http://localhost/api/me', {
+    method,
+    headers: { cookie },
+  });
+}
+
+function makeReqWithBody(method: string, body: unknown, cookie = 'demo_auth=valid-token'): NextRequest {
+  return new NextRequest('http://localhost/api/me', {
+    method,
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/me', () => {
+  it('returns user info with default preferred_mode charterer', async () => {
+    const { GET } = await import('@/app/api/me/route');
+    const res = await GET(makeReq('GET'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ id: 'alice', email: 'alice', preferred_mode: 'charterer' });
+  });
+
+  it('returns preferred_mode owner after PATCH sets it', async () => {
+    const { GET, PATCH } = await import('@/app/api/me/route');
+    await PATCH(makeReqWithBody('PATCH', { preferred_mode: 'owner' }));
+    const res = await GET(makeReq('GET'));
+    const body = await res.json();
+    expect(body.preferred_mode).toBe('owner');
+  });
+
+  it('returns 401 when cookie invalid', async () => {
+    mockVerifyAuthCookie.mockResolvedValueOnce(null);
+    const { GET } = await import('@/app/api/me/route');
+    const res = await GET(makeReq('GET'));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /api/me', () => {
+  it('persists owner mode', async () => {
+    const { PATCH } = await import('@/app/api/me/route');
+    const res = await PATCH(makeReqWithBody('PATCH', { preferred_mode: 'owner' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.preferred_mode).toBe('owner');
+  });
+
+  it('returns 400 for invalid mode', async () => {
+    const { PATCH } = await import('@/app/api/me/route');
+    const res = await PATCH(makeReqWithBody('PATCH', { preferred_mode: 'invalid' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockVerifyAuthCookie.mockResolvedValueOnce(null);
+    const { PATCH } = await import('@/app/api/me/route');
+    const res = await PATCH(makeReqWithBody('PATCH', { preferred_mode: 'owner' }));
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import type Database from 'better-sqlite3';
+import { getAuthConfig } from '@/lib/auth/config';
+import { verifyAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { getStore } from '@/lib/session-store';
+
+const VALID_MODES = ['charterer', 'owner'] as const;
+type Mode = (typeof VALID_MODES)[number];
+
+async function resolveUsername(req: NextRequest): Promise<string | null> {
+  const authConfig = getAuthConfig();
+  if (!authConfig.enabled) return 'demo';
+  if (!authConfig.secret) return null;
+  const cookieValue = req.cookies.get(AUTH_COOKIE_NAME)?.value;
+  if (!cookieValue) return null;
+  const payload = await verifyAuthCookie(cookieValue, authConfig.secret);
+  return payload?.user ?? null;
+}
+
+function getOrInitMode(db: Database.Database, username: string): Mode {
+  const row = db
+    .prepare<[string], { preferred_mode: Mode }>('SELECT preferred_mode FROM user_preferences WHERE username = ?')
+    .get(username);
+  if (!row) {
+    db.prepare('INSERT OR IGNORE INTO user_preferences (username) VALUES (?)').run(username);
+    return 'charterer';
+  }
+  return row.preferred_mode;
+}
+
+export async function GET(req: NextRequest) {
+  const username = await resolveUsername(req);
+  if (!username) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const db = getStore().getDatabase();
+  const preferred_mode = getOrInitMode(db, username);
+  return NextResponse.json({ id: username, email: username, preferred_mode });
+}
+
+export async function PATCH(req: NextRequest) {
+  const username = await resolveUsername(req);
+  if (!username) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+  const mode = body.preferred_mode;
+  if (typeof mode !== 'string' || !VALID_MODES.includes(mode as Mode)) {
+    return NextResponse.json({ error: 'invalid preferred_mode' }, { status: 400 });
+  }
+  const db = getStore().getDatabase();
+  db.prepare('INSERT OR REPLACE INTO user_preferences (username, preferred_mode) VALUES (?, ?)').run(username, mode);
+  return NextResponse.json({ id: username, email: username, preferred_mode: mode as Mode });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,11 @@ import { Inter } from 'next/font/google';
 import { cookies } from 'next/headers';
 import { getTrialState, daysRemaining, isExpired } from '@/lib/trial';
 import { TrialBanner } from '@/components/onboarding/TrialBanner';
-import BottomNav from '@/components/nav/BottomNav';
+import { getAuthConfig } from '@/lib/auth/config';
+import { verifyAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { getStore } from '@/lib/session-store';
+import { ModeProvider, AppShell } from '@/design-system/patterns';
+import type { Mode } from '@/design-system/patterns';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -31,21 +35,95 @@ async function TrialBannerWrapper() {
   }
 }
 
+async function resolveInitialMode(cookieHeader: string | null): Promise<Mode> {
+  try {
+    const authConfig = getAuthConfig();
+    const secret = authConfig.secret;
+    if (!secret) return 'charterer';
+    if (!cookieHeader) return 'charterer';
+
+    // Parse cookie header to extract demo_auth value
+    const authCookieValue = cookieHeader
+      .split(';')
+      .map(s => s.trim())
+      .find(s => s.startsWith(`${AUTH_COOKIE_NAME}=`))
+      ?.slice(AUTH_COOKIE_NAME.length + 1);
+    if (!authCookieValue) return 'charterer';
+
+    const payload = await verifyAuthCookie(authCookieValue, secret);
+    if (!payload) return 'charterer';
+
+    const db = getStore().getDatabase();
+    const row = db
+      .prepare<[string], { preferred_mode: Mode }>('SELECT preferred_mode FROM user_preferences WHERE username = ?')
+      .get(payload.user);
+    if (row?.preferred_mode === 'owner') return 'owner';
+  } catch {
+    // Non-critical — fall through to default
+  }
+  return 'charterer';
+}
+
 export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const authConfig = getAuthConfig();
+
+  // Check if user is authenticated to decide whether to wrap with AppShell
+  let isAuthenticated = !authConfig.enabled; // if auth disabled → demo mode, always show shell
+  let username: string | null = null;
+
+  if (authConfig.enabled && authConfig.secret) {
+    const cookieValue = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+    if (cookieValue) {
+      const payload = await verifyAuthCookie(cookieValue, authConfig.secret).catch(() => null);
+      if (payload) {
+        isAuthenticated = true;
+        username = payload.user;
+      }
+    }
+  } else if (!authConfig.enabled) {
+    username = 'demo';
+  }
+
   // The UI chrome is English; per-content RTL handling lives next to the
   // content (EmailBodyViewer derives dir from the body via detectTextDirection).
   // Browser Accept-Language used to leak ru/de/he into <html> and broke
   // mixed-locale demo scenarios — see stab/rtl-per-content.
+  if (!isAuthenticated) {
+    return (
+      <html lang="en" dir="ltr">
+        <body className={inter.className}>
+          {children}
+        </body>
+      </html>
+    );
+  }
+
+  // Resolve preferred_mode from DB (username is set when isAuthenticated)
+  let initialMode: Mode = 'charterer';
+  if (username) {
+    try {
+      const db = getStore().getDatabase();
+      const row = db
+        .prepare<[string], { preferred_mode: Mode }>('SELECT preferred_mode FROM user_preferences WHERE username = ?')
+        .get(username);
+      if (row?.preferred_mode === 'owner') initialMode = 'owner';
+    } catch {
+      // Non-critical — default to charterer
+    }
+  }
+
   return (
     <html lang="en" dir="ltr">
       <body className={inter.className}>
         <TrialBannerWrapper />
-        {children}
-        <BottomNav />
+        <ModeProvider initial={initialMode}>
+          <AppShell>{children}</AppShell>
+        </ModeProvider>
       </body>
     </html>
   );

--- a/design-system/patterns/AIBarPlaceholder.tsx
+++ b/design-system/patterns/AIBarPlaceholder.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useMode } from './useMode';
+
+export function AIBarPlaceholder() {
+  const { t } = useMode();
+  return (
+    <div className="hidden md:flex items-center gap-2 bg-ds-surface border-b border-ds-border px-6 py-2 text-sm text-ds-text-subtle">
+      <span className="flex-1">💬 {t('aibar.placeholder')}</span>
+      <kbd className="bg-ds-surface-muted text-ds-text-muted px-1.5 py-0.5 rounded text-[10px] font-semibold">
+        ⌘K
+      </kbd>
+    </div>
+  );
+}

--- a/design-system/patterns/AppShell.tsx
+++ b/design-system/patterns/AppShell.tsx
@@ -1,0 +1,16 @@
+'use client';
+import type { ReactNode } from 'react';
+import { TopNav } from './TopNav';
+import { BottomNav } from './BottomNav';
+import { AIBarPlaceholder } from './AIBarPlaceholder';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-ds-bg text-ds-text flex flex-col">
+      <TopNav />
+      <AIBarPlaceholder />
+      <main className="flex-1 pb-16 md:pb-0">{children}</main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/design-system/patterns/BottomNav.tsx
+++ b/design-system/patterns/BottomNav.tsx
@@ -1,0 +1,40 @@
+'use client';
+import Link from 'next/link';
+import { Home, Sparkles, Box, MoreHorizontal } from 'lucide-react';
+import { useMode } from './useMode';
+import { cn } from '@/design-system/primitives/_utils';
+
+export function BottomNav() {
+  const { isCharterer } = useMode();
+  const items = [
+    { href: '/dashboard', label: 'Dashboard', Icon: Home },
+    { href: '/matches', label: 'Matches', Icon: Sparkles },
+    {
+      href: isCharterer ? '/cargo' : '/vessels',
+      label: isCharterer ? 'Cargo' : 'Vessels',
+      Icon: Box,
+    },
+    { href: '/more', label: 'More', Icon: MoreHorizontal },
+  ];
+
+  return (
+    <nav
+      className="md:hidden fixed bottom-0 inset-x-0 z-30 bg-ds-surface border-t border-ds-border flex items-stretch h-14 pb-[env(safe-area-inset-bottom,0px)]"
+      aria-label="Mobile navigation"
+    >
+      {items.map(({ href, label, Icon }) => (
+        <Link
+          key={href}
+          href={href}
+          className={cn(
+            'flex-1 flex flex-col items-center justify-center gap-0.5 text-ds-text-muted hover:text-ds-text min-h-[44px]',
+          )}
+          aria-label={label}
+        >
+          <Icon size={20} aria-hidden="true" />
+          <span className="text-[10px] font-medium">{label}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/design-system/patterns/ModeProvider.tsx
+++ b/design-system/patterns/ModeProvider.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { createContext, useCallback, useMemo, useState, type ReactNode } from 'react';
+
+export type Mode = 'charterer' | 'owner';
+
+export interface ModeContextValue {
+  mode: Mode;
+  setMode: (m: Mode) => void;
+}
+
+export const ModeContext = createContext<ModeContextValue | null>(null);
+
+export function ModeProvider({ initial, children }: { initial: Mode; children: ReactNode }) {
+  const [mode, setModeState] = useState<Mode>(() => {
+    if (typeof window === 'undefined') return initial;
+    const params = new URLSearchParams(window.location.search);
+    const urlMode = params.get('mode');
+    if (urlMode === 'charterer' || urlMode === 'owner') return urlMode;
+    return initial;
+  });
+
+  const setMode = useCallback((m: Mode) => {
+    setModeState(m);
+    // optimistic; fire-and-forget PATCH
+    fetch('/api/me', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ preferred_mode: m }),
+    }).catch(() => {});
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      url.searchParams.set('mode', m);
+      window.history.replaceState({}, '', url.toString());
+    }
+  }, []);
+
+  const value = useMemo(() => ({ mode, setMode }), [mode, setMode]);
+  return <ModeContext.Provider value={value}>{children}</ModeContext.Provider>;
+}

--- a/design-system/patterns/ModeSwitcher.tsx
+++ b/design-system/patterns/ModeSwitcher.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useMode } from './useMode';
+import { cn } from '@/design-system/primitives/_utils';
+
+export function ModeSwitcher({ className }: { className?: string }) {
+  const { mode, setMode } = useMode();
+  return (
+    <div
+      className={cn('inline-flex bg-ds-surface-muted rounded-ds-md p-0.5 text-xs', className)}
+      role="group"
+      aria-label="Application mode"
+    >
+      {(['charterer', 'owner'] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => setMode(m)}
+          aria-pressed={mode === m}
+          className={cn(
+            'px-3 py-1 rounded-ds-sm transition-colors duration-ds-fast capitalize',
+            mode === m
+              ? 'bg-ds-accent text-ds-accent-fg font-semibold'
+              : 'text-ds-text-muted hover:text-ds-text',
+          )}
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/design-system/patterns/TopNav.tsx
+++ b/design-system/patterns/TopNav.tsx
@@ -1,0 +1,75 @@
+'use client';
+import Link from 'next/link';
+import { useMode } from './useMode';
+import { ModeSwitcher } from './ModeSwitcher';
+import { cn } from '@/design-system/primitives/_utils';
+
+const MORE_ITEMS = [
+  { href: '/charterers', label: 'Charterers' },
+  { href: '/recap', label: 'Recap' },
+  { href: '/laytime', label: 'Laytime' },
+  { href: '/psc', label: 'PSC' },
+  { href: '/commission', label: 'Commission' },
+  { href: '/clauses', label: 'Clauses' },
+  { href: '/email', label: 'Email' },
+  { href: '/settings', label: 'Settings' },
+];
+
+export function TopNav() {
+  const { isCharterer } = useMode();
+  const third = isCharterer ? { href: '/cargo', label: 'Cargo' } : { href: '/vessels', label: 'Vessels' };
+  const fourth = isCharterer ? { href: '/vessels', label: 'Vessels' } : { href: '/cargo', label: 'Cargo' };
+
+  return (
+    <header className="hidden md:flex items-center gap-6 bg-ds-surface border-b border-ds-border px-6 py-3 sticky top-0 z-30">
+      <Link href="/dashboard" className="text-ds-accent font-bold text-lg shrink-0" aria-label="Quantika home">
+        Q
+      </Link>
+      <nav className="flex items-center gap-6 text-sm" aria-label="Primary navigation">
+        <NavLink href="/dashboard">Dashboard</NavLink>
+        <NavLink href="/matches">Matches</NavLink>
+        <NavLink href={third.href}>{third.label}</NavLink>
+        <NavLink href={fourth.href}>{fourth.label}</NavLink>
+        <NavLink href="/market">Market</NavLink>
+        <MoreDropdown />
+      </nav>
+      <div className="ml-auto shrink-0">
+        <ModeSwitcher />
+      </div>
+    </header>
+  );
+}
+
+function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link href={href} className={cn('text-ds-text-muted hover:text-ds-text font-medium transition-colors duration-ds-fast')}>
+      {children}
+    </Link>
+  );
+}
+
+function MoreDropdown() {
+  return (
+    <details className="relative">
+      <summary
+        className="text-ds-text-muted hover:text-ds-text font-medium cursor-pointer list-none"
+        role="button"
+        aria-label="More"
+      >
+        ⋯ More
+      </summary>
+      <ul className="absolute right-0 mt-2 min-w-[180px] bg-ds-surface border border-ds-border rounded-ds-md shadow-lg py-1 z-40">
+        {MORE_ITEMS.map((it) => (
+          <li key={it.href}>
+            <Link
+              href={it.href}
+              className="block px-3 py-1.5 text-sm text-ds-text hover:bg-ds-surface-muted"
+            >
+              {it.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/design-system/patterns/__tests__/AppShell.test.tsx
+++ b/design-system/patterns/__tests__/AppShell.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ModeProvider } from '../ModeProvider';
+import { AppShell } from '../AppShell';
+
+jest.mock('next/link', () => {
+  const Link = ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href={href} {...props}>{children}</a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+jest.mock('lucide-react', () => ({
+  Home: () => <svg data-testid="icon-home" />,
+  Sparkles: () => <svg data-testid="icon-sparkles" />,
+  Box: () => <svg data-testid="icon-box" />,
+  MoreHorizontal: () => <svg data-testid="icon-more" />,
+}));
+
+describe('AppShell', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as typeof global.fetch;
+  });
+
+  it('renders children', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <AppShell><div>page content</div></AppShell>
+      </ModeProvider>,
+    );
+    expect(screen.getByText('page content')).toBeInTheDocument();
+  });
+
+  it('renders Matches nav link (in top nav)', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <AppShell><div>page content</div></AppShell>
+      </ModeProvider>,
+    );
+    // TopNav desktop link (may appear multiple times across top + bottom nav)
+    const matchLinks = screen.getAllByRole('link', { name: /matches/i });
+    expect(matchLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders ModeSwitcher with charterer active', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <AppShell><div>page content</div></AppShell>
+      </ModeProvider>,
+    );
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders both TopNav and BottomNav (Dashboard appears twice)', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <AppShell><div>page</div></AppShell>
+      </ModeProvider>,
+    );
+    const dashLinks = screen.getAllByRole('link', { name: /dashboard/i });
+    // One in TopNav + one in BottomNav
+    expect(dashLinks.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/design-system/patterns/__tests__/BottomNav.test.tsx
+++ b/design-system/patterns/__tests__/BottomNav.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ModeProvider } from '../ModeProvider';
+import { BottomNav } from '../BottomNav';
+
+jest.mock('next/link', () => {
+  const Link = ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href={href} {...props}>{children}</a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+// lucide-react icon mocks to avoid svg rendering issues
+jest.mock('lucide-react', () => ({
+  Home: () => <svg data-testid="icon-home" />,
+  Sparkles: () => <svg data-testid="icon-sparkles" />,
+  Box: () => <svg data-testid="icon-box" />,
+  MoreHorizontal: () => <svg data-testid="icon-more" />,
+}));
+
+describe('BottomNav', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as typeof global.fetch;
+  });
+
+  it('renders 4 nav links with labels', () => {
+    render(<ModeProvider initial="charterer"><BottomNav /></ModeProvider>);
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /matches/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /cargo/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /more/i })).toBeInTheDocument();
+  });
+
+  it('charterer mode shows Cargo link', () => {
+    render(<ModeProvider initial="charterer"><BottomNav /></ModeProvider>);
+    expect(screen.getByRole('link', { name: /cargo/i })).toHaveAttribute('href', '/cargo');
+  });
+
+  it('owner mode shows Vessels link instead of Cargo', () => {
+    render(<ModeProvider initial="owner"><BottomNav /></ModeProvider>);
+    expect(screen.getByRole('link', { name: /vessels/i })).toHaveAttribute('href', '/vessels');
+    expect(screen.queryByRole('link', { name: /cargo/i })).not.toBeInTheDocument();
+  });
+});

--- a/design-system/patterns/__tests__/ModeSwitcher.test.tsx
+++ b/design-system/patterns/__tests__/ModeSwitcher.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ModeProvider } from '../ModeProvider';
+import { ModeSwitcher } from '../ModeSwitcher';
+
+describe('ModeSwitcher', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as typeof global.fetch;
+  });
+
+  it('renders both modes, active=charterer initially', () => {
+    render(<ModeProvider initial="charterer"><ModeSwitcher /></ModeProvider>);
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /owner/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders both modes, active=owner when initial=owner', () => {
+    render(<ModeProvider initial="owner"><ModeSwitcher /></ModeProvider>);
+    expect(screen.getByRole('button', { name: /owner/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking owner toggles mode', () => {
+    render(<ModeProvider initial="charterer"><ModeSwitcher /></ModeProvider>);
+    fireEvent.click(screen.getByRole('button', { name: /owner/i }));
+    expect(screen.getByRole('button', { name: /owner/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking charterer from owner reverts', () => {
+    render(<ModeProvider initial="owner"><ModeSwitcher /></ModeProvider>);
+    fireEvent.click(screen.getByRole('button', { name: /charterer/i }));
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/design-system/patterns/__tests__/TopNav.test.tsx
+++ b/design-system/patterns/__tests__/TopNav.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ModeProvider } from '../ModeProvider';
+import { TopNav } from '../TopNav';
+
+// next/link renders as <a> in tests
+jest.mock('next/link', () => {
+  const Link = ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href={href} {...props}>{children}</a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+describe('TopNav', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as typeof global.fetch;
+  });
+
+  it('renders 5 primary nav links + More button in charterer mode', () => {
+    render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /matches/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /cargo/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /vessels/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /market/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /more/i })).toBeInTheDocument();
+  });
+
+  it('charterer mode: Cargo is 3rd nav link, Vessels is 4th', () => {
+    const { container } = render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+    // Only direct <a> children of nav — excludes More dropdown links inside <details>
+    const navLinks = Array.from(container.querySelectorAll('nav[aria-label="Primary navigation"] > a'));
+    const texts = navLinks.map(l => l.textContent);
+    expect(texts).toEqual(['Dashboard', 'Matches', 'Cargo', 'Vessels', 'Market']);
+  });
+
+  it('owner mode: Vessels is 3rd nav link, Cargo is 4th', () => {
+    const { container } = render(<ModeProvider initial="owner"><TopNav /></ModeProvider>);
+    const navLinks = Array.from(container.querySelectorAll('nav[aria-label="Primary navigation"] > a'));
+    const texts = navLinks.map(l => l.textContent);
+    expect(texts).toEqual(['Dashboard', 'Matches', 'Vessels', 'Cargo', 'Market']);
+  });
+
+  it('renders ModeSwitcher with charterer + owner buttons', () => {
+    render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /owner/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/design-system/patterns/__tests__/useMode.test.tsx
+++ b/design-system/patterns/__tests__/useMode.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, act } from '@testing-library/react';
+import { ModeProvider } from '../ModeProvider';
+import { useMode } from '../useMode';
+
+function Probe() {
+  const { mode, isCharterer, isOwner, t, setMode } = useMode();
+  return (
+    <>
+      <span data-testid="mode">{mode}</span>
+      <span data-testid="iss">{String(isCharterer)}/{String(isOwner)}</span>
+      <span data-testid="copy">{t('aibar.placeholder')}</span>
+      <button onClick={() => setMode(mode === 'charterer' ? 'owner' : 'charterer')}>swap</button>
+    </>
+  );
+}
+
+describe('useMode (design-system)', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as typeof global.fetch;
+  });
+
+  it('returns initial mode charterer + correct flags', () => {
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('mode')).toHaveTextContent('charterer');
+    expect(screen.getByTestId('iss')).toHaveTextContent('true/false');
+  });
+
+  it('returns initial mode owner + correct flags', () => {
+    render(<ModeProvider initial="owner"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('mode')).toHaveTextContent('owner');
+    expect(screen.getByTestId('iss')).toHaveTextContent('false/true');
+  });
+
+  it('t() returns mode-aware copy for charterer', () => {
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('copy').textContent).toMatch(/груз/i);
+  });
+
+  it('t() returns mode-aware copy for owner', () => {
+    render(<ModeProvider initial="owner"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('copy').textContent).toMatch(/судно/i);
+  });
+
+  it('setMode updates context', () => {
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    act(() => { screen.getByText('swap').click(); });
+    expect(screen.getByTestId('mode')).toHaveTextContent('owner');
+  });
+
+  it('URL ?mode=owner overrides initial charterer', () => {
+    window.history.pushState({}, '', '?mode=owner');
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('mode')).toHaveTextContent('owner');
+  });
+
+  it('URL ?mode=charterer overrides initial owner', () => {
+    window.history.pushState({}, '', '?mode=charterer');
+    render(<ModeProvider initial="owner"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('mode')).toHaveTextContent('charterer');
+  });
+});

--- a/design-system/patterns/index.ts
+++ b/design-system/patterns/index.ts
@@ -1,0 +1,8 @@
+export { AppShell } from './AppShell';
+export { TopNav } from './TopNav';
+export { BottomNav } from './BottomNav';
+export { ModeSwitcher } from './ModeSwitcher';
+export { AIBarPlaceholder } from './AIBarPlaceholder';
+export { ModeProvider } from './ModeProvider';
+export { useMode } from './useMode';
+export type { Mode, ModeContextValue } from './ModeProvider';

--- a/design-system/patterns/useMode.ts
+++ b/design-system/patterns/useMode.ts
@@ -1,0 +1,33 @@
+'use client';
+import { useContext } from 'react';
+import { ModeContext, type Mode } from './ModeProvider';
+
+const COPY: Record<Mode, Record<string, string>> = {
+  charterer: {
+    'aibar.placeholder': 'Спроси про груз или кинь email от брокера…',
+    'nav.thirdSlot': 'Cargo',
+    'nav.fourthSlot': 'Vessels',
+    'page.title.suffix': 'Charterer',
+    'matches.empty.cta': 'Загрузи первый груз → найдём суда',
+  },
+  owner: {
+    'aibar.placeholder': 'Спроси про судно или кинь open-position email…',
+    'nav.thirdSlot': 'Vessels',
+    'nav.fourthSlot': 'Cargo',
+    'page.title.suffix': 'Owner',
+    'matches.empty.cta': 'Добавь первое судно → найдём грузы',
+  },
+};
+
+export function useMode() {
+  const ctx = useContext(ModeContext);
+  if (!ctx) throw new Error('useMode must be inside <ModeProvider>');
+  const { mode, setMode } = ctx;
+  return {
+    mode,
+    setMode,
+    isCharterer: mode === 'charterer',
+    isOwner: mode === 'owner',
+    t: (key: string) => COPY[mode][key] ?? key,
+  };
+}

--- a/docs/superpowers/plans/2026-05-24-r2-appshell-modeswitcher-plan.md
+++ b/docs/superpowers/plans/2026-05-24-r2-appshell-modeswitcher-plan.md
@@ -1,0 +1,913 @@
+# R2 — AppShell + ModeSwitcher · Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development`. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Обернуть приложение в AppShell (TopNav 5+More / BottomNav mobile / ModeSwitcher / AIBarPlaceholder), все на R1 primitives. Не трогаем page контент.
+
+**Architecture:** AppShell wraps `app/(authenticated)/layout.tsx` (новая route group). ModeProvider context оборачивает children. Mode resolves: URL `?mode=` → DB `users.preferred_mode` → default. `/api/me` GET/PATCH для persist. Mode-aware nav-slot mapping через `useMode()`.
+
+**Tech Stack:** Next.js 16 app router, design-system/ primitives R1, React Context, SQLite migration, jest + Playwright.
+
+**Spec:** [/docs/superpowers/specs/2026-05-24-r2-appshell-modeswitcher-design.md](../specs/2026-05-24-r2-appshell-modeswitcher-design.md)
+
+**Branch:** `design/r2-appshell-modeswitcher` (создан orchestrator'ом).
+
+**Tier:** M · ~20 файлов · ~4-5 дней. Low-risk: parallel layer, существующие pages не трогаем.
+
+---
+
+## Pre-flight
+
+- [ ] **0.1 — Worktree:**
+  ```bash
+  cd ~/work/quantika-demo
+  git fetch origin
+  git worktree add .worktrees/r2-appshell design/r2-appshell-modeswitcher
+  cd .worktrees/r2-appshell
+  ```
+
+- [ ] **0.2 — Verify R1 merged:** `git log --oneline origin/main | grep -i 'design-system' | head -1` → должна быть строка R1 squash commit.
+
+---
+
+## Task 1: Migration 037 (preferred_mode)
+
+**Files:**
+- Create: `lib/migrations/037-add-user-preferred-mode.ts`
+- Test: `__tests__/lib/migrations/037.test.ts`
+
+- [ ] **1.1 — Failing test:**
+
+```ts
+// __tests__/lib/migrations/037.test.ts
+import Database from 'better-sqlite3';
+import { migrate } from '../../../lib/migrations/runner';
+
+describe('migration 037 — preferred_mode', () => {
+  it('adds preferred_mode column to users with default charterer', () => {
+    const db = new Database(':memory:');
+    migrate(db, { upTo: 37 });
+    db.prepare("INSERT INTO users (id, email) VALUES ('u1', 'a@b.c')").run();
+    const u = db.prepare("SELECT preferred_mode FROM users WHERE id='u1'").get() as { preferred_mode: string };
+    expect(u.preferred_mode).toBe('charterer');
+  });
+
+  it('allows owner mode', () => {
+    const db = new Database(':memory:');
+    migrate(db, { upTo: 37 });
+    db.prepare("INSERT INTO users (id, email, preferred_mode) VALUES ('u2', 'b@c.d', 'owner')").run();
+    const u = db.prepare("SELECT preferred_mode FROM users WHERE id='u2'").get() as { preferred_mode: string };
+    expect(u.preferred_mode).toBe('owner');
+  });
+});
+```
+
+- [ ] **1.2 — Run:** FAIL (migration missing).
+
+- [ ] **1.3 — Implement:**
+
+```ts
+// lib/migrations/037-add-user-preferred-mode.ts
+import type { Database } from 'better-sqlite3';
+
+export const migration037 = {
+  version: 37,
+  name: '037-add-user-preferred-mode',
+  up(db: Database): void {
+    db.exec(`ALTER TABLE users ADD COLUMN preferred_mode TEXT NOT NULL DEFAULT 'charterer'`);
+  },
+};
+```
+
+Register в `lib/migrations/index.ts` (или migrations registry — смотри как PR #428 регистрировал 036).
+
+- [ ] **1.4 — Run:** PASS.
+
+- [ ] **1.5 — Commit:**
+```bash
+git add lib/migrations/037-add-user-preferred-mode.ts lib/migrations/index.ts __tests__/lib/migrations/037.test.ts
+git commit -m "feat(r2): migration 037 — users.preferred_mode column"
+```
+
+---
+
+## Task 2: /api/me endpoint
+
+**Files:**
+- Create: `app/api/me/route.ts`
+- Test: `__tests__/api/me.test.ts`
+
+- [ ] **2.1 — Failing test:**
+
+```ts
+// __tests__/api/me.test.ts
+import { GET, PATCH } from '@/app/api/me/route';
+import { makeAuthRequest } from '../helpers/auth'; // existing test helper
+
+describe('/api/me', () => {
+  it('GET returns user info with preferred_mode', async () => {
+    const req = await makeAuthRequest('GET', '/api/me');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ id: expect.any(String), email: expect.any(String), preferred_mode: 'charterer' });
+  });
+
+  it('PATCH preferred_mode persists', async () => {
+    const req = await makeAuthRequest('PATCH', '/api/me', { preferred_mode: 'owner' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.preferred_mode).toBe('owner');
+  });
+
+  it('PATCH rejects invalid mode', async () => {
+    const req = await makeAuthRequest('PATCH', '/api/me', { preferred_mode: 'invalid' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('GET without auth → 401 (middleware already handles)', async () => {
+    // covered by middleware test; smoke check
+    const req = new Request('http://localhost/api/me');
+    const res = await GET(req as any);
+    // Note: middleware intercepts before route handler — this is documentation only
+    expect([200, 401]).toContain(res.status);
+  });
+});
+```
+
+- [ ] **2.2 — Run:** FAIL.
+
+- [ ] **2.3 — Implement:**
+
+```ts
+// app/api/me/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSession } from '@/lib/session';
+import { getDb } from '@/lib/db';
+
+const VALID_MODES = ['charterer', 'owner'] as const;
+type Mode = typeof VALID_MODES[number];
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const db = getDb();
+  const user = db.prepare('SELECT id, email, preferred_mode FROM users WHERE id = ?').get(session.userId) as
+    | { id: string; email: string; preferred_mode: Mode }
+    | undefined;
+  if (!user) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(user);
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const body = await req.json().catch(() => ({}));
+  const mode = body.preferred_mode;
+  if (!VALID_MODES.includes(mode)) {
+    return NextResponse.json({ error: 'invalid preferred_mode' }, { status: 400 });
+  }
+  const db = getDb();
+  db.prepare('UPDATE users SET preferred_mode = ? WHERE id = ?').run(mode, session.userId);
+  const updated = db.prepare('SELECT id, email, preferred_mode FROM users WHERE id = ?').get(session.userId);
+  return NextResponse.json(updated);
+}
+```
+
+> **Adapt:** `getSession`, `getDb`, `lib/session` — точные имена смотри в существующих API routes (e.g. `app/api/matches/route.ts`).
+
+- [ ] **2.4 — Run:** PASS.
+
+- [ ] **2.5 — Commit:**
+```bash
+git add app/api/me/route.ts __tests__/api/me.test.ts
+git commit -m "feat(r2): /api/me GET + PATCH for preferred_mode"
+```
+
+---
+
+## Task 3: useMode hook + ModeProvider context
+
+**Files:**
+- Create: `design-system/patterns/ModeProvider.tsx`
+- Create: `design-system/patterns/useMode.ts`
+- Test: `design-system/__tests__/useMode.test.tsx`
+
+- [ ] **3.1 — Failing test:**
+
+```tsx
+// design-system/__tests__/useMode.test.tsx
+import { render, screen, act } from '@testing-library/react';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { useMode } from '../patterns/useMode';
+
+function Probe() {
+  const { mode, isCharterer, isOwner, t, setMode } = useMode();
+  return (
+    <>
+      <span data-testid="mode">{mode}</span>
+      <span data-testid="iss">{String(isCharterer)}/{String(isOwner)}</span>
+      <span data-testid="copy">{t('aibar.placeholder')}</span>
+      <button onClick={() => setMode(mode === 'charterer' ? 'owner' : 'charterer')}>swap</button>
+    </>
+  );
+}
+
+describe('useMode (design-system)', () => {
+  it('returns initial mode charterer + correct flags', () => {
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('mode')).toHaveTextContent('charterer');
+    expect(screen.getByTestId('iss')).toHaveTextContent('true/false');
+  });
+
+  it('t() returns mode-aware copy', () => {
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    expect(screen.getByTestId('copy').textContent).toMatch(/груз|cargo/i);
+    // owner copy distinct
+  });
+
+  it('setMode updates context', () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+    act(() => { screen.getByText('swap').click(); });
+    expect(screen.getByTestId('mode')).toHaveTextContent('owner');
+  });
+});
+```
+
+- [ ] **3.2 — Run:** FAIL.
+
+- [ ] **3.3 — Implement provider:**
+
+```tsx
+// design-system/patterns/ModeProvider.tsx
+'use client';
+import { createContext, useCallback, useMemo, useState, type ReactNode } from 'react';
+
+export type Mode = 'charterer' | 'owner';
+
+interface ModeContextValue {
+  mode: Mode;
+  setMode: (m: Mode) => void;
+}
+
+export const ModeContext = createContext<ModeContextValue | null>(null);
+
+export function ModeProvider({ initial, children }: { initial: Mode; children: ReactNode }) {
+  const [mode, setModeState] = useState<Mode>(initial);
+
+  const setMode = useCallback((m: Mode) => {
+    setModeState(m);
+    // optimistic; fire-and-forget PATCH
+    fetch('/api/me', { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ preferred_mode: m }) }).catch(() => {});
+    // sync URL (?mode=)
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      url.searchParams.set('mode', m);
+      window.history.replaceState({}, '', url.toString());
+    }
+  }, []);
+
+  const value = useMemo(() => ({ mode, setMode }), [mode, setMode]);
+  return <ModeContext.Provider value={value}>{children}</ModeContext.Provider>;
+}
+```
+
+```tsx
+// design-system/patterns/useMode.ts
+'use client';
+import { useContext } from 'react';
+import { ModeContext, type Mode } from './ModeProvider';
+
+const COPY: Record<Mode, Record<string, string>> = {
+  charterer: {
+    'aibar.placeholder': 'Спроси про груз или кинь email от брокера…',
+    'nav.thirdSlot': 'Cargo',
+    'nav.fourthSlot': 'Vessels',
+    'page.title.suffix': 'Charterer',
+    'matches.empty.cta': 'Загрузи первый груз → найдём суда',
+  },
+  owner: {
+    'aibar.placeholder': 'Спроси про судно или кинь open-position email…',
+    'nav.thirdSlot': 'Vessels',
+    'nav.fourthSlot': 'Cargo',
+    'page.title.suffix': 'Owner',
+    'matches.empty.cta': 'Добавь первое судно → найдём грузы',
+  },
+};
+
+export function useMode() {
+  const ctx = useContext(ModeContext);
+  if (!ctx) throw new Error('useMode must be inside <ModeProvider>');
+  const { mode, setMode } = ctx;
+  return {
+    mode,
+    setMode,
+    isCharterer: mode === 'charterer',
+    isOwner: mode === 'owner',
+    t: (key: string) => COPY[mode][key] ?? key,
+  };
+}
+```
+
+- [ ] **3.4 — Run:** PASS. Commit:
+```bash
+git add design-system/patterns/ModeProvider.tsx design-system/patterns/useMode.ts design-system/__tests__/useMode.test.tsx
+git commit -m "feat(r2): ModeProvider context + useMode hook with mode-aware t() dictionary"
+```
+
+---
+
+## Task 4: ModeSwitcher component
+
+**Files:**
+- Create: `design-system/patterns/ModeSwitcher.tsx`
+- Test: `design-system/__tests__/ModeSwitcher.test.tsx`
+
+- [ ] **4.1 — Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { ModeSwitcher } from '../patterns/ModeSwitcher';
+
+describe('ModeSwitcher', () => {
+  it('renders both modes, active = charterer initially', () => {
+    render(<ModeProvider initial="charterer"><ModeSwitcher /></ModeProvider>);
+    expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /owner/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking owner toggles', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    render(<ModeProvider initial="charterer"><ModeSwitcher /></ModeProvider>);
+    await userEvent.click(screen.getByRole('button', { name: /owner/i }));
+    expect(screen.getByRole('button', { name: /owner/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+```
+
+- [ ] **4.2 — Implement:**
+
+```tsx
+// design-system/patterns/ModeSwitcher.tsx
+'use client';
+import { useMode } from './useMode';
+import { cn } from '@/design-system/primitives/_utils';
+
+export function ModeSwitcher({ className }: { className?: string }) {
+  const { mode, setMode } = useMode();
+  return (
+    <div className={cn('inline-flex bg-ds-surface-muted rounded-ds-md p-0.5 text-xs', className)} role="group" aria-label="Application mode">
+      {(['charterer', 'owner'] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => setMode(m)}
+          aria-pressed={mode === m}
+          className={cn(
+            'px-3 py-1 rounded-ds-sm transition-colors duration-ds-fast capitalize',
+            mode === m ? 'bg-ds-accent text-ds-accent-fg font-semibold' : 'text-ds-text-muted hover:text-ds-text'
+          )}
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **4.3 — Run PASS. Commit `feat(r2): add ModeSwitcher component`.**
+
+---
+
+## Task 5: TopNav component
+
+**Files:**
+- Create: `design-system/patterns/TopNav.tsx`
+- Test: `design-system/__tests__/TopNav.test.tsx`
+
+- [ ] **5.1 — Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { TopNav } from '../patterns/TopNav';
+
+describe('TopNav', () => {
+  it('renders 5 primary nav items + More dropdown trigger', () => {
+    render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /matches/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /cargo/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /vessels/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /market/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /more/i })).toBeInTheDocument();
+  });
+
+  it('owner mode swaps Cargo and Vessels positions', () => {
+    const { container } = render(<ModeProvider initial="owner"><TopNav /></ModeProvider>);
+    const links = container.querySelectorAll('nav a');
+    const texts = Array.from(links).map(l => l.textContent);
+    // Owner: Dashboard, Matches, Vessels, Cargo, Market
+    expect(texts).toEqual(['Dashboard', 'Matches', 'Vessels', 'Cargo', 'Market']);
+  });
+});
+```
+
+- [ ] **5.2 — Implement:**
+
+```tsx
+// design-system/patterns/TopNav.tsx
+'use client';
+import Link from 'next/link';
+import { useMode } from './useMode';
+import { ModeSwitcher } from './ModeSwitcher';
+import { cn } from '@/design-system/primitives/_utils';
+
+const MORE_ITEMS = [
+  { href: '/charterers', label: 'Charterers' },
+  { href: '/recap', label: 'Recap' },
+  { href: '/laytime', label: 'Laytime' },
+  { href: '/psc', label: 'PSC' },
+  { href: '/commission', label: 'Commission' },
+  { href: '/clauses', label: 'Clauses' },
+  { href: '/email', label: 'Email' },
+  { href: '/settings', label: 'Settings' },
+];
+
+export function TopNav() {
+  const { isCharterer } = useMode();
+  const third = isCharterer ? { href: '/cargo', label: 'Cargo' } : { href: '/vessels', label: 'Vessels' };
+  const fourth = isCharterer ? { href: '/vessels', label: 'Vessels' } : { href: '/cargo', label: 'Cargo' };
+
+  return (
+    <header className="hidden md:flex items-center gap-6 bg-ds-surface border-b border-ds-border px-6 py-3 sticky top-0 z-30">
+      <Link href="/dashboard" className="text-ds-accent font-bold text-lg">Q</Link>
+      <nav className="flex items-center gap-6 text-sm">
+        <NavLink href="/dashboard">Dashboard</NavLink>
+        <NavLink href="/matches">Matches</NavLink>
+        <NavLink href={third.href}>{third.label}</NavLink>
+        <NavLink href={fourth.href}>{fourth.label}</NavLink>
+        <NavLink href="/market">Market</NavLink>
+        <MoreDropdown items={MORE_ITEMS} />
+      </nav>
+      <div className="ml-auto"><ModeSwitcher /></div>
+    </header>
+  );
+}
+
+function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link href={href} className="text-ds-text-muted hover:text-ds-text font-medium">
+      {children}
+    </Link>
+  );
+}
+
+function MoreDropdown({ items }: { items: { href: string; label: string }[] }) {
+  return (
+    <details className="relative">
+      <summary className="text-ds-text-muted hover:text-ds-text font-medium cursor-pointer list-none" aria-label="More">⋯ More</summary>
+      <ul className="absolute right-0 mt-2 min-w-[180px] bg-ds-surface border border-ds-border rounded-ds-md shadow-lg py-1 z-40">
+        {items.map((it) => (
+          <li key={it.href}>
+            <Link href={it.href} className="block px-3 py-1.5 text-sm text-ds-text hover:bg-ds-surface-muted">{it.label}</Link>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+```
+
+- [ ] **5.3 — Run PASS. Commit `feat(r2): add TopNav with 5 primary + More dropdown + ModeSwitcher`.**
+
+---
+
+## Task 6: BottomNav (mobile)
+
+**Files:**
+- Create: `design-system/patterns/BottomNav.tsx`
+- Test: `design-system/__tests__/BottomNav.test.tsx`
+
+- [ ] **6.1 — Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { BottomNav } from '../patterns/BottomNav';
+
+describe('BottomNav', () => {
+  it('renders 4 icons with labels', () => {
+    render(<ModeProvider initial="charterer"><BottomNav /></ModeProvider>);
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /matches/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /cargo/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /more/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **6.2 — Implement:**
+
+```tsx
+// design-system/patterns/BottomNav.tsx
+'use client';
+import Link from 'next/link';
+import { Home, Sparkles, Box, MoreHorizontal } from 'lucide-react';
+import { useMode } from './useMode';
+import { cn } from '@/design-system/primitives/_utils';
+
+export function BottomNav() {
+  const { isCharterer } = useMode();
+  const items = [
+    { href: '/dashboard', label: 'Dashboard', Icon: Home },
+    { href: '/matches', label: 'Matches', Icon: Sparkles },
+    { href: isCharterer ? '/cargo' : '/vessels', label: isCharterer ? 'Cargo' : 'Vessels', Icon: Box },
+    { href: '/more', label: 'More', Icon: MoreHorizontal },
+  ];
+  return (
+    <nav className="md:hidden fixed bottom-0 inset-x-0 z-30 bg-ds-surface border-t border-ds-border flex items-stretch h-14">
+      {items.map(({ href, label, Icon }) => (
+        <Link
+          key={href}
+          href={href}
+          className={cn('flex-1 flex flex-col items-center justify-center gap-0.5 text-ds-text-muted hover:text-ds-text', 'min-h-[44px]')}
+        >
+          <Icon size={20} />
+          <span className="text-[10px] font-medium">{label}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+}
+```
+
+- [ ] **6.3 — Run PASS. Commit `feat(r2): add BottomNav (mobile, 4 icons, ≥44px tap targets)`.**
+
+---
+
+## Task 7: AIBarPlaceholder (visual stub)
+
+**Files:**
+- Create: `design-system/patterns/AIBarPlaceholder.tsx`
+
+- [ ] **7.1 — Implement (no behavioural test — это placeholder):**
+
+```tsx
+// design-system/patterns/AIBarPlaceholder.tsx
+'use client';
+import { useMode } from './useMode';
+
+export function AIBarPlaceholder() {
+  const { t } = useMode();
+  return (
+    <div className="hidden md:flex items-center gap-2 bg-ds-surface border-b border-ds-border px-6 py-2 text-sm text-ds-text-subtle">
+      <span className="flex-1">💬 {t('aibar.placeholder')}</span>
+      <kbd className="bg-ds-surface-muted text-ds-text-muted px-1.5 py-0.5 rounded text-[10px] font-semibold">⌘K</kbd>
+    </div>
+  );
+}
+```
+
+- [ ] **7.2 — Commit `feat(r2): add AIBarPlaceholder (visual stub, R3 will activate)`.**
+
+---
+
+## Task 8: AppShell
+
+**Files:**
+- Create: `design-system/patterns/AppShell.tsx`
+- Test: `design-system/__tests__/AppShell.test.tsx`
+
+- [ ] **8.1 — Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { AppShell } from '../patterns/AppShell';
+
+describe('AppShell', () => {
+  it('renders children + nav + mode switcher', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <AppShell><div>page content</div></AppShell>
+      </ModeProvider>
+    );
+    expect(screen.getByText('page content')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /matches/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /charterer/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **8.2 — Implement:**
+
+```tsx
+// design-system/patterns/AppShell.tsx
+'use client';
+import type { ReactNode } from 'react';
+import { TopNav } from './TopNav';
+import { BottomNav } from './BottomNav';
+import { AIBarPlaceholder } from './AIBarPlaceholder';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-ds-bg text-ds-text flex flex-col">
+      <TopNav />
+      <AIBarPlaceholder />
+      <main className="flex-1 pb-16 md:pb-0">{children}</main>
+      <BottomNav />
+    </div>
+  );
+}
+```
+
+- [ ] **8.3 — Run PASS. Commit `feat(r2): add AppShell wrapping TopNav + AIBarPlaceholder + BottomNav`.**
+
+---
+
+## Task 9: Patterns barrel
+
+**Files:**
+- Create: `design-system/patterns/index.ts`
+
+- [ ] **9.1 — Write:**
+
+```ts
+// design-system/patterns/index.ts
+export { AppShell } from './AppShell';
+export { TopNav } from './TopNav';
+export { BottomNav } from './BottomNav';
+export { ModeSwitcher } from './ModeSwitcher';
+export { AIBarPlaceholder } from './AIBarPlaceholder';
+export { ModeProvider } from './ModeProvider';
+export { useMode } from './useMode';
+export type { Mode } from './ModeProvider';
+```
+
+- [ ] **9.2 — Commit `feat(r2): patterns barrel exports`.**
+
+---
+
+## Task 10: Wire AppShell into app layout
+
+**Files:**
+- Create: `app/(authenticated)/layout.tsx`
+- Modify: `app/layout.tsx`
+
+> **Goal:** AppShell обёрнут вокруг ВСЕХ authenticated страниц без перемещения page.tsx. Используем Next.js route groups.
+
+- [ ] **10.1 — Read existing `app/layout.tsx`:** `cat app/layout.tsx` — посмотри текущую структуру. Скорее всего там общий HTML+Body. Не трогай.
+
+- [ ] **10.2 — Создай route group layout:**
+
+```tsx
+// app/(authenticated)/layout.tsx
+import type { ReactNode } from 'react';
+import { cookies } from 'next/headers';
+import { getSession } from '@/lib/session';
+import { getDb } from '@/lib/db';
+import { ModeProvider, AppShell } from '@/design-system/patterns';
+import { redirect } from 'next/navigation';
+
+export default async function AuthenticatedLayout({ children }: { children: ReactNode }) {
+  const cookieStore = await cookies();
+  // Adapt to real getSession signature
+  const session = await getSession({ cookies: cookieStore } as any).catch(() => null);
+  if (!session) redirect('/login');
+
+  let mode: 'charterer' | 'owner' = 'charterer';
+  try {
+    const db = getDb();
+    const u = db.prepare('SELECT preferred_mode FROM users WHERE id = ?').get(session.userId) as { preferred_mode: 'charterer' | 'owner' } | undefined;
+    if (u?.preferred_mode === 'owner') mode = 'owner';
+  } catch {}
+
+  return (
+    <ModeProvider initial={mode}>
+      <AppShell>{children}</AppShell>
+    </ModeProvider>
+  );
+}
+```
+
+- [ ] **10.3 — Move existing pages into route group:**
+  Для каждой authenticated page (dashboard, matches, cargo, vessels, market, charterers, etc.) — НЕ перемещай файлы (Next.js auto-detects route group). Просто создавай `app/(authenticated)/...` mirroring. **Альтернатива минимум-инвазивная:** оставь существующие pages где они есть, AppShell wrap не через route group, а через modification `app/layout.tsx` с conditional:
+
+  **Simpler approach (рекомендую):**
+
+```tsx
+// app/layout.tsx — modify
+import { ModeProvider, AppShell } from '@/design-system/patterns';
+import { cookies } from 'next/headers';
+import { getSession } from '@/lib/session';
+import { getDb } from '@/lib/db';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const session = await getSession({ cookies: cookieStore } as any).catch(() => null);
+
+  if (!session) {
+    return (
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    );
+  }
+
+  let mode: 'charterer' | 'owner' = 'charterer';
+  try {
+    const db = getDb();
+    const u = db.prepare('SELECT preferred_mode FROM users WHERE id = ?').get(session.userId) as any;
+    if (u?.preferred_mode === 'owner') mode = 'owner';
+  } catch {}
+
+  return (
+    <html lang="en">
+      <body>
+        <ModeProvider initial={mode}>
+          <AppShell>{children}</AppShell>
+        </ModeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+> Existing `app/layout.tsx` уже импортит globals.css и шрифты — сохрани все эти imports, добавь только ModeProvider/AppShell wrap.
+
+- [ ] **10.4 — Run dev server `npm run dev`** → http://localhost:3000/matches должна показать TopNav сверху + ModeSwitcher + page content внизу. Скриншот для verification.
+
+- [ ] **10.5 — Run all tests:** `npm test`. Все 2950+ green ожидаемо.
+
+- [ ] **10.6 — Commit `feat(r2): wire AppShell into root layout for authenticated routes`.**
+
+---
+
+## Task 11: URL `?mode=` override
+
+**Files:**
+- Modify: `design-system/patterns/ModeProvider.tsx`
+- Test: append к existing `useMode.test.tsx`
+
+- [ ] **11.1 — Test:**
+
+```tsx
+// extend design-system/__tests__/useMode.test.tsx
+it('URL ?mode=owner overrides initial', () => {
+  // Mock window.location.search
+  Object.defineProperty(window, 'location', { value: { search: '?mode=owner', href: 'http://test/?mode=owner' }, writable: true });
+  render(<ModeProvider initial="charterer"><Probe /></ModeProvider>);
+  // After mount, URL takes precedence
+  expect(screen.getByTestId('mode')).toHaveTextContent('owner');
+});
+```
+
+- [ ] **11.2 — Update ModeProvider to read URL on init:**
+
+```tsx
+// в ModeProvider.tsx, в useState init:
+const [mode, setModeState] = useState<Mode>(() => {
+  if (typeof window === 'undefined') return initial;
+  const params = new URLSearchParams(window.location.search);
+  const urlMode = params.get('mode');
+  if (urlMode === 'charterer' || urlMode === 'owner') return urlMode;
+  return initial;
+});
+```
+
+- [ ] **11.3 — Run PASS. Commit `feat(r2): URL ?mode= overrides DB preference`.**
+
+---
+
+## Task 12: Visual regression + a11y
+
+**Files:**
+- Create: `tests/visual/app-shell.spec.ts`
+
+- [ ] **12.1 — Spec:**
+
+```ts
+// tests/visual/app-shell.spec.ts
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const PAGE = '/matches'; // any authenticated page
+
+test.describe('AppShell visual + a11y', () => {
+  test('desktop layout snapshot', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(PAGE);
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveScreenshot('app-shell-desktop.png', { fullPage: false, maxDiffPixelRatio: 0.02 });
+  });
+
+  test('mobile bottom-nav visible at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 700 });
+    await page.goto(PAGE);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('nav').last()).toBeVisible();
+    await expect(page).toHaveScreenshot('app-shell-mobile.png', { fullPage: false, maxDiffPixelRatio: 0.02 });
+  });
+
+  test('mode toggle swaps Cargo↔Vessels nav order', async ({ page }) => {
+    await page.goto(PAGE + '?mode=charterer');
+    const navLinks1 = await page.locator('header nav a').allTextContents();
+    expect(navLinks1).toEqual(['Dashboard', 'Matches', 'Cargo', 'Vessels', 'Market']);
+
+    await page.goto(PAGE + '?mode=owner');
+    const navLinks2 = await page.locator('header nav a').allTextContents();
+    expect(navLinks2).toEqual(['Dashboard', 'Matches', 'Vessels', 'Cargo', 'Market']);
+  });
+
+  test('a11y — 0 violations on shell', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.waitForLoadState('networkidle');
+    const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+});
+```
+
+> **Auth note:** Playwright нуждается в auth cookie для access `/matches`. Если есть `playwright/setup-auth.ts` или fixture — используй. Иначе временно добавь `/matches` в middleware bypass ТОЛЬКО для test environment (через `NEXT_PUBLIC_E2E=true`), потом удали.
+
+- [ ] **12.2 — Generate baseline + verify:**
+
+```bash
+npx playwright test tests/visual/app-shell.spec.ts --update-snapshots
+npx playwright test tests/visual/app-shell.spec.ts
+```
+
+Expected: 4 PASS.
+
+- [ ] **12.3 — Commit `test(r2): visual regression + a11y for AppShell + mode swap`.**
+
+---
+
+## Task 13: TS strict + full regression + PR
+
+- [ ] **13.1 — TS strict:** `npx tsc --noEmit`. 0 errors.
+- [ ] **13.2 — Jest full:** `npm test`. All green (2950 existing + new R2).
+- [ ] **13.3 — Playwright full:** `npx playwright test tests/visual`. All green (R1 3 + R2 4 = 7 + a11y).
+- [ ] **13.4 — Smoke main pages:** `npm run dev`, открой / dashboard / matches / cargo / vessels / market / settings — все рендерятся с новым shell.
+- [ ] **13.5 — Push + PR:**
+
+```bash
+git push -u origin design/r2-appshell-modeswitcher
+gh pr create --base main --title "R2: AppShell + TopNav + BottomNav + ModeSwitcher" --body "$(cat <<'EOF'
+## R2 — AppShell foundation
+
+Реализует §3.2-§3.4 из [redesign spec](../docs/superpowers/specs/2026-05-24-quantika-demo-full-redesign-design.md). Использует только R1 primitives.
+
+### Что добавилось
+- `design-system/patterns/` — AppShell, TopNav (5 + More), BottomNav (mobile, ≥44px tap), ModeSwitcher, ModeProvider, useMode hook, AIBarPlaceholder (R3 активирует)
+- `lib/migrations/037` — `users.preferred_mode` (default charterer)
+- `app/api/me` — GET + PATCH
+- `app/layout.tsx` — wrapped в ModeProvider + AppShell для authenticated
+- `tests/visual/app-shell.spec.ts` — Playwright + axe
+
+### Что НЕ изменилось
+- Existing pages (matches/cargo/vessels/...) — не трогаем
+- Backend API кроме /api/me
+- components/ui/* (R1 coexistence preserved)
+
+### Verification
+- TS strict 0 errors
+- Jest existing + new — все green
+- Playwright + axe — все green
+- Smoke main pages — render with new shell
+
+### Next
+R3 (AIBar + ⌘K) и R4 (LiveStrip) могут стартовать параллельно.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **13.6 — НЕ auto-merge.** /test-skill cold-QA gate запустит orchestrator отдельно.
+
+---
+
+## Success criteria
+
+- ✅ AppShell обёрнут вокруг authenticated страниц
+- ✅ Mode toggle меняет nav-order реактивно без reload
+- ✅ Mode persists в DB; URL ?mode= overrides
+- ✅ Mobile breakpoint показывает BottomNav (4 icons, ≥44px), прячет TopNav
+- ✅ TS strict 0, jest green, Playwright visual + a11y 0 violations
+- ✅ Существующие страницы продолжают работать
+
+## Out of scope
+
+- AIBar функционал (R3)
+- ⌘K palette (R3)
+- LiveStrip (R4)
+- Per-page polish (R5)
+- Удаление старых components/ui/* (R5)

--- a/docs/superpowers/plans/2026-05-24-r3-aibar-cmdk-plan.md
+++ b/docs/superpowers/plans/2026-05-24-r3-aibar-cmdk-plan.md
@@ -1,0 +1,674 @@
+# R3 — AIBar + ⌘K Palette · Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`.
+
+**Goal:** Заменить R2 AIBarPlaceholder на работающий AIBar + ⌘K palette с tabs (Actions/Navigate/Help/Recents) + Floating HelpFAB.
+
+**Spec:** [/docs/superpowers/specs/2026-05-24-r3-aibar-cmdk-design.md](../specs/2026-05-24-r3-aibar-cmdk-design.md)
+**Branch:** `design/r3-aibar-cmdk` (create from main after R2 merged)
+**Depends:** R2 (AppShell, useMode, Dialog primitive)
+**Tier:** M · ~15 файлов · ~3-4 дня
+
+---
+
+## Pre-flight
+
+- [ ] **0.1** Worktree:
+```bash
+cd ~/work/quantika-demo
+git fetch origin
+git checkout main && git pull
+git checkout -b design/r3-aibar-cmdk
+git worktree add .worktrees/r3-aibar design/r3-aibar-cmdk
+cd .worktrees/r3-aibar
+```
+
+- [ ] **0.2** Verify R2 merged: `grep -l 'AppShell' design-system/patterns/index.ts` → должен экспортить.
+
+---
+
+## Task 1: usePalette hook
+
+**Files:**
+- Create: `design-system/patterns/usePalette.ts`
+- Test: `design-system/__tests__/usePalette.test.tsx`
+
+- [ ] **1.1 Failing test:**
+
+```tsx
+import { render, screen, act } from '@testing-library/react';
+import { usePalette, PaletteProvider } from '../patterns/usePalette';
+
+function Probe() {
+  const { open, isOpen, close } = usePalette();
+  return (
+    <>
+      <span data-testid="state">{isOpen ? 'open' : 'closed'}</span>
+      <button onClick={open}>open</button>
+      <button onClick={close}>close</button>
+    </>
+  );
+}
+
+describe('usePalette', () => {
+  it('opens and closes', () => {
+    render(<PaletteProvider><Probe /></PaletteProvider>);
+    expect(screen.getByTestId('state')).toHaveTextContent('closed');
+    act(() => { screen.getByText('open').click(); });
+    expect(screen.getByTestId('state')).toHaveTextContent('open');
+    act(() => { screen.getByText('close').click(); });
+    expect(screen.getByTestId('state')).toHaveTextContent('closed');
+  });
+
+  it('⌘K opens palette globally', () => {
+    render(<PaletteProvider><Probe /></PaletteProvider>);
+    act(() => {
+      const event = new KeyboardEvent('keydown', { key: 'k', metaKey: true });
+      window.dispatchEvent(event);
+    });
+    expect(screen.getByTestId('state')).toHaveTextContent('open');
+  });
+});
+```
+
+- [ ] **1.2 Implement:**
+
+```tsx
+// design-system/patterns/usePalette.ts
+'use client';
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
+
+export type PaletteTab = 'actions' | 'navigate' | 'help' | 'recents';
+
+interface Ctx {
+  isOpen: boolean;
+  activeTab: PaletteTab;
+  open: (tab?: PaletteTab) => void;
+  close: () => void;
+  setTab: (t: PaletteTab) => void;
+}
+
+const PaletteCtx = createContext<Ctx | null>(null);
+
+export function PaletteProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<PaletteTab>('actions');
+
+  const open = useCallback((tab?: PaletteTab) => {
+    if (tab) setActiveTab(tab);
+    setIsOpen(true);
+  }, []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setIsOpen((v) => !v);
+      } else if (e.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <PaletteCtx.Provider value={{ isOpen, activeTab, open, close, setTab: setActiveTab }}>
+      {children}
+    </PaletteCtx.Provider>
+  );
+}
+
+export function usePalette() {
+  const ctx = useContext(PaletteCtx);
+  if (!ctx) throw new Error('usePalette must be inside <PaletteProvider>');
+  return ctx;
+}
+```
+
+- [ ] **1.3 Run PASS. Commit `feat(r3): usePalette hook + ⌘K global listener`.**
+
+---
+
+## Task 2: ActionsTab content
+
+**Files:**
+- Create: `design-system/patterns/PaletteTabs/ActionsTab.tsx`
+- Test: `design-system/__tests__/ActionsTab.test.tsx`
+
+- [ ] **2.1 Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { ActionsTab } from '../patterns/PaletteTabs/ActionsTab';
+
+describe('ActionsTab', () => {
+  it('lists charterer-mode actions', () => {
+    render(<ModeProvider initial="charterer"><ActionsTab query="" onSelect={() => {}} /></ModeProvider>);
+    expect(screen.getByText(/find vessel/i)).toBeInTheDocument();
+  });
+
+  it('filters by query', async () => {
+    render(<ModeProvider initial="charterer"><ActionsTab query="recap" onSelect={() => {}} /></ModeProvider>);
+    expect(screen.getByText(/generate recap/i)).toBeInTheDocument();
+    expect(screen.queryByText(/find vessel/i)).toBeNull();
+  });
+});
+```
+
+- [ ] **2.2 Implement:**
+
+```tsx
+// design-system/patterns/PaletteTabs/ActionsTab.tsx
+'use client';
+import { useMode } from '../useMode';
+import { cn } from '@/design-system/primitives/_utils';
+
+interface Action { id: string; label: string; description?: string; handler: () => void; }
+
+function getActions(mode: 'charterer' | 'owner'): Action[] {
+  const common: Action[] = [
+    { id: 'recap', label: 'Generate recap from last fixture', handler: () => location.href = '/recap' },
+    { id: 'market', label: 'Show market — HSS Med rate', handler: () => location.href = '/market' },
+  ];
+  return mode === 'charterer'
+    ? [{ id: 'find-v', label: 'Find vessel for cargo', handler: () => location.href = '/matches' }, ...common]
+    : [{ id: 'find-c', label: 'Find cargo for vessel', handler: () => location.href = '/matches' }, ...common];
+}
+
+export function ActionsTab({ query, onSelect }: { query: string; onSelect: () => void }) {
+  const { mode } = useMode();
+  const all = getActions(mode);
+  const filtered = query ? all.filter((a) => a.label.toLowerCase().includes(query.toLowerCase())) : all;
+  if (filtered.length === 0) return <div className="p-4 text-ds-text-subtle text-sm">No matching actions</div>;
+  return (
+    <ul className="p-1">
+      {filtered.map((a) => (
+        <li key={a.id}>
+          <button
+            type="button"
+            onClick={() => { a.handler(); onSelect(); }}
+            className={cn('w-full text-left px-3 py-2 rounded-ds-sm text-sm text-ds-text', 'hover:bg-ds-surface-muted')}
+          >
+            {a.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **2.3 Run PASS. Commit `feat(r3): ActionsTab with mode-aware filtering`.**
+
+---
+
+## Task 3: NavigateTab
+
+**Files:**
+- Create: `design-system/patterns/PaletteTabs/NavigateTab.tsx`
+- Test: `design-system/__tests__/NavigateTab.test.tsx`
+
+- [ ] **3.1 Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NavigateTab } from '../patterns/PaletteTabs/NavigateTab';
+
+it('NavigateTab lists routes and filters', async () => {
+  render(<NavigateTab query="" onSelect={() => {}} />);
+  expect(screen.getByText('Matches')).toBeInTheDocument();
+  expect(screen.getByText('Cargo')).toBeInTheDocument();
+});
+
+it('filters by query', () => {
+  render(<NavigateTab query="set" onSelect={() => {}} />);
+  expect(screen.getByText('Settings')).toBeInTheDocument();
+  expect(screen.queryByText('Matches')).toBeNull();
+});
+```
+
+- [ ] **3.2 Implement:**
+
+```tsx
+// design-system/patterns/PaletteTabs/NavigateTab.tsx
+'use client';
+import Link from 'next/link';
+
+const ROUTES = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/matches', label: 'Matches' },
+  { href: '/cargo', label: 'Cargo' },
+  { href: '/vessels', label: 'Vessels' },
+  { href: '/market', label: 'Market' },
+  { href: '/charterers', label: 'Charterers' },
+  { href: '/recap', label: 'Recap' },
+  { href: '/email', label: 'Email' },
+  { href: '/settings', label: 'Settings' },
+  { href: '/upgrade', label: 'Upgrade' },
+];
+
+export function NavigateTab({ query, onSelect }: { query: string; onSelect: () => void }) {
+  const filtered = query ? ROUTES.filter((r) => r.label.toLowerCase().includes(query.toLowerCase())) : ROUTES;
+  if (filtered.length === 0) return <div className="p-4 text-ds-text-subtle text-sm">No matching pages</div>;
+  return (
+    <ul className="p-1">
+      {filtered.map((r) => (
+        <li key={r.href}>
+          <Link href={r.href} onClick={onSelect} className="block px-3 py-2 rounded-ds-sm text-sm text-ds-text hover:bg-ds-surface-muted">
+            {r.label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **3.3 Run PASS. Commit `feat(r3): NavigateTab with route filter`.**
+
+---
+
+## Task 4: HelpTab + /api/help/ask
+
+**Files:**
+- Create: `design-system/patterns/PaletteTabs/HelpTab.tsx`
+- Create: `app/api/help/ask/route.ts`
+- Test: `__tests__/api/help-ask.test.ts`
+- Test: `design-system/__tests__/HelpTab.test.tsx`
+
+- [ ] **4.1 Backend test:**
+
+```ts
+import { POST } from '@/app/api/help/ask/route';
+import { makeAuthRequest } from '../helpers/auth';
+
+it('POST returns answer + sources', async () => {
+  const req = await makeAuthRequest('POST', '/api/help/ask', { query: 'how to connect Gmail' });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toMatchObject({ answer: expect.any(String), sources: expect.any(Array) });
+});
+
+it('rejects empty query', async () => {
+  const req = await makeAuthRequest('POST', '/api/help/ask', { query: '' });
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+});
+```
+
+- [ ] **4.2 Implement endpoint:**
+
+```ts
+// app/api/help/ask/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSession } from '@/lib/session';
+
+export async function POST(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { query } = await req.json().catch(() => ({}));
+  if (typeof query !== 'string' || query.trim().length < 3) {
+    return NextResponse.json({ error: 'query must be ≥3 chars' }, { status: 400 });
+  }
+
+  // TODO: integrate with Knowledge Phase 2 RAG (/api/knowledge/ask if exists)
+  // Stub: forward to RAG or return canned response
+  try {
+    const rag = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/knowledge/ask`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: req.headers.get('cookie') ?? '' },
+      body: JSON.stringify({ query }),
+    });
+    if (rag.ok) {
+      const data = await rag.json();
+      return NextResponse.json({ answer: data.answer ?? data.text ?? '', sources: data.sources ?? [] });
+    }
+  } catch { /* fall through */ }
+
+  // Fallback canned answer
+  return NextResponse.json({
+    answer: 'Quantika умеет парсить email, считать TCE, генерить recap. Конкретный гайд скоро появится в docs.',
+    sources: [{ title: 'Quick start', url: '/docs/quickstart' }],
+  });
+}
+```
+
+- [ ] **4.3 Implement HelpTab:**
+
+```tsx
+// design-system/patterns/PaletteTabs/HelpTab.tsx
+'use client';
+import { useEffect, useState } from 'react';
+import { Skeleton } from '@/design-system/primitives';
+
+interface Answer { answer: string; sources: { title: string; url: string }[] }
+
+export function HelpTab({ query }: { query: string }) {
+  const [data, setData] = useState<Answer | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (query.length < 3) { setData(null); return; }
+    setLoading(true);
+    const ctrl = new AbortController();
+    fetch('/api/help/ask', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query }),
+      signal: ctrl.signal,
+    })
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+    return () => ctrl.abort();
+  }, [query]);
+
+  if (query.length < 3) return <div className="p-4 text-ds-text-subtle text-sm">Type your question (≥3 chars)…</div>;
+  if (loading) return <div className="p-4 space-y-2"><Skeleton className="h-4 w-3/4" /><Skeleton className="h-4 w-2/3" /></div>;
+  if (!data) return null;
+  return (
+    <div className="p-4 space-y-3">
+      <p className="text-sm text-ds-text leading-relaxed">{data.answer}</p>
+      {data.sources.length > 0 && (
+        <div className="text-xs text-ds-text-muted">
+          <span className="font-semibold">Sources:</span>{' '}
+          {data.sources.map((s, i) => (
+            <a key={i} href={s.url} className="text-ds-accent underline mr-2">{s.title}</a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **4.4 Run PASS. Commit `feat(r3): HelpTab + /api/help/ask (RAG-backed with fallback)`.**
+
+---
+
+## Task 5: RecentsTab
+
+**Files:**
+- Create: `design-system/patterns/PaletteTabs/RecentsTab.tsx`
+
+- [ ] **5.1 Implement (simple, no test required for stub):**
+
+```tsx
+// design-system/patterns/PaletteTabs/RecentsTab.tsx
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface Recent { href: string; label: string; ts: number }
+
+export function RecentsTab({ onSelect }: { onSelect: () => void }) {
+  const [items, setItems] = useState<Recent[]>([]);
+  useEffect(() => {
+    try { setItems(JSON.parse(localStorage.getItem('quantika.recents') || '[]')); } catch {}
+  }, []);
+  if (items.length === 0) return <div className="p-4 text-ds-text-subtle text-sm">No recent actions yet</div>;
+  return (
+    <ul className="p-1">
+      {items.slice(0, 5).map((r) => (
+        <li key={r.href}>
+          <Link href={r.href} onClick={onSelect} className="block px-3 py-2 rounded-ds-sm text-sm text-ds-text hover:bg-ds-surface-muted">
+            {r.label} <span className="text-ds-text-subtle text-xs">· {new Date(r.ts).toLocaleString('en-US')}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **5.2 Commit `feat(r3): RecentsTab from localStorage`.**
+
+---
+
+## Task 6: CmdKPalette container
+
+**Files:**
+- Create: `design-system/patterns/CmdKPalette.tsx`
+- Test: `design-system/__tests__/CmdKPalette.test.tsx`
+
+- [ ] **6.1 Failing test:**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ModeProvider } from '../patterns/ModeProvider';
+import { PaletteProvider, usePalette } from '../patterns/usePalette';
+import { CmdKPalette } from '../patterns/CmdKPalette';
+
+function Trigger() { const { open } = usePalette(); return <button onClick={() => open()}>x</button>; }
+
+describe('CmdKPalette', () => {
+  it('opens with tabs and input', async () => {
+    render(<ModeProvider initial="charterer"><PaletteProvider><Trigger /><CmdKPalette /></PaletteProvider></ModeProvider>);
+    await userEvent.click(screen.getByText('x'));
+    expect(screen.getByPlaceholderText(/search|ask/i)).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /actions/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /navigate/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /help/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **6.2 Implement:**
+
+```tsx
+// design-system/patterns/CmdKPalette.tsx
+'use client';
+import { useState, useRef, useEffect } from 'react';
+import { Dialog, Input, Tabs } from '@/design-system/primitives';
+import { usePalette } from './usePalette';
+import { ActionsTab } from './PaletteTabs/ActionsTab';
+import { NavigateTab } from './PaletteTabs/NavigateTab';
+import { HelpTab } from './PaletteTabs/HelpTab';
+import { RecentsTab } from './PaletteTabs/RecentsTab';
+
+export function CmdKPalette() {
+  const { isOpen, close, activeTab, setTab } = usePalette();
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isOpen]);
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(v) => { if (!v) close(); }}>
+      <Dialog.Content className="!max-w-xl !top-[20vh] !translate-y-0">
+        <Dialog.Title className="!mb-2">Quick actions</Dialog.Title>
+        <Input ref={inputRef} placeholder="Search or ask…" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <div className="mt-3">
+          <Tabs.Root value={activeTab} onValueChange={(v: any) => setTab(v)}>
+            <Tabs.List>
+              <Tabs.Trigger value="actions">Actions</Tabs.Trigger>
+              <Tabs.Trigger value="navigate">Navigate</Tabs.Trigger>
+              <Tabs.Trigger value="help">Help</Tabs.Trigger>
+              <Tabs.Trigger value="recents">Recents</Tabs.Trigger>
+            </Tabs.List>
+            <Tabs.Panel value="actions"><ActionsTab query={query} onSelect={close} /></Tabs.Panel>
+            <Tabs.Panel value="navigate"><NavigateTab query={query} onSelect={close} /></Tabs.Panel>
+            <Tabs.Panel value="help"><HelpTab query={query} /></Tabs.Panel>
+            <Tabs.Panel value="recents"><RecentsTab onSelect={close} /></Tabs.Panel>
+          </Tabs.Root>
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+```
+
+- [ ] **6.3 Run PASS. Commit `feat(r3): CmdKPalette container with 4 tabs`.**
+
+---
+
+## Task 7: AIBar (replaces placeholder)
+
+**Files:**
+- Create: `design-system/patterns/AIBar.tsx`
+- Modify: `design-system/patterns/AppShell.tsx`
+- Modify: `design-system/patterns/index.ts`
+
+- [ ] **7.1 Implement:**
+
+```tsx
+// design-system/patterns/AIBar.tsx
+'use client';
+import { useMode } from './useMode';
+import { usePalette } from './usePalette';
+
+export function AIBar() {
+  const { t } = useMode();
+  const { open } = usePalette();
+  return (
+    <button
+      type="button"
+      onClick={() => open('help')}
+      className="hidden md:flex items-center gap-2 w-full bg-ds-surface border-b border-ds-border px-6 py-2 text-sm text-ds-text-subtle hover:bg-ds-surface-muted text-left"
+      aria-label="Open AI assistant"
+    >
+      <span className="flex-1">💬 {t('aibar.placeholder')}</span>
+      <kbd className="bg-ds-surface-muted text-ds-text-muted px-1.5 py-0.5 rounded text-[10px] font-semibold">⌘K</kbd>
+    </button>
+  );
+}
+```
+
+- [ ] **7.2 Update AppShell:**
+
+```tsx
+// design-system/patterns/AppShell.tsx (replace AIBarPlaceholder import + usage)
+import { AIBar } from './AIBar';
+import { CmdKPalette } from './CmdKPalette';
+import { PaletteProvider } from './usePalette';
+import { HelpFAB } from './HelpFAB';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return (
+    <PaletteProvider>
+      <div className="min-h-screen bg-ds-bg text-ds-text flex flex-col">
+        <TopNav />
+        <AIBar />
+        <main className="flex-1 pb-16 md:pb-0">{children}</main>
+        <BottomNav />
+        <HelpFAB />
+        <CmdKPalette />
+      </div>
+    </PaletteProvider>
+  );
+}
+```
+
+- [ ] **7.3 Update barrel + commit `feat(r3): AIBar replacing placeholder, wired into AppShell`.**
+
+---
+
+## Task 8: HelpFAB
+
+**Files:**
+- Create: `design-system/patterns/HelpFAB.tsx`
+
+- [ ] **8.1 Implement:**
+
+```tsx
+// design-system/patterns/HelpFAB.tsx
+'use client';
+import { usePalette } from './usePalette';
+import { usePathname } from 'next/navigation';
+
+const HIDDEN_ON = ['/login', '/'];
+
+export function HelpFAB() {
+  const { open } = usePalette();
+  const path = usePathname();
+  if (HIDDEN_ON.includes(path)) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => open('help')}
+      aria-label="Help"
+      className="fixed bottom-20 md:bottom-6 right-6 z-40 bg-ds-accent text-ds-accent-fg rounded-ds-full h-12 w-12 flex items-center justify-center shadow-lg hover:scale-105 transition-transform duration-ds-fast"
+    >
+      ?
+    </button>
+  );
+}
+```
+
+- [ ] **8.2 Commit `feat(r3): HelpFAB floating button`.**
+
+---
+
+## Task 9: Visual regression + a11y
+
+**Files:**
+- Create: `tests/visual/cmdk-palette.spec.ts`
+
+- [ ] **9.1 Spec:**
+
+```ts
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('⌘K opens palette', async ({ page }) => {
+  await page.goto('/matches');
+  await page.keyboard.press('Meta+k');
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page).toHaveScreenshot('palette-open.png', { maxDiffPixelRatio: 0.02 });
+});
+
+test('HelpFAB visible on /matches', async ({ page }) => {
+  await page.goto('/matches');
+  await expect(page.getByRole('button', { name: 'Help' })).toBeVisible();
+});
+
+test('AIBar clickable', async ({ page }) => {
+  await page.goto('/matches');
+  await page.getByRole('button', { name: /open ai assistant/i }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+});
+
+test('a11y — 0 violations with palette open', async ({ page }) => {
+  await page.goto('/matches');
+  await page.keyboard.press('Meta+k');
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});
+```
+
+- [ ] **9.2 Generate baseline + commit `test(r3): visual + a11y for CmdKPalette + HelpFAB`.**
+
+---
+
+## Task 10: Final + PR
+
+- [ ] **10.1** TS strict 0 errors, jest green, Playwright + axe green
+- [ ] **10.2** Push + PR `R3: AIBar + ⌘K Palette + HelpFAB`
+- [ ] **10.3** NO auto-merge — /test-skill QA gate отдельно
+
+## Success criteria
+
+- ⌘K из любой page opens palette
+- AIBar click opens palette (Help tab)
+- HelpFAB visible на authenticated routes
+- HelpTab fires /api/help/ask на ≥3 chars query
+- TS strict + tests green
+
+## Out of scope
+
+- SSE streaming RAG (R6)
+- Voice input (R6)
+- Persistent chat history (future)

--- a/docs/superpowers/plans/2026-05-24-r4-livestrip-plan.md
+++ b/docs/superpowers/plans/2026-05-24-r4-livestrip-plan.md
@@ -1,0 +1,642 @@
+# R4 — LiveStrip + Cached List · Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`.
+
+**Goal:** Активный «processing live» UX на `/matches`: SSE-driven LiveStrip + cached list + match-toasts + fresh-card animation. Главная UX-фишка приложения.
+
+**Spec:** [r4-livestrip-design.md](../specs/2026-05-24-r4-livestrip-design.md)
+**Branch:** `design/r4-livestrip` (create after R2 merged; can run parallel to R3)
+**Depends:** R1 primitives, R2 AppShell
+**Tier:** L · ~15 файлов + integration в existing processor · ~5-7 дней
+
+---
+
+## Pre-flight
+
+- [ ] **0.1** Worktree от main (после R2 merge):
+```bash
+cd ~/work/quantika-demo
+git fetch origin
+git checkout main && git pull
+git checkout -b design/r4-livestrip
+git worktree add .worktrees/r4-livestrip design/r4-livestrip
+cd .worktrees/r4-livestrip
+```
+
+- [ ] **0.2** Find existing job processor: `grep -rn 'process.*email\\|emails/parse\\|jobs.*table' lib/ app/api/ --include='*.ts' | head -20`. Document: путь, sig, current schema of jobs table.
+
+---
+
+## Task 1: Migration 038 (jobs.progress_percent)
+
+**Files:**
+- Create: `lib/migrations/038-jobs-progress.ts`
+- Test: `__tests__/lib/migrations/038.test.ts`
+
+- [ ] **1.1** Сначала проверь существует ли уже колонка: `grep -n 'progress_percent' lib/migrations/*.ts lib/db/schema.ts 2>/dev/null`. Если уже есть — Task 1 skip, переходи к Task 2.
+
+- [ ] **1.2** Failing test:
+
+```ts
+import Database from 'better-sqlite3';
+import { migrate } from '../../../lib/migrations/runner';
+
+it('migration 038 adds progress_percent + current_step to jobs', () => {
+  const db = new Database(':memory:');
+  migrate(db, { upTo: 38 });
+  const cols = db.prepare("PRAGMA table_info(jobs)").all() as { name: string }[];
+  const names = cols.map(c => c.name);
+  expect(names).toContain('progress_percent');
+  expect(names).toContain('current_step');
+});
+```
+
+- [ ] **1.3** Implement:
+
+```ts
+// lib/migrations/038-jobs-progress.ts
+import type { Database } from 'better-sqlite3';
+export const migration038 = {
+  version: 38,
+  name: '038-jobs-progress',
+  up(db: Database): void {
+    db.exec(`ALTER TABLE jobs ADD COLUMN progress_percent INTEGER NOT NULL DEFAULT 0`);
+    db.exec(`ALTER TABLE jobs ADD COLUMN current_step TEXT`);
+  },
+};
+```
+
+Register in `lib/migrations/index.ts`. PASS. Commit `feat(r4): migration 038 — jobs.progress_percent + current_step`.
+
+---
+
+## Task 2: Per-user pub/sub event emitter
+
+**Files:**
+- Create: `lib/jobs/event-emitter.ts`
+- Test: `__tests__/lib/jobs/event-emitter.test.ts`
+
+- [ ] **2.1** Failing test:
+
+```ts
+import { jobEvents, emitJobUpdate, emitMatchCreated } from '@/lib/jobs/event-emitter';
+
+it('per-user channels do not leak across users', () => {
+  const received: any[] = [];
+  const off = jobEvents.subscribe('user-1', (e) => received.push(e));
+  emitJobUpdate('user-1', { id: 'j1', status: 'processing', progress_percent: 50 });
+  emitJobUpdate('user-2', { id: 'j2', status: 'processing', progress_percent: 30 });
+  expect(received).toHaveLength(1);
+  expect(received[0]).toMatchObject({ type: 'job-update', data: { id: 'j1' } });
+  off();
+});
+
+it('emitMatchCreated delivers to right user', () => {
+  const received: any[] = [];
+  const off = jobEvents.subscribe('user-A', (e) => received.push(e));
+  emitMatchCreated('user-A', { match_id: 'm1', score: 94 });
+  expect(received[0]).toMatchObject({ type: 'match-created', data: { match_id: 'm1' } });
+  off();
+});
+```
+
+- [ ] **2.2** Implement:
+
+```ts
+// lib/jobs/event-emitter.ts
+type Event = { type: 'job-update' | 'match-created'; data: Record<string, unknown> };
+type Handler = (e: Event) => void;
+
+const channels = new Map<string, Set<Handler>>();
+
+export const jobEvents = {
+  subscribe(userId: string, handler: Handler): () => void {
+    let set = channels.get(userId);
+    if (!set) { set = new Set(); channels.set(userId, set); }
+    set.add(handler);
+    return () => {
+      set!.delete(handler);
+      if (set!.size === 0) channels.delete(userId);
+    };
+  },
+};
+
+function emit(userId: string, event: Event): void {
+  const set = channels.get(userId);
+  if (!set) return;
+  for (const h of set) h(event);
+}
+
+export function emitJobUpdate(userId: string, data: { id: string; status: string; progress_percent: number; current_step?: string; email_subject?: string; from?: string }): void {
+  emit(userId, { type: 'job-update', data });
+}
+
+export function emitMatchCreated(userId: string, data: { match_id: string; score: number; vessel_name?: string; cargo_summary?: string }): void {
+  emit(userId, { type: 'match-created', data });
+}
+```
+
+- [ ] **2.3** PASS. Commit `feat(r4): in-memory per-user pub/sub event emitter`.
+
+---
+
+## Task 3: SSE endpoint /api/jobs/stream
+
+**Files:**
+- Create: `app/api/jobs/stream/route.ts`
+- Test: `__tests__/api/jobs-stream.test.ts`
+
+- [ ] **3.1** Test (smoke-level — SSE harder to unit-test):
+
+```ts
+import { GET } from '@/app/api/jobs/stream/route';
+import { makeAuthRequest } from '../helpers/auth';
+
+it('returns SSE response with correct headers when authenticated', async () => {
+  const req = await makeAuthRequest('GET', '/api/jobs/stream');
+  const res = await GET(req);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('text/event-stream');
+  expect(res.headers.get('cache-control')).toContain('no-cache');
+});
+
+it('returns 401 without auth', async () => {
+  const req = new Request('http://localhost/api/jobs/stream');
+  const res = await GET(req as any);
+  expect([401, 200]).toContain(res.status); // middleware may intercept first
+});
+```
+
+- [ ] **3.2** Implement:
+
+```ts
+// app/api/jobs/stream/route.ts
+import { type NextRequest } from 'next/server';
+import { getSession } from '@/lib/session';
+import { jobEvents } from '@/lib/jobs/event-emitter';
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return new Response('Unauthorized', { status: 401 });
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const send = (event: { type: string; data: unknown }) => {
+        controller.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event.data)}\n\n`));
+      };
+
+      // Initial comment to open connection
+      controller.enqueue(encoder.encode(': connected\n\n'));
+
+      const off = jobEvents.subscribe(session.userId, send);
+
+      // Heartbeat every 25s (avoid proxy timeout)
+      const hb = setInterval(() => {
+        try { controller.enqueue(encoder.encode(': heartbeat\n\n')); } catch { /* closed */ }
+      }, 25000);
+
+      // Cleanup on close
+      req.signal.addEventListener('abort', () => {
+        off();
+        clearInterval(hb);
+        try { controller.close(); } catch {}
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      'connection': 'keep-alive',
+      'x-accel-buffering': 'no', // disable nginx buffering
+    },
+  });
+}
+```
+
+- [ ] **3.3** PASS. Commit `feat(r4): SSE /api/jobs/stream with per-user channel + heartbeat`.
+
+---
+
+## Task 4: Wire existing processor to emit events
+
+**Files:**
+- Modify: existing job processor (path found in Task 0.2)
+
+- [ ] **4.1** Identify entry points in processor — `grep -rn 'jobs.*update\\|matches.*insert\\|emails/parse' lib/jobs/ lib/email/ 2>/dev/null | head`. Document concrete file.
+
+- [ ] **4.2** Add emit calls (example pattern — adapt to real code):
+
+```ts
+// In existing processor — at progress points:
+import { emitJobUpdate, emitMatchCreated } from '@/lib/jobs/event-emitter';
+
+// when starting:
+db.prepare('UPDATE jobs SET progress_percent = 10, current_step = ? WHERE id = ?').run('parsing email', jobId);
+emitJobUpdate(userId, { id: jobId, status: 'processing', progress_percent: 10, current_step: 'parsing email' });
+
+// when extracted:
+emitJobUpdate(userId, { id: jobId, status: 'processing', progress_percent: 50, current_step: 'matching vessels' });
+
+// when match inserted:
+emitMatchCreated(userId, { match_id, score, vessel_name, cargo_summary });
+
+// when done:
+emitJobUpdate(userId, { id: jobId, status: 'done', progress_percent: 100 });
+```
+
+- [ ] **4.3** Add test that exercises full pipeline:
+
+```ts
+import { processEmail } from '@/lib/jobs/process-email'; // adapt
+import { jobEvents } from '@/lib/jobs/event-emitter';
+
+it('processor emits job-update + match-created events', async () => {
+  const received: any[] = [];
+  jobEvents.subscribe('test-user', (e) => received.push(e));
+  await processEmail({ userId: 'test-user', emailBody: '...test fixture...' });
+  const types = received.map(r => r.type);
+  expect(types).toContain('job-update');
+  expect(types).toContain('match-created'); // assuming fixture creates match
+});
+```
+
+- [ ] **4.4** PASS. Commit `feat(r4): wire job processor to emit progress + match events`.
+
+---
+
+## Task 5: useLiveJobs hook
+
+**Files:**
+- Create: `design-system/patterns/useLiveJobs.ts`
+- Test: `design-system/__tests__/useLiveJobs.test.tsx`
+
+- [ ] **5.1** Test:
+
+```tsx
+import { renderHook, act } from '@testing-library/react';
+import { useLiveJobs } from '../patterns/useLiveJobs';
+
+// Mock EventSource
+class MockES { onmessage: any; close = jest.fn(); addEventListener(t: string, h: any) { (this as any)[`on${t}`] = h; } }
+beforeEach(() => { (global as any).EventSource = jest.fn(() => new MockES()); });
+
+it('returns initial empty state', () => {
+  const { result } = renderHook(() => useLiveJobs());
+  expect(result.current.jobs).toEqual([]);
+  expect(result.current.latestMatch).toBeNull();
+});
+
+it('updates jobs on job-update event', () => {
+  const es = new MockES();
+  (global as any).EventSource = jest.fn(() => es);
+  const { result } = renderHook(() => useLiveJobs());
+  act(() => {
+    (es as any).onjob-update?.({ data: JSON.stringify({ id: 'j1', status: 'processing', progress_percent: 50 }) });
+  });
+  expect(result.current.jobs).toHaveLength(1);
+});
+```
+
+- [ ] **5.2** Implement:
+
+```tsx
+// design-system/patterns/useLiveJobs.ts
+'use client';
+import { useEffect, useState, useCallback } from 'react';
+
+export interface LiveJob { id: string; status: string; progress_percent: number; current_step?: string; email_subject?: string; from?: string }
+export interface NewMatch { match_id: string; score: number; vessel_name?: string; cargo_summary?: string; createdAt: number }
+
+export function useLiveJobs() {
+  const [jobs, setJobs] = useState<LiveJob[]>([]);
+  const [latestMatch, setLatestMatch] = useState<NewMatch | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let es: EventSource | null = null;
+    let retry = 1000;
+    let cancelled = false;
+
+    function connect() {
+      if (cancelled) return;
+      es = new EventSource('/api/jobs/stream');
+      es.addEventListener('job-update', (ev) => {
+        const data = JSON.parse((ev as MessageEvent).data) as LiveJob;
+        setJobs((prev) => {
+          const idx = prev.findIndex((j) => j.id === data.id);
+          if (data.status === 'done' || data.progress_percent === 100) {
+            // remove on done after 2s
+            setTimeout(() => setJobs((p) => p.filter((j) => j.id !== data.id)), 2000);
+          }
+          if (idx === -1) return [...prev, data];
+          const next = [...prev]; next[idx] = data; return next;
+        });
+      });
+      es.addEventListener('match-created', (ev) => {
+        const data = JSON.parse((ev as MessageEvent).data) as Omit<NewMatch, 'createdAt'>;
+        setLatestMatch({ ...data, createdAt: Date.now() });
+      });
+      es.onerror = () => {
+        es?.close();
+        retry = Math.min(retry * 2, 30_000);
+        setTimeout(connect, retry);
+      };
+    }
+    connect();
+    return () => { cancelled = true; es?.close(); };
+  }, []);
+
+  const dismissMatch = useCallback(() => setLatestMatch(null), []);
+  return { jobs, latestMatch, dismissMatch };
+}
+```
+
+- [ ] **5.3** PASS. Commit `feat(r4): useLiveJobs hook with SSE + reconnect`.
+
+---
+
+## Task 6: LiveStripCard
+
+**Files:**
+- Create: `design-system/patterns/LiveStripCard.tsx`
+- Test: `design-system/__tests__/LiveStripCard.test.tsx`
+
+- [ ] **6.1** Test + impl:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { LiveStripCard } from '../patterns/LiveStripCard';
+
+it('renders queue state', () => {
+  render(<LiveStripCard from="Boris" subject="HSS cargo" status="queue" />);
+  expect(screen.getByText('Boris')).toBeInTheDocument();
+});
+
+it('renders done with checkmark', () => {
+  render(<LiveStripCard from="Boris" subject="HSS" status="done" matchHint="MV Atlas 94" />);
+  expect(screen.getByText(/MV Atlas 94/)).toBeInTheDocument();
+});
+```
+
+```tsx
+// design-system/patterns/LiveStripCard.tsx
+'use client';
+import { cn } from '@/design-system/primitives/_utils';
+
+interface Props { from: string; subject: string; status: 'queue' | 'active' | 'done'; matchHint?: string; }
+
+export function LiveStripCard({ from, subject, status, matchHint }: Props) {
+  return (
+    <div className={cn(
+      'bg-ds-surface border rounded-ds-sm px-2 py-1.5 text-[10px]',
+      status === 'queue' && 'border-orange-200 opacity-60',
+      status === 'active' && 'border-amber-400 ring-2 ring-amber-200',
+      status === 'done' && 'border-green-300 bg-green-50',
+    )}>
+      <div className="font-semibold text-ds-text">{from}</div>
+      <div className="text-ds-text-muted truncate">{subject}</div>
+      <div className={cn('text-[9px] mt-0.5 uppercase tracking-wide', status === 'done' && 'text-green-700 font-semibold', status === 'active' && 'text-amber-700 font-semibold', status === 'queue' && 'text-ds-text-subtle')}>
+        {status === 'queue' && 'queue'}
+        {status === 'active' && '⋯ processing'}
+        {status === 'done' && `✓ ${matchHint ?? 'done'}`}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **6.2** Commit `feat(r4): LiveStripCard with queue/active/done states`.
+
+---
+
+## Task 7: LiveStrip container
+
+**Files:**
+- Create: `design-system/patterns/LiveStrip.tsx`
+- Test: `design-system/__tests__/LiveStrip.test.tsx`
+
+- [ ] **7.1** Test:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { LiveStrip } from '../patterns/LiveStrip';
+
+it('hidden when no jobs', () => {
+  const { container } = render(<LiveStrip jobs={[]} />);
+  expect(container.firstChild).toBeNull();
+});
+
+it('visible with progress when 1+ jobs', () => {
+  render(<LiveStrip jobs={[
+    { id: 'j1', status: 'processing', progress_percent: 50, from: 'Boris', email_subject: 'HSS' },
+  ]} />);
+  expect(screen.getByText(/Boris/)).toBeInTheDocument();
+  expect(screen.getByRole('progressbar')).toBeInTheDocument();
+});
+```
+
+- [ ] **7.2** Implement:
+
+```tsx
+// design-system/patterns/LiveStrip.tsx
+'use client';
+import { LiveStripCard } from './LiveStripCard';
+import type { LiveJob } from './useLiveJobs';
+
+export function LiveStrip({ jobs }: { jobs: LiveJob[] }) {
+  if (jobs.length === 0) return null;
+  const done = jobs.filter((j) => j.progress_percent >= 100).length;
+  const total = jobs.length;
+  const avgPercent = Math.round(jobs.reduce((s, j) => s + j.progress_percent, 0) / total);
+  return (
+    <div className="bg-gradient-to-r from-amber-50 to-orange-50 border-b border-amber-300 px-6 py-3" role="region" aria-label="Live email processing">
+      <div className="flex items-center justify-between text-xs text-amber-900 mb-2">
+        <span><b>📥 Обрабатываем {total} email{total > 1 ? "'ов" : ''}</b> · {done}/{total} готово</span>
+        <span className="text-amber-700">live</span>
+      </div>
+      <div className="h-1.5 bg-amber-100 rounded-full overflow-hidden" role="progressbar" aria-valuenow={avgPercent} aria-valuemin={0} aria-valuemax={100}>
+        <div className="h-full bg-amber-500 transition-all duration-300" style={{ width: `${avgPercent}%` }} />
+      </div>
+      <div className="mt-2 grid grid-cols-2 md:grid-cols-5 gap-1.5">
+        {jobs.slice(0, 5).map((j) => (
+          <LiveStripCard
+            key={j.id}
+            from={j.from ?? '...'}
+            subject={j.email_subject ?? j.current_step ?? ''}
+            status={j.progress_percent === 0 ? 'queue' : j.progress_percent >= 100 ? 'done' : 'active'}
+            matchHint={j.current_step}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **7.3** Commit `feat(r4): LiveStrip container with gradient + progress + 5-slot grid`.
+
+---
+
+## Task 8: MatchToast
+
+**Files:**
+- Create: `design-system/patterns/MatchToast.tsx`
+- Test: `design-system/__tests__/MatchToast.test.tsx`
+
+- [ ] **8.1** Test:
+
+```tsx
+import { render, screen, act } from '@testing-library/react';
+import { MatchToast } from '../patterns/MatchToast';
+
+it('renders match info', () => {
+  render(<MatchToast match={{ match_id: 'm1', score: 94, vessel_name: 'MV Atlas', cargo_summary: 'HSS Constanta', createdAt: Date.now() }} onDismiss={() => {}} />);
+  expect(screen.getByText(/MV Atlas/)).toBeInTheDocument();
+  expect(screen.getByText(/94/)).toBeInTheDocument();
+});
+
+it('null match → nothing rendered', () => {
+  const { container } = render(<MatchToast match={null} onDismiss={() => {}} />);
+  expect(container.firstChild).toBeNull();
+});
+
+it('auto-dismisses after 5s', () => {
+  jest.useFakeTimers();
+  const dismiss = jest.fn();
+  render(<MatchToast match={{ match_id: 'm1', score: 94, createdAt: Date.now() }} onDismiss={dismiss} />);
+  act(() => { jest.advanceTimersByTime(5100); });
+  expect(dismiss).toHaveBeenCalled();
+  jest.useRealTimers();
+});
+```
+
+- [ ] **8.2** Implement:
+
+```tsx
+// design-system/patterns/MatchToast.tsx
+'use client';
+import { useEffect } from 'react';
+import type { NewMatch } from './useLiveJobs';
+
+export function MatchToast({ match, onDismiss }: { match: NewMatch | null; onDismiss: () => void }) {
+  useEffect(() => {
+    if (!match) return;
+    const tid = setTimeout(onDismiss, 5000);
+    return () => clearTimeout(tid);
+  }, [match, onDismiss]);
+  if (!match) return null;
+  return (
+    <div role="status" aria-live="polite" className="fixed bottom-6 right-6 z-50 bg-green-50 border border-green-300 text-green-900 rounded-ds-md px-4 py-3 shadow-lg flex items-center gap-2">
+      <span>✨ Новый match:</span>
+      <b>{match.vessel_name ?? `match #${match.match_id}`}</b>
+      <span className="text-xs text-green-700">score {match.score}</span>
+      <button onClick={onDismiss} aria-label="dismiss" className="ml-2 text-green-700 hover:text-green-900">✕</button>
+    </div>
+  );
+}
+```
+
+- [ ] **8.3** Commit `feat(r4): MatchToast with auto-dismiss + accessible region`.
+
+---
+
+## Task 9: Wire into MatchesClient
+
+**Files:**
+- Modify: `app/matches/MatchesClient.tsx` (или какой это сейчас файл)
+
+- [ ] **9.1** Read existing MatchesClient. Identify integration point (above match list).
+
+- [ ] **9.2** Add (минимально-инвазивно):
+
+```tsx
+import { LiveStrip } from '@/design-system/patterns/LiveStrip';
+import { MatchToast } from '@/design-system/patterns/MatchToast';
+import { useLiveJobs } from '@/design-system/patterns/useLiveJobs';
+
+export function MatchesClient(/* existing props */) {
+  // ... existing state ...
+  const { jobs, latestMatch, dismissMatch } = useLiveJobs();
+
+  // when latestMatch.match_id appears — re-fetch matches list (или optimistic insert)
+  useEffect(() => {
+    if (!latestMatch) return;
+    // existing refetch helper
+    refetchMatches?.();
+  }, [latestMatch?.match_id]);
+
+  return (
+    <>
+      <LiveStrip jobs={jobs} />
+      {/* existing matches table/cards */}
+      <MatchToast match={latestMatch} onDismiss={dismissMatch} />
+    </>
+  );
+}
+```
+
+- [ ] **9.3** Smoke test existing matches behaviour preserved.
+
+- [ ] **9.4** Commit `feat(r4): wire LiveStrip + MatchToast into MatchesClient`.
+
+---
+
+## Task 10: E2E Playwright + axe
+
+**Files:**
+- Create: `tests/visual/live-strip.spec.ts`
+
+- [ ] **10.1** Spec:
+
+```ts
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('LiveStrip hidden when no active jobs', async ({ page }) => {
+  await page.goto('/matches');
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByRole('region', { name: /live email processing/i })).toHaveCount(0);
+});
+
+test('a11y on /matches with mock job', async ({ page }) => {
+  // mock SSE endpoint via route interception
+  await page.route('**/api/jobs/stream', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'event: job-update\ndata: {"id":"j1","status":"processing","progress_percent":50,"from":"Boris","email_subject":"HSS"}\n\n',
+    });
+  });
+  await page.goto('/matches');
+  await page.waitForTimeout(500);
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});
+```
+
+- [ ] **10.2** Commit `test(r4): Playwright + axe for LiveStrip`.
+
+---
+
+## Task 11: Final + PR
+
+- [ ] **11.1** TS strict, jest, Playwright + axe green
+- [ ] **11.2** Push + PR `R4: Matches LiveStrip + SSE job stream + cached list integration`
+- [ ] **11.3** NO auto-merge
+
+## Success criteria
+
+- LiveStrip auto-show/hide based on active jobs
+- Real progress percent
+- match-toast appears + auto-dismiss
+- Cached list still works
+- TS strict + tests green
+
+## Out of scope
+
+- WebSocket replacement
+- Cross-tab broadcast
+- Persistent event log

--- a/docs/superpowers/plans/2026-05-24-r5-per-page-polish-plan.md
+++ b/docs/superpowers/plans/2026-05-24-r5-per-page-polish-plan.md
@@ -1,0 +1,180 @@
+# R5 — Per-Page Polish Pass · Master Plan
+
+> **For agentic workers:** Этот plan — **master coordinator**, конкретные waves R5a-R5f имеют свои task'и (генерируются динамически orchestrator'ом из §3 main spec'а). Каждая wave = отдельный dispatch с `subagent-driven-development`.
+
+**Goal:** Применить design-system + fixed layouts (§5a) на все ~22 страницы. ~6 wave'ов × 2-3 дня = ~10-15 рабочих дней с параллелизмом.
+
+**Spec:** [r5-per-page-polish-design.md](../specs/2026-05-24-r5-per-page-polish-design.md)
+**Depends:** R1, R2, R3, R4 (все merged)
+**Tier:** L (master) / M (per wave) · ~22 страниц + ~80 файлов суммарно
+
+---
+
+## Pre-flight (orchestrator)
+
+- [ ] **0.1** Verify R1-R4 merged: `git log --oneline origin/main | grep -E 'R[1-4]:' | head`
+- [ ] **0.2** Create master branch для tracking: `git checkout -b design/r5-master`
+- [ ] **0.3** Run grep audit для current usage: `grep -rl 'components/ui/' app/ | sort > /tmp/r5-pages-to-migrate.txt`
+
+---
+
+## Wave R5a — Dashboard + Matches
+
+**Branch:** `design/r5a-dashboard-matches`
+**Subagent prompt:**
+
+```
+Goal: Migrate app/dashboard/* and app/matches/* to design-system + Maritime Deep tokens + chosen patterns (Agenda-first + KPI for Dashboard, Table-first toggle for Matches).
+
+CONSTRAINTS:
+- Use ONLY design-system/primitives/* and design-system/patterns/* (no shadcn for new code).
+- Maritime Deep tokens (bg-ds-*, text-ds-*).
+- LiveStrip уже работает в Matches (R4) — НЕ переделывать, только применить новые tokens + filter chips + sort + density toggle.
+- Dashboard: KPI strip 4 tiles top (Open matches / Active cargoes / BDI / HSS rate) + 3 sections (To-do / Recent matches / Inbox).
+- Matches: Cards/Table toggle in filter bar; Table default desktop, Cards default mobile.
+- Mode-aware via useMode() (charterer vs owner column order).
+- Mobile variants: Dashboard stacked sections, Matches Cards.
+- Visual baseline per page; axe a11y 0 violations.
+- Existing tests must stay green.
+- NO bus logic changes.
+
+OUTCOME: 2 PRs (one for dashboard, one for matches) OR 1 combined PR. Each with visual baseline + a11y test.
+```
+
+ETA ~2-3 дня. NO auto-merge.
+
+---
+
+## Wave R5b — Match detail + Cargo + Vessels
+
+**Branch:** `design/r5b-match-cargo-vessels`
+**Subagent prompt:**
+
+```
+Goal: Migrate /match/[id], /cargo, /vessels.
+
+PATTERNS:
+- Match detail (/match/[id]): Split layout + sticky AI side-panel (220px right). Tabs Overview/Economics/Quote/Conversation. Mobile → bottom-sheet for side-panel.
+- Cargo + Vessels: Table-first + AI-add bar top + click-row → side-panel detail. SAME pattern for both, differ only in columns/fields.
+
+CONSTRAINTS same as R5a. AI-add bar wires to existing /api/email/parse or /api/cargo/parse.
+
+3 pages migrated. ETA 2-3 дня.
+```
+
+---
+
+## Wave R5c — Charterers + Market + Recap
+
+**Branch:** `design/r5c-charterers-market-recap`
+
+```
+Goal: 3 pages.
+
+PATTERNS:
+- Charterers: Table (как Cargo) + extra cols Last-snippet + HOT/WARM/COLD coloring (cell-bg).
+- Market: Multi-section digest (KPI tiles + Routes + Fixtures + Knowledge) + click → drill-down focused chart.
+- Recap: Form-first + AI assist (fill/missing-highlight) + Sources panel right + "Generate full text" button.
+
+ETA 2-3 дня.
+```
+
+---
+
+## Wave R5d — Email + Onboarding + Upgrade
+
+**Branch:** `design/r5d-email-onboarding-upgrade`
+
+```
+Goal: 3 pages.
+
+PATTERNS:
+- /email: Stream of action-cards с parsed fields, Accept/Edit/Reject/📄 Original, low-confidence highlighted amber.
+- /onboarding: Pre-loaded demo data + persistent banner "Connect Gmail (1 OAuth)" + mode auto-detect on first real email.
+- /upgrade: Usage-aware inside product (current plan + usage bars + contextual upgrade prompt). Plus separate /upgrade/plans for classic 3-tier landing (linked from "See all plans").
+
+ETA 2-3 дня.
+```
+
+---
+
+## Wave R5e — Apply patterns (bulk minor pages)
+
+**Branch:** `design/r5e-bulk-pattern-apply`
+
+```
+Goal: 10 pages — apply already-decided patterns без brainstorm.
+
+| Page | Pattern |
+|---|---|
+| /laytime | Recap-style (form + AI + sources) |
+| /psc | Table-first (как Cargo) |
+| /commission | Table + side-modal (Cargo) |
+| /clauses | Table + rich-text side-modal |
+| /request | Form-first + AI suggests |
+| /processing | LiveStrip-like full-page |
+| /summary | Read-only digest (Market mini) |
+| /more | Simple drawer-style links |
+| /vessel/[id] | Split + AI side-panel (Match-detail read-only) |
+| /fixture | Read-only Recap view |
+
+CONSTRAINTS: bulk-style, не пиши full custom UI — copy-and-adapt из other R5 waves. 10 pages × ~30 min each = ~5h.
+```
+
+ETA 2-3 дня.
+
+---
+
+## Wave R5f — Landing + Settings (NEW route)
+
+**Branch:** `design/r5f-landing-settings`
+
+```
+Goal: 2 large new pages.
+
+LANDING (app/page.tsx, public):
+- Product-demo hero: live LiveStrip demo embedded (DEMO badge)
+- Features strip (3 icons)
+- Pricing pills (3, link to /upgrade)
+- Trust logos
+- Footer
+
+SETTINGS (app/settings/* — NEW route):
+- Sidebar (~10 разделов): Profile / Password & 2FA / Notifications / Integrations / Team / API & webhooks / Plan & usage / Payment / Invoices / Export / Danger
+- Default = Integrations
+- URL anchors: /settings/integrations, /settings/billing, etc.
+- Each section = own component (extract to design-system/patterns/settings/* OR app/settings/_components/*)
+
+ETA 1-2 дня.
+```
+
+---
+
+## R5-final: Cleanup deprecated components
+
+**Branch:** `design/r5-final-cleanup`
+
+- [ ] Audit: `grep -rl 'from .components/ui/' app/`. Expected: 0 lines.
+- [ ] If 0: `git rm -r components/ui/`. Commit `chore(r5-final): remove deprecated shadcn ui components — design-system fully adopted`.
+- [ ] If >0: file QUESTIONS.md per remaining usage, escalate.
+- [ ] Update `tailwind.config.ts`: remove old `--background`, `--primary` etc. token colors (keep only `ds.*`).
+- [ ] Smoke test main pages. PR + admin-merge.
+
+---
+
+## Success criteria
+
+- All 22 pages use design-system primitives + Maritime Deep tokens
+- Mobile variants for each
+- Visual regression baselines updated for all pages
+- axe 0 violations
+- `components/ui/*` deleted
+- Existing tests + new visual all green
+- Living docs/ROADMAP-CURRENT-STATE.md updated
+
+## Out of scope
+
+- Bus logic changes
+- Backend API changes
+- Admin pages (defer)
+- Dark mode (R6)

--- a/docs/superpowers/plans/2026-05-24-r6-a11y-perf-plan.md
+++ b/docs/superpowers/plans/2026-05-24-r6-a11y-perf-plan.md
@@ -1,0 +1,216 @@
+# R6 — A11y + Perf + Polish · Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`.
+
+**Goal:** Финальный audit & polish: a11y, perf, motion, dark-mode prep, living docs.
+
+**Spec:** [r6-a11y-perf-design.md](../specs/2026-05-24-r6-a11y-perf-design.md)
+**Branch:** `design/r6-a11y-perf` (after R5 merged)
+**Depends:** R1-R5
+**Tier:** M · ~25 файлов · ~3-5 дней
+
+---
+
+## Pre-flight
+
+- [ ] **0.1** Verify R5 merged: `grep -L 'components/ui/' app/**/*.tsx` empty.
+- [ ] **0.2** Install perf tools: `npm i -D @next/bundle-analyzer @lhci/cli`. Commit lockfile change.
+
+---
+
+## Task 1: A11y page audit (per page)
+
+**Files:**
+- Create: `tests/a11y/pages/<page>.spec.ts` per migrated page (~20 files)
+
+- [ ] **1.1** Generate spec template:
+
+```ts
+// tests/a11y/pages/dashboard.spec.ts
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('/dashboard a11y — 0 wcag2a/aa violations', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle');
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});
+```
+
+Copy-and-rename для каждой page (~20 files). Run all. Fix any violations inline.
+
+- [ ] **1.2** Commit per fix `fix(a11y): /<page> — <issue>`.
+
+- [ ] **1.3** Write `docs/a11y-audit-r6.md` summary table (page | violations found | fixed).
+
+---
+
+## Task 2: Skip-to-content link
+
+**Files:**
+- Modify: `design-system/patterns/AppShell.tsx`
+
+- [ ] **2.1** Add visually-hidden skip-link:
+
+```tsx
+<a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 z-50 bg-ds-accent text-ds-accent-fg px-3 py-2 rounded-ds-md">Skip to content</a>
+<main id="main-content" ...>{children}</main>
+```
+
+- [ ] **2.2** Add test in `tests/a11y/skip-link.spec.ts`. Commit `feat(a11y): add skip-to-content link in AppShell`.
+
+---
+
+## Task 3: ARIA labels on icon-only buttons
+
+- [ ] **3.1** Grep: `grep -rn '<button.*lucide\\|<svg.*aria-label' design-system/`. Find icon-only buttons missing `aria-label`.
+- [ ] **3.2** Add labels (BottomNav already has labels; HelpFAB has "Help"; verify TopNav More dropdown summary).
+- [ ] **3.3** Commit `fix(a11y): add aria-label to icon-only buttons`.
+
+---
+
+## Task 4: Lighthouse perf baseline
+
+**Files:**
+- Create: `tests/perf/lighthouse.config.json`
+- Create: `scripts/lh-baseline.sh`
+
+- [ ] **4.1** Lighthouse config (audit /dashboard, /matches, /, /market, /cargo).
+
+```json
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:3000/", "http://localhost:3000/dashboard", "http://localhost:3000/matches"],
+      "numberOfRuns": 3,
+      "settings": { "preset": "desktop" }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.85 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }]
+      }
+    }
+  }
+}
+```
+
+- [ ] **4.2** Run baseline. Document failures. Fix:
+  - next/image для all images
+  - dynamic imports for heavy modals
+  - font preload
+- [ ] **4.3** Commit `chore(perf): lighthouse baseline + fixes — perf ≥85, a11y ≥95`.
+
+---
+
+## Task 5: Bundle analysis
+
+- [ ] **5.1** Add to `next.config.js`:
+
+```js
+const withBundleAnalyzer = require('@next/bundle-analyzer')({ enabled: process.env.ANALYZE === 'true' });
+module.exports = withBundleAnalyzer({ /* existing */ });
+```
+
+- [ ] **5.2** Run `ANALYZE=true npm run build`. Identify >50kb chunks. Audit для removals (heavy libs unused).
+
+- [ ] **5.3** Code-split Dialog/Sheet content (если popup mod heavy):
+
+```tsx
+const RecapComposer = dynamic(() => import('@/components/recap/RecapComposer'), { ssr: false });
+```
+
+- [ ] **5.4** Commit `perf: bundle split + analyzer config`.
+
+---
+
+## Task 6: Motion audit
+
+- [ ] **6.1** Grep: `grep -rn 'transition-\\|animate-' design-system/ | grep -v 'duration-ds-'`. Identify hardcoded durations.
+- [ ] **6.2** Replace hardcoded `duration-200` → `duration-ds-base` etc.
+- [ ] **6.3** Verify `@media (prefers-reduced-motion)` зануляет — test в browser DevTools.
+- [ ] **6.4** Commit `chore(motion): unify all transitions to ds-motion tokens`.
+
+---
+
+## Task 7: Dark mode token prep
+
+**Files:**
+- Modify: `design-system/tokens/colors.css`
+
+- [ ] **7.1** Add dark tokens:
+
+```css
+[data-theme="dark"] {
+  --ds-bg: #0f172a;
+  --ds-surface: #1e293b;
+  --ds-surface-muted: #334155;
+  --ds-border: #334155;
+  --ds-text: #f1f5f9;
+  --ds-text-muted: #94a3b8;
+  --ds-text-subtle: #64748b;
+  --ds-accent: #fbbf24;
+  --ds-accent-fg: #0f172a;
+  --ds-accent-soft: #422006;
+  --ds-accent-soft-fg: #fde68a;
+  /* semantic stays */
+}
+```
+
+- [ ] **7.2** Document в `design-system/README.md` под секцию "Dark mode (prep, not active)".
+
+- [ ] **7.3** Commit `feat(theme): dark mode tokens drafted — not active yet`.
+
+---
+
+## Task 8: Living docs update
+
+**Files:**
+- Modify: `docs/ROADMAP-CURRENT-STATE.md`
+- Create: `docs/design-system.md`
+- Modify: `docs/superpowers/README.md` (или create)
+
+- [ ] **8.1** ROADMAP add section "Full Redesign R1-R6 COMPLETED 2026-...":
+
+```markdown
+## Full Redesign (R1-R6) — COMPLETED 2026-XX-XX
+
+- R1: design-system foundation (Maritime Deep, 15 primitives, /design preview)
+- R2: AppShell + ModeSwitcher (charterer/owner)
+- R3: AIBar + ⌘K palette + HelpFAB
+- R4: LiveStrip + SSE jobs + match toasts
+- R5: per-page polish (22 pages migrated, components/ui removed)
+- R6: a11y (axe 0, Lighthouse a11y ≥95) + perf (Lighthouse ≥85) + dark-mode tokens drafted
+
+Specs: docs/superpowers/specs/2026-05-24-*
+Plans: docs/superpowers/plans/2026-05-24-*
+```
+
+- [ ] **8.2** Create `docs/design-system.md` overview (~50 lines).
+
+- [ ] **8.3** Commit `docs(roadmap): R1-R6 full redesign COMPLETED`.
+
+---
+
+## Task 9: Final PR + ROADMAP
+
+- [ ] **9.1** TS strict + jest + Playwright + axe all green
+- [ ] **9.2** Push + PR `R6: A11y + Perf + Motion + Dark-mode prep + Living docs`
+- [ ] **9.3** /test-skill cold-QA gate
+- [ ] **9.4** Admin-merge
+
+## Success criteria
+
+- axe 0 violations on all pages
+- Lighthouse a11y ≥95, perf ≥85
+- Skip-to-content link present
+- All transitions use ds-motion tokens
+- Dark mode tokens drafted
+- ROADMAP updated
+
+## Out of scope
+
+- Activate dark mode toggle (R6.5 later)
+- i18n
+- Major UX changes (R5 closed those)

--- a/docs/superpowers/specs/2026-05-24-r2-appshell-modeswitcher-design.md
+++ b/docs/superpowers/specs/2026-05-24-r2-appshell-modeswitcher-design.md
@@ -1,0 +1,189 @@
+# R2 — AppShell + IA + ModeSwitcher (Design Spec)
+
+**Дата:** 2026-05-24
+**Статус:** Draft → ready for plan
+**Parent spec:** [2026-05-24-quantika-demo-full-redesign-design.md](2026-05-24-quantika-demo-full-redesign-design.md) §3.2, §3.3, §5a-#2
+
+## 1. Цель
+
+Обернуть приложение в единый AppShell с:
+- Top-nav из 5 primary + dropdown "More"
+- Persistent ModeSwitcher (charterer ↔ owner) с URL `?mode=` + DB persist
+- Mobile bottom-nav (4 иконки) replace top-nav на ≤768px
+- AI-bar placeholder (visual только; функционал в R3)
+- Использует **только** primitives из R1 (design-system/)
+
+Не трогаем: бизнес-логика, parsers, matching, R5 per-section polish.
+
+## 2. Layout (из brainstorm экран 1-2)
+
+### Desktop (≥769px)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Q │ Dashboard · Matches · Cargo · Vessels · Market  ⋯ More │ TopNav
+│                                       [Charterer|Owner]    │ ModeSwitcher
+├─────────────────────────────────────────────────────────────┤
+│  🔍 Ask anything…                                      ⌘K  │ AIBar (placeholder)
+├─────────────────────────────────────────────────────────────┤
+│  Page content (children)                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Mobile (≤768px)
+
+```
+┌──────────────────────────┐
+│ Q  Quantika    [Mode 🍔] │ Compact top + drawer trigger
+├──────────────────────────┤
+│ Page content             │
+│                          │
+├──────────────────────────┤
+│ 🏠   ✨    📦    ⋯       │ BottomNav (Dashboard / Matches / Cargo+Vessels / More)
+└──────────────────────────┘
+```
+
+## 3. Mode awareness
+
+| Element | Charterer mode | Owner mode |
+|---|---|---|
+| Top-nav slot 3 | **Cargo** | **Vessels** |
+| Top-nav slot 4 | **Vessels** | **Cargo** |
+| AIBar placeholder | «Спроси про груз или кинь email…» | «Спроси про судно или кинь open-position email…» |
+| Page meta (`<title>`) | "Quantika — Charterer" | "Quantika — Owner" |
+| Match list sort default | by score | by TCE |
+
+Mode hook возвращает `{ mode: 'charterer'|'owner', setMode: (m) => void, isCharterer: boolean, isOwner: boolean, t: (key) => string }`.
+
+`t()` — mode-aware copy lookup. Hardcoded dictionary в `useMode.ts` (i18n не делаем сейчас).
+
+## 4. Data flow
+
+### `users.preferred_mode`
+
+Migration `037-add-user-preferred-mode.ts`:
+```sql
+ALTER TABLE users ADD COLUMN preferred_mode TEXT NOT NULL DEFAULT 'charterer';
+```
+
+### `/api/me`
+
+```ts
+// GET /api/me → { id, email, preferred_mode }
+// PATCH /api/me { preferred_mode: 'charterer'|'owner' } → updated user
+```
+
+Both endpoints auth-gated (existing middleware), session-isolated.
+
+### URL state
+
+`?mode=charterer` или `?mode=owner` overrides DB preference for current view. Shareable links. Не персистит.
+
+Mode-resolve order:
+1. URL `?mode=` если present
+2. DB `users.preferred_mode`
+3. Default `'charterer'` (новые юзеры)
+
+### React Context
+
+```tsx
+// design-system/patterns/ModeProvider.tsx
+<ModeProvider initial={mode}>
+  {children}
+</ModeProvider>
+
+// usage
+const { mode, setMode, isCharterer, t } = useMode();
+```
+
+`setMode()` оптимистично обновляет context + URL + fire-and-forget PATCH.
+
+## 5. Files (R2 = ~20 файлов)
+
+### NEW
+
+```
+design-system/patterns/
+├── AppShell.tsx           — layout wrapper
+├── TopNav.tsx             — desktop nav (5 + More)
+├── BottomNav.tsx          — mobile nav (4 icons)
+├── ModeSwitcher.tsx       — toggle button
+├── ModeProvider.tsx       — React Context
+├── useMode.ts             — hook + t() dictionary
+├── AIBarPlaceholder.tsx   — visual only (interactive in R3)
+└── __tests__/
+    ├── AppShell.test.tsx
+    ├── TopNav.test.tsx
+    ├── ModeSwitcher.test.tsx
+    └── useMode.test.tsx
+
+lib/migrations/
+└── 037-add-user-preferred-mode.ts
+
+app/api/me/
+└── route.ts               — GET + PATCH
+
+tests/visual/
+└── app-shell.spec.ts      — Playwright shell + mode toggle
+```
+
+### MODIFIED
+
+```
+app/layout.tsx             — wrap всё в ModeProvider если user authenticated
+                            (или create app/(authenticated)/layout.tsx group)
+middleware.ts              — добавить /api/me (auth required, no bypass)
+```
+
+Существующие страницы (matches/cargo/etc.) **НЕ ТРОГАЕМ**. AppShell обернёт их через layout-route без изменений в page.tsx.
+
+## 6. Responsive strategy
+
+Tailwind breakpoints (existing):
+- `<768px` = mobile → BottomNav active, TopNav hidden
+- `≥768px` = desktop → TopNav active, BottomNav hidden
+
+Mode-switcher:
+- Desktop: top-right в TopNav
+- Mobile: внутри drawer (hamburger в compact top)
+
+## 7. Routes
+
+R2 НЕ переписывает существующие routes. Только добавляет AppShell wrap. Slot mapping в TopNav обрабатывается через `useMode()`:
+
+```tsx
+const navItems = isCharterer
+  ? [...primary, 'Cargo', 'Vessels', ...]
+  : [...primary, 'Vessels', 'Cargo', ...];
+```
+
+## 8. Success criteria
+
+- ✅ `<AppShell>` обёрнут вокруг всех authenticated страниц
+- ✅ Mode toggle меняет nav-order реактивно (без reload)
+- ✅ Mode persists в DB после reload, URL `?mode=` overrides
+- ✅ Mobile breakpoint показывает BottomNav, прячет TopNav
+- ✅ TS strict 0 errors, jest + Playwright visual + axe green
+- ✅ Существующие страницы продолжают работать (regression check)
+
+## 9. Out of scope
+
+- ❌ AIBar функционал (R3)
+- ❌ ⌘K palette (R3)
+- ❌ LiveStrip (R4)
+- ❌ Per-page polish (R5)
+- ❌ Удаление старых components/ui/* (R5 финал)
+- ❌ Page-level layout reorgs (только shell wrap)
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Mode toggle ломает существующие страницы (рассчитывают на одну роль) | AppShell не trigger'ит refetch — старые pages игнорируют mode пока не мигрированы в R5 |
+| Layout shift при mode switch | CSS-only nav swap, no re-mount |
+| Migration 037 на проде | NOT NULL DEFAULT 'charterer' — backward-compatible |
+| /api/me race на init | useMode hook lazy-load, suspense fallback |
+
+## 11. Next
+
+R2 merged → R3 (AIBar + ⌘K) и R4 (LiveStrip) могут стартовать параллельно.

--- a/docs/superpowers/specs/2026-05-24-r3-aibar-cmdk-design.md
+++ b/docs/superpowers/specs/2026-05-24-r3-aibar-cmdk-design.md
@@ -1,0 +1,115 @@
+# R3 — AIBar + ⌘K Palette (Design Spec)
+
+**Дата:** 2026-05-24
+**Parent:** §3.4 + §5a-#1 + экран 14 (AI chat-help)
+**Depends:** R1 primitives, R2 AppShell/useMode
+
+## 1. Цель
+
+Заменить R2 `AIBarPlaceholder` на работающий компонент:
+- Persistent visible search-bar в shell (mode-aware placeholder)
+- ⌘K (Cmd+K / Ctrl+K) → full-width palette с 3 категориями
+- Floating "?" Help-кнопка в bottom-right (использует тот же palette с tab='Help')
+
+## 2. Palette UX
+
+| Tab | Содержимое | Источник данных |
+|---|---|---|
+| **Actions** | "Find vessel for 47k HSS Constanta", "Generate recap", "Show market HSS", ... mode-aware list | hardcoded `ACTIONS` array + handler per item |
+| **Navigate** | Quick-jump в любую page (matches, cargo, vessels, market, settings, …) + last 5 matches | static route list + recent localStorage |
+| **Help** (AI-chat) | Free-text question → AI ответ через RAG (`/api/knowledge/ask`) | streaming response |
+| **Recents** | Last 5 user actions (visited pages, opened matches) | localStorage |
+
+Поведение:
+- ⌘K на любой странице → palette opens
+- Type → fuzzy-filter actions+navigate; ≥3 chars → fire RAG search для Help
+- Esc / outside-click → close
+- Enter → execute selected
+- Arrow keys → navigate items
+
+## 3. AIBar (always visible)
+
+В `AppShell` место `AIBarPlaceholder` заменяется на `<AIBar />`:
+- Click on input → opens palette
+- ⌘K kbd shortcut → opens palette
+- Mobile: collapsed icon (🔍) tap → opens palette as full-screen sheet
+
+## 4. Floating Help button (bottom-right)
+
+```tsx
+<HelpFAB />  // visible on all pages except /login, /
+```
+Click → opens palette с pre-selected Help tab + auto-focus input.
+
+## 5. Backend
+
+- Reuse existing `/api/knowledge/ask` if exists (Knowledge Phase 2 RAG)
+- Иначе создать lightweight `/api/help/ask` proxy
+
+```ts
+// POST /api/help/ask { query: string }
+// → { answer: string, sources: { title, url }[] }
+```
+
+Streaming через Server-Sent-Events опционально (для UX можно сделать non-streaming в R3, streaming в R6 polish).
+
+## 6. Files
+
+```
+design-system/patterns/
+├── AIBar.tsx              — replaces AIBarPlaceholder
+├── CmdKPalette.tsx        — modal/dialog (Dialog primitive)
+├── PaletteTabs/
+│   ├── ActionsTab.tsx
+│   ├── NavigateTab.tsx
+│   ├── HelpTab.tsx
+│   └── RecentsTab.tsx
+├── HelpFAB.tsx
+├── usePalette.ts          — open/close state + ⌘K listener
+└── __tests__/
+    ├── AIBar.test.tsx
+    ├── CmdKPalette.test.tsx
+    └── usePalette.test.tsx
+
+app/api/help/ask/
+└── route.ts               — POST handler (proxy to /api/knowledge/ask или own RAG)
+```
+
+MODIFIED:
+- `design-system/patterns/AppShell.tsx` — replace `AIBarPlaceholder` → `AIBar` + add `HelpFAB`
+- `design-system/patterns/index.ts` — export AIBar, CmdKPalette, HelpFAB
+
+## 7. Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| `⌘K` / `Ctrl+K` | Open palette |
+| `Esc` | Close |
+| `↑` `↓` | Navigate items |
+| `Enter` | Execute selected |
+| `Tab` | Switch palette tabs |
+
+## 8. Success criteria
+
+- ⌘K из любой page → palette opens, focus в input
+- Type "matches" → Navigate tab фильтрует, Enter → router.push('/matches')
+- Type free-text question + Tab to Help → RAG answer rendered
+- Mobile: AIBar icon → full-screen sheet
+- HelpFAB на /dashboard виден, на /login — нет
+- TS strict, jest, Playwright + axe — green
+
+## 9. Out of scope
+
+- Streaming SSE для RAG answer (R6 polish)
+- Voice input (R6 nice-to-have)
+- Multi-language help (i18n не делаем)
+- Persistent chat history (R3 = stateless per-open)
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| ⌘K conflict с browser default (search) | preventDefault в keydown |
+| RAG endpoint slow → palette laggy | Show skeleton in Help tab; non-blocking; timeout 8s → "try later" |
+| HelpFAB overlaps content на small screens | bottom-right with padding, suppress на BottomNav routes |
+| Recents leak between users | localStorage scoped by user_id (key `recents:${userId}`) |

--- a/docs/superpowers/specs/2026-05-24-r4-livestrip-design.md
+++ b/docs/superpowers/specs/2026-05-24-r4-livestrip-design.md
@@ -1,0 +1,136 @@
+# R4 — Matches LiveStrip + Cached List (Design Spec)
+
+**Дата:** 2026-05-24
+**Parent:** §3.5 + экраны 2 + live-processing.html mockup
+**Depends:** R1 primitives, R2 AppShell
+
+## 1. Цель
+
+Главная UX-фишка приложения. `/matches` всегда показывает:
+- **Cached matches** мгновенно (SSR + initial fetch)
+- **LiveStrip** сверху когда есть активная email-обработка (SSE-driven)
+- **Toast** «✨ Новый match» при появлении свежего
+- **Fresh-card animation** (зелёная обводка 10 сек) на свежей карточке
+
+## 2. Backend
+
+### Migration 038: jobs.progress_percent (если ещё нет)
+
+```sql
+ALTER TABLE jobs ADD COLUMN progress_percent INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN current_step TEXT;
+```
+
+### SSE endpoint `/api/jobs/stream`
+
+```
+GET /api/jobs/stream → Server-Sent-Events
+event: job-update
+data: { id, status, progress_percent, current_step, email_subject, from }
+
+event: match-created
+data: { match_id, score, vessel_name, cargo_summary }
+```
+
+Auth-gated, session-isolated (только jobs текущего user'а).
+
+### Trigger SSE events
+
+В существующем job processor (`lib/jobs/process-email.ts` или подобном) добавить:
+- `emitJobUpdate(jobId, progressPercent, currentStep)` после каждого шага
+- `emitMatchCreated(matchData)` после insert в matches table
+
+In-memory pub/sub через EventEmitter; per-user channel.
+
+## 3. Frontend components
+
+```
+design-system/patterns/
+├── LiveStrip.tsx              — gradient amber strip, 5-slot grid, progress bar
+├── LiveStripCard.tsx          — single email card (queue/active/done state)
+├── MatchToast.tsx             — auto-dismiss after 5s
+├── useLiveJobs.ts             — SSE hook (returns { jobs, latestMatch })
+└── __tests__/
+    ├── LiveStrip.test.tsx
+    ├── useLiveJobs.test.tsx
+
+app/api/jobs/stream/
+└── route.ts                    — SSE handler
+
+lib/jobs/
+└── event-emitter.ts            — per-user pub/sub singleton (in-memory)
+```
+
+## 4. UX-детали (из live-processing.html mockup)
+
+- LiveStrip background: gradient amber-50 → orange-50 (Maritime Deep accent-soft)
+- 5 cards в grid (queue / active / done states styled differently)
+- Progress bar: real `progress_percent` от job, не fake
+- "ETA ~20 сек" hint estimated by remaining queue × avg processing time
+- Match-toast: green border, "✨ Новый match: MV Atlas → ...", auto-dismiss 5s
+- Card slide-in animation: fresh card highlight зелёным fade 10s
+
+## 5. Mode awareness
+
+- Charterer mode: strip text "Обрабатываем 5 email'ов от брокеров (груз)"
+- Owner mode: "Обрабатываем 5 email'ов (открытые суда)"
+- (Mode hook used)
+
+## 6. Modify `/matches` page
+
+`app/matches/page.tsx` (или MatchesClient):
+1. SSR/initial fetch — existing cached matches
+2. `<LiveStrip />` mount above list (auto-hides when no active jobs)
+3. SSE subscription via `useLiveJobs()` updates list reactively
+
+**КРИТИЧНО:** не сломать существующий cached-list flow. LiveStrip = additive над текущим UI.
+
+## 7. Empty state
+
+| State | UI |
+|---|---|
+| 0 cached + 0 jobs (новый user) | LiveStrip placeholder: «👇 Подключи Gmail / кинь email / опиши груз словами» + ниже sample-fixture с пометкой `DEMO` |
+| 0 cached + есть active job | LiveStrip с прогрессом, ниже skeleton |
+| cached есть + 0 jobs | List как обычно, strip hidden |
+| cached + active jobs | List + strip + toasts |
+
+## 8. Files (~15)
+
+NEW:
+- `lib/migrations/038-jobs-progress.ts`
+- `lib/jobs/event-emitter.ts`
+- `app/api/jobs/stream/route.ts`
+- `design-system/patterns/LiveStrip.tsx`
+- `design-system/patterns/LiveStripCard.tsx`
+- `design-system/patterns/MatchToast.tsx`
+- `design-system/patterns/useLiveJobs.ts`
+- tests for each
+
+MODIFIED:
+- `app/matches/MatchesClient.tsx` — add `<LiveStrip />` above list + `useLiveJobs()` subscription
+- `lib/jobs/process-email.ts` (or wherever existing processor lives) — emit events at progress points
+- `middleware.ts` — `/api/jobs/stream` нужен auth (no bypass), но SSE-headers correct
+
+## 9. Out of scope
+
+- WebSocket replacement (SSE достаточно для unidirectional)
+- Persistence event log (in-memory only; refresh = re-fetch state)
+- Cross-tab sync (broadcast channel — R6 polish)
+- Pre-existing job processor logic — НЕ переписываем
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| SSE connection drops on mobile sleep | Auto-reconnect with exponential backoff в useLiveJobs |
+| Memory leak от EventEmitter listeners | Cleanup в useEffect return |
+| Job processor doesn't emit events (existing legacy) | Wrap existing process function with emit-on-progress proxy |
+| Toast spam если 20 emails сразу | Batch: показывать только последний + counter «+3 more» |
+| Fake-timers tests на animation | useFakeTimers с manual advanceTimersByTime в jest |
+
+## 11. Success criteria
+
+- LiveStrip появляется при первой active job, исчезает в покое
+- Real progress (не fake), match-toasts работают
+- Cached list рендерится мгновенно
+- TS strict + jest + Playwright visual + axe

--- a/docs/superpowers/specs/2026-05-24-r5-per-page-polish-design.md
+++ b/docs/superpowers/specs/2026-05-24-r5-per-page-polish-design.md
@@ -1,0 +1,134 @@
+# R5 — Per-Page Polish Pass (Design Spec)
+
+**Дата:** 2026-05-24
+**Parent:** §5a (10 brainstormed screens + 13 pattern-applied) + per-screen specs
+**Depends:** R1 (primitives), R2 (AppShell), R3 (AIBar+⌘K), R4 (LiveStrip)
+
+## 1. Цель
+
+Применить **design-system + fixed layout patterns из §5a** ко всем ~22 страницам. Никаких новых layout-решений. Каждая страница:
+1. Импортит из `design-system/primitives/` и `design-system/patterns/`
+2. Использует Maritime Deep токены (`bg-ds-bg`, `text-ds-text`, etc.)
+3. Применяет зафиксированный паттерн (table-first / split / form-first / etc.)
+4. Получает mobile-companion variant (bottom-sheet, swipe-style, etc.)
+5. Empty-state per §5a
+
+## 2. Декомпозиция (5 параллельных subagents)
+
+| Wave | Pages | Subagent | ETA |
+|---|---|---|---|
+| **R5a** | Dashboard + Matches | sub1 | 2-3 дня |
+| **R5b** | Match detail + Cargo + Vessels | sub2 | 2-3 дня |
+| **R5c** | Charterers + Market + Recap | sub3 | 2-3 дня |
+| **R5d** | Email + Onboarding + Upgrade | sub4 | 2-3 дня |
+| **R5e** | Apply patterns (Laytime/PSC/Commission/Clauses/Request/Processing/Summary/More/Vessel/Fixture) — bulk | sub5 | 2-3 дня |
+| **R5f** | Landing public page + Settings | sub6 | 1-2 дня |
+
+Wave может стартовать параллельно после R1-R4 merged. ≤3 active dispatch на root@.
+
+## 3. Pattern reference (из главного spec §5a)
+
+| Page | Pattern | Key elements |
+|---|---|---|
+| Dashboard | Agenda-first + KPI strip | 4 KPI tiles top + 3 sections (To-do/Matches/Inbox) |
+| Matches | Table-first + Cards/Table toggle | LiveStrip (R4) + filter chips + sort + density toggle |
+| Match detail | Split + sticky AI side-panel | Tabs Overview/Economics/Quote/Conversation + 220px right-panel |
+| Cargo+Vessels | Table + AI-add bar + side-modal | AI parse-bar top + table + click→side panel |
+| Charterers | Table + Last-snippet + HOT/WARM/COLD | Table-style same as Cargo + colored status column |
+| Market | Multi-section digest + drill-down | KPI tiles + Routes + Fixtures + Knowledge; click → focused chart |
+| Recap | Form-first + AI assist + Sources panel | Structured form + AI fill + sources side-panel + "Generate full text" |
+| Email | Stream of action-cards + 📄 Original button | Card per email + parsed fields + Accept/Edit/Reject + modal |
+| Onboarding | Pre-loaded demo + banner + auto-detect mode | DEMO badge + sticky "Connect Gmail" + auto-mode |
+| Upgrade | Usage-aware inside + landing for "See all plans" | current plan + usage bars + contextual upgrade + link to /upgrade/plans |
+| Landing public | Product-demo hero + features + pricing pill | Live LiveStrip demo embed + 3 feature cards + 3 pricing pills |
+| Settings | Sidebar + content | 10 sections, default = Integrations, anchor URLs |
+| Notifications | Bell dropdown only (MVP) | Bell in TopNav → popup; full page YAGNI |
+| Help/Docs | AI chat-help floating (R3 уже сделал HelpFAB) | — R3 |
+| Laytime | Form-first + AI assist | Apply Recap pattern (forms+sources panel) |
+| PSC | Table-first | Apply Cargo pattern |
+| Commission | Table + side-modal | Apply Cargo pattern |
+| Clauses | Table + side-modal (rich edit) | Apply Cargo pattern |
+| Request | Form-first + AI suggests | Apply Recap pattern |
+| Processing | LiveStrip-like full-page | Apply LiveStrip variant |
+| Summary | Read-only digest | Apply Market section pattern |
+| More | Simple drawer-style links | Native list |
+| Vessel detail | Split + AI side-panel (read-only) | Apply Match-detail pattern |
+| Fixture | Read-only Recap view | Apply Recap pattern (no edit) |
+
+## 4. Claude Design user-loop (опционально)
+
+**При желании user может полировать pixel-perfect ДО кода:**
+1. User открывает Claude Design (claude.ai web)
+2. Промпт: "Quantika /matches Maritime Deep palette navy+amber, table 12 rows, LiveStrip top, ..."
+3. Итерирует 2-3 раза → export PNG
+4. Кидает PNG в чат
+5. Orchestrator добавляет PNG в handover для R5x subagent'а
+6. Subagent ships pixel-perfect против reference
+
+Loop: ~30 мин на page вместо blind-imp ~3ч.
+
+**Без user-loop:** subagent работает по spec text-only — окей для большинства pages, для ключевых (Dashboard, Match detail) рекомендуется loop.
+
+## 5. Migration rules
+
+- НЕ ломать существующие routes/URLs
+- НЕ удалять старые `components/ui/*` пока (R5 финал удалит после миграции последней страницы)
+- НЕ менять backend API
+- Existing tests must continue PASS (jest + Playwright regression)
+- Each page migration = own commit + own visual baseline
+
+## 6. Per-page checklist (для каждого subagent на page)
+
+- [ ] Read current page file, document existing components/imports
+- [ ] Replace `components/ui/*` → `design-system/primitives/*` где есть аналог
+- [ ] Apply layout pattern из §3 этого spec'а
+- [ ] Add Maritime Deep tokens (`bg-ds-*`, `text-ds-*`)
+- [ ] Apply useMode() для mode-aware copy/sort/columns
+- [ ] Add mobile variant (768px breakpoint)
+- [ ] Empty-state per §5a (или Skeleton + sample-fixture)
+- [ ] Visual regression baseline updated
+- [ ] axe a11y 0 violations
+- [ ] Existing tests still green
+- [ ] Commit `feat(r5x): polish /pagename to design-system`
+
+## 7. Files (per page ~3-5 modifications)
+
+**Modified:**
+- `app/<page>/page.tsx` / `<page>Client.tsx`
+- Component files specific to page
+- Page-level test files (если требуется update)
+- `tests/visual/pages/<page>.spec.ts` (new visual baseline)
+
+**No deletes** — старые `components/ui/*` removed только в R5-final.
+
+## 8. R5-final task (после всех waves)
+
+- Identify pages still using `components/ui/*`: `grep -rl 'components/ui/' app/`
+- If 0 left → delete `components/ui/*`, `git rm`, commit `chore(r5-final): remove deprecated shadcn ui components`
+- If >0 left → file QUESTIONS.md, escalate
+
+## 9. Out of scope
+
+- New layout decisions (зафиксированы в §5a)
+- Backend API changes
+- Bus logic, matching, parsers
+- Admin pages (low priority, defer)
+- Dark mode (R6)
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Migration breaks page silently | Each page = own visual snapshot baseline; CI diff catches |
+| Parallel waves conflict в `package.json` / `tailwind.config` | R5 не меняет shared config (только R1 могла) |
+| Subagent over-zealous «cleanup» (см. R1 lessons) | Explicit constraint в handover: "ONLY apply token swap + pattern; NO other refactor" |
+| Different subagents inconsistent results | Pattern table (§3) — ground truth; QA gate per wave |
+
+## 11. Success criteria
+
+- All 22 pages use design-system primitives + tokens
+- Every page имеет mobile variant
+- Visual regression baselines for all migrated pages
+- axe 0 violations per page
+- `components/ui/*` deleted (R5-final)
+- Existing tests + new visual all green

--- a/docs/superpowers/specs/2026-05-24-r6-a11y-perf-design.md
+++ b/docs/superpowers/specs/2026-05-24-r6-a11y-perf-design.md
@@ -1,0 +1,112 @@
+# R6 — A11y + Perf + Polish (Design Spec)
+
+**Дата:** 2026-05-24
+**Parent:** §3 closing items + post-R5
+**Depends:** R1-R5 merged
+
+## 1. Цель
+
+Финальный polish после миграции всех страниц:
+1. **A11y** — global audit, contrast fixes, ARIA, focus management, screen-reader
+2. **Perf** — Lighthouse, bundle analysis, code-split, image opt
+3. **Motion** — `prefers-reduced-motion`, transition tuning
+4. **Dark mode prep** — token-layer готовность (full impl optional later)
+5. **Living docs** — update README + ROADMAP
+
+## 2. A11y audit
+
+### Tool stack
+- axe-core/playwright на КАЖДОЙ странице (новые baseline)
+- Manual: VoiceOver/NVDA smoke check 5 ключевых pages
+- Lighthouse a11y score ≥95 per page
+
+### Areas
+- Color contrast (Maritime Deep: amber-100 + amber-800 = 10.9:1 ✓; verify все combinations)
+- Focus order — keyboard tab through palette/dialog/sheet/forms
+- Focus trap в overlays
+- ARIA labels на icon-only buttons (BottomNav, HelpFAB)
+- Live regions для toasts + LiveStrip
+- Skip-to-content link в AppShell
+- Form labels связаны (htmlFor)
+- Heading hierarchy без skipped levels
+
+### Output
+- `tests/a11y/pages/<page>.spec.ts` per migrated page
+- `docs/a11y-audit-r6.md` — найденное + fixes
+
+## 3. Perf audit
+
+### Tool stack
+- `@next/bundle-analyzer` — bundle composition
+- Lighthouse CI на 5 главных pages (CI gate)
+- `npm run build` analysis
+
+### Targets
+- Lighthouse perf ≥85 desktop / ≥75 mobile per page
+- Bundle: first-load JS ≤200kb на главных pages
+- LCP ≤2.5s, CLS ≤0.1, INP ≤200ms
+
+### Likely fixes
+- Image sizing: next/image для all `<img>`
+- Code-split: dynamic import for Dialog/Sheet contents
+- Defer non-critical scripts
+- Preconnect к external APIs (если есть)
+- Font preload
+
+### Output
+- `lighthouse-r6.json` baseline
+- `docs/perf-audit-r6.md`
+
+## 4. Motion polish
+
+- All transitions используют `--ds-motion-*` tokens
+- `@media (prefers-reduced-motion: reduce)` zeroes durations (уже в R1 tokens)
+- Audit для harsh transitions (no >400ms на UI elements)
+
+## 5. Dark mode prep
+
+- Add `data-theme="dark"` token overrides в `design-system/tokens/colors.css`
+- НЕ активировать toggle (опционально в future R6.5)
+- Document в README
+
+## 6. Living docs update
+
+- `docs/ROADMAP-CURRENT-STATE.md` — section "Full redesign R1-R6 completed"
+- `docs/design-system.md` — обновлённая card "system as of <date>"
+- `docs/superpowers/README.md` — link на spec/plans tree
+
+## 7. Files
+
+NEW:
+- `tests/a11y/pages/*.spec.ts` (per migrated page, ~20 files)
+- `tests/perf/lighthouse.config.json`
+- `docs/a11y-audit-r6.md`
+- `docs/perf-audit-r6.md`
+
+MODIFIED:
+- ROADMAP, READMEs
+- design-system/tokens/colors.css (dark mode tokens)
+- next.config.js (bundle analyzer, optimization flags)
+
+## 8. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Lighthouse score depends on prod server load | Run locally + record baseline; CI gate as floor not ceiling |
+| Dark mode tokens conflict | Scope under `[data-theme="dark"]` selector |
+| A11y fix breaks visual baseline | Update visual baseline + add explicit a11y test for the fix |
+
+## 9. Out of scope
+
+- Full dark mode UI (only token prep)
+- i18n
+- Animations rewrite (token tuning only)
+
+## 10. Success criteria
+
+- axe 0 violations on all migrated pages
+- Lighthouse a11y ≥95 / perf ≥85
+- Bundle first-load JS ≤200kb on Dashboard, Matches
+- prefers-reduced-motion respected
+- Dark mode tokens drafted (not active)
+- Living docs reflect R1-R6 complete

--- a/lib/migrations/037-add-user-preferred-mode.ts
+++ b/lib/migrations/037-add-user-preferred-mode.ts
@@ -1,0 +1,19 @@
+import type { Migration } from './types';
+
+const migration037: Migration = {
+  version: 37,
+  name: '037-add-user-preferred-mode',
+  up(db) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS user_preferences (
+        username       TEXT PRIMARY KEY,
+        preferred_mode TEXT NOT NULL DEFAULT 'charterer'
+      )
+    `);
+  },
+  down(db) {
+    db.exec('DROP TABLE IF EXISTS user_preferences');
+  },
+};
+
+export default migration037;

--- a/lib/migrations/__tests__/037-add-user-preferred-mode.test.ts
+++ b/lib/migrations/__tests__/037-add-user-preferred-mode.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests — migration 037 (user_preferences table with preferred_mode).
+ *
+ * Covers:
+ *   - up() creates user_preferences table with username PK and preferred_mode column
+ *   - Default preferred_mode is 'charterer'
+ *   - Allows 'owner' mode
+ *   - up() is idempotent (CREATE TABLE IF NOT EXISTS)
+ *   - Migration metadata (version, name)
+ */
+
+import Database from 'better-sqlite3';
+import migration037 from '../037-add-user-preferred-mode';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration037.up(db);
+  return db;
+}
+
+describe('migration 037 — user_preferences table', () => {
+  it('creates user_preferences table', () => {
+    const db = freshDb();
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='user_preferences'").get();
+    expect(row).toBeTruthy();
+  });
+
+  it('default preferred_mode is charterer', () => {
+    const db = freshDb();
+    db.prepare("INSERT INTO user_preferences (username) VALUES ('alice')").run();
+    const u = db.prepare("SELECT preferred_mode FROM user_preferences WHERE username='alice'").get() as { preferred_mode: string };
+    expect(u.preferred_mode).toBe('charterer');
+  });
+
+  it('allows owner mode', () => {
+    const db = freshDb();
+    db.prepare("INSERT INTO user_preferences (username, preferred_mode) VALUES ('bob', 'owner')").run();
+    const u = db.prepare("SELECT preferred_mode FROM user_preferences WHERE username='bob'").get() as { preferred_mode: string };
+    expect(u.preferred_mode).toBe('owner');
+  });
+
+  it('is idempotent — re-running up() does not throw', () => {
+    const db = new Database(':memory:');
+    migration037.up(db);
+    expect(() => migration037.up(db)).not.toThrow();
+  });
+
+  it('has version=37', () => {
+    expect(migration037.version).toBe(37);
+  });
+
+  it('has name="037-add-user-preferred-mode"', () => {
+    expect(migration037.name).toBe('037-add-user-preferred-mode');
+  });
+});

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -34,6 +34,7 @@ import migration033 from './033-matches-score-breakdown';
 import migration034 from './034-matches-unique-constraint';
 import migration035 from './035-matches-tce-distance';
 import migration036 from './036-matches-freight-rate';
+import migration037 from './037-add-user-preferred-mode';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037];

--- a/tests/visual/app-shell.spec.ts
+++ b/tests/visual/app-shell.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// /design is a public bypass path — accessible without auth and shows AppShell
+// when DEMO_AUTH_ENABLED=false (demo mode, always authenticated).
+// For authenticated environments, use PLAYWRIGHT_AUTH_COOKIE env var.
+const PAGE = process.env.PLAYWRIGHT_APPSHELL_PAGE ?? '/design';
+
+test.describe('AppShell visual + a11y', () => {
+  test('desktop layout: TopNav visible at 1280px', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(PAGE);
+    await page.waitForLoadState('networkidle');
+    // TopNav has sticky position and is hidden on mobile via md:hidden
+    const header = page.locator('header').first();
+    await expect(header).toBeVisible();
+    await expect(page).toHaveScreenshot('app-shell-desktop.png', {
+      fullPage: false,
+      maxDiffPixelRatio: 0.02,
+    });
+  });
+
+  test('mobile: BottomNav visible at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 700 });
+    await page.goto(PAGE);
+    await page.waitForLoadState('networkidle');
+    // BottomNav has md:hidden = visible on mobile
+    const bottomNav = page.locator('nav[aria-label="Mobile navigation"]');
+    await expect(bottomNav).toBeVisible();
+    await expect(page).toHaveScreenshot('app-shell-mobile.png', {
+      fullPage: false,
+      maxDiffPixelRatio: 0.02,
+    });
+  });
+
+  test('mode toggle swaps Cargo↔Vessels nav order', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await page.goto(`${PAGE}?mode=charterer`);
+    await page.waitForLoadState('networkidle');
+    const navLinks1 = await page.locator('nav[aria-label="Primary navigation"] > a').allTextContents();
+    expect(navLinks1).toEqual(['Dashboard', 'Matches', 'Cargo', 'Vessels', 'Market']);
+
+    await page.goto(`${PAGE}?mode=owner`);
+    await page.waitForLoadState('networkidle');
+    const navLinks2 = await page.locator('nav[aria-label="Primary navigation"] > a').allTextContents();
+    expect(navLinks2).toEqual(['Dashboard', 'Matches', 'Vessels', 'Cargo', 'Market']);
+  });
+
+  test('a11y — 0 WCAG2 violations on shell', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(PAGE);
+    await page.waitForLoadState('networkidle');
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## R2 — AppShell foundation

Реализует §3.2–§3.4 из [redesign spec](docs/superpowers/specs/2026-05-24-r2-appshell-modeswitcher-design.md). Использует только R1 primitives.

### Что добавилось

- **`design-system/patterns/`** — AppShell, TopNav (5+More), BottomNav (mobile ≥44px), ModeSwitcher, ModeProvider, useMode hook с mode-aware `t()`, AIBarPlaceholder (R3 активирует)
- **`lib/migrations/037`** — `user_preferences(username PK, preferred_mode DEFAULT 'charterer')`
- **`app/api/me`** — GET + PATCH, auth via `verifyAuthCookie`, fallback to 'demo' when `DEMO_AUTH_ENABLED=false`
- **`app/layout.tsx`** — wrapped в `ModeProvider + AppShell` для authenticated; `/login` и bypass paths рендерятся без shell
- **`tests/visual/app-shell.spec.ts`** — Playwright spec (desktop TopNav, mobile BottomNav, mode swap, axe a11y)

### Что НЕ изменилось

- Существующие pages (matches/cargo/vessels/...) — не трогаем
- `middleware.ts` — не изменён
- `AUTH_BYPASS_PATHS` — не изменены
- `components/ui/*` — не трогаем (R1 coexistence preserved)

### Ключевые решения

- Нет `users` таблицы → создана `user_preferences(username PK, preferred_mode)` вместо `ALTER TABLE users`
- auth keyed by HMAC cookie username (`AuthPayload.user`)
- URL `?mode=` override через `useState(() => URLSearchParams(window.location.search))` на клиенте
- 5 failing pre-existing design-system tests (`@testing-library/user-event` не установлен, появились в R1) — не регрессия R2

### Verification

- TS strict: 0 errors (`--skipLibCheck`)
- Jest: 34 new tests green, 6960 existing tests green (5 pre-existing failures — R1 gap, user-event не установлен)
- Playwright visual: spec готов, baselines генерируются на `--update-snapshots`

### Next

R3 (AIBar + ⌘K) и R4 (LiveStrip) могут стартовать параллельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)