### PR TITLE
feat(market): #496 VLSFO/MGO/EUA KPI tiles + #497 Knowledge feed source+date

### DIFF
--- a/__tests__/api/market-bunker-kpi.test.ts
+++ b/__tests__/api/market-bunker-kpi.test.ts
@@ -1,0 +1,76 @@
+import Database from 'better-sqlite3';
+import migration023 from '@/lib/migrations/023-bunker-prices-rewrite';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+describe('GET /api/market/bunker-kpi', () => {
+  beforeEach(() => {
+    testDb = new Database(':memory:');
+    migration023.up(testDb);
+  });
+
+  afterEach(() => {
+    testDb.close();
+    jest.resetModules();
+  });
+
+  it('returns 400 when grade param is missing', async () => {
+    const { GET } = await import('@/app/api/market/bunker-kpi/route');
+    const req = new Request('http://localhost/api/market/bunker-kpi');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/invalid grade/i);
+  });
+
+  it('returns 400 for unknown grade', async () => {
+    const { GET } = await import('@/app/api/market/bunker-kpi/route');
+    const req = new Request('http://localhost/api/market/bunker-kpi?grade=IFO380');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when DB has no NLRTM data for grade', async () => {
+    testDb.prepare('DELETE FROM bunker_prices WHERE port_unlocode = ?').run('NLRTM');
+    const { GET } = await import('@/app/api/market/bunker-kpi/route');
+    const req = new Request('http://localhost/api/market/bunker-kpi?grade=VLSFO');
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns value, unit, period for seeded VLSFO row', async () => {
+    const { GET } = await import('@/app/api/market/bunker-kpi/route');
+    const req = new Request('http://localhost/api/market/bunker-kpi?grade=VLSFO');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.value).toBe('number');
+    expect(json.unit).toBe('USD/mt');
+    expect(typeof json.period).toBe('string');
+  });
+
+  it('returns value for MGO grade', async () => {
+    const { GET } = await import('@/app/api/market/bunker-kpi/route');
+    const req = new Request('http://localhost/api/market/bunker-kpi?grade=MGO');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.value).toBe(1192);
+    expect(json.unit).toBe('USD/mt');
+  });
+
+  it('accepts lowercase grade param', async () => {
+    const { GET } = await import('@/app/api/market/bunker-kpi/route');
+    const req = new Request('http://localhost/api/market/bunker-kpi?grade=vlsfo');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.value).toBe(791);
+  });
+});

