### PR TITLE
fix(auth): #559 #560 protected redirect + auth landing

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -112,12 +112,12 @@ describe('middleware auth guard', () => {
   });
 
   describe('protected routes with valid auth cookie', () => {
-    it('passes through / with valid cookie', async () => {
+    it('redirects / to /dashboard with valid cookie (#560)', async () => {
       const cookie = await makeValidCookie();
       const req = makeReq('/', cookie);
       const res = await runMiddleware(req);
-      // Should not redirect to login
-      expect(res.status).not.toBe(302);
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/dashboard');
     });
 
     it('passes through /api/ai/match with valid cookie (CSRF check will follow)', async () => {
@@ -126,6 +126,33 @@ describe('middleware auth guard', () => {
       const req = makeReq('/dashboard', cookie);
       const res = await runMiddleware(req);
       expect(res.status).not.toBe(302);
+    });
+
+    it('passes through /matches with valid cookie (session_id check is page-level)', async () => {
+      const cookie = await makeValidCookie();
+      const req = makeReq('/matches', cookie);
+      const res = await runMiddleware(req);
+      expect(res.status).not.toBe(302);
+    });
+  });
+
+  describe('acceptance criteria for #559 and #560', () => {
+    it('#559 — GET /matches without auth cookie redirects to /login (NOT /)', async () => {
+      const req = makeReq('/matches');
+      const res = await runMiddleware(req);
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toContain('/login');
+      expect(location).not.toBe('http://localhost/');
+    });
+
+    it('#560 — GET / with valid session redirects to /dashboard (NOT public landing)', async () => {
+      const cookie = await makeValidCookie();
+      const req = makeReq('/', cookie);
+      const res = await runMiddleware(req);
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toContain('/dashboard');
     });
   });
 

--- a/app/cargo/page.tsx
+++ b/app/cargo/page.tsx
@@ -29,9 +29,9 @@ function fmtWeight(mt: number | null): string | null {
 export default async function CargoPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
-  if (!sessionId) redirect('/');
+  if (!sessionId) redirect('/dashboard');
   const session = getSession(sessionId);
-  if (!session) redirect('/');
+  if (!session) redirect('/dashboard');
 
   const rows: CargoRow[] = session.parsedCargos.map((cargo) => {
     const email = session.emails.find((e) => e.id === cargo.emailId);

--- a/app/email/page.tsx
+++ b/app/email/page.tsx
@@ -43,9 +43,9 @@ const CATEGORY_COLORS: Record<EmailCategory, string> = {
 export default async function EmailInboxPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
-  if (!sessionId) redirect('/');
+  if (!sessionId) redirect('/dashboard');
   const session = getSession(sessionId);
-  if (!session) redirect('/');
+  if (!session) redirect('/dashboard');
 
   const { emails, processedEmails } = session;
 

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -26,9 +26,9 @@ export default async function MatchDetailPage({ params }: Props) {
 
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
-  if (!sessionId) redirect('/');
+  if (!sessionId) redirect('/dashboard');
   const session = getSession(sessionId);
-  if (!session) redirect('/');
+  if (!session) redirect('/dashboard');
 
   if (isNaN(dbId) || dbId < 1) notFound();
 

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -16,11 +16,11 @@ export const metadata: Metadata = {
 export default async function MatchesPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
-  if (!sessionId) redirect('/');
+  if (!sessionId) redirect('/dashboard');
   const session = getSession(sessionId);
-  if (!session) redirect('/');
+  if (!session) redirect('/dashboard');
 
-  if (process.env.MATCHES_ENABLED !== "true" && !session.isSampleData) redirect('/');
+  if (process.env.MATCHES_ENABLED !== "true" && !session.isSampleData) redirect('/dashboard');
 
   const db = getStore().getDatabase();
 

--- a/app/recap/page.tsx
+++ b/app/recap/page.tsx
@@ -13,9 +13,9 @@ export const metadata: Metadata = {
 export default async function RecapIndexPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
-  if (!sessionId) redirect('/');
+  if (!sessionId) redirect('/dashboard');
   const session = getSession(sessionId);
-  if (!session) redirect('/');
+  if (!session) redirect('/dashboard');
 
   const { recaps, emails, parsedCargos, parsedVessels } = session;
 

--- a/app/vessels/page.tsx
+++ b/app/vessels/page.tsx
@@ -30,9 +30,9 @@ function fmtDwt(dwt: number | null): string | null {
 export default async function VesselsPage() {
   const cookieStore = await cookies();
   const sessionId = cookieStore.get('session_id')?.value;
-  if (!sessionId) redirect('/');
+  if (!sessionId) redirect('/dashboard');
   const session = getSession(sessionId);
-  if (!session) redirect('/');
+  if (!session) redirect('/dashboard');
 
   const rows: VesselRow[] = session.parsedVessels.map((vessel) => {
     const email = session.emails.find((e) => e.id === vessel.emailId);

--- a/middleware.ts
+++ b/middleware.ts
@@ -82,6 +82,11 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
       return NextResponse.redirect(loginUrl, { status: 302 });
     }
 
+    // Authenticated users on the public landing page belong on /dashboard (#560)
+    if (pathname === '/') {
+      return NextResponse.redirect(new URL('/dashboard', getRequestBaseUrl(request)), { status: 302 });
+    }
+
     // /processing requires a csrf_token cookie (set by Google OAuth or /api/sample).
     // Demo-auth-only users navigating here directly have no session or CSRF token,
     // so the pipeline would immediately 403 on all API calls. Redirect to upload CTA instead.


### PR DESCRIPTION
## Summary

- **#559** — protected pages (`/matches`, `/cargo`, `/email`, `/vessels`, `/recap`, `/match/[id]`) redirect to `/dashboard` instead of `/` when `session_id` cookie is absent (authenticated user with no sample data)
- **#560** — authenticated users hitting `/` are now redirected to `/dashboard` via middleware, eliminating the confusing authenticated-AppShell-over-public-landing state

## Changes

| File | Change |
|------|--------|
| `middleware.ts` | Add: if `payload` (authenticated) and `pathname === '/'` → 302 to `/dashboard` |
| `app/matches/page.tsx` | `redirect('/')` → `redirect('/dashboard')` (3 occurrences incl. `MATCHES_ENABLED` guard) |
| `app/cargo/page.tsx` | Same |
| `app/email/page.tsx` | Same |
| `app/vessels/page.tsx` | Same |
| `app/recap/page.tsx` | Same |
| `app/match/[id]/page.tsx` | Same |
| `__tests__/middleware-auth.test.ts` | Update passthrough test + add explicit acceptance tests for #559 and #560 |

## Acceptance criteria

| Issue | Criterion | Status | Evidence |
|-------|-----------|--------|----------|
| #559 | GET /matches without auth cookie → 302 to /login (NOT /) | ✓ | middleware-auth.test.ts "#559 — GET /matches without auth cookie redirects to /login" |
| #559 | Authenticated user on /matches without session_id → /dashboard (NOT /) | ✓ | app/matches/page.tsx:19 redirect('/dashboard') |
| #560 | GET / with valid session → 302 to /dashboard | ✓ | middleware-auth.test.ts "#560 — GET / with valid session redirects to /dashboard" + middleware.ts |

## Test plan

- [x] npx jest --findRelatedTests middleware.ts __tests__/middleware-auth.test.ts — 55/55 passed
- [x] git status --porcelain — clean

Closes #559
Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)