### PR TITLE
fix(rsc): #517 Suspense stuck on hard nav — cookies() outside Suspense

### DIFF
--- a/__tests__/rsc-streaming-suspense.test.ts
+++ b/__tests__/rsc-streaming-suspense.test.ts
@@ -1,11 +1,15 @@
 /**
- * Regression: #450 — /matches and /dashboard RSC streaming skeleton forever.
+ * Regression: #450 + #517 — RSC streaming skeleton forever on hard navigation.
  *
- * Verifies that components using useSearchParams() are wrapped in <Suspense>,
- * and that async RSC components in the layout are wrapped in <Suspense>.
+ * #450: MatchesClient uses useSearchParams() → must be wrapped in <Suspense>.
+ * #517: TrialBannerWrapper called cookies() inside <Suspense> in the root layout.
+ *       Calling a dynamic Next.js function (cookies/headers) inside a Suspense
+ *       boundary caused the streaming response to stall on hard nav — all
+ *       authenticated pages showed an empty body.innerText after 8+ seconds.
  *
- * Without these boundaries, Next.js 16 bails out to CSR and the loading.tsx
- * skeleton never resolves.
+ * Fix: TrialBannerWrapper now receives sessionId as a prop (resolved in the
+ * layout's own await cookies() call) so no dynamic function is called inside
+ * the Suspense boundary.
  */
 
 import * as fs from 'fs';
@@ -17,7 +21,7 @@ function read(relPath: string): string {
   return fs.readFileSync(path.join(ROOT, relPath), 'utf8');
 }
 
-describe('RSC streaming Suspense boundaries — regression #450', () => {
+describe('RSC streaming Suspense boundaries — regression #450 + #517', () => {
   describe('app/matches/page.tsx', () => {
     let src: string;
     beforeAll(() => { src = read('app/matches/page.tsx'); });
@@ -49,7 +53,6 @@ describe('RSC streaming Suspense boundaries — regression #450', () => {
     });
 
     it('wraps TrialBannerWrapper in <Suspense>', () => {
-      // Find the <Suspense ...> that immediately wraps <TrialBannerWrapper />
       const trialIdx = src.indexOf('<TrialBannerWrapper');
       expect(trialIdx).toBeGreaterThan(-1);
 
@@ -58,9 +61,60 @@ describe('RSC streaming Suspense boundaries — regression #450', () => {
       const lastSuspenseOpen = before.lastIndexOf('<Suspense');
       expect(lastSuspenseOpen).toBeGreaterThan(-1);
 
-      // <TrialBannerWrapper /> must be followed by </Suspense>
+      // <TrialBannerWrapper .../> must be followed by </Suspense>
       const after = src.slice(trialIdx);
-      expect(after).toMatch(/<TrialBannerWrapper\s*\/>[\s\S]*?<\/Suspense>/);
+      expect(after).toMatch(/<TrialBannerWrapper[^/].*\/>[\s\S]*?<\/Suspense>/);
+    });
+
+    it('passes sessionId as prop to TrialBannerWrapper (#517)', () => {
+      // TrialBannerWrapper must receive sessionId prop — not call cookies() itself
+      expect(src).toMatch(/<TrialBannerWrapper\s+sessionId=/);
+    });
+  });
+
+  describe('TrialBannerWrapper — #517 fix: no cookies() inside Suspense', () => {
+    let src: string;
+    beforeAll(() => { src = read('app/layout.tsx'); });
+
+    it('TrialBannerWrapper function does not call cookies() (#517)', () => {
+      // Extract the TrialBannerWrapper function body
+      const fnStart = src.indexOf('async function TrialBannerWrapper(');
+      expect(fnStart).toBeGreaterThan(-1);
+
+      // Find the closing brace of the function
+      // Walk chars counting braces from the opening {
+      let depth = 0;
+      let bodyStart = -1;
+      let fnEnd = -1;
+      for (let i = fnStart; i < src.length; i++) {
+        if (src[i] === '{') {
+          depth++;
+          if (depth === 1) bodyStart = i;
+        } else if (src[i] === '}') {
+          depth--;
+          if (depth === 0) { fnEnd = i; break; }
+        }
+      }
+      expect(bodyStart).toBeGreaterThan(-1);
+      expect(fnEnd).toBeGreaterThan(-1);
+
+      const fnBody = src.slice(bodyStart, fnEnd + 1);
+      // cookies() must NOT be called inside TrialBannerWrapper
+      expect(fnBody).not.toMatch(/\bcookies\s*\(/);
+    });
+
+    it('TrialBannerWrapper accepts sessionId parameter (#517)', () => {
+      expect(src).toMatch(/async function TrialBannerWrapper\s*\(\s*\{[^}]*sessionId/);
+    });
+
+    it('layout resolves sessionId from cookieStore before the Suspense (#517)', () => {
+      // sessionId must be derived from cookieStore.get('session_id') BEFORE the
+      // <Suspense>/<TrialBannerWrapper> render, ensuring no dynamic call inside Suspense
+      const sessionIdIdx = src.indexOf("cookieStore.get('session_id')");
+      const trialWrapperIdx = src.indexOf('<TrialBannerWrapper');
+      expect(sessionIdIdx).toBeGreaterThan(-1);
+      expect(trialWrapperIdx).toBeGreaterThan(-1);
+      expect(sessionIdIdx).toBeLessThan(trialWrapperIdx);
     });
   });
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,12 +21,8 @@ export const metadata: Metadata = {
   description: 'See how AI handles your freight email in 2 minutes',
 };
 
-async function TrialBannerWrapper() {
+async function TrialBannerWrapper({ sessionId }: { sessionId: string }) {
   try {
-    const cookieStore = await cookies();
-    const sessionId = cookieStore.get('session_id')?.value;
-    if (!sessionId) return null;
-
     const trial = await getTrialState(sessionId);
     if (!trial) return null;
 
@@ -112,6 +108,8 @@ export default async function RootLayout({
     );
   }
 
+  const sessionId = cookieStore.get('session_id')?.value;
+
   // Resolve preferred_mode: cookie fast-path first, then DB
   let initialMode: Mode = 'charterer';
   const modeCookie = cookieStore.get('preferred_mode')?.value;
@@ -135,9 +133,11 @@ export default async function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />
       </head>
       <body className={inter.className}>
-        <Suspense fallback={null}>
-          <TrialBannerWrapper />
-        </Suspense>
+        {sessionId && (
+          <Suspense fallback={null}>
+            <TrialBannerWrapper sessionId={sessionId} />
+          </Suspense>
+        )}
         <ModeProvider initial={initialMode}>
           <AppShell>{children}</AppShell>
         </ModeProvider>


### PR DESCRIPTION
Closes #517. Root cause: TrialBannerWrapper called cookies() inside Suspense boundary in root layout — Next.js 16 stalls RSC streaming. Fix: hoist cookies() to layout level, pass sessionId as prop. 10/10 tests green.