--- a/__tests__/api/market-eua-kpi.test.ts
+++ b/__tests__/api/market-eua-kpi.test.ts
@@ -23,8 +23,8 @@ describe('GET /api/market/eua-kpi', () => {
   it('returns 404 when DB has no EUA data', async () => {
     testDb.exec('DELETE FROM eua_prices');
     const { GET } = await import('@/app/api/market/eua-kpi/route');
-    const req = new Request('http://localhost/api/market/eua-kpi');
-    const res = await GET(req);
+    
+    const res = await GET();
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toMatch(/no eua data/i);
@@ -32,8 +32,8 @@ describe('GET /api/market/eua-kpi', () => {
 
   it('returns value, unit, period for seeded spot row', async () => {
     const { GET } = await import('@/app/api/market/eua-kpi/route');
-    const req = new Request('http://localhost/api/market/eua-kpi');
-    const res = await GET(req);
+    
+    const res = await GET();
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.value).toBe(72.65);
@@ -50,8 +50,8 @@ describe('GET /api/market/eua-kpi', () => {
       .run('2026-05-20', 75.10);
 
     const { GET } = await import('@/app/api/market/eua-kpi/route');
-    const req = new Request('http://localhost/api/market/eua-kpi');
-    const res = await GET(req);
+    
+    const res = await GET();
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.value).toBe(75.10);

--- a/__tests__/api/market-eua-kpi.test.ts
+++ b/__tests__/api/market-eua-kpi.test.ts
@@ -1,0 +1,60 @@
+import Database from 'better-sqlite3';
+import migration024 from '@/lib/migrations/024-eua-prices-rewrite';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+describe('GET /api/market/eua-kpi', () => {
+  beforeEach(() => {
+    testDb = new Database(':memory:');
+    migration024.up(testDb);
+  });
+
+  afterEach(() => {
+    testDb.close();
+    jest.resetModules();
+  });
+
+  it('returns 404 when DB has no EUA data', async () => {
+    testDb.exec('DELETE FROM eua_prices');
+    const { GET } = await import('@/app/api/market/eua-kpi/route');
+    const req = new Request('http://localhost/api/market/eua-kpi');
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/no eua data/i);
+  });
+
+  it('returns value, unit, period for seeded spot row', async () => {
+    const { GET } = await import('@/app/api/market/eua-kpi/route');
+    const req = new Request('http://localhost/api/market/eua-kpi');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.value).toBe(72.65);
+    expect(json.unit).toBe('€/tCO₂');
+    expect(json.period).toBe('2026-05-04');
+  });
+
+  it('returns most recent row when multiple dates exist', async () => {
+    testDb
+      .prepare(
+        `INSERT INTO eua_prices (price_date, price_eur_per_tco2, contract_type, source, fetched_at)
+         VALUES (?, ?, 'spot', 'test', datetime('now'))`,
+      )
+      .run('2026-05-20', 75.10);
+
+    const { GET } = await import('@/app/api/market/eua-kpi/route');
+    const req = new Request('http://localhost/api/market/eua-kpi');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.value).toBe(75.10);
+    expect(json.period).toBe('2026-05-20');
+  });
+});

--- a/app/api/market/bunker-kpi/route.ts
+++ b/app/api/market/bunker-kpi/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
+import { getStore } from '@/lib/session-store';
+
+const VALID_GRADES = new Set(['VLSFO', 'MGO']);
+const DEFAULT_PORT = 'NLRTM';
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { searchParams } = new URL(request.url);
+  const grade = searchParams.get('grade')?.toUpperCase();
+
+  if (!grade || !VALID_GRADES.has(grade)) {
+    return NextResponse.json(
+      { error: 'Missing or invalid grade. Use ?grade=VLSFO|MGO' },
+      { status: 400 },
+    );
+  }
+
+  const db = getStore().getDatabase();
+  const row = getLatestBunkerPrice(db, DEFAULT_PORT, grade);
+
+  if (!row) {
+    return NextResponse.json(
+      { error: `No data available for ${grade}` },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    { value: row.price_usd_per_mt, unit: 'USD/mt', period: row.price_date },
+    { headers: { 'Cache-Control': 'public, max-age=1800, s-maxage=1800' } },
+  );
+}

--- a/app/api/market/eua-kpi/route.ts
+++ b/app/api/market/eua-kpi/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getLatestEuaPrice } from '@/lib/market/eua-repository';
+import { getStore } from '@/lib/session-store';
+
+export async function GET(): Promise<NextResponse> {
+  const db = getStore().getDatabase();
+  const row = getLatestEuaPrice(db, 'spot');
+
+  if (!row) {
+    return NextResponse.json(
+      { error: 'No EUA data available' },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    { value: row.price_eur_per_tco2, unit: '€/tCO₂', period: row.price_date },
+    { headers: { 'Cache-Control': 'public, max-age=1800, s-maxage=1800' } },
+  );
+}

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -13,7 +13,7 @@ interface IndexData {
   source: string;
 }
 
-const KPI_TILES = [
+const BALTIC_TILES = [
   {
     key: 'bdi',
     label: 'BDI',
@@ -53,6 +53,39 @@ const KPI_TILES = [
     sparklinePath: 'M2 6 L10 7 L17 5 L24 8 L31 7 L38 10 L46 11 L54 13',
     sparklineDir: 'down' as const,
     delta: { pct: '−0.5%', pts: '−8 pts', dir: 'down' as const },
+  },
+] as const;
+
+const COMMODITY_TILES = [
+  {
+    key: 'vlsfo',
+    label: 'VLSFO',
+    subLabel: 'Rotterdam',
+    url: '/api/market/bunker-kpi?grade=VLSFO',
+    unit: 'USD/mt',
+    sparklinePath: 'M2 10 L10 9 L17 11 L24 8 L31 9 L38 7 L46 8 L54 6',
+    sparklineDir: 'up' as const,
+    delta: { pct: '+0.5%', pts: '+4 $/mt', dir: 'up' as const },
+  },
+  {
+    key: 'mgo',
+    label: 'MGO',
+    subLabel: 'Rotterdam',
+    url: '/api/market/bunker-kpi?grade=MGO',
+    unit: 'USD/mt',
+    sparklinePath: 'M2 8 L10 9 L17 7 L24 10 L31 8 L38 11 L46 9 L54 12',
+    sparklineDir: 'down' as const,
+    delta: { pct: '−0.3%', pts: '−4 $/mt', dir: 'down' as const },
+  },
+  {
+    key: 'eua',
+    label: 'EUA',
+    subLabel: 'carbon · spot',
+    url: '/api/market/eua-kpi',
+    unit: '€/tCO₂',
+    sparklinePath: 'M2 12 L10 10 L17 9 L24 11 L31 8 L38 7 L46 6 L54 4',
+    sparklineDir: 'up' as const,
+    delta: { pct: '+1.8%', pts: '+1.3 €', dir: 'up' as const },
   },
 ] as const;
 
@@ -177,22 +210,40 @@ export default function MarketPage() {
           </div>
         </header>
 
-        {/* KPI Strip — 4 Baltic index tiles */}
-        <section aria-label="Baltic indices" className="grid grid-cols-4 gap-4 mb-10">
-          {KPI_TILES.map((tile) => (
-            <MarketKpiTile
-              key={tile.key}
-              label={tile.label}
-              subLabel={tile.subLabel}
-              url={tile.url}
-              unit={tile.unit}
-              sparklinePath={tile.sparklinePath}
-              sparklineDir={tile.sparklineDir}
-              delta={tile.delta}
-              isActive={activeKpi === tile.key}
-              onClick={() => setActiveKpi(activeKpi === tile.key ? null : tile.key)}
-            />
-          ))}
+        {/* KPI Strip — Baltic indices + bunker + EUA */}
+        <section aria-label="Market KPIs" className="mb-10 space-y-3">
+          <div className="grid grid-cols-4 gap-4">
+            {BALTIC_TILES.map((tile) => (
+              <MarketKpiTile
+                key={tile.key}
+                label={tile.label}
+                subLabel={tile.subLabel}
+                url={tile.url}
+                unit={tile.unit}
+                sparklinePath={tile.sparklinePath}
+                sparklineDir={tile.sparklineDir}
+                delta={tile.delta}
+                isActive={activeKpi === tile.key}
+                onClick={() => setActiveKpi(activeKpi === tile.key ? null : tile.key)}
+              />
+            ))}
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            {COMMODITY_TILES.map((tile) => (
+              <MarketKpiTile
+                key={tile.key}
+                label={tile.label}
+                subLabel={tile.subLabel}
+                url={tile.url}
+                unit={tile.unit}
+                sparklinePath={tile.sparklinePath}
+                sparklineDir={tile.sparklineDir}
+                delta={tile.delta}
+                isActive={activeKpi === tile.key}
+                onClick={() => setActiveKpi(activeKpi === tile.key ? null : tile.key)}
+              />
+            ))}
+          </div>
         </section>
 
         {/* TODO: drill-down chart for activeKpi — future feature */}

--- a/components/market/KnowledgeFeed.tsx
+++ b/components/market/KnowledgeFeed.tsx
@@ -5,14 +5,56 @@ interface KnowledgeRow {
   icon: string;
   iconVariant?: 'tag' | 'default';
   title: string;
+  source: string;
+  date: string;
   tag: string;
 }
 
 const ARTICLES: KnowledgeRow[] = [
-  { icon: '§', iconVariant: 'tag', title: 'IMSBC code 2026 update — HSS Group A', tag: 'Regulation' },
-  { icon: '€', title: 'EU ETS phase 2 — bunker surcharge', tag: 'Compliance' },
-  { icon: '⚓', title: 'Algeciras congestion update', tag: 'Ports' },
-  { icon: '⛽', title: 'VLSFO Rotterdam — week 21 spread', tag: 'Bunker' },
+  {
+    icon: '§',
+    iconVariant: 'tag',
+    title: 'IMSBC code 2026 update — HSS Group A amendments',
+    source: 'IMO / Baltic Exchange',
+    date: '2026-05-20',
+    tag: 'IMSBC',
+  },
+  {
+    icon: '§',
+    iconVariant: 'tag',
+    title: 'IGC code — LNG cargo containment revision',
+    source: 'IMO',
+    date: '2026-05-15',
+    tag: 'IGC',
+  },
+  {
+    icon: '⚓',
+    title: 'Port DA schedule changes — Rotterdam Q2 2026',
+    source: 'Port Authority Rotterdam',
+    date: '2026-05-12',
+    tag: 'Port DA',
+  },
+  {
+    icon: '⚓',
+    title: 'Algeciras congestion surcharge — DA update',
+    source: 'Algeciras Port Authority',
+    date: '2026-05-10',
+    tag: 'Port DA',
+  },
+  {
+    icon: '€',
+    title: 'EU ETS phase 2 — bunker surcharge guidance',
+    source: 'EU Commission',
+    date: '2026-05-08',
+    tag: 'Compliance',
+  },
+  {
+    icon: '⛽',
+    title: 'VLSFO Rotterdam — week 21 spread analysis',
+    source: 'Ship & Bunker',
+    date: '2026-05-07',
+    tag: 'Bunker',
+  },
 ];
 
 const ICON_CLS = {
@@ -33,26 +75,32 @@ export function KnowledgeFeed() {
         </Link>
       </div>
 
-      {ARTICLES.map((row, i) => (
-        <div
-          key={i}
-          className="grid items-center py-3.5 px-1 border-b border-slate-100 last:border-b-0 hover:bg-slate-50/50 transition-colors cursor-pointer"
-          style={{ gridTemplateColumns: '28px 1fr auto 16px', gap: '14px' }}
-        >
-          <span
-            className={`w-7 h-7 rounded-lg flex items-center justify-center text-xs font-mono flex-shrink-0 ${
-              ICON_CLS[row.iconVariant ?? 'default']
-            }`}
+      <div className="overflow-y-auto max-h-[340px]">
+        {ARTICLES.map((row, i) => (
+          <div
+            key={i}
+            className="grid items-center py-3 px-1 border-b border-slate-100 last:border-b-0 hover:bg-slate-50/50 transition-colors cursor-pointer"
+            style={{ gridTemplateColumns: '28px 1fr auto', gap: '12px' }}
           >
-            {row.icon}
-          </span>
-          <p className="text-[14.5px] text-slate-900 tracking-tight leading-snug">{row.title}</p>
-          <span className="font-mono text-[10.5px] tracking-[0.08em] uppercase text-slate-500 rounded-full px-2 py-1 bg-slate-100 whitespace-nowrap">
-            {row.tag}
-          </span>
-          <span className="text-slate-400 font-mono text-sm">→</span>
-        </div>
-      ))}
+            <span
+              className={`w-7 h-7 rounded-lg flex items-center justify-center text-xs font-mono flex-shrink-0 ${
+                ICON_CLS[row.iconVariant ?? 'default']
+              }`}
+            >
+              {row.icon}
+            </span>
+            <div className="min-w-0">
+              <p className="text-[13.5px] text-slate-900 tracking-tight leading-snug truncate">{row.title}</p>
+              <p className="font-mono text-[10.5px] text-slate-400 mt-0.5">
+                {row.source} · {row.date}
+              </p>
+            </div>
+            <span className="font-mono text-[10px] tracking-[0.06em] uppercase text-slate-500 rounded-full px-2 py-1 bg-slate-100 whitespace-nowrap flex-shrink-0">
+              {row.tag}
+            </span>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- **#496**: Added VLSFO, MGO (Rotterdam bunker) and EUA (carbon allowance spot) KPI tiles to the /market page, alongside existing BDI/BCI/BSI/BHSI Baltic tiles. New endpoints: `GET /api/market/bunker-kpi?grade=VLSFO|MGO` and `GET /api/market/eua-kpi`. Data sourced from existing `bunker_prices` (NLRTM, migration 023) and `eua_prices` (migration 024) tables.
- **#497**: Updated `KnowledgeFeed` with `source` + `date` fields per card, IMSBC/IGC/port DA specific articles, and a scrollable container (`max-h-[340px] overflow-y-auto`).

## Files changed
- `app/api/market/bunker-kpi/route.ts` — new endpoint (VLSFO/MGO, 400/404 guards)
- `app/api/market/eua-kpi/route.ts` — new endpoint (EUA spot, 404 guard)
- `app/market/page.tsx` — split KPI tiles into Baltic (4) + Commodity (3) rows
- `components/market/KnowledgeFeed.tsx` — source+date fields, 6 IMSBC/IGC/DA articles, scrollable

## Test plan
- [x] `__tests__/api/market-bunker-kpi.test.ts` — 6 behavioral tests (400/404/200/grade normalization)
- [x] `__tests__/api/market-eua-kpi.test.ts` — 3 behavioral tests (404/200/most-recent row)
- [x] Existing `market-page` and `market-baltic-kpi` tests: 9/9 green
- [ ] Visual: `/market` shows 7 KPI tiles (4 Baltic + 3 commodity) + Knowledge feed with source/date

Closes #496
Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)