### PR TITLE
fix(market): #583 BCI adapter + refresh loop wire-up

### DIFF
--- a/docs/superpowers/plans/2026-05-27-583-bci-refresh.md
+++ b/docs/superpowers/plans/2026-05-27-583-bci-refresh.md
@@ -1,0 +1,38 @@
+# Issue #583 — BCI (Baltic Capesize) not in market refresh loop
+
+**Source:** Found during #567 ops refresh run (2026-05-27). После manual refresh BDI+BHSI обновились до 2026-05-26, BCI остался 2026-05-09 (18 дней stale).
+
+**Tier:** M (risk-override: parser/scraper if adapter needs creation) · creative=no
+
+## Hypothesis tree
+
+- **H1: BCI adapter exists, не wired в orchestration.** `lib/market/adapters/bci-*.ts` есть, но `scripts/knowledge/cron/refresh-market-indices.ts` его не вызывает. Fix: добавить вызов в orchestration. SMALLEST scope.
+- **H2: BCI adapter не существует, нужно создать.** Источник: handybulk (как BDI/BHSI после PR #570) или stooq или Baltic Exchange. Fix: clone существующий adapter (например handybulk-bdi) с BCI selector.
+- **H3: BCI data выгружается через тот же endpoint что BDI** (один URL, multiple indices) — нужно поправить parsing чтобы вернуть array вместо single value.
+
+## Investigation steps
+
+1. `ls lib/market/adapters/` — ищем BCI-related файлы
+2. `grep -rn "bci\|capesize\|BCI" lib/market/ scripts/knowledge/cron/` — посмотреть references
+3. Открыть `scripts/knowledge/cron/refresh-market-indices.ts` — список вызываемых adapters
+4. Если adapter существует → H1 (add to orchestration). Если нет → H2 (clone handybulk-bdi pattern с BCI selectors из того же handybulk source если он публикует BCI; иначе stooq fallback).
+
+## Fix scope
+
+**H1 case:**
+- `scripts/knowledge/cron/refresh-market-indices.ts` — добавить call BCI adapter
+- 1 file change, 2-3 lines
+
+**H2 case:**
+- `lib/market/adapters/handybulk-bci.ts` (новый) — копия handybulk-bdi с измененным selector
+- `scripts/knowledge/cron/refresh-market-indices.ts` — добавить вызов
+- `__tests__/market/handybulk-bci.test.ts` — fixture + behavioral
+
+## Out of scope
+- Drewry WCI (#582)
+- /api/market/* auth (#581)
+- Frontend display (если приложение не показывает BCI — отдельное product decision)
+
+## QA gate
+- jest на adapter green
+- Manual smoke: `npx tsx scripts/knowledge/cron/refresh-market-indices.ts` → sqlite verify BCI price_date current

--- a/lib/market/__tests__/bci-adapter.test.ts
+++ b/lib/market/__tests__/bci-adapter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Behavioral tests for lib/market/bci-adapter.ts
+ *
+ * PI2: calls parseBciHtml() with real HTML input (not string-match only).
+ * Uses the shared handybulk-bhsi.html fixture which includes BCI in daily paragraphs.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
+import { parseBciHtml, refreshBci, BciStructureChangedError } from '../bci-adapter';
+import { getLatestBalticIndex } from '../baltic-repository';
+
+const FIXTURE_HTML = fs.readFileSync(
+  path.join(__dirname, 'fixtures', 'handybulk-bhsi.html'),
+  'utf-8',
+);
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration019.up(db);
+  return db;
+}
+
+describe('parseBciHtml', () => {
+  it('parses BCI value from fixture HTML (PI2: real parser call)', () => {
+    const result = parseBciHtml(FIXTURE_HTML);
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe(4954);
+  });
+
+  it('parses date from DD-Month-YYYY format', () => {
+    const result = parseBciHtml(FIXTURE_HTML);
+    expect(result!.date).toBe('2026-05-22');
+  });
+
+  it('returns null for empty HTML (boundary: empty)', () => {
+    expect(parseBciHtml('')).toBeNull();
+  });
+
+  it('returns null when BCI row is missing (boundary: structure changed)', () => {
+    const html = '<html><body><p>22-May-2026</p><p>The Baltic Dry Index (BDI) rose to 1,456 points.</p></body></html>';
+    expect(parseBciHtml(html)).toBeNull();
+  });
+
+  it('parses comma-formatted value', () => {
+    const html =
+      '<p>The Baltic Capesize Index (BCI) increased by 50 points to 5,210 points.</p>';
+    const result = parseBciHtml(html);
+    expect(result!.value).toBe(5210);
+  });
+
+  it('falls back to today when no date entry precedes BCI value', () => {
+    const html =
+      '<p>The Baltic Capesize Index (BCI) decreased by 30 points to 4,900 points.</p>';
+    const result = parseBciHtml(html);
+    expect(result).not.toBeNull();
+    expect(result!.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('refreshBci (PI2: real DB upsert)', () => {
+  it('upserts BCI row into baltic_indices', async () => {
+    const db = makeDb();
+    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_HTML);
+
+    await refreshBci(db, fakeFetcher);
+
+    const row = getLatestBalticIndex(db, 'BCI');
+    expect(row).not.toBeNull();
+    expect(row!.value).toBe(4954);
+    expect(row!.price_date).toBe('2026-05-22');
+    expect(row!.index_code).toBe('BCI');
+    expect(row!.source).toContain('handybulk');
+
+    db.close();
+  });
+
+  it('is idempotent — second call does not duplicate', async () => {
+    const db = makeDb();
+    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_HTML);
+
+    await refreshBci(db, fakeFetcher);
+    await refreshBci(db, fakeFetcher);
+
+    const count = (
+      db.prepare("SELECT COUNT(*) as n FROM baltic_indices WHERE index_code='BCI'").get() as { n: number }
+    ).n;
+    expect(count).toBe(1);
+
+    db.close();
+  });
+
+  it('throws BciStructureChangedError when HTML has no BCI entry', async () => {
+    const db = makeDb();
+    const fakeFetcher = jest.fn().mockResolvedValue('<html><body>no data</body></html>');
+
+    await expect(refreshBci(db, fakeFetcher)).rejects.toThrow(BciStructureChangedError);
+
+    db.close();
+  });
+
+  it('propagates network errors', async () => {
+    const db = makeDb();
+    const fakeFetcher = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    await expect(refreshBci(db, fakeFetcher)).rejects.toThrow('Network error');
+
+    db.close();
+  });
+});

--- a/lib/market/bci-adapter.ts
+++ b/lib/market/bci-adapter.ts
@@ -1,0 +1,92 @@
+import type Database from 'better-sqlite3';
+import { upsertBalticIndex } from './baltic-repository';
+
+// Same source page as BDI/BHSI — all four Baltic indices appear in daily paragraphs.
+export const HANDYBULK_BCI_URL = 'https://www.handybulk.com/baltic-dry-index/';
+
+export class BciStructureChangedError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'BciStructureChangedError';
+  }
+}
+
+const MONTH_MAP: Record<string, string> = {
+  january: '01', february: '02', march: '03', april: '04',
+  may: '05', june: '06', july: '07', august: '08',
+  september: '09', october: '10', november: '11', december: '12',
+};
+
+// Match: "Baltic Capesize Index (BCI) ... to 4,954 points" or "... to 4954 points"
+// The `to\s+` anchor avoids matching the intermediate "increased by X points" fragment.
+const BCI_VALUE_PATTERN =
+  /Baltic Capesize Index[^(]*\(BCI\)[^.]*?\bto\s+(?:reach\s+)?(\d{1,2},\d{3}|\d{3,5})\s*points/i;
+
+// Match: DD-Month-YYYY (e.g. 22-May-2026)
+const DATE_PATTERN =
+  /(\d{1,2})-(January|February|March|April|May|June|July|August|September|October|November|December)-(\d{4})/gi;
+
+/**
+ * Parses BCI value and date from handybulk.com/baltic-dry-index/ HTML.
+ * Finds the first "Baltic Capesize Index (BCI) ... NNN points" sentence and
+ * the nearest DD-Month-YYYY date that precedes it.
+ * Returns null if the page structure has changed and the value cannot be found.
+ */
+export function parseBciHtml(html: string): { value: number; date: string } | null {
+  const valueMatch = html.match(BCI_VALUE_PATTERN);
+  if (!valueMatch) return null;
+
+  const value = parseFloat(valueMatch[1].replace(/,/g, ''));
+  if (!Number.isFinite(value) || value <= 0) return null;
+
+  const beforeValue = html.slice(0, html.indexOf(valueMatch[0]));
+  const dateMatches = [...beforeValue.matchAll(DATE_PATTERN)];
+
+  let indexDate: string;
+  if (dateMatches.length > 0) {
+    const last = dateMatches[dateMatches.length - 1];
+    const [, day, monthName, year] = last;
+    const month = MONTH_MAP[monthName.toLowerCase()];
+    indexDate = month
+      ? `${year}-${month}-${day.padStart(2, '0')}`
+      : new Date().toISOString().slice(0, 10);
+  } else {
+    indexDate = new Date().toISOString().slice(0, 10);
+  }
+
+  return { value, date: indexDate };
+}
+
+export type HtmlFetcher = (url: string) => Promise<string>;
+
+const defaultFetcher: HtmlFetcher = async (url) => {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'Quantika-Demo/1.0 (+https://demo.quantika.org)' },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) throw new Error(`Handybulk BCI fetch failed: HTTP ${res.status}`);
+  return res.text();
+};
+
+export async function refreshBci(
+  db: Database.Database,
+  fetcher: HtmlFetcher = defaultFetcher,
+): Promise<{ rowsChanged: number }> {
+  const html = await fetcher(HANDYBULK_BCI_URL);
+
+  const parsed = parseBciHtml(html);
+  if (!parsed) {
+    throw new BciStructureChangedError(
+      'BCI value not found in HTML — handybulk page structure may have changed',
+    );
+  }
+
+  upsertBalticIndex(db, {
+    index_code: 'BCI',
+    value: parsed.value,
+    price_date: parsed.date,
+    source: HANDYBULK_BCI_URL,
+  });
+
+  return { rowsChanged: 1 };
+}

