### PR TITLE
feat(security): rate-limit /api/parser/email — 20 req/min per session

### DIFF
--- a/app/api/parser/email/__tests__/rate-limit.test.ts
+++ b/app/api/parser/email/__tests__/rate-limit.test.ts
@@ -1,0 +1,48 @@
+jest.mock('@/lib/session', () => {
+  const { NextResponse } = jest.requireActual('next/server');
+  return {
+    requireSession: (req: { cookies: { get: (n: string) => { value: string } | undefined } }) => {
+      const sessionId = req.cookies.get('session_id')?.value;
+      if (!sessionId) return NextResponse.json({ error: 'No session' }, { status: 401 });
+      return { session: { id: sessionId }, sessionId };
+    },
+  };
+});
+
+jest.mock('@/lib/ai-provider', () => ({
+  callAiJson: jest.fn().mockResolvedValue(null),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/parser/email/route';
+
+const LONG_TEXT = 'A'.repeat(20);
+
+function makeRequest(sessionId: string): NextRequest {
+  return new NextRequest('http://localhost/api/parser/email', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Cookie: `session_id=${sessionId}`,
+    },
+    body: JSON.stringify({ text: LONG_TEXT }),
+  });
+}
+
+describe('rate-limiting: /api/parser/email', () => {
+  it('allows 20 requests and returns 429 on the 21st', async () => {
+    // Unique key per run so module-level singleton state never bleeds across test files
+    const sessionId = `rl-test-${Date.now()}-${Math.random()}`;
+
+    for (let i = 0; i < 20; i++) {
+      const res = await POST(makeRequest(sessionId));
+      expect(res.status).toBe(200);
+    }
+
+    const res21 = await POST(makeRequest(sessionId));
+    expect(res21.status).toBe(429);
+    const body = await res21.json() as { error: string };
+    expect(body.error).toMatch(/too many requests/i);
+    expect(res21.headers.get('Retry-After')).not.toBeNull();
+  });
+});

--- a/app/api/parser/email/route.ts
+++ b/app/api/parser/email/route.ts
@@ -5,10 +5,20 @@ import { CARGO_INQUIRY_PARSER_PROMPT } from '@/lib/prompts';
 import { parseCargoAIResponse, type RawCargoItem } from '@/lib/parsing/parse-cargo-ai';
 import { PARSE_CARGO_SCHEMA } from '@/lib/schemas';
 import { cfValue } from '@/lib/types';
+import { parserEmailRateLimiter } from '@/lib/rate-limit';
 
 export async function POST(req: NextRequest) {
   const authResult = requireSession(req);
   if (authResult instanceof NextResponse) return authResult;
+  const { sessionId } = authResult;
+
+  const { allowed, retryAfterMs } = parserEmailRateLimiter.check(sessionId);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(Math.ceil(retryAfterMs / 1000)) } },
+    );
+  }
 
   const body = await req.json().catch(() => ({})) as { text?: unknown };
   const text = typeof body.text === 'string' ? body.text.trim() : null;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -54,3 +54,4 @@ export class RateLimiter {
 }
 
 export const aiRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 20 });
+export const parserEmailRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 20 });


### PR DESCRIPTION
## Summary
- Added `parserEmailRateLimiter` singleton to `lib/rate-limit.ts` (20 req/min, 60s window)
- Applied rate-limit check in `app/api/parser/email/route.ts` keyed by `sessionId` (post-auth, always available)
- Returns 429 with `Retry-After` header when limit exceeded

## PI2 behavioral test
`app/api/parser/email/__tests__/rate-limit.test.ts` — calls `POST()` 20× (all 200), then 21st → 429 with `Retry-After` header. Uses unique `sessionId` per run to avoid singleton state bleed.

## Test plan
- [x] `npx jest app/api/parser/email/` — 14/14 green
- [x] `npx jest lib/__tests__/rate-limit.test.ts` — 6/6 green
- [x] `git status --porcelain` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)