### PR TITLE
fix(login): #500 bare layout + #501 nav hidden + #502 Maritime Deep button

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -162,6 +162,23 @@ describe('middleware auth guard', () => {
     });
   });
 
+  describe('x-pathname header on passthrough', () => {
+    it('sets x-pathname on /login bypass passthrough', async () => {
+      const req = makeReq('/login');
+      const res = await runMiddleware(req);
+      expect(res.status).not.toBe(302);
+      expect(res.headers.get('x-pathname')).toBe('/login');
+    });
+
+    it('sets x-pathname on authenticated page passthrough', async () => {
+      const cookie = await makeValidCookie();
+      const req = makeReq('/dashboard', cookie);
+      const res = await runMiddleware(req);
+      expect(res.status).not.toBe(302);
+      expect(res.headers.get('x-pathname')).toBe('/dashboard');
+    });
+  });
+
   describe('/processing guard — csrf_token required', () => {
     it('redirects demo_auth user to / when no csrf_token cookie', async () => {
       const cookie = await makeValidCookie();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { Inter } from 'next/font/google';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { getTrialState, daysRemaining, isExpired } from '@/lib/trial';
 import { TrialBanner } from '@/components/onboarding/TrialBanner';
 import { getAuthConfig } from '@/lib/auth/config';
@@ -74,6 +74,8 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const cookieStore = await cookies();
+  const headersList = await headers();
+  const currentPath = headersList.get('x-pathname') ?? '';
   const authConfig = getAuthConfig();
 
   // Check if user is authenticated to decide whether to wrap with AppShell
@@ -97,7 +99,7 @@ export default async function RootLayout({
   // content (EmailBodyViewer derives dir from the body via detectTextDirection).
   // Browser Accept-Language used to leak ru/de/he into <html> and broke
   // mixed-locale demo scenarios — see stab/rtl-per-content.
-  if (!isAuthenticated) {
+  if (!isAuthenticated || currentPath === '/login') {
     return (
       <html lang="en" dir="ltr" suppressHydrationWarning>
         <head>

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,21 +1,5 @@
 import type { ReactNode } from 'react';
 
-/**
- * Minimal layout for /login — isolates from the main app layout.
- * No header, no nav, no providers that depend on session state.
- */
 export default function LoginLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en">
-      <body
-        style={{
-          margin: 0,
-          fontFamily: 'system-ui, -apple-system, sans-serif',
-          background: '#f8fafc',
-        }}
-      >
-        {children}
-      </body>
-    </html>
-  );
+  return <>{children}</>;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -108,8 +108,8 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
             style={{
               width: '100%',
               padding: '0.7rem',
-              background: '#2563eb',
-              color: '#fff',
+              background: 'var(--ds-accent)',
+              color: 'var(--ds-accent-fg)',
               border: 'none',
               borderRadius: '8px',
               fontWeight: 600,

--- a/middleware.ts
+++ b/middleware.ts
@@ -121,6 +121,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     const response = NextResponse.next();
     response.headers.set('X-RateLimit-Remaining', String(remaining));
     response.headers.set('X-RateLimit-Limit', '20');
+    response.headers.set('x-pathname', pathname);
     return response;
   }
 
@@ -133,7 +134,9 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     }
   }
 
-  return NextResponse.next();
+  const response = NextResponse.next();
+  response.headers.set('x-pathname', pathname);
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

- **#500**: `/login` was rendering full AppShell (TopNav, ModeSwitcher, Bell) because `isAuthenticated = !authConfig.enabled` — in demo mode this was always `true`. Fix: middleware injects `x-pathname` header; root layout reads it and skips AppShell for `/login` regardless of auth state. Also removed invalid `<html><body>` tags from `app/login/layout.tsx` (nested html elements in non-root layout).
- **#501**: Automatically fixed by #500 — TopNav is no longer rendered on `/login`. (Active-state logic `pathname.startsWith(href+'/')` was already correct; Cargo was appearing because AppShell showed at all.)
- **#502**: Sign in CTA button now uses `var(--ds-accent)` (Maritime Deep navy `#0f172a`) + `var(--ds-accent-fg)` (amber `#fbbf24`) instead of hardcoded generic blue `#2563eb`.

## Files changed

| File | Change |
|---|---|
| `middleware.ts` | Add `x-pathname` header on all `NextResponse.next()` returns |
| `app/layout.tsx` | Import `headers`; skip AppShell when `currentPath === '/login'` |
| `app/login/layout.tsx` | Remove invalid `<html><body>` tags → simple passthrough |
| `app/login/page.tsx` | Button: `#2563eb` → `var(--ds-accent)` / `var(--ds-accent-fg)` |
| `__tests__/middleware-auth.test.ts` | +2 behavioral tests for `x-pathname` header |

## Test plan

- [x] `npx jest middleware-auth` — 35/35 pass (+2 new `x-pathname` header tests)
- [ ] Visit `/login` — should show bare centered form, no TopNav/Bell/ModeSwitcher
- [ ] Sign in button should appear navy with amber text (Maritime Deep)
- [ ] Authenticated user visiting `/login` should also see bare form (not AppShell)

Closes #500, Closes #501, Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)