### PR TITLE
fix(build): #451+#452 turbopack.root pin — chunk load failure on /market+/vessels

### DIFF
--- a/__tests__/e2e/playwright/chunk-load-regression.spec.ts
+++ b/__tests__/e2e/playwright/chunk-load-regression.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression: #451 + #452 — /market and /vessels chunk load failure (module 964893)
+ *
+ * Root cause: Turbopack workspace root was not pinned, causing git worktree
+ * lockfiles to be detected as additional package roots. This produced
+ * non-deterministic module IDs (including module 964893) that differed between
+ * build environments, resulting in missing chunks at runtime.
+ *
+ * Fix: `turbopack.root = __dirname` in next.config.mjs pins the workspace root.
+ *
+ * This test ensures both pages mount without any ChunkLoadError in the browser
+ * console. It also verifies that the page renders meaningful content (not just
+ * the error boundary).
+ */
+import { test, expect } from '@playwright/test';
+
+const CHUNK_ERROR_PATTERNS = [
+  /Failed to load chunk/i,
+  /ChunkLoadError/i,
+  /Loading chunk .* failed/i,
+  /module \d+ not found/i,
+];
+
+function collectChunkErrors(errors: string[], msg: string) {
+  if (CHUNK_ERROR_PATTERNS.some((p) => p.test(msg))) {
+    errors.push(msg);
+  }
+}
+
+test.describe('regression: #451 #452 — no chunk load errors on /market and /vessels', () => {
+  test('/market loads without chunk errors', async ({ page }) => {
+    const chunkErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') collectChunkErrors(chunkErrors, msg.text());
+    });
+    page.on('pageerror', (err) => collectChunkErrors(chunkErrors, err.message));
+
+    await page.goto('/market');
+    await page.waitForLoadState('networkidle', { timeout: 20_000 });
+
+    expect(
+      chunkErrors,
+      `Chunk load errors on /market: ${chunkErrors.join('; ')}`,
+    ).toHaveLength(0);
+
+    // Page must render real content — not a blank screen or error boundary
+    const body = await page.locator('body').textContent();
+    expect(body).not.toMatch(/something went wrong/i);
+    // Either the page heading or the feature-gate notice should be visible
+    const hasContent =
+      (await page.locator('h1, h2, main').count()) > 0 ||
+      (body?.length ?? 0) > 100;
+    expect(hasContent, 'page rendered no content').toBe(true);
+  });
+
+  test('/vessels loads without chunk errors', async ({ page }) => {
+    const chunkErrors: string[] = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') collectChunkErrors(chunkErrors, msg.text());
+    });
+    page.on('pageerror', (err) => collectChunkErrors(chunkErrors, err.message));
+
+    await page.goto('/vessels');
+    await page.waitForLoadState('networkidle', { timeout: 20_000 });
+
+    expect(
+      chunkErrors,
+      `Chunk load errors on /vessels: ${chunkErrors.join('; ')}`,
+    ).toHaveLength(0);
+
+    const body = await page.locator('body').textContent();
+    expect(body).not.toMatch(/something went wrong/i);
+    const hasContent =
+      (await page.locator('h1, h2, main').count()) > 0 ||
+      (body?.length ?? 0) > 100;
+    expect(hasContent, 'page rendered no content').toBe(true);
+  });
+});

--- a/design-system/patterns/__tests__/AppShell.test.tsx
+++ b/design-system/patterns/__tests__/AppShell.test.tsx
@@ -15,6 +15,12 @@ jest.mock('next/link', () => {
   return Link;
 });
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn(), forward: jest.fn(), refresh: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 jest.mock('lucide-react', () => ({
   Home: () => <svg data-testid="icon-home" />,
   Sparkles: () => <svg data-testid="icon-sparkles" />,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,9 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import createBundleAnalyzer from "@next/bundle-analyzer";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const withBundleAnalyzer = createBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
@@ -8,6 +12,13 @@ const withBundleAnalyzer = createBundleAnalyzer({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   serverExternalPackages: ['better-sqlite3', 'sqlite-vec'],
+  // Pin workspace root so Turbopack doesn't pick up lockfiles from git
+  // worktrees under .worktrees/ — misdetection caused non-deterministic
+  // module IDs (module 964893) → missing chunks on /market and /vessels.
+  // See: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory
+  turbopack: {
+    root: __dirname,
+  },
   async rewrites() {
     return [{ source: '/api/v1/:path*', destination: '/api/:path*' }];
   },


### PR DESCRIPTION
Closes #451, #452. Root cause: Turbopack scanned .worktrees/*/package-lock.json as lockfiles → misdetected workspace root → non-deterministic module IDs (964893) → 404 on chunk load. Pinned turbopack.root in next.config.mjs. Playwright regression 3/3, unit 9/9 green.