### PR TITLE
fix(ui): #499 CmdK keyboard tests + #503 column labels + #504 FilterBar

### DIFF
--- a/app/charterers/page.tsx
+++ b/app/charterers/page.tsx
@@ -8,7 +8,7 @@
  * - Modal submit → POST /api/charterers → refresh list
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CharterersTable, type Charterer } from '@/components/charterers/CharterersTable';
 import { NewChartererModal } from '@/components/charterers/NewChartererModal';
 
@@ -19,6 +19,16 @@ export default function CharterersPage() {
   const [charterers, setCharterers] = useState<Charterer[]>([]);
   const [loading, setLoading] = useState(isFeatureEnabled);
   const [showForm, setShowForm] = useState(false);
+  const [filterQuery, setFilterQuery] = useState('');
+  const [sortOrder, setSortOrder] = useState<'recent' | 'alpha'>('recent');
+
+  const displayed = useMemo(() => {
+    const filtered = filterQuery
+      ? charterers.filter(c => c.name.toLowerCase().includes(filterQuery.toLowerCase()))
+      : charterers;
+    if (sortOrder === 'alpha') return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+    return filtered;
+  }, [charterers, filterQuery, sortOrder]);
 
   useEffect(() => {
     if (!isFeatureEnabled) return;
@@ -59,7 +69,7 @@ export default function CharterersPage() {
             </h1>
             {charterers.length > 0 && (
               <span style={{ fontSize: 13, color: 'var(--ds-text-muted)', fontFamily: '"Geist Mono", ui-monospace, monospace' }}>
-                {charterers.length} contacts
+                {filterQuery ? `${displayed.length} of ${charterers.length}` : charterers.length} contacts
               </span>
             )}
           </div>
@@ -79,6 +89,46 @@ export default function CharterersPage() {
             Add Charterer
           </button>
         </header>
+
+        {/* FilterBar */}
+        <div style={{ display: 'flex', gap: 10, marginBottom: 14, alignItems: 'center' }}>
+          <input
+            type="search"
+            aria-label="Search by company"
+            placeholder="Search by company…"
+            value={filterQuery}
+            onChange={(e) => setFilterQuery(e.target.value)}
+            style={{
+              flex: 1,
+              height: 36,
+              padding: '0 12px',
+              fontSize: 14,
+              border: '1px solid var(--ds-border)',
+              borderRadius: 8,
+              background: 'var(--ds-surface)',
+              color: 'var(--ds-text)',
+              outline: 'none',
+            }}
+          />
+          <select
+            aria-label="Sort order"
+            value={sortOrder}
+            onChange={(e) => setSortOrder(e.target.value as 'recent' | 'alpha')}
+            style={{
+              height: 36,
+              padding: '0 10px',
+              fontSize: 13,
+              border: '1px solid var(--ds-border)',
+              borderRadius: 8,
+              background: 'var(--ds-surface)',
+              color: 'var(--ds-text)',
+              cursor: 'pointer',
+            }}
+          >
+            <option value="recent">Recent</option>
+            <option value="alpha">Alphabetical</option>
+          </select>
+        </div>
 
         {/* Legend */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16, fontFamily: '"Geist Mono", ui-monospace, monospace', fontSize: 11, color: 'var(--ds-text-muted)' }}>
@@ -114,7 +164,7 @@ export default function CharterersPage() {
           <p style={{ fontSize: 14, color: 'var(--ds-text-muted)', padding: '32px 0', textAlign: 'center' }}>Loading…</p>
         ) : (
           <div style={{ border: '1px solid var(--ds-border)', borderRadius: 10, background: 'var(--ds-surface)', overflow: 'hidden' }}>
-            <CharterersTable charterers={charterers} />
+            <CharterersTable charterers={displayed} />
           </div>
         )}
       </div>

--- a/components/charterers/CharterersTable.tsx
+++ b/components/charterers/CharterersTable.tsx
@@ -73,7 +73,7 @@ export function CharterersTable({ charterers }: Props) {
         </colgroup>
         <thead>
           <tr>
-            {['Name', 'LC Req.', 'Last note', 'Status'].map((h, i) => (
+            {['Company', 'LC Req.', 'Last Contact', 'Status'].map((h, i) => (
               <th
                 key={h}
                 style={{

--- a/components/charterers/__tests__/CharterersTable.test.tsx
+++ b/components/charterers/__tests__/CharterersTable.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => '/charterers',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { CharterersTable, type Charterer } from '../CharterersTable';
+
+const SAMPLE: Charterer[] = [
+  { id: '1', name: 'Alpha Corp', tier: 'blue-chip', require_lc: 0, notes: 'big player' },
+  { id: '2', name: 'Beta Ltd', tier: 'second', require_lc: 1, notes: null },
+  { id: '3', name: 'Gamma SA', tier: 'weak', require_lc: 0, notes: 'small account' },
+];
+
+describe('CharterersTable column labels', () => {
+  it('shows Company column header (not NAME)', () => {
+    render(<CharterersTable charterers={SAMPLE} />);
+    expect(screen.getByRole('columnheader', { name: /company/i })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: /^name$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Last Contact column header (not LAST NOTE)', () => {
+    render(<CharterersTable charterers={SAMPLE} />);
+    expect(screen.getByRole('columnheader', { name: /last contact/i })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: /last note/i })).not.toBeInTheDocument();
+  });
+
+  it('renders all rows', () => {
+    render(<CharterersTable charterers={SAMPLE} />);
+    expect(screen.getByText('Alpha Corp')).toBeInTheDocument();
+    expect(screen.getByText('Beta Ltd')).toBeInTheDocument();
+    expect(screen.getByText('Gamma SA')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no charterers', () => {
+    render(<CharterersTable charterers={[]} />);
+    expect(screen.getByText(/no charterers found/i)).toBeInTheDocument();
+  });
+});

--- a/design-system/__tests__/CmdKPalette.test.tsx
+++ b/design-system/__tests__/CmdKPalette.test.tsx
@@ -47,4 +47,50 @@ describe('CmdKPalette', () => {
     act(() => { screen.getByText('open-palette').click(); });
     expect(screen.getByText(/find vessel/i)).toBeInTheDocument();
   });
+
+  it('opens with Cmd+K (Mac)', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <PaletteProvider>
+          <CmdKPalette />
+        </PaletteProvider>
+      </ModeProvider>,
+    );
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { metaKey: true, key: 'k', bubbles: true }));
+    });
+    expect(screen.getByPlaceholderText(/search or ask/i)).toBeInTheDocument();
+  });
+
+  it('opens with Ctrl+K (Windows/Linux)', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <PaletteProvider>
+          <CmdKPalette />
+        </PaletteProvider>
+      </ModeProvider>,
+    );
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'k', bubbles: true }));
+    });
+    expect(screen.getByPlaceholderText(/search or ask/i)).toBeInTheDocument();
+  });
+
+  it('closes on second Cmd+K press', () => {
+    render(
+      <ModeProvider initial="charterer">
+        <PaletteProvider>
+          <CmdKPalette />
+        </PaletteProvider>
+      </ModeProvider>,
+    );
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { metaKey: true, key: 'k', bubbles: true }));
+    });
+    expect(screen.getByPlaceholderText(/search or ask/i)).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { metaKey: true, key: 'k', bubbles: true }));
+    });
+    expect(screen.queryByPlaceholderText(/search or ask/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- **#499** Add behavioral tests verifying `⌘K` (Mac) and `Ctrl+K` (Win/Linux) globally open the command palette — keyboard handler was already implemented correctly in `usePalette.tsx`; tests confirm it works
- **#503** Rename column headers in `CharterersTable`: `Name` → `Company`, `Last note` → `Last Contact`
- **#504** Add `FilterBar` above charterers table with search-by-company input and Recent/Alphabetical sort dropdown; client-side filtering via `useMemo`

## Files changed
- `design-system/__tests__/CmdKPalette.test.tsx` — 3 new keyboard tests (Cmd+K open, Ctrl+K open, second Cmd+K closes)
- `components/charterers/CharterersTable.tsx` — column header labels
- `app/charterers/page.tsx` — FilterBar + filter/sort state
- `components/charterers/__tests__/CharterersTable.test.tsx` — new: column label + empty state tests

## Test plan
- [ ] `npx jest CmdKPalette CharterersTable --no-coverage` — 9/9 green
- [ ] Press ⌘K on any authenticated page → palette opens
- [ ] `/charterers` shows "Company" and "Last Contact" headers
- [ ] Search input filters rows in real-time; sort dropdown reorders by name

Closes #499 #503 #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)