### PR TITLE
R6-partial: a11y baseline + bundle analyzer + motion tokens + dark mode prep

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -49,6 +49,24 @@ R1 НЕ удаляет старые компоненты. Они продолж�
 
 **Не используй design-system и shadcn в одном новом компоненте** — выбирай одно.
 
+## Dark mode (prep, not active)
+
+Token overrides for `[data-theme="dark"]` are defined in `tokens/colors.css`.
+To activate, set `data-theme="dark"` on `<html>`. No toggle UI is implemented yet (R6.5).
+
+Key dark overrides:
+- `--ds-bg: #0f172a` (slate-950)
+- `--ds-surface: #1e293b` (slate-800)
+- `--ds-accent: #fbbf24` → inverted: amber becomes the primary button, navy becomes fg
+- All semantic colors adjusted for dark-background contrast
+
+## A11y
+
+- Skip-to-content link is rendered in `AppShell` — visually hidden until focused
+- All icon-only buttons carry `aria-label`
+- Transitions use `--ds-motion-*` tokens; `prefers-reduced-motion` zeros all durations
+- Axe baseline specs: `tests/a11y/pages/` (run via `npm run test:a11y`)
+
 ## Tests
 
 ```bash

--- a/design-system/__tests__/AppShell.test.tsx
+++ b/design-system/__tests__/AppShell.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { AppShell } from '../patterns/AppShell';
+
+// Stub child components that depend on router / client-only hooks
+jest.mock('../patterns/TopNav', () => ({ TopNav: () => <nav data-testid="top-nav" /> }));
+jest.mock('../patterns/BottomNav', () => ({ BottomNav: () => <nav data-testid="bottom-nav" /> }));
+jest.mock('../patterns/AIBar', () => ({ AIBar: () => <div data-testid="ai-bar" /> }));
+jest.mock('../patterns/HelpFAB', () => ({ HelpFAB: () => <button data-testid="help-fab" /> }));
+jest.mock('../patterns/CmdKPalette', () => ({ CmdKPalette: () => <div data-testid="cmd-k" /> }));
+jest.mock('../patterns/usePalette', () => ({
+  PaletteProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('AppShell', () => {
+  it('renders skip-to-content link targeting #main-content', () => {
+    render(<AppShell><div>page content</div></AppShell>);
+    const skipLink = screen.getByRole('link', { name: /skip to content/i });
+    expect(skipLink).toHaveAttribute('href', '#main-content');
+  });
+
+  it('main element has id=main-content', () => {
+    render(<AppShell><div>page content</div></AppShell>);
+    expect(document.getElementById('main-content')).toBeInTheDocument();
+  });
+});

--- a/design-system/patterns/AppShell.tsx
+++ b/design-system/patterns/AppShell.tsx
@@ -11,9 +11,15 @@ export function AppShell({ children }: { children: ReactNode }) {
   return (
     <PaletteProvider>
       <div className="min-h-screen bg-ds-bg text-ds-text flex flex-col">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-ds-accent focus:text-ds-accent-fg focus:px-3 focus:py-2 focus:rounded-ds-md focus:font-medium"
+        >
+          Skip to content
+        </a>
         <TopNav />
         <AIBar />
-        <main className="flex-1 pb-16 md:pb-0">{children}</main>
+        <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
         <BottomNav />
         <HelpFAB />
         <CmdKPalette />

--- a/design-system/patterns/LiveStrip.tsx
+++ b/design-system/patterns/LiveStrip.tsx
@@ -37,7 +37,7 @@ export function LiveStrip({ jobs }: { jobs: LiveJob[] }) {
         aria-valuemax={100}
       >
         <div
-          className="h-full bg-amber-500 transition-all duration-300"
+          className="h-full bg-amber-500 transition-all duration-ds-slow"
           style={{ width: `${avgPercent}%` }}
         />
       </div>

--- a/design-system/tokens/colors.css
+++ b/design-system/tokens/colors.css
@@ -28,3 +28,34 @@
   --ds-info: #1d4ed8;
   --ds-info-soft: #eff6ff;
 }
+
+/* Dark mode prep — not active (no toggle yet). Apply via data-theme="dark" on <html>. */
+[data-theme="dark"] {
+  /* Surface */
+  --ds-bg: #0f172a;
+  --ds-surface: #1e293b;
+  --ds-surface-muted: #334155;
+  --ds-border: #334155;
+  --ds-border-strong: #475569;
+
+  /* Text */
+  --ds-text: #f1f5f9;
+  --ds-text-muted: #94a3b8;
+  --ds-text-subtle: #64748b;
+
+  /* Brand accent — amber preserved for contrast on dark navy */
+  --ds-accent: #fbbf24;
+  --ds-accent-fg: #0f172a;
+  --ds-accent-soft: #422006;
+  --ds-accent-soft-fg: #fde68a;
+
+  /* Semantic */
+  --ds-success: #34d399;
+  --ds-success-soft: #064e3b;
+  --ds-warn: #fbbf24;
+  --ds-warn-soft: #451a03;
+  --ds-danger: #f87171;
+  --ds-danger-soft: #450a0a;
+  --ds-info: #60a5fa;
+  --ds-info-soft: #1e3a5f;
+}

--- a/docs/perf-audit-r6-partial.md
+++ b/docs/perf-audit-r6-partial.md
@@ -1,0 +1,55 @@
+# Bundle Perf Audit — R6-partial
+
+**Date:** 2026-05-24  
+**Branch:** design/r6-partial-a11y-perf  
+**Tool:** @next/bundle-analyzer (webpack mode)  
+**Command:** `npm run analyze` (= `ANALYZE=true next build --webpack`)
+
+> **Note:** Next.js 16 uses Turbopack by default. Bundle analyzer requires webpack mode (`--webpack` flag).
+> Use `npm run analyze` (added to package.json in this PR).
+> Interactive HTML reports: `.next/analyze/{client,nodejs,edge}.html`
+
+---
+
+## Top-5 Heavy Chunks (raw / gzip)
+
+| Rank | Chunk | Raw | Gzip | Notes |
+|------|-------|-----|------|-------|
+| 1 | `4657-*.js` | 461 kB | 142 kB | Vendor bundle — likely @base-ui/react + lucide-react |
+| 2 | `main-*.js` | 410 kB | 129 kB | Next.js main runtime + client router |
+| 3 | `4bd1b696-*.js` | 195 kB | 61 kB | React DOM (client error boundaries) |
+| 4 | `framework-*.js` | 185 kB | 58 kB | React + React-DOM core |
+| 5 | `9da6db1e-*.js` | 183 kB | 60 kB | Vendor — class-variance-authority + tailwind-merge |
+
+**Honourable mention:**
+- `app/match/[id]/page-*.js` — 143 kB raw / 32 kB gzip — match detail page (largest page chunk)
+- `polyfills-*.js` — 110 kB raw / 39 kB gzip — Next.js polyfills
+
+---
+
+## First-load JS per route (estimated from chunks)
+
+Dashboard, Matches, Design pages each load:
+- framework (~58 kB gz) + main (~129 kB gz) + page-specific (<20 kB gz)
+- **Estimated first-load: ~210–230 kB gzip** — over the 200 kB target for dashboard/matches
+
+`match/[id]` page: higher at ~270 kB gzip due to 32 kB page chunk + shared.
+
+---
+
+## Recommendations (R6-final / R7)
+
+1. **Chunk 1 (`4657`) — lucide-react tree-shaking** — verify all icon imports are named (not `import * from 'lucide-react'`). Expected saving: 30–60 kB raw.
+2. **Main chunk** — Next.js router client is fixed overhead; consider route prefetch tuning.
+3. **match/[id] page** — 143 kB page chunk is large. Audit for heavy inline dependencies (fuzzysort, searoute-ts). Dynamic-import heavy sections.
+4. **posthog-js** — check if loaded eagerly. Should be `dynamic(() => import('posthog-js'), { ssr: false })`.
+5. **pdfkit** — server-only, but verify it's not leaking into client bundle.
+
+---
+
+## Analyzer reports
+
+After running `npm run analyze`, open:
+- `.next/analyze/client.html` — client-side bundle treemap
+- `.next/analyze/nodejs.html` — server bundle treemap
+- `.next/analyze/edge.html` — edge runtime (middleware)

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,6 +16,8 @@ const config = {
     '/tests/e2e/kpi-timeout\\.spec\\.ts$',
     // R1 visual regression specs (run via playwright, not jest)
     '/tests/visual/',
+    // R6 a11y specs (run via playwright.a11y.config.ts, not jest)
+    '/tests/a11y/',
     ...(process.cwd().includes('/.wave/') ? [] : ['/.wave/']),
     ...(process.cwd().includes('/.claude/worktrees/') ? [] : ['/\\.claude/worktrees/']),
   ],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,9 @@
 import { withSentryConfig } from "@sentry/nextjs";
+import createBundleAnalyzer from "@next/bundle-analyzer";
+
+const withBundleAnalyzer = createBundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -8,7 +13,7 @@ const nextConfig = {
   },
 };
 
-export default withSentryConfig(nextConfig, {
+export default withSentryConfig(withBundleAnalyzer(nextConfig), {
   silent: true,
   org: "",
   project: "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
         "@eslint/eslintrc": "^3.3.1",
+        "@next/bundle-analyzer": "^16.2.6",
         "@playwright/test": "^1.60.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2342,6 +2343,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
@@ -4359,6 +4370,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.6.tgz",
+      "integrity": "sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
@@ -5350,6 +5371,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@posthog/core": {
       "version": "1.29.3",
@@ -9343,6 +9371,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -10676,6 +10717,13 @@
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -10948,6 +10996,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexify": {
       "version": "4.1.3",
@@ -12636,6 +12691,22 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -15231,6 +15302,16 @@
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -15689,6 +15770,16 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -17604,6 +17695,21 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -18701,6 +18807,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -19305,6 +19421,66 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:smoke:prod": "SMOKE_BASE_URL=https://demo.quantika.org playwright test --config=__tests__/e2e/playwright.config.smoke.ts smoke/tier1-health.spec.ts",
     "test:smoke:tier1": "playwright test --config=__tests__/e2e/playwright.config.smoke.ts smoke/tier1-health.spec.ts",
     "test:e2e": "playwright test",
+    "test:a11y": "playwright test --config=playwright.a11y.config.ts",
+    "analyze": "ANALYZE=true next build --webpack",
     "build:extension": "cd extensions/gmail && npm install --no-audit --no-fund --silent && npm run build",
     "knowledge:status": "npx tsx scripts/knowledge/status.ts",
     "knowledge:refresh": "npx tsx scripts/knowledge/refresh.ts",
@@ -74,6 +76,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@eslint/eslintrc": "^3.3.1",
+    "@next/bundle-analyzer": "^16.2.6",
     "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.a11y.config.ts
+++ b/playwright.a11y.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/a11y',
+  timeout: 60000,
+  expect: { timeout: 15000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report-a11y', open: 'never' }],
+  ],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  ...(!process.env.PLAYWRIGHT_BASE_URL && {
+    webServer: {
+      command: 'npm run build && npm run start',
+      url: 'http://localhost:3000',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000,
+    },
+  }),
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  outputDir: 'test-results-a11y',
+});

--- a/tests/a11y/pages/dashboard.spec.ts
+++ b/tests/a11y/pages/dashboard.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('/dashboard a11y — 0 wcag2a/aa violations', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle');
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});

--- a/tests/a11y/pages/design.spec.ts
+++ b/tests/a11y/pages/design.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('/design a11y — 0 wcag2a/aa violations', async ({ page }) => {
+  await page.goto('/design');
+  await page.waitForLoadState('networkidle');
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});

--- a/tests/a11y/pages/index.spec.ts
+++ b/tests/a11y/pages/index.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('/ a11y — 0 wcag2a/aa violations', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});

--- a/tests/a11y/pages/matches.spec.ts
+++ b/tests/a11y/pages/matches.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('/matches a11y — 0 wcag2a/aa violations', async ({ page }) => {
+  await page.goto('/matches');
+  await page.waitForLoadState('networkidle');
+  const results = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).analyze();
+  expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+});

--- a/tests/a11y/skip-link.spec.ts
+++ b/tests/a11y/skip-link.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('skip-to-content link is present and functional on /dashboard', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle');
+
+  const skipLink = page.locator('a[href="#main-content"]');
+  await expect(skipLink).toBeAttached();
+
+  // Focus via keyboard — Tab from body
+  await page.keyboard.press('Tab');
+  await expect(skipLink).toBeFocused();
+
+  // main-content landmark must exist
+  const main = page.locator('#main-content');
+  await expect(main).toBeAttached();
+});


### PR DESCRIPTION
## Summary

- **Task 2** — Skip-to-content link in `AppShell` (sr-only, visible on focus via `Tab`, targets `#main-content`)
- **Task 3** — ARIA labels audit: all icon-only buttons verified (HelpFAB, AIBar, MatchToast, BottomNav, MoreDropdown already compliant)
- **Task 5** — `@next/bundle-analyzer` added to `next.config.mjs`; `npm run analyze` script; HTML reports in `.next/analyze/`
- **Task 6** — Motion audit: replaced hardcoded `duration-300` → `duration-ds-slow` in `LiveStrip.tsx`; all other transitions already use `duration-ds-*` tokens
- **Task 7** — `[data-theme="dark"]` token layer in `design-system/tokens/colors.css` (not active, no toggle)
- **A11y baseline** — 4 Playwright+axe specs (`tests/a11y/pages/`) + skip-link behavioral spec; `playwright.a11y.config.ts`; `npm run test:a11y`
- **Bundle audit** — `docs/perf-audit-r6-partial.md` with top-5 heavy chunks, gzip sizes, recommendations

## Excluded from R6-partial (pending R5 merge)

- Task 1: full per-page a11y (only 4 current pages covered)
- Task 4: Lighthouse CI gate
- Tasks 8-9: ROADMAP/living-docs final update

## Test plan

- [ ] `npm test` — 636 suites, 7045 tests green
- [ ] `npm run test:a11y` — 5 Playwright a11y specs (requires running dev server)
- [ ] `npm run analyze` — opens `.next/analyze/client.html` bundle treemap
- [ ] Tab to first element on `/dashboard` → skip-link becomes visible
- [ ] Set `data-theme="dark"` on `<html>` → all ds-* variables switch to dark palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)