### PR TITLE
fix(market): #544 BDI history panel — regression test

### DIFF
--- a/__tests__/components/market/MetricHistoryPanel.test.tsx
+++ b/__tests__/components/market/MetricHistoryPanel.test.tsx
@@ -58,6 +58,8 @@ describe('MetricHistoryPanel — #529 panel visible + chart', () => {
     });
 
     expect(global.fetch).toHaveBeenCalledWith('/api/market/indices?name=bdi&days=30');
+    // #544: when API returns rows, panel must NOT show "No data available"
+    expect(screen.queryByText('No data available')).not.toBeInTheDocument();
   });
 
   it('calls onClose when close button is clicked', () => {


### PR DESCRIPTION
Closes #544

Subagent confirmed: underlying API fix landed in #549 (W-A market wave). Issue was OPEN due to PR body literal-newline bug (Closes #545 #544 #487 не parsed). Added explicit regression test `expect(screen.queryByText(No data available)).not.toBeInTheDocument()` to MetricHistoryPanel.test.tsx (19/19 green).

auto-merge when CI green.