### PR TITLE
fix(vessels): #452 React error #31 — fmtOpenDate handles {open,close,display} object

### DIFF
--- a/__tests__/e2e/playwright/vessels.spec.ts
+++ b/__tests__/e2e/playwright/vessels.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression guard for #452 — /vessels page crash.
+ * React error #31: object {open,close,display} rendered as React child
+ * React error #419: hydration mismatch
+ */
+test.describe('/vessels page — regression #452', () => {
+  test('page loads without React error #31 or hydration errors', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => {
+      consoleErrors.push(`${err.message}\n${err.stack ?? ''}`);
+    });
+
+    await page.goto('/vessels', { waitUntil: 'networkidle', timeout: 20_000 });
+    await page.waitForTimeout(1_500);
+
+    const reactObjectErrors = consoleErrors.filter((e) =>
+      /Minified React error #31/i.test(e) ||
+      /Objects are not valid as a React child/i.test(e) ||
+      /Minified React error #418/i.test(e) ||
+      /Hydration failed/i.test(e) ||
+      /Text content does not match/i.test(e),
+    );
+
+    expect(
+      reactObjectErrors,
+      `Got ${reactObjectErrors.length} React error(s): ${reactObjectErrors.slice(0, 2).join('; ')}`,
+    ).toEqual([]);
+  });
+
+  test('page renders vessels heading and table', async ({ page }) => {
+    await page.goto('/vessels', { waitUntil: 'networkidle', timeout: 20_000 });
+
+    await expect(page.getByRole('heading', { name: /^Vessels$/ })).toBeVisible();
+    await expect(page.locator('[data-testid="vessels-table-card"]')).toBeVisible();
+  });
+});

--- a/__tests__/lib/vessels-utils.test.ts
+++ b/__tests__/lib/vessels-utils.test.ts
@@ -1,0 +1,51 @@
+import { fmtOpenDate } from '@/lib/vessels-utils';
+
+describe('fmtOpenDate', () => {
+  it('returns null for null field', () => {
+    expect(fmtOpenDate(null)).toBeNull();
+  });
+
+  it('returns null for undefined field', () => {
+    expect(fmtOpenDate(undefined)).toBeNull();
+  });
+
+  it('returns plain string value as-is', () => {
+    expect(fmtOpenDate({ value: '2026-05-22', confidence: 'confirmed' })).toBe('2026-05-22');
+  });
+
+  it('returns null for empty string value', () => {
+    expect(fmtOpenDate({ value: '', confidence: 'confirmed' })).toBeNull();
+  });
+
+  it('returns display from {open, close, display} object — primary display field', () => {
+    const field = {
+      value: { open: '2026-05-10', close: '2026-05-12', display: '10/12 May' } as unknown as string,
+      confidence: 'interpreted' as const,
+    };
+    expect(fmtOpenDate(field)).toBe('10/12 May');
+  });
+
+  it('falls back to open when display is null', () => {
+    const field = {
+      value: { open: '2026-05-10', close: '2026-05-12', display: null } as unknown as string,
+      confidence: 'interpreted' as const,
+    };
+    expect(fmtOpenDate(field)).toBe('2026-05-10');
+  });
+
+  it('returns null when display and open are both null', () => {
+    const field = {
+      value: { open: null, close: null, display: null } as unknown as string,
+      confidence: 'uncertain' as const,
+    };
+    expect(fmtOpenDate(field)).toBeNull();
+  });
+
+  it('handles spot/display-only object (no year case)', () => {
+    const field = {
+      value: { open: null, close: null, display: 'spot' } as unknown as string,
+      confidence: 'confirmed' as const,
+    };
+    expect(fmtOpenDate(field)).toBe('spot');
+  });
+});

--- a/app/vessels/page.tsx
+++ b/app/vessels/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getSession } from '@/lib/session';
 import { cfValue } from '@/lib/types';
+import { fmtOpenDate } from '@/lib/vessels-utils';
 import VesselsClient, { type VesselRow } from './VesselsClient';
 
 export const metadata: Metadata = {
@@ -24,6 +25,7 @@ function fmtDwt(dwt: number | null): string | null {
   if (dwt >= 1000) return `${Math.round(dwt / 1000)}k`;
   return String(dwt);
 }
+
 
 export default async function VesselsPage() {
   const cookieStore = await cookies();
@@ -47,7 +49,7 @@ export default async function VesselsPage() {
       vesselKey: getVesselKey(vessel.vesselType),
       dwtSummer: fmtDwt(dwtVal),
       openPosition: cfValue(vessel.openPosition) ?? null,
-      openDate: cfValue(vessel.openDate) ?? null,
+      openDate: fmtOpenDate(vessel.openDate),
       status: hasMatch ? 'match' : 'open',
       sourceTag: email ? 'Email' : 'Manual',
       sourceName: email

--- a/lib/vessels-utils.ts
+++ b/lib/vessels-utils.ts
@@ -1,0 +1,18 @@
+import type { ConfidenceField } from '@/lib/types';
+
+/**
+ * Extract a display string from a vessel openDate ConfidenceField.
+ * The LLM may return .value as a plain string OR as {open, close, display}
+ * for date ranges (per parse-vessel prompt). If the value is an object,
+ * prefer .display (human-readable), then .open (ISO date).
+ */
+export function fmtOpenDate(field: ConfidenceField<string> | null | undefined): string | null {
+  if (!field) return null;
+  const val: unknown = field.value;
+  if (typeof val === 'string') return val || null;
+  if (typeof val === 'object' && val !== null) {
+    const obj = val as { display?: string | null; open?: string | null };
+    return obj.display ?? obj.open ?? null;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #452. Root cause: vessel.openDate is sometimes {open,close,display} object; was rendered raw. Fix: lib/vessels-utils.ts fmtOpenDate() handles both string and object (prefers .display). 8 unit + 1 Playwright regression.