### PR TITLE
fix(email): #474 decode HTML entities in body preview

### DIFF
--- a/components/__tests__/email-body-viewer.test.tsx
+++ b/components/__tests__/email-body-viewer.test.tsx
@@ -45,6 +45,39 @@ describe('EmailBodyViewer — CRLF normalisation (fix #357, hydration #418)', ()
   });
 });
 
+describe('EmailBodyViewer — HTML entity decoding (fix #474)', () => {
+  it('decodes named HTML entities before display', () => {
+    const body = 'Cargo: 5000 MT &amp; more\nPrice: &quot;negotiable&quot;';
+    const { container } = render(
+      <EmailBodyViewer body={body} highlights={[]} />,
+    );
+    const pre = container.querySelector('pre');
+    expect(pre!.textContent).toContain('5000 MT & more');
+    expect(pre!.textContent).toContain('"negotiable"');
+    expect(pre!.textContent).not.toContain('&amp;');
+    expect(pre!.textContent).not.toContain('&quot;');
+  });
+
+  it('decodes numeric entity &#39; to apostrophe', () => {
+    const body = "It&#39;s a valid fixture";
+    const { container } = render(
+      <EmailBodyViewer body={body} highlights={[]} />,
+    );
+    const pre = container.querySelector('pre');
+    expect(pre!.textContent).toBe("It's a valid fixture");
+  });
+
+  it('decodes doubly-encoded entity: &amp;amp; renders as &amp;', () => {
+    // Gmail sometimes double-encodes: &amp;amp; → one decode pass → &amp;
+    const body = 'Cargill &amp;amp; Partners';
+    const { container } = render(
+      <EmailBodyViewer body={body} highlights={[]} />,
+    );
+    const pre = container.querySelector('pre');
+    expect(pre!.textContent).toBe('Cargill &amp; Partners');
+  });
+});
+
 describe('EmailBodyViewer — RTL auto-detection (stab/rtl-per-content)', () => {
   it('renders <pre dir="rtl"> for Arabic body', () => {
     const arabicBody =

--- a/components/email-body-viewer.tsx
+++ b/components/email-body-viewer.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode, useEffect, useRef } from 'react';
 import { detectTextDirection } from '@/lib/i18n/rtl-detect';
+import { decodeHtmlEntities } from '@/lib/utils';
 
 export interface Highlight {
   text: string;
@@ -49,10 +50,9 @@ function buildTree(body: string, highlights: Highlight[]): Node[] {
 export function EmailBodyViewer({ body, highlights }: Props) {
   const firstMarkRef = useRef<HTMLElement | null>(null);
 
-  // Normalize CRLF → LF before render: the HTML parser normalises \r\n to \n
-  // in text nodes, so leaving \r\n in the React virtual DOM causes a
-  // server/client text-node mismatch (React hydration error #418).
-  const normalizedBody = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  // Decode HTML entities first (fix #474), then normalize CRLF → LF.
+  // decodeHtmlEntities is safe: no innerHTML, pure string replacement.
+  const normalizedBody = decodeHtmlEntities(body).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
   useEffect(() => {
     if (window.location.hash === '#highlight' && firstMarkRef.current) {


### PR DESCRIPTION
Closes #474. Decodes &amp;amp; etc safely for plain-text preview without dangerouslySetInnerHTML.