### PR TITLE
fix(#582): Drewry WCI adapter — HTML structure changed

### DIFF
--- a/docs/superpowers/plans/2026-05-27-582-drewry-wci.md
+++ b/docs/superpowers/plans/2026-05-27-582-drewry-wci.md
@@ -1,0 +1,37 @@
+# Issue #582 — Drewry WCI adapter broken (HTML structure changed)
+
+**Source:** Found during #567 ops refresh run (2026-05-27). Adapter завершается с 'HTML structure changed', WCI данные не обновляются.
+
+**Tier:** M (risk-override: parser/scraper) · creative=no · unknown-root-cause → hypothesis-tree
+
+## Hypothesis tree (исследовать по порядку)
+
+- **H1: HTML selector path changed.** Drewry поменял CSS classes / DOM structure → existing CSS/regex selectors не находят value. Fix: открыть source HTML, найти новый selector path.
+- **H2: URL moved.** 301/404 — страница переехала. Fix: обновить URL constant.
+- **H3: JS-rendered.** Страница использует client-side rendering, серверный response пустой → нужен headless browser (puppeteer/playwright) вместо плоского fetch.
+- **H4: Cloudflare/rate-limit interstitial.** Drewry блокирует bot UA → нужен realistic UA или session cookies.
+- **H5: Data moved to JSON endpoint / GraphQL.** Найти API endpoint вместо парсить HTML (предпочтительно — более стабильно).
+
+## Investigation steps
+
+1. `curl -A "Mozilla/5.0 ..." https://www.drewry.co.uk/.../world-container-index-assessed-by-drewry > /tmp/drewry-current.html`
+2. `grep -iE "wci|composite|world container" /tmp/drewry-current.html | head -20`
+3. Сравнить с тем что парсит adapter (`lib/market/adapters/drewry-wci.ts` или подобный).
+4. Если HTML пустой / boilerplate (без чисел) → H3/H4 (нужен headless).
+5. Если HTML содержит числа но другая разметка → H1 (обновить selector).
+
+## Fix scope
+
+- `lib/market/adapters/drewry-wci.ts` — обновлённый selector / URL / parsing logic
+- `__tests__/market/drewry-wci-adapter.test.ts` (или подобный) — behavioral test на новой fixture HTML
+- НЕ менять orchestration (`refresh-market-indices.ts`) если только URL/parser change.
+
+## Out of scope
+- BCI (#583, отдельный)
+- /api/market/* auth bypass (#581, уже в работе)
+- Cron schedule changes
+
+## QA gate
+- jest --findRelatedTests на adapter green
+- Manual smoke: run adapter в isolation, verify ненулевое WCI value
+- Acceptance: после fix, ручной запуск `refresh-market-indices.ts` обновляет WCI row в bunker_prices / wci_indices таблице с current price_date.

--- a/lib/market/__tests__/drewry-adapter.test.ts
+++ b/lib/market/__tests__/drewry-adapter.test.ts
@@ -18,6 +18,12 @@ const FIXTURE_HTML = fs.readFileSync(
   'utf-8',
 );
 
+// Current page structure (2026-05+): WCI value embedded in bullet text
+const FIXTURE_HTML_CURRENT = fs.readFileSync(
+  path.join(__dirname, 'fixtures', 'drewry-wci-2026-05-21.html'),
+  'utf-8',
+);
+
 function makeDb(): Database.Database {
   const db = new Database(':memory:');
   migration027.up(db);
@@ -110,6 +116,45 @@ describe('refreshDrewryWci (PI2: real DB upsert)', () => {
     const fakeFetcher = jest.fn().mockRejectedValue(new Error('Connection refused'));
 
     await expect(refreshDrewryWci(db, fakeFetcher)).rejects.toThrow('Connection refused');
+
+    db.close();
+  });
+});
+
+// #582: Drewry changed page structure — value is now in bullet text, not a composite card
+describe('parseWciHtml — current page structure (2026-05+)', () => {
+  it('parses WCI value from bullet-text format (PI2: real parser call)', () => {
+    const result = parseWciHtml(FIXTURE_HTML_CURRENT);
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe(2712);
+  });
+
+  it('parses date from "Thursday, 21 May 2026" heading', () => {
+    const result = parseWciHtml(FIXTURE_HTML_CURRENT);
+    expect(result!.date).toBe('2026-05-21');
+  });
+
+  it('ignores first WCI mention (no dollar value nearby) and picks the correct bullet value', () => {
+    // The new HTML has two "World Container Index (WCI)" occurrences:
+    // 1st: "WCI has been the go-to..." — no $ within 200 chars
+    // 2nd: "WCI increased 6% to $2,712" — should be matched
+    const result = parseWciHtml(FIXTURE_HTML_CURRENT);
+    expect(result!.value).toBe(2712);
+  });
+});
+
+describe('refreshDrewryWci — current page structure (PI2: real DB upsert)', () => {
+  it('upserts drewry-bb row from current page structure with correct value and date', async () => {
+    const db = makeDb();
+    const fakeFetcher = jest.fn().mockResolvedValue(FIXTURE_HTML_CURRENT);
+
+    await refreshDrewryWci(db, fakeFetcher);
+
+    const row = getLatestIndex(db, 'drewry-bb');
+    expect(row).not.toBeNull();
+    expect(row!.value).toBe(2712);
+    expect(row!.index_date).toBe('2026-05-21');
+    expect(row!.unit).toBe('USD/FEU');
 
     db.close();
   });

--- a/lib/market/__tests__/fixtures/drewry-wci-2026-05-21.html
+++ b/lib/market/__tests__/fixtures/drewry-wci-2026-05-21.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="En">
+<head>
+  <meta charset="UTF-8">
+  <title>Drewry - Service Expertise - World Container Index - 21 May</title>
+  <meta name="description" content="21 May 2026: Rally in freight rates continued, with the composite index rising for the third week this month.">
+</head>
+<body>
+  <div id="ao-main">
+    <p>Rally in freight rates continued, with the composite index rising for the third week this month.</p>
+    <p>The first to publish benchmark container spot market freight rates back in 2006.</p>
+    <p>The Drewry World Container Index (WCI) has been the go-to, independent, global reference for index-linked contracts.
+       If your organisation is considering index-linked contracts or requires regional visibility/coverage beyond the eight
+       trade lanes provided below, our CFRI product provides comprehensive coverage against 6,700 global port pairs.</p>
+    <h4>Our detailed assessment for Thursday, 21 May 2026</h4>
+    <ul>
+      <li>The Drewry World Container Index (WCI) increased 6% to $2,712 per 40ft container, mainly due to higher freight rates on the Asia to Europe trade route.</li>
+      <li>On the Asia-Europe trade route, spot rates increased this week.</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/lib/market/drewry-adapter.ts
+++ b/lib/market/drewry-adapter.ts
@@ -11,8 +11,12 @@ export class DrewryStructureChangedError extends Error {
   }
 }
 
-// "Composite" heading then dollar value in next element, e.g. <div>$2,365</div>
-const WCI_VALUE_PATTERN =
+// Current page structure (2026-05+): inline bullet text, e.g. "WCI) increased 6% to $2,712 per 40ft"
+const WCI_VALUE_PATTERN_CURRENT =
+  /World Container Index\s*\(WCI\)[^$]{0,200}\$\s*([\d,]+(?:\.\d+)?)/i;
+
+// Legacy page structure: dedicated composite card, e.g. <h3>Composite</h3><div>$2,365</div>
+const WCI_VALUE_PATTERN_LEGACY =
   /Composite[\s\S]{0,300}?\$\s*([\d,]+(?:\.\d+)?)/i;
 
 // "DD Month YYYY" date string (e.g. "15 May 2026")
@@ -31,7 +35,7 @@ const MONTHS: Record<string, string> = {
  * Returns null if the value cannot be found (page structure changed).
  */
 export function parseWciHtml(html: string): { value: number; date: string } | null {
-  const valueMatch = html.match(WCI_VALUE_PATTERN);
+  const valueMatch = html.match(WCI_VALUE_PATTERN_CURRENT) ?? html.match(WCI_VALUE_PATTERN_LEGACY);
   if (!valueMatch) return null;
 
   const value = parseFloat(valueMatch[1].replace(/,/g, ''));


### PR DESCRIPTION
Closes #582.

## Root cause (H1 confirmed)
Drewry убрал dedicated composite card (`<h3>Composite</h3><div class='wci-value'>$2,365</div>`) и теперь значение в bullet-тексте: `'World Container Index (WCI) increased 6% to $2,712 per 40ft container'`. Старая regex `Composite[\s\S]{0,300}?\$` не находила match (distance >300 chars).

## Fix
- `lib/market/drewry-adapter.ts` — новый pattern для bullet-format
- `lib/market/__tests__/drewry-adapter.test.ts` — behavioral test 'current page structure' + legacy fixture тесты сохранены
- `lib/market/__tests__/fixtures/drewry-wci-2026-05-21.html` — fresh fixture

## Tests
- Behavioral PI2: `refreshDrewryWci` парсит `result.value === 2712`, `result.date === '2026-05-21'`
- Legacy compat: 10/10 original tests pass
- Cross-cutting grep: no broken callers (только adapter referencs patterns)

## Plan
docs/superpowers/plans/2026-05-27-582-drewry-wci.md

🤖 Generated with Claude Code