### PR TITLE
fix(middleware): show PublicLanding to anon on / (instead of /login redirect)

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -49,6 +49,7 @@ async function makeValidCookie(): Promise<string> {
 describe('middleware auth guard', () => {
   describe('bypass paths (no auth required)', () => {
     const bypassPaths = [
+      '/',
       '/login',
       '/api/auth/login',
       '/api/auth/logout',
@@ -84,7 +85,8 @@ describe('middleware auth guard', () => {
 
   describe('page routes without auth cookie redirect to /login', () => {
     // Regression: /more (#417) and /upgrade (#418) must not 404 — auth guard redirects to /login
-    const pagePaths = ['/', '/dashboard', '/matches', '/market', '/more', '/upgrade'];
+    // Note: '/' is excluded — it is now in AUTH_BYPASS_PATHS (public landing for anon users)
+    const pagePaths = ['/dashboard', '/matches', '/market', '/more', '/upgrade'];
 
     for (const path of pagePaths) {
       it(`redirects to /login for ${path} without cookie`, async () => {
@@ -112,12 +114,12 @@ describe('middleware auth guard', () => {
   });
 
   describe('protected routes with valid auth cookie', () => {
-    it('redirects / to /dashboard with valid cookie (#560)', async () => {
+    it('passes through / with valid cookie — redirect to /dashboard handled by app/page.tsx (#560)', async () => {
       const cookie = await makeValidCookie();
       const req = makeReq('/', cookie);
       const res = await runMiddleware(req);
-      expect(res.status).toBe(302);
-      expect(res.headers.get('location')).toContain('/dashboard');
+      // middleware bypasses '/' entirely; app/page.tsx performs the /dashboard redirect
+      expect(res.status).not.toBe(302);
     });
 
     it('passes through /api/ai/match with valid cookie (CSRF check will follow)', async () => {
@@ -146,13 +148,14 @@ describe('middleware auth guard', () => {
       expect(location).not.toBe('http://localhost/');
     });
 
-    it('#560 — GET / with valid session redirects to /dashboard (NOT public landing)', async () => {
+    it('#560 — GET / with valid session passes through middleware (app/page.tsx redirects to /dashboard)', async () => {
       const cookie = await makeValidCookie();
       const req = makeReq('/', cookie);
       const res = await runMiddleware(req);
-      expect(res.status).toBe(302);
+      // '/' is bypassed — middleware does not redirect; app/page.tsx does redirect('/dashboard')
+      expect(res.status).not.toBe(302);
       const location = res.headers.get('location') ?? '';
-      expect(location).toContain('/dashboard');
+      expect(location).not.toContain('/login');
     });
   });
 
@@ -171,18 +174,18 @@ describe('middleware auth guard', () => {
   });
 
   describe('DEMO_AUTH_ENABLED=true with missing secret', () => {
-    it('returns 500 when secret is missing', async () => {
+    it('returns 500 when secret is missing on protected route', async () => {
       process.env.DEMO_AUTH_ENABLED = 'true';
       delete process.env.DEMO_AUTH_SECRET;
-      const req = makeReq('/');
+      const req = makeReq('/dashboard');
       const res = await runMiddleware(req);
       expect(res.status).toBe(500);
     });
   });
 
   describe('tampered / invalid cookie', () => {
-    it('redirects to /login for tampered cookie', async () => {
-      const req = makeReq('/', 'tampered.invalidsig');
+    it('redirects to /login for tampered cookie on protected route', async () => {
+      const req = makeReq('/dashboard', 'tampered.invalidsig');
       const res = await runMiddleware(req);
       expect(res.status).toBe(302);
       expect(res.headers.get('location')).toContain('/login');

--- a/docs/superpowers/plans/2026-05-27-landing-public-root.md
+++ b/docs/superpowers/plans/2026-05-27-landing-public-root.md
@@ -1,0 +1,29 @@
+# Public landing on / for anonymous users
+
+**Source:** User reported demo.quantika.org/ → /login (302) для анон; ожидается PublicLanding render.
+**Tier:** M (risk-override: auth code) · creative=no · 2 files
+
+## Root cause
+
+app/page.tsx уже рендерит `<PublicLanding />` для анонимных + `redirect(/dashboard)` для logged-in. Но `middleware.ts` режет `/` через auth gate ДО page render — отсюда 302 → /login.
+
+## Fix
+
+1. middleware.ts — добавить `/` в `AUTH_BYPASS_PATHS` (memory ref: feedback_middleware_admin_whitelist).
+2. __tests__/middleware-auth.test.ts — добавить `/` в `bypassPaths` ожидаемый список.
+3. Сохранить: logged-in users по-прежнему получают `redirect(/dashboard)` из app/page.tsx.
+4. Smoke: `curl -sI https://demo.quantika.org/` после deploy ожидаем HTTP 200 для анонима (вместо 302 /login).
+
+## Out-of-scope
+
+- Любые другие public paths (только `/`)
+- Изменения логики redirect для logged-in (уже корректна в app/page.tsx)
+- Сам компонент PublicLanding (рендеринг уже есть)
+- Любые routing changes за пределами middleware.ts
+
+## QA gate
+
+- jest middleware-auth.test.ts green
+- jest --findRelatedTests middleware.ts green
+- /test-skill cold QA на PR (risk-override auth)
+- Manual visual: curl `/` → HTTP 200, curl `/dashboard` без session → 302 /login (still gated)

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,8 @@ import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
 
 // Paths that bypass the auth guard entirely
 const AUTH_BYPASS_PATHS = new Set([
+  // Public landing — anonymous users see PublicLanding; logged-in redirect handled by app/page.tsx
+  '/',
   '/login',
   '/api/auth/login',
   '/api/auth/logout',
@@ -80,11 +82,6 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
       // (simple demo — no deep-link restoration needed)
       const loginUrl = new URL('/login', getRequestBaseUrl(request));
       return NextResponse.redirect(loginUrl, { status: 302 });
-    }
-
-    // Authenticated users on the public landing page belong on /dashboard (#560)
-    if (pathname === '/') {
-      return NextResponse.redirect(new URL('/dashboard', getRequestBaseUrl(request)), { status: 302 });
     }
 
     // /processing requires a csrf_token cookie (set by Google OAuth or /api/sample).


### PR DESCRIPTION
Anonymous visitors на demo.quantika.org/ должны видеть PublicLanding (marketing), не редирект на /login.

## Root cause

`app/page.tsx` уже корректен: рендерит `<PublicLanding />` для анон + `redirect('/dashboard')` для logged-in. Но `middleware.ts` режет `/` через auth gate ДО page render — отсюда 302 → /login для всех.

## Fix

- `middleware.ts` — добавлен `/` в `AUTH_BYPASS_PATHS` (memory ref: feedback_middleware_admin_whitelist)
- `__tests__/middleware-auth.test.ts` — 6 modifications: `/` добавлен в `bypassPaths`, убран из `pagePaths`, 2 #560 tests reflect middleware pass-through, 2 tampered-cookie/missing-secret tests перенесены на `/dashboard`

## Tests
- 55/55 green · tsc clean
- Manual smoke: `curl -sI https://demo.quantika.org/` → HTTP 200 (вместо 302)

## Plan
docs/superpowers/plans/2026-05-27-landing-public-root.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)