### PR TITLE
fix(matches): #528 add TCE sort option

### DIFF
--- a/__tests__/matches-sort.test.tsx
+++ b/__tests__/matches-sort.test.tsx
@@ -88,4 +88,28 @@ describe('MatchesClient.tsx — sort controls (#350)', () => {
     // Must have .sort in this block
     expect(filteredBlock).toMatch(/\.sort\s*\(/);
   });
+
+  it('sort dropdown includes TCE option unconditionally (#528)', () => {
+    const src = readSource();
+    // TCE option must exist
+    expect(src).toMatch(/value="tce"/);
+    // Must NOT be gated behind isOwner
+    expect(src).not.toMatch(/isOwner\s*&&\s*<option[^>]*value="tce"/);
+  });
+
+  it('sort by tce uses tce_usd_per_day descending comparator (#528)', () => {
+    const src = readSource();
+    // Comparator must sort by tce_usd_per_day numerically descending
+    expect(src).toMatch(/sortBy\s*===\s*['"]tce['"]/);
+    expect(src).toMatch(/tce_usd_per_day/);
+    // b - a order means descending
+    expect(src).toMatch(/b\.tce_usd_per_day.*-.*a\.tce_usd_per_day|b\.tce_usd_per_day.*a\.tce_usd_per_day/);
+  });
+
+  it('sort dropdown has data-testid on all 3 options (#528)', () => {
+    const src = readSource();
+    expect(src).toMatch(/data-testid="sort-score"/);
+    expect(src).toMatch(/data-testid="sort-freshness"/);
+    expect(src).toMatch(/data-testid="sort-tce"/);
+  });
 });

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -371,7 +371,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
               >
                 <option data-testid="sort-score" value="score">Score</option>
                 <option data-testid="sort-freshness" value="freshness">Freshness</option>
-                {isOwner && <option value="tce">TCE/day</option>}
+                <option data-testid="sort-tce" value="tce">TCE/day</option>
               </select>
             </div>
 


### PR DESCRIPTION
Closes #528. /matches Sort dropdown now has Score / Freshness / TCE.