### PR TITLE
fix(#581): expose /api/market/{baltic,bunker}-kpi to anon

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -66,6 +66,8 @@ describe('middleware auth guard', () => {
       '/sitemap.xml',
       '/robots.txt',
       '/design',
+      '/api/market/baltic-kpi',
+      '/api/market/bunker-kpi',
     ];
 
     for (const path of bypassPaths) {

--- a/docs/superpowers/plans/2026-05-27-581-market-api-public.md
+++ b/docs/superpowers/plans/2026-05-27-581-market-api-public.md
@@ -1,0 +1,27 @@
+# Issue #581 — market widgets Unavailable for anon
+
+**RC (confirmed via investigation disp-152132):** `/api/market/baltic-kpi` и `/api/market/bunker-kpi` не в AUTH_BYPASS_PATHS → middleware.ts возвращает 401 для анон → KpiCard → Unavailable UI.
+
+**Tier:** M (risk-override: auth code) · creative=no · 2 files
+
+## Fix
+
+1. `middleware.ts` — добавить в `AUTH_BYPASS_PATHS`:
+   - `/api/market/baltic-kpi`
+   - `/api/market/bunker-kpi`
+2. `__tests__/middleware-auth.test.ts` — добавить эти 2 пути в `bypassPaths` параметризованный массив.
+
+## Pre-removal grep (sanity)
+- grep AUTH_BYPASS_PATHS __tests__/ — единственный test-список
+- grep "/api/market/" app/ lib/ components/ — убедиться endpoint'ы не имеют PII (публичные индексы + цены топлива, safe для анон)
+
+## Out of scope
+- Authentication mechanism (только bypass list change)
+- Любые другие /api/* paths
+- Сам KpiCard или PublicLanding markup
+- Stale data fix (#567 — ops action, отдельно)
+
+## QA gate
+- jest middleware-auth.test.ts green
+- jest --findRelatedTests middleware.ts green
+- Manual smoke: curl https://demo.quantika.org/api/market/baltic-kpi?code=BDI → HTTP 200 + JSON

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,6 +32,9 @@ const AUTH_BYPASS_PATHS = new Set([
   '/robots.txt',
   // Design preview page — internal gallery, no sensitive data
   '/design',
+  // Market KPI endpoints — public index data (BDI/BHSI/bunker prices), safe for anonymous
+  '/api/market/baltic-kpi',
+  '/api/market/bunker-kpi',
 ]);
 
 const AUTH_BYPASS_PREFIXES = ['/_next/static', '/_next/image', '/_next/webpack'];


### PR DESCRIPTION
Closes #581.

## Root cause
Per investigation (disp-20260527-152132): /api/market/baltic-kpi и /api/market/bunker-kpi не в AUTH_BYPASS_PATHS → middleware возвращает 401 для анон → KpiCard на PublicLanding показывает 'Unavailable / Retry'.

## Fix
- middleware.ts +2 path entries в AUTH_BYPASS_PATHS
- __tests__/middleware-auth.test.ts +2 в bypassPaths array

## Tests
57/57 green (jest --findRelatedTests middleware.ts __tests__/middleware-auth.test.ts)

## Related
- #567 ops actions (cron install + manual refresh) — выполнены параллельно
- #582 Drewry WCI broken (отдельно)
- #583 BCI not in refresh loop (отдельно)

🤖 Generated with Claude Code