### PR TITLE
fix(ui): LOW QA-walker batch — Bell + mobile-AI + entity-decode + confidence-invert

### DIFF
--- a/app/email/page.tsx
+++ b/app/email/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { getSession } from '@/lib/session';
 import { Card, Button } from '@/design-system/primitives';
-import { formatDate } from '@/lib/utils';
+import { formatDate, decodeHtmlEntities } from '@/lib/utils';
 import type { EmailCategory } from '@/lib/types';
 
 export const metadata: Metadata = {
@@ -90,7 +90,7 @@ export default async function EmailInboxPage() {
         </div>
 
         {sorted.map(({ email, processed }) => {
-          const isLowConfidence = processed && processed.confidence < 80;
+          const isLowConfidence = processed && processed.confidence < 0.8;
           const category = processed?.type;
 
           return (
@@ -114,7 +114,7 @@ export default async function EmailInboxPage() {
                       )}
                       {isLowConfidence && (
                         <span className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-ds-sm border border-amber-300 text-amber-700 bg-amber-50">
-                          Low confidence {processed.confidence}%
+                          Low confidence {Math.round(processed.confidence * 100)}%
                         </span>
                       )}
                     </div>
@@ -131,7 +131,7 @@ export default async function EmailInboxPage() {
 
                 {/* Snippet */}
                 <p className="text-sm text-ds-text-muted line-clamp-2 leading-relaxed">
-                  {email.snippet}
+                  {decodeHtmlEntities(email.snippet)}
                 </p>
 
                 {/* Action buttons */}

--- a/design-system/patterns/BottomNav.tsx
+++ b/design-system/patterns/BottomNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, Sparkles, Box, MoreHorizontal, LogOut } from 'lucide-react';
+import { Sparkles, Box, Zap, MoreHorizontal, LogOut } from 'lucide-react';
 import { useMode } from './useMode';
 import { cn } from '@/design-system/primitives/_utils';
 
@@ -9,15 +9,19 @@ export function BottomNav() {
   const { isCharterer } = useMode();
   const pathname = usePathname();
   const items = [
-    { href: '/dashboard', label: 'Dashboard', Icon: Home },
     { href: '/matches', label: 'Matches', Icon: Sparkles },
     {
       href: isCharterer ? '/cargo' : '/vessels',
       label: isCharterer ? 'Cargo' : 'Vessels',
       Icon: Box,
     },
-    { href: '/more', label: 'More', Icon: MoreHorizontal },
   ];
+
+  const handleAIClick = () => {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('open-command-palette'));
+    }
+  };
 
   return (
     <nav
@@ -42,6 +46,27 @@ export function BottomNav() {
           </Link>
         );
       })}
+      <button
+        type="button"
+        onClick={handleAIClick}
+        className="flex-1 flex flex-col items-center justify-center gap-0.5 min-h-[44px] text-ds-text-muted hover:text-ds-text transition-colors"
+        aria-label="AI command palette"
+      >
+        <Zap size={20} aria-hidden="true" />
+        <span className="text-[10px] font-medium">AI</span>
+      </button>
+      <Link
+        href="/more"
+        aria-current={pathname === '/more' ? 'page' : undefined}
+        className={cn(
+          'flex-1 flex flex-col items-center justify-center gap-0.5 min-h-[44px] transition-colors',
+          pathname === '/more' ? 'text-ds-accent' : 'text-ds-text-muted hover:text-ds-text',
+        )}
+        aria-label="More"
+      >
+        <MoreHorizontal size={20} aria-hidden="true" />
+        <span className="text-[10px] font-medium">More</span>
+      </Link>
       <form method="POST" action="/api/auth/logout" className="flex-1">
         <button
           type="submit"

--- a/design-system/patterns/TopNav.tsx
+++ b/design-system/patterns/TopNav.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { useMode } from './useMode';
 import { ModeSwitcher } from './ModeSwitcher';
 import { DarkToggle } from './DarkToggle';
+import { Bell } from 'lucide-react';
 import { cn } from '@/design-system/primitives/_utils';
 
 const MORE_ITEMS = [
@@ -36,6 +37,13 @@ export function TopNav() {
         <MoreDropdown />
       </nav>
       <div className="ml-auto shrink-0 flex items-center gap-2">
+        <button
+          type="button"
+          aria-label="Notifications"
+          className="inline-flex items-center justify-center w-9 h-9 rounded-ds-md text-ds-text-muted hover:text-ds-text hover:bg-ds-surface-muted transition-colors duration-ds-fast"
+        >
+          <Bell className="h-5 w-5" aria-hidden="true" />
+        </button>
         <DarkToggle />
         <ModeSwitcher />
       </div>

--- a/design-system/patterns/__tests__/AppShell.test.tsx
+++ b/design-system/patterns/__tests__/AppShell.test.tsx
@@ -23,6 +23,8 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('lucide-react', () => ({
   Home: () => <svg data-testid="icon-home" />,
+  Bell: () => <svg data-testid="icon-bell" />,
+  Zap: () => <svg data-testid="icon-zap" />,
   Sparkles: () => <svg data-testid="icon-sparkles" />,
   Box: () => <svg data-testid="icon-box" />,
   MoreHorizontal: () => <svg data-testid="icon-more" />,
@@ -66,14 +68,14 @@ describe('AppShell', () => {
     expect(screen.getByRole('button', { name: /charterer/i })).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('renders both TopNav and BottomNav (Dashboard appears twice)', () => {
+  it('renders both TopNav and BottomNav (Matches appears in both)', () => {
     render(
       <ModeProvider initial="charterer">
         <AppShell><div>page</div></AppShell>
       </ModeProvider>,
     );
-    const dashLinks = screen.getAllByRole('link', { name: /dashboard/i });
+    const matchLinks = screen.getAllByRole('link', { name: /matches/i });
     // One in TopNav + one in BottomNav
-    expect(dashLinks.length).toBeGreaterThanOrEqual(2);
+    expect(matchLinks.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/design-system/patterns/__tests__/BottomNav.test.tsx
+++ b/design-system/patterns/__tests__/BottomNav.test.tsx
@@ -17,9 +17,9 @@ jest.mock('next/link', () => {
 
 // lucide-react icon mocks to avoid svg rendering issues
 jest.mock('lucide-react', () => ({
-  Home: () => <svg data-testid="icon-home" />,
   Sparkles: () => <svg data-testid="icon-sparkles" />,
   Box: () => <svg data-testid="icon-box" />,
+  Zap: () => <svg data-testid="icon-zap" />,
   MoreHorizontal: () => <svg data-testid="icon-more" />,
   LogOut: () => <svg data-testid="icon-logout" />,
 }));
@@ -30,12 +30,12 @@ describe('BottomNav', () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true }) as typeof global.fetch;
   });
 
-  it('renders 4 nav links with labels', () => {
+  it('renders nav with Matches, mode-primary, AI, More', () => {
     render(<ModeProvider initial="charterer"><BottomNav /></ModeProvider>);
-    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /matches/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /cargo/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /more/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ai command palette/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^more$/i })).toBeInTheDocument();
   });
 
   it('charterer mode shows Cargo link', () => {
@@ -47,5 +47,14 @@ describe('BottomNav', () => {
     render(<ModeProvider initial="owner"><BottomNav /></ModeProvider>);
     expect(screen.getByRole('link', { name: /vessels/i })).toHaveAttribute('href', '/vessels');
     expect(screen.queryByRole('link', { name: /cargo/i })).not.toBeInTheDocument();
+  });
+
+  it('AI button dispatches open-command-palette event', () => {
+    const listener = jest.fn();
+    window.addEventListener('open-command-palette', listener);
+    render(<ModeProvider initial="charterer"><BottomNav /></ModeProvider>);
+    screen.getByRole('button', { name: /ai command palette/i }).click();
+    expect(listener).toHaveBeenCalled();
+    window.removeEventListener('open-command-palette', listener);
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,3 +63,36 @@ export function sanitizeEmailBody(body: string): string {
     .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
+
+const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+/**
+ * Decode common HTML entities (named + numeric) in a plain text string.
+ * Safe for SSR — does not use DOMParser. Use before rendering text that
+ * may contain entity-encoded characters (e.g. email snippets/bodies).
+ */
+export function decodeHtmlEntities(s: string): string {
+  if (!s) return s;
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, ent) => {
+    if (ent[0] === '#') {
+      const code = ent[1] === 'x' || ent[1] === 'X'
+        ? parseInt(ent.slice(2), 16)
+        : parseInt(ent.slice(1), 10);
+      if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return match;
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return match;
+      }
+    }
+    const mapped = HTML_ENTITY_MAP[ent.toLowerCase()];
+    return mapped ?? match;
+  });
+}


### PR DESCRIPTION
Closes #455 #456 #474 #475. Mechanical UI fixes.

- **#455** TopNav: add Bell notifications icon to right-cluster (left of DarkToggle).
- **#456** BottomNav: restructure mobile nav to 4 slots per R2 spec — Matches / Cargo-or-Vessels / AI / More. AI button dispatches `open-command-palette` CustomEvent.
- **#474** /email body preview: snippets passed through new `decodeHtmlEntities` util in lib/utils so `&lt;`, `&gt;`, `&#39;` etc. render as readable characters.
- **#475** /email low-confidence threshold: fixed inverted comparison (was `< 80` against a 0-1 scale value, so all rows flagged). Now `< 0.8`; display multiplies by 100 to show real %.

Tests updated: BottomNav.test (Zap mock + AI button assertion + dispatched event), AppShell.test (lucide mock adds Bell+Zap; Dashboard-twice assertion → Matches-twice).