### PR TITLE
feat(r65 v2): dark-mode toggle — ThemeProvider WITHOUT html/body wrapper

### DIFF
--- a/__tests__/components/DarkToggle.test.tsx
+++ b/__tests__/components/DarkToggle.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@/design-system/patterns/ThemeProvider';
+import { DarkToggle } from '@/design-system/patterns/DarkToggle';
+
+function withTheme(ui: React.ReactElement) {
+  return <ThemeProvider>{ui}</ThemeProvider>;
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  document.documentElement.removeAttribute('data-theme');
+  document.documentElement.classList.remove('dark');
+  document.cookie = 'quantika_theme=; path=/; max-age=0';
+});
+
+describe('ThemeProvider — no html/body wrapping (prod 500 guard)', () => {
+  it('does NOT render <html> or <body> elements', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <div data-testid="child">content</div>
+      </ThemeProvider>,
+    );
+    // ThemeProvider must never produce nested html/body — that caused prod 500 via double-html hydration error
+    expect(container.querySelector('html')).toBeNull();
+    expect(container.querySelector('body')).toBeNull();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});
+
+describe('DarkToggle — PI2 behavioral', () => {
+  it('click toggle → documentElement gets data-theme=dark and .dark class', async () => {
+    const user = userEvent.setup();
+    render(withTheme(<DarkToggle />));
+
+    const btn = screen.getByRole('button', { name: /switch to dark mode/i });
+    await user.click(btn);
+
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('toggle back to light removes data-theme and .dark class', async () => {
+    const user = userEvent.setup();
+    render(withTheme(<DarkToggle />));
+
+    const btn = screen.getByRole('button', { name: /switch to dark mode/i });
+    await user.click(btn); // → dark
+    await user.click(btn); // → light
+
+    expect(document.documentElement).not.toHaveAttribute('data-theme');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('reload preserves dark — cookie is set and ThemeProvider reads it on mount', async () => {
+    document.cookie = 'quantika_theme=dark; path=/; max-age=31536000';
+
+    render(withTheme(<DarkToggle />));
+    await act(async () => {});
+
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('first visit: respects prefers-color-scheme dark', async () => {
+    (window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+
+    render(withTheme(<DarkToggle />));
+    await act(async () => {});
+
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/__tests__/e2e/playwright/dark-mode.spec.ts
+++ b/__tests__/e2e/playwright/dark-mode.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Dark-mode toggle e2e — regression guard for prod 500 incident (PR #464 revert).
+ *
+ * Root cause was double-html hydration error. These tests verify:
+ * (a) document has exactly ONE <html> root (no nested html tags)
+ * (b) .dark class applied to documentElement after toggle click
+ * (c) quantika_theme=dark cookie set
+ * (d) authenticated route (/dashboard) returns 200 with toggle active
+ */
+
+test.describe('Dark-mode toggle', () => {
+  test('(a) single <html> root — no double-html hydration', async ({ page }) => {
+    await page.goto('/dashboard');
+    const htmlCount = await page.evaluate(() => document.querySelectorAll('html').length);
+    expect(htmlCount).toBe(1);
+  });
+
+  test('(b) toggle click adds .dark class to documentElement', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const toggle = page.getByRole('button', { name: /switch to dark mode/i });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const hasDark = await page.evaluate(() =>
+      document.documentElement.classList.contains('dark'),
+    );
+    expect(hasDark).toBe(true);
+  });
+
+  test('(c) cookie quantika_theme=dark set after toggle', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    const toggle = page.getByRole('button', { name: /switch to dark mode/i });
+    await toggle.click();
+
+    const cookies = await page.context().cookies();
+    const themeCookie = cookies.find((c) => c.name === 'quantika_theme');
+    expect(themeCookie?.value).toBe('dark');
+  });
+
+  test('(d) /dashboard returns 200 with dark mode active', async ({ page }) => {
+    // Set dark mode cookie before navigation to simulate returning user
+    await page.context().addCookies([
+      { name: 'quantika_theme', value: 'dark', path: '/', domain: 'localhost' },
+    ]);
+
+    const res = await page.goto('/dashboard');
+    expect(res?.status()).toBe(200);
+
+    // Verify the bootstrap script applied dark class before hydration
+    const hasDark = await page.evaluate(() =>
+      document.documentElement.classList.contains('dark'),
+    );
+    expect(hasDark).toBe(true);
+  });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,9 @@ import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 
+// Inline script runs before React hydration to prevent flash on dark-mode first paint.
+const THEME_SCRIPT = `(function(){try{var c=document.cookie.match(/quantika_theme=(dark|light)/);var t=c?c[1]:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');if(t==='dark'){document.documentElement.setAttribute('data-theme','dark');document.documentElement.classList.add('dark')}}catch(e){}})()`;
+
 export const metadata: Metadata = {
   title: 'Quantika Demo — AI for Freight Email',
   description: 'See how AI handles your freight email in 2 minutes',
@@ -96,7 +99,10 @@ export default async function RootLayout({
   // mixed-locale demo scenarios — see stab/rtl-per-content.
   if (!isAuthenticated) {
     return (
-      <html lang="en" dir="ltr">
+      <html lang="en" dir="ltr" suppressHydrationWarning>
+        <head>
+          <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
+        </head>
         <body className={inter.className}>
           {children}
         </body>
@@ -122,7 +128,10 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang="en" dir="ltr">
+    <html lang="en" dir="ltr" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
+      </head>
       <body className={inter.className}>
         <Suspense fallback={null}>
           <TrialBannerWrapper />

--- a/app/more/page.tsx
+++ b/app/more/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { DarkToggle } from '@/design-system/patterns';
 
 export const metadata: Metadata = {
   title: 'More — Quantika',
@@ -33,6 +34,12 @@ export default function MorePage() {
                 Dashboard
                 <span className="text-ds-text-muted text-xs">→</span>
               </Link>
+            </li>
+            <li>
+              <span className="flex items-center justify-between w-full rounded-ds-md px-4 py-3 text-sm font-medium text-ds-text min-h-[44px]">
+                Appearance
+                <DarkToggle />
+              </span>
             </li>
             <li>
               <span className="flex items-center justify-between w-full rounded-ds-md px-4 py-3 text-sm font-medium text-ds-text-muted min-h-[44px]">

--- a/design-system/patterns/AppShell.tsx
+++ b/design-system/patterns/AppShell.tsx
@@ -6,29 +6,32 @@ import { AIBar } from './AIBar';
 import { CmdKPalette } from './CmdKPalette';
 import { HelpFAB } from './HelpFAB';
 import { PaletteProvider } from './usePalette';
+import { ThemeProvider } from './ThemeProvider';
 import { ToastProvider } from '@/components/ui/toast/toast-context';
 import { ToastContainer } from '@/components/ui/toast/toast-container';
 
 export function AppShell({ children }: { children: ReactNode }) {
   return (
-    <ToastProvider>
-      <PaletteProvider>
-        <div className="min-h-screen bg-ds-bg text-ds-text flex flex-col">
-          <a
-            href="#main-content"
-            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-ds-accent focus:text-ds-accent-fg focus:px-3 focus:py-2 focus:rounded-ds-md focus:font-medium"
-          >
-            Skip to content
-          </a>
-          <TopNav />
-          <AIBar />
-          <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
-          <BottomNav />
-          <HelpFAB />
-          <CmdKPalette />
-          <ToastContainer />
-        </div>
-      </PaletteProvider>
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <PaletteProvider>
+          <div className="min-h-screen bg-ds-bg text-ds-text flex flex-col">
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-ds-accent focus:text-ds-accent-fg focus:px-3 focus:py-2 focus:rounded-ds-md focus:font-medium"
+            >
+              Skip to content
+            </a>
+            <TopNav />
+            <AIBar />
+            <main id="main-content" className="flex-1 pb-16 md:pb-0">{children}</main>
+            <BottomNav />
+            <HelpFAB />
+            <CmdKPalette />
+            <ToastContainer />
+          </div>
+        </PaletteProvider>
+      </ToastProvider>
+    </ThemeProvider>
   );
 }

--- a/design-system/patterns/DarkToggle.tsx
+++ b/design-system/patterns/DarkToggle.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { Sun, Moon } from 'lucide-react';
+import { useTheme } from './ThemeProvider';
+import { cn } from '@/design-system/primitives/_utils';
+
+export function DarkToggle({ className }: { className?: string }) {
+  const { theme, toggle } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-pressed={theme === 'dark'}
+      className={cn(
+        'p-1.5 rounded-ds-sm text-ds-text-muted hover:text-ds-text hover:bg-ds-surface-muted transition-colors duration-ds-fast',
+        className,
+      )}
+    >
+      {theme === 'dark'
+        ? <Sun size={16} aria-hidden="true" />
+        : <Moon size={16} aria-hidden="true" />}
+    </button>
+  );
+}

--- a/design-system/patterns/ThemeProvider.tsx
+++ b/design-system/patterns/ThemeProvider.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'dark' | 'light';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({ theme: 'light', toggle: () => {} });
+
+const COOKIE = 'quantika_theme';
+
+export function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.setAttribute('data-theme', 'dark');
+    root.classList.add('dark');
+  } else {
+    root.removeAttribute('data-theme');
+    root.classList.remove('dark');
+  }
+  document.cookie = `${COOKIE}=${theme}; path=/; max-age=31536000; SameSite=Lax`;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const saved = document.cookie.match(new RegExp(`${COOKIE}=(dark|light)`))?.[1] as Theme | undefined;
+    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const resolved = saved ?? (prefersDark ? 'dark' : 'light');
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time mount init from cookie/media query
+    setTheme(resolved);
+    applyTheme(resolved);
+  }, []);
+
+  const toggle = () => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    applyTheme(next);
+  };
+
+  return <ThemeContext.Provider value={{ theme, toggle }}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext);
+}

--- a/design-system/patterns/TopNav.tsx
+++ b/design-system/patterns/TopNav.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useMode } from './useMode';
 import { ModeSwitcher } from './ModeSwitcher';
+import { DarkToggle } from './DarkToggle';
 import { cn } from '@/design-system/primitives/_utils';
 
 const MORE_ITEMS = [
@@ -34,7 +35,8 @@ export function TopNav() {
         <NavLink href="/market">Market</NavLink>
         <MoreDropdown />
       </nav>
-      <div className="ml-auto shrink-0">
+      <div className="ml-auto shrink-0 flex items-center gap-2">
+        <DarkToggle />
         <ModeSwitcher />
       </div>
     </header>

--- a/design-system/patterns/__tests__/AppShell.test.tsx
+++ b/design-system/patterns/__tests__/AppShell.test.tsx
@@ -27,6 +27,8 @@ jest.mock('lucide-react', () => ({
   Box: () => <svg data-testid="icon-box" />,
   MoreHorizontal: () => <svg data-testid="icon-more" />,
   LogOut: () => <svg data-testid="icon-logout" />,
+  Sun: () => <svg data-testid="icon-sun" />,
+  Moon: () => <svg data-testid="icon-moon" />,
 }));
 
 describe('AppShell', () => {

--- a/design-system/patterns/index.ts
+++ b/design-system/patterns/index.ts
@@ -1,4 +1,6 @@
 export { AppShell } from './AppShell';
+export { ThemeProvider, useTheme } from './ThemeProvider';
+export { DarkToggle } from './DarkToggle';
 export { ToastProvider, useToast, ToastContainer } from '@/components/ui/toast';
 export { TopNav } from './TopNav';
 export { BottomNav } from './BottomNav';


### PR DESCRIPTION
Closes R6.5. Re-implementation of reverted #464. Root cause of prior 500: ThemeProvider rendered nested html/body inside RootLayout. Fix: provider returns children only; theme applied via useEffect on document.documentElement; cookie persist; bootstrap script in head for first paint. Regression test: __tests__/components/DarkToggle.test.tsx asserts 'ThemeProvider renders NO html/body'. Playwright dark-mode.spec.ts checks single-html-root + .dark class + cookie + /dashboard 200.