### PR TITLE
fix(market): #567 Baltic refresh real root-cause — scrapers replaced + cron added

### DIFF
--- a/lib/knowledge/bootstrap.ts
+++ b/lib/knowledge/bootstrap.ts
@@ -179,10 +179,10 @@ export const KNOWLEDGE_REGISTRY: RegisterSourceInput[] = [
   // === Market indices ===
   {
     slug: 'market-bdi',
-    name: 'Baltic Dry Index (stooq.com CSV)',
+    name: 'Baltic Dry Index (handybulk.com daily summary)',
     kind: 'structured_rows',
     category: 'market',
-    source_url: 'https://stooq.com/q/d/l/?s=bdi&i=d',
+    source_url: 'https://www.handybulk.com/baltic-dry-index/',
     license: 'Public scrape (fair use)',
     refresh_mode: 'auto-daily',
     stale_threshold_days: 3,
@@ -191,10 +191,10 @@ export const KNOWLEDGE_REGISTRY: RegisterSourceInput[] = [
   },
   {
     slug: 'market-bhsi',
-    name: 'Baltic Handysize Index (handybulk.com)',
+    name: 'Baltic Handysize Index (handybulk.com daily summary)',
     kind: 'structured_rows',
     category: 'market',
-    source_url: 'https://www.handybulk.com/',
+    source_url: 'https://www.handybulk.com/baltic-dry-index/',
     license: 'Public scrape (fair use)',
     refresh_mode: 'auto-daily',
     stale_threshold_days: 3,

--- a/lib/market/__tests__/bdi-adapter.test.ts
+++ b/lib/market/__tests__/bdi-adapter.test.ts
@@ -1,13 +1,14 @@
 /**
  * Behavioral tests for lib/market/bdi-adapter.ts
  *
- * PI2: calls parseBdiCsv() with real CSV input (not string-match only).
- * Uses inline fixture CSV that mirrors stooq.com format.
+ * PI2: calls parseBdiCsv() / parseBdiHtml() with real input (not string-match only).
+ * parseBdiCsv tests use inline CSV (stooq legacy path, kept for coverage).
+ * parseBdiHtml + refreshBdi tests use FIXTURE_HTML mirroring handybulk.com format.
  */
 
 import Database from 'better-sqlite3';
 import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
-import { parseBdiCsv, refreshBdi, BdiStructureChangedError } from '../bdi-adapter';
+import { parseBdiCsv, parseBdiHtml, refreshBdi, BdiStructureChangedError } from '../bdi-adapter';
 import { getLatestBalticIndex } from '../baltic-repository';
 
 const FIXTURE_CSV = [
@@ -15,6 +16,15 @@ const FIXTURE_CSV = [
   '2026-05-26,1440,1465,1425,1455,0',
   '2026-05-23,1410,1445,1405,1440,0',
 ].join('\n');
+
+// Mirrors handybulk.com/baltic-dry-index/ paragraph format. Value 1,455 / 2026-05-26
+// matches the expectations carried over from FIXTURE_CSV so no assertion changes needed.
+const FIXTURE_HTML = `<div>
+  <p>26-May-2026</p>
+  <div><p>The Baltic Dry Index (BDI) increased by 15 points to reach 1,455 points. The Baltic Handysize Index (BHSI) decreased by 2 points to 530 points.</p></div>
+  <p>23-May-2026</p>
+  <div><p>The Baltic Dry Index (BDI) decreased by 25 points to reach 1,440 points.</p></div>
+</div>`;
 
 function makeDb(): Database.Database {
   const db = new Database(':memory:');
@@ -61,10 +71,37 @@ describe('parseBdiCsv', () => {
   });
 });
 
+describe('parseBdiHtml', () => {
+  it('parses BDI value from fixture HTML (PI2: real parser call)', () => {
+    const result = parseBdiHtml(FIXTURE_HTML);
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe(1455);
+  });
+
+  it('parses ISO date from DD-Month-YYYY header', () => {
+    const result = parseBdiHtml(FIXTURE_HTML);
+    expect(result!.date).toBe('2026-05-26');
+  });
+
+  it('returns null for empty string (boundary: empty)', () => {
+    expect(parseBdiHtml('')).toBeNull();
+  });
+
+  it('returns null when no BDI paragraph is present', () => {
+    expect(parseBdiHtml('<p>26-May-2026</p><p>No shipping data here.</p>')).toBeNull();
+  });
+
+  it('returns null when there is no date entry', () => {
+    expect(
+      parseBdiHtml('The Baltic Dry Index (BDI) rose to 2,991 points.'),
+    ).toBeNull();
+  });
+});
+
 describe('refreshBdi (PI2: real DB upsert)', () => {
   it('upserts BDI row into baltic_indices', async () => {
     const db = makeDb();
-    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_CSV);
+    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_HTML);
 
     await refreshBdi(db, fakeFetcher);
 
@@ -79,7 +116,7 @@ describe('refreshBdi (PI2: real DB upsert)', () => {
 
   it('is idempotent — second call with same date does not duplicate', async () => {
     const db = makeDb();
-    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_CSV);
+    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_HTML);
 
     await refreshBdi(db, fakeFetcher);
     await refreshBdi(db, fakeFetcher);
@@ -94,11 +131,9 @@ describe('refreshBdi (PI2: real DB upsert)', () => {
     db.close();
   });
 
-  it('throws BdiStructureChangedError when CSV has only a header row', async () => {
+  it('throws BdiStructureChangedError when HTML contains no BDI entry', async () => {
     const db = makeDb();
-    const fakeFetcher = jest
-      .fn()
-      .mockResolvedValue('Date,Open,High,Low,Close,Volume\n');
+    const fakeFetcher = jest.fn().mockResolvedValue('<html><body>no data</body></html>');
 
     await expect(refreshBdi(db, fakeFetcher)).rejects.toThrow(BdiStructureChangedError);
 

--- a/lib/market/__tests__/bhsi-adapter.test.ts
+++ b/lib/market/__tests__/bhsi-adapter.test.ts
@@ -2,7 +2,7 @@
  * Behavioral tests for lib/market/bhsi-adapter.ts
  *
  * PI2: calls parseBhsiHtml() with real HTML input (not string-match only).
- * Uses fixture HTML that mirrors the expected handybulk.com table structure.
+ * Uses fixture HTML that mirrors handybulk.com/baltic-dry-index/ paragraph format.
  */
 
 import * as fs from 'fs';
@@ -33,7 +33,7 @@ describe('parseBhsiHtml', () => {
     expect(result!.value).toBe(530);
   });
 
-  it('parses date from DD/MM/YYYY format', () => {
+  it('parses date from DD-Month-YYYY format', () => {
     const result = parseBhsiHtml(FIXTURE_HTML);
     expect(result!.date).toBe('2026-05-22');
   });
@@ -55,13 +55,14 @@ describe('parseBhsiHtml', () => {
 
   it('parses comma-formatted value', () => {
     const html =
-      '<table><tr><td>BHSI</td><td>1,234</td><td>22/05/2026</td></tr></table>';
+      '<p>The Baltic Handysize Index (BHSI) increased by 10 points to 1,234 points.</p>';
     const result = parseBhsiHtml(html);
     expect(result!.value).toBe(1234);
   });
 
-  it('falls back to today when date column absent', () => {
-    const html = '<table><tr><td>BHSI</td><td>530</td></tr></table>';
+  it('falls back to today when no date entry precedes BHSI value', () => {
+    const html =
+      '<p>The Baltic Handysize Index (BHSI) decreased by 5 points to 530 points.</p>';
     const result = parseBhsiHtml(html);
     expect(result).not.toBeNull();
     expect(result!.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);

--- a/lib/market/__tests__/fixtures/handybulk-bhsi.html
+++ b/lib/market/__tests__/fixtures/handybulk-bhsi.html
@@ -2,42 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Handybulk Shipping – Market Data</title>
+  <title>Baltic Dry Index | HandyBulk</title>
 </head>
 <body>
-  <header>
-    <nav><a href="/">Home</a></nav>
-  </header>
-  <main>
-    <section class="market-data-section">
-      <h2>Baltic Exchange Indices</h2>
-      <table class="indices-table">
-        <thead>
-          <tr>
-            <th>Index</th>
-            <th>Points</th>
-            <th>Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>BDI</td>
-            <td>1,456</td>
-            <td>22/05/2026</td>
-          </tr>
-          <tr>
-            <td>BHSI</td>
-            <td>530</td>
-            <td>22/05/2026</td>
-          </tr>
-          <tr>
-            <td>BSI</td>
-            <td>962</td>
-            <td>22/05/2026</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-  </main>
+<div class="entry-content">
+  <p>22-May-2026</p>
+  <div>
+    <p>The Baltic Dry Index (BDI) increased by 27 points to reach 1,456 points. The Baltic Capesize Index (BCI) increased by 120 points to 4,954 points. The Baltic Supramax Index (BSI) decreased by 4 points to 962 points. The Baltic Handysize Index (BHSI) decreased by 3 points to 530 points.</p>
+  </div>
+
+  <p>21-May-2026</p>
+  <div>
+    <p>The Baltic Dry Index (BDI) decreased by 41 points to reach 1,429 points. The Baltic Handysize Index (BHSI) decreased by 2 points to 532 points.</p>
+  </div>
+</div>
 </body>
 </html>

--- a/lib/market/bdi-adapter.ts
+++ b/lib/market/bdi-adapter.ts
@@ -1,8 +1,18 @@
 import type Database from 'better-sqlite3';
 import { upsertBalticIndex } from './baltic-repository';
 
-// stooq.com free CSV endpoint for Baltic Dry Index (BDI), newest row first.
+// stooq.com is now API-key-gated; HANDYBULK_BDI_URL is the active source.
+// Kept for backward-compat (existing unit tests still cover the CSV path).
 export const STOOQ_BDI_URL = 'https://stooq.com/q/d/l/?s=bdi&i=d';
+
+// handybulk.com/baltic-dry-index/ — daily BDI summaries in paragraph format.
+export const HANDYBULK_BDI_URL = 'https://www.handybulk.com/baltic-dry-index/';
+
+const MONTH_MAP: Record<string, string> = {
+  january: '01', february: '02', march: '03', april: '04',
+  may: '05', june: '06', july: '07', august: '08',
+  september: '09', october: '10', november: '11', december: '12',
+};
 
 export class BdiStructureChangedError extends Error {
   constructor(msg: string) {
@@ -12,9 +22,8 @@ export class BdiStructureChangedError extends Error {
 }
 
 /**
- * Parses BDI value and date from a stooq.com CSV string.
- * Expected header: Date,Open,High,Low,Close,Volume (newest row first).
- * Returns null if the structure has changed or no rows are present.
+ * @deprecated stooq.com now requires an API key. Use parseBdiHtml() instead.
+ * Kept exported so existing tests continue to cover the CSV path.
  */
 export function parseBdiCsv(csv: string): { value: number; date: string } | null {
   const lines = csv.trim().split('\n');
@@ -37,27 +46,61 @@ export function parseBdiCsv(csv: string): { value: number; date: string } | null
   return { value, date };
 }
 
-export type CsvFetcher = (url: string) => Promise<string>;
+/**
+ * Parses BDI value and date from handybulk.com/baltic-dry-index/ HTML.
+ * Scans for the first DD-Month-YYYY entry whose following text contains
+ * "Baltic Dry Index (BDI) … X,XXX points".
+ * Returns null if no matching entry is found.
+ */
+export function parseBdiHtml(html: string): { value: number; date: string } | null {
+  const dateRegex =
+    /(\d{1,2})-(January|February|March|April|May|June|July|August|September|October|November|December)-(\d{4})/gi;
 
-const defaultFetcher: CsvFetcher = async (url) => {
+  let m: RegExpExecArray | null;
+  while ((m = dateRegex.exec(html)) !== null) {
+    const [, day, monthName, year] = m;
+    const month = MONTH_MAP[monthName.toLowerCase()];
+    if (!month) continue;
+
+    const date = `${year}-${month}-${day.padStart(2, '0')}`;
+    const ctx = html.slice(m.index, m.index + 1500);
+
+    const bdiM = ctx.match(
+      /Baltic Dry Index[^(]*\(BDI\)[^.]*?(\d{1,2},\d{3}|\d{4,5})\s*points/i,
+    );
+    if (!bdiM) continue;
+
+    const value = parseFloat(bdiM[1].replace(/,/g, ''));
+    if (!Number.isFinite(value) || value <= 0) continue;
+
+    return { value, date };
+  }
+
+  return null;
+}
+
+export type CsvFetcher = (url: string) => Promise<string>;
+export type HtmlFetcher = (url: string) => Promise<string>;
+
+const defaultFetcher: HtmlFetcher = async (url) => {
   const res = await fetch(url, {
     headers: { 'User-Agent': 'Quantika-Demo/1.0 (+https://demo.quantika.org)' },
     signal: AbortSignal.timeout(30_000),
   });
-  if (!res.ok) throw new Error(`Stooq BDI fetch failed: HTTP ${res.status}`);
+  if (!res.ok) throw new Error(`Handybulk BDI fetch failed: HTTP ${res.status}`);
   return res.text();
 };
 
 export async function refreshBdi(
   db: Database.Database,
-  fetcher: CsvFetcher = defaultFetcher,
+  fetcher: HtmlFetcher = defaultFetcher,
 ): Promise<{ rowsChanged: number }> {
-  const csv = await fetcher(STOOQ_BDI_URL);
+  const html = await fetcher(HANDYBULK_BDI_URL);
 
-  const parsed = parseBdiCsv(csv);
+  const parsed = parseBdiHtml(html);
   if (!parsed) {
     throw new BdiStructureChangedError(
-      'BDI value not found in CSV — stooq page structure may have changed',
+      'BDI value not found in HTML — handybulk page structure may have changed',
     );
   }
 
@@ -65,7 +108,7 @@ export async function refreshBdi(
     index_code: 'BDI',
     value: parsed.value,
     price_date: parsed.date,
-    source: STOOQ_BDI_URL,
+    source: HANDYBULK_BDI_URL,
   });
 
   return { rowsChanged: 1 };

--- a/lib/market/bhsi-adapter.ts
+++ b/lib/market/bhsi-adapter.ts
@@ -2,7 +2,10 @@ import type Database from 'better-sqlite3';
 import { upsertIndex } from './market-indices-repository';
 import { upsertBalticIndex } from './baltic-repository';
 
-export const HANDYBULK_URL = 'https://www.handybulk.com/';
+// The homepage (https://www.handybulk.com/) is now fully JS-rendered with no
+// static BHSI table.  The /baltic-dry-index/ subpage serves daily paragraph
+// summaries in static HTML that include BHSI values.
+export const HANDYBULK_URL = 'https://www.handybulk.com/baltic-dry-index/';
 
 export class HandybulkStructureChangedError extends Error {
   constructor(msg: string) {
@@ -11,15 +14,24 @@ export class HandybulkStructureChangedError extends Error {
   }
 }
 
-// Match <td>BHSI</td><td>530</td><td>22/05/2026</td>
-const BHSI_VALUE_PATTERN =
-  /<td[^>]*>\s*BHSI\s*<\/td>\s*<td[^>]*>\s*([\d,]+(?:\.\d+)?)\s*<\/td>/i;
+const MONTH_MAP: Record<string, string> = {
+  january: '01', february: '02', march: '03', april: '04',
+  may: '05', june: '06', july: '07', august: '08',
+  september: '09', october: '10', november: '11', december: '12',
+};
 
-const BHSI_DATE_PATTERN =
-  /<td[^>]*>\s*BHSI\s*<\/td>\s*<td[^>]*>[\d,]+(?:\.\d+)?\s*<\/td>\s*<td[^>]*>\s*(\d{2}\/\d{2}\/\d{4})\s*<\/td>/i;
+// Match: "Baltic Handysize Index (BHSI) ... to 843 points" or "... to 1,234 points"
+const BHSI_VALUE_PATTERN =
+  /Baltic Handysize Index[^(]*\(BHSI\)[^.]*?(\d{1,2},\d{3}|\d{3,4})\s*points/i;
+
+// Match: DD-Month-YYYY (e.g. 22-May-2026)
+const DATE_PATTERN =
+  /(\d{1,2})-(January|February|March|April|May|June|July|August|September|October|November|December)-(\d{4})/gi;
 
 /**
- * Parses BHSI value and date from handybulk.com HTML.
+ * Parses BHSI value and date from handybulk.com/baltic-dry-index/ HTML.
+ * Finds the first "Baltic Handysize Index (BHSI) ... NNN points" sentence and
+ * the nearest DD-Month-YYYY date that precedes it.
  * Returns null if the page structure has changed and the value cannot be found.
  */
 export function parseBhsiHtml(html: string): { value: number; date: string } | null {
@@ -27,14 +39,20 @@ export function parseBhsiHtml(html: string): { value: number; date: string } | n
   if (!valueMatch) return null;
 
   const value = parseFloat(valueMatch[1].replace(/,/g, ''));
-  if (!Number.isFinite(value) || value < 0) return null;
+  if (!Number.isFinite(value) || value <= 0) return null;
 
-  // Extract date DD/MM/YYYY → YYYY-MM-DD; fall back to today if absent
-  const dateMatch = html.match(BHSI_DATE_PATTERN);
+  // Find the latest DD-Month-YYYY date that appears before the BHSI value
+  const beforeValue = html.slice(0, html.indexOf(valueMatch[0]));
+  const dateMatches = [...beforeValue.matchAll(DATE_PATTERN)];
+
   let indexDate: string;
-  if (dateMatch) {
-    const parts = dateMatch[1].split('/');
-    indexDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
+  if (dateMatches.length > 0) {
+    const last = dateMatches[dateMatches.length - 1];
+    const [, day, monthName, year] = last;
+    const month = MONTH_MAP[monthName.toLowerCase()];
+    indexDate = month
+      ? `${year}-${month}-${day.padStart(2, '0')}`
+      : new Date().toISOString().slice(0, 10);
   } else {
     indexDate = new Date().toISOString().slice(0, 10);
   }
@@ -49,7 +67,7 @@ const defaultFetcher: HtmlFetcher = async (url) => {
     headers: { 'User-Agent': 'Quantika-Demo/1.0 (+https://demo.quantika.org)' },
     signal: AbortSignal.timeout(30_000),
   });
-  if (!res.ok) throw new Error(`Handybulk fetch failed: HTTP ${res.status}`);
+  if (!res.ok) throw new Error(`Handybulk BHSI fetch failed: HTTP ${res.status}`);
   return res.text();
 };
 
@@ -76,8 +94,8 @@ export async function refreshBhsi(
     fetched_at: new Date().toISOString(),
   });
 
-  // Also write to baltic_indices: /api/market/baltic-kpi and /api/market/indices
-  // both read BHSI from baltic_indices, not market_indices (#558).
+  // /api/market/baltic-kpi and /api/market/indices both read BHSI from
+  // baltic_indices, not market_indices (#558).
   upsertBalticIndex(db, {
     index_code: 'BHSI',
     value: parsed.value,

--- a/scripts/ops/quantika-market-refresh.cron
+++ b/scripts/ops/quantika-market-refresh.cron
@@ -1,0 +1,22 @@
+# /etc/cron.d/quantika-market-refresh
+#
+# Daily BDI/BHSI refresh for Quantika Demo.
+# Baltic Exchange publishes ~1 PM London; run at 07:00 CEST (05:00 UTC)
+# on weekdays to pick up previous-day data.
+#
+# INSTALLATION (run after deploy):
+#   sudo cp scripts/ops/quantika-market-refresh.cron /etc/cron.d/quantika-market-refresh
+#   sudo chmod 644 /etc/cron.d/quantika-market-refresh
+#   sudo chown root:root /etc/cron.d/quantika-market-refresh
+#
+# VERIFY:
+#   tail -f /var/log/quantika-market-refresh.log
+#
+# MANUAL RUN (from app directory):
+#   cd /root/work/quantika-demo && npx tsx scripts/knowledge/cron/refresh-market-indices.ts
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# weekdays at 05:00 UTC (07:00 CEST / 08:00 BY)
+0 5 * * 1-5 root cd /root/work/quantika-demo && npx tsx scripts/knowledge/cron/refresh-market-indices.ts >> /var/log/quantika-market-refresh.log 2>&1


### PR DESCRIPTION
Closes #567

W2 root-cause investigation (real fix не как #565 которое только тест прошло):
- 3 scrapers были broken: stooq.com нужен API key, handybulk homepage стала JS-rendered, drewry.co.uk блокирует сервер
- Fix: переключил BDI + BHSI adapters на handybulk.com/baltic-dry-index/ (paragraph parser без JS)
- Cron job отсутствовал в crontab — добавлен scripts/ops/quantika-market-refresh.cron (weekday 07:00 CEST)

Verified: BDI=2991 (2026-05-22) ✓, BHSI=843 (2026-05-22) ✓. Tests 29/29, TSC clean.

Post-merge ops (deploy-affecting):
```
sudo cp scripts/ops/quantika-market-refresh.cron /etc/cron.d/quantika-market-refresh
sudo chmod 644 /etc/cron.d/quantika-market-refresh && sudo chown root:root /etc/cron.d/quantika-market-refresh
cd /root/quantika-demo && npx tsx scripts/knowledge/cron/refresh-market-indices.ts
```

auto-merge when CI green.