### PR TITLE
security(deps): patch 4 moderate vulnerabilities (qs, ws, brace-expansion, esbuild)

### DIFF
--- a/QUESTIONS.md
+++ b/QUESTIONS.md
@@ -1,13 +1,1 @@
-# R3 Subagent Questions
-
-- [/] Q001 [19:00] type=blocked path=/root/work/quantika-demo/.worktrees/r3-aibar — Push blocked by auto-mode classifier: all 18 files committed to branch design/r3-aibar-cmdk (commit 5ecc50a), need orchestrator to authorize `git push -u origin design/r3-aibar-cmdk` then `gh pr create`. → STUCK: branch already on origin (up to date with origin/design/r3-aibar-cmdk) — push resolved; `gh pr create` forbidden for monitor, needs human orchestrator.
-
-# R6 Open Questions
-
-- [/] Q002 [10:00] type=blocked path=/root/work/quantika-demo/.worktrees/r6-final/components/ui — Cannot delete components/ui/: 40 imports across 22 files (app/ loading skeletons, components/match, components/recap). Components in use: PageSkeleton, Button, Badge, Card, Progress. Decision: (a) migrate all 22 files to ds.* equivalents then delete, or (b) keep components/ui/ as internal library. If (b), update R6 acceptance criteria. → STUCK: different worktree (r6-final); PR #447 merged — question is now moot
-
-- [/] Q003 [10:00] type=question path=/root/work/quantika-demo/.worktrees/r6-final/tailwind.config.ts — Old shadcn tokens (hsl(var(--xxx))) still referenced by components/ui/. Cannot remove until Q002 resolved. Safe to keep ds.* and legacy tokens in parallel. → STUCK: different worktree (r6-final); PR #447 merged — question is moot
-
-- [/] Q004 [10:00] type=question path=/root/work/quantika-demo/.worktrees/r6-final/tests/a11y/pages — A11y specs for /match/[id], /vessel/[id], /fixture/[id] use placeholder IDs. If IDs absent from demo seed, axe tests the 404/empty-state page. Acceptable baseline OR seed known IDs first? → STUCK: different worktree (r6-final); PR #447 merged — question is moot
-
-- [/] Q005 [10:05] type=blocked path=/root/work/quantika-demo/.worktrees/r6-final — Push blocked by auto-mode classifier. Branch `design/r6-final-wt` has 1 commit (5bb85cb) ready. → STUCK: different worktree (r6-final); PR #447 already merged — question is moot
+- [ ] Q001 [current] type=blocked path=/root/work/quantika-demo/.worktrees/dependabot-mod5 — Push to origin/claude/dependabot-mod5 blocked by auto-classifier (rule: "НЕ push без явного разрешения orchestrator"). Commit 8ed30b3 is ready. Need explicit push permission to create PR and merge security fixes (qs 6.15.2, ws 8.21.0, brace-expansion, esbuild ^0.25.0).

--- a/extensions/gmail/package.json
+++ b/extensions/gmail/package.json
@@ -7,7 +7,7 @@
     "watch": "node esbuild.config.mjs --watch"
   },
   "devDependencies": {
-    "esbuild": "^0.20.0",
+    "esbuild": "^0.25.0",
     "@types/chrome": "^0.0.260"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8793,9 +8793,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16742,9 +16742,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -19789,9 +19789,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Closes 4 of 6 GitHub security alerts (qs 6.15.2, ws 8.21.0, brace-expansion auto-dismissed, esbuild ^0.25.0 in gmail subdir). Skipped: postcss (needs next@9 major), pytest 9 (major bump).