--- a/scripts/knowledge/cron/refresh-market-indices.ts
+++ b/scripts/knowledge/cron/refresh-market-indices.ts
@@ -2,6 +2,8 @@
 /**
  * Market indices refresh cron script
  *
+ * BDI   — fetched daily from handybulk.com (Baltic Dry Index, points)
+ * BCI   — fetched daily from handybulk.com (Baltic Capesize Index, points)
  * BHSI  — fetched daily from handybulk.com (Baltic Handysize Index, USD/day)
  * WCI   — fetched weekly from drewry.co.uk (World Container Index composite, USD/FEU)
  *
@@ -20,6 +22,7 @@ import {
 } from '@/lib/knowledge/governance';
 import { refreshBhsi } from '@/lib/market/bhsi-adapter';
 import { refreshBdi } from '@/lib/market/bdi-adapter';
+import { refreshBci } from '@/lib/market/bci-adapter';
 import { refreshDrewryWci } from '@/lib/market/drewry-adapter';
 import type Database from 'better-sqlite3';
 
@@ -49,10 +52,11 @@ export async function main(): Promise<void> {
   const db = getStore().getDb();
 
   const okBdi = await runOne(db, 'market-bdi', (d) => refreshBdi(d));
+  const okBci = await runOne(db, 'market-bci', (d) => refreshBci(d));
   const okBhsi = await runOne(db, 'market-bhsi', (d) => refreshBhsi(d));
   const okDrewry = await runOne(db, 'market-drewry-wci', (d) => refreshDrewryWci(d));
 
-  const success = okBdi || okBhsi || okDrewry;
+  const success = okBdi || okBci || okBhsi || okDrewry;
   console.log(
     `[${CRON_NAME}] ${success ? '✓ Completed successfully' : '✗ All sources failed'}`,
   );


### PR DESCRIPTION
## Summary
- BCI (Baltic Capesize Index) was seeded statically at 2026-05-09 but never refreshed (18 days stale)
- Added `lib/market/bci-adapter.ts` — parses BCI from same handybulk.com page as BDI/BHSI
- Wired `refreshBci()` into `scripts/knowledge/cron/refresh-market-indices.ts`
- Added behavioral test suite (10 tests, PI2: real DB upserts via `refreshBci()`)

## Root cause
H2 (adapter missing) — BCI data was present on the handybulk.com page all along but no parser or orchestration call existed.

## Test plan
- [ ] `npx jest lib/market/__tests__/bci-adapter.test.ts` — 10/10 green
- [ ] `npx tsx scripts/knowledge/cron/refresh-market-indices.ts` on VPS — BCI row updates to today's date
- [ ] `SELECT index_code, price_date, value FROM baltic_indices WHERE index_code='BCI'` — verify current date

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)