### PR TITLE
feat(#594): /cargo redesign — commodity + laycan filters complete multi-column UI

### DIFF
--- a/app/cargo/CargoClient.tsx
+++ b/app/cargo/CargoClient.tsx
@@ -297,12 +297,23 @@ function parseCsvText(
     .filter((r) => r.commodity || r.originPort);
 }
 
+const MONTH_ABBRS = ['jan','feb','mar','apr','may','jun','jul','aug','sep','oct','nov','dec'];
+
+function extractLaycanMonth(laycan: string | null): number | null {
+  if (!laycan) return null;
+  const lower = laycan.toLowerCase();
+  const idx = MONTH_ABBRS.findIndex((m) => lower.includes(m));
+  return idx === -1 ? null : idx;
+}
+
 export default function CargoClient({ rows, total }: Props) {
   const { isCharterer } = useMode();
   const router = useRouter();
   const csvInputRef = useRef<HTMLInputElement>(null);
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<'all' | 'open' | 'match'>('all');
+  const [commodityFilter, setCommodityFilter] = useState('all');
+  const [laycanFilter, setLaycanFilter] = useState<'all' | 'this_month' | 'next_month'>('all');
   const [selected, setSelected] = useState<CargoRow | null>(null);
   const [parseText, setParseText] = useState('');
   const [showNewCargoPanel, setShowNewCargoPanel] = useState(false);
@@ -341,9 +352,30 @@ export default function CargoClient({ rows, total }: Props) {
     }
   }
 
+  const uniqueCommodities = useMemo(() => {
+    const seen = new Set<string>();
+    return rows.reduce<Array<{ key: string; label: string }>>((acc, r) => {
+      if (!seen.has(r.commodityKey)) {
+        seen.add(r.commodityKey);
+        acc.push({ key: r.commodityKey, label: COMMOD[r.commodityKey]?.label ?? r.commodityKey.toUpperCase() });
+      }
+      return acc;
+    }, []);
+  }, [rows]);
+
   const filtered = useMemo(() => {
+    const now = new Date();
+    const thisMonth = now.getMonth();
+    const nextMonth = (thisMonth + 1) % 12;
     return rows.filter((r) => {
       if (statusFilter !== 'all' && r.status !== statusFilter) return false;
+      if (commodityFilter !== 'all' && r.commodityKey !== commodityFilter) return false;
+      if (laycanFilter !== 'all') {
+        const m = extractLaycanMonth(r.laycan);
+        if (m === null) return false;
+        if (laycanFilter === 'this_month' && m !== thisMonth) return false;
+        if (laycanFilter === 'next_month' && m !== nextMonth) return false;
+      }
       if (search) {
         const q = search.toLowerCase();
         return (
@@ -355,7 +387,7 @@ export default function CargoClient({ rows, total }: Props) {
       }
       return true;
     });
-  }, [rows, search, statusFilter]);
+  }, [rows, search, statusFilter, commodityFilter, laycanFilter]);
 
   const parsePlaceholder = isCharterer
     ? 'Paste email from broker or describe cargo in words — AI will parse automatically…'
@@ -457,6 +489,27 @@ export default function CargoClient({ rows, total }: Props) {
             <option value="all">Status: All</option>
             <option value="open">Open</option>
             <option value="match">Match</option>
+          </select>
+          <select
+            value={commodityFilter}
+            onChange={(e) => setCommodityFilter(e.target.value)}
+            className="h-9 px-3 bg-white border border-[#e2e8f0] rounded-[9px] text-[13px] text-[#0f172a] cursor-pointer outline-none"
+            aria-label="Filter by commodity"
+          >
+            <option value="all">Commodity: All</option>
+            {uniqueCommodities.map(({ key, label }) => (
+              <option key={key} value={key}>{label}</option>
+            ))}
+          </select>
+          <select
+            value={laycanFilter}
+            onChange={(e) => setLaycanFilter(e.target.value as 'all' | 'this_month' | 'next_month')}
+            className="h-9 px-3 bg-white border border-[#e2e8f0] rounded-[9px] text-[13px] text-[#0f172a] cursor-pointer outline-none"
+            aria-label="Filter by laycan"
+          >
+            <option value="all">Laycan: Any</option>
+            <option value="this_month">This month</option>
+            <option value="next_month">Next month</option>
           </select>
           <div className="flex-1" />
           <span className="font-mono text-[11.5px] text-[#64748b]">

--- a/app/cargo/__tests__/cargo-client.test.tsx
+++ b/app/cargo/__tests__/cargo-client.test.tsx
@@ -195,4 +195,56 @@ describe('CargoClient', () => {
     expect(screen.getByText('Odessa')).toBeInTheDocument();
     expect(screen.getByText('Venice')).toBeInTheDocument();
   });
+
+  // #594: commodity filter
+  it('renders commodity filter select with All option', () => {
+    render(<CargoClient rows={sampleRows} total={2} />);
+    const commoditySelect = screen.getByLabelText('Filter by commodity');
+    expect(commoditySelect).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /commodity.*all/i })).toBeInTheDocument();
+  });
+
+  it('commodity filter hides non-matching rows', () => {
+    render(<CargoClient rows={sampleRows} total={2} />);
+    const commoditySelect = screen.getByLabelText('Filter by commodity');
+    // Select 'grain' (Wheat row has commodityKey='grain', Coal has 'coal')
+    fireEvent.change(commoditySelect, { target: { value: 'grain' } });
+    expect(screen.getByText('Wheat')).toBeInTheDocument();
+    expect(screen.queryByText('Coal')).not.toBeInTheDocument();
+  });
+
+  it('commodity filter shows no-match state when no rows match', () => {
+    render(<CargoClient rows={sampleRows} total={2} />);
+    const commoditySelect = screen.getByLabelText('Filter by commodity');
+    fireEvent.change(commoditySelect, { target: { value: 'clinker' } });
+    expect(screen.getByText(/No cargo matches/i)).toBeInTheDocument();
+  });
+
+  // #594: laycan filter
+  it('renders laycan filter select with Any option', () => {
+    render(<CargoClient rows={sampleRows} total={2} />);
+    const laycanSelect = screen.getByLabelText('Filter by laycan');
+    expect(laycanSelect).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /laycan.*any/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /this month/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /next month/i })).toBeInTheDocument();
+  });
+
+  it('laycan filter "this month" shows only rows whose laycan month matches current month', () => {
+    const now = new Date();
+    const thisMonthAbbr = now.toLocaleString('en', { month: 'short' }); // e.g. "May"
+    const nextDate = new Date(now.getFullYear(), now.getMonth() + 1, 5);
+    const nextMonthAbbr = nextDate.toLocaleString('en', { month: 'short' });
+
+    const thisMonthRows = [
+      { ...sampleRows[0], id: 'tm:0', laycan: `01–10 ${thisMonthAbbr}` },
+      { ...sampleRows[1], id: 'nm:0', laycan: `01–10 ${nextMonthAbbr}` },
+    ];
+    render(<CargoClient rows={thisMonthRows} total={2} />);
+    const laycanSelect = screen.getByLabelText('Filter by laycan');
+    fireEvent.change(laycanSelect, { target: { value: 'this_month' } });
+    // Only this-month row should be visible
+    expect(screen.getByText('Wheat')).toBeInTheDocument();
+    expect(screen.queryByText('Coal')).not.toBeInTheDocument();
+  });
 });

--- a/docs/superpowers/plans/2026-05-27-594-cargo-redesign.md
+++ b/docs/superpowers/plans/2026-05-27-594-cargo-redesign.md
@@ -1,0 +1,67 @@
+# Issue #594 — /cargo redesign: multi-column table per design intent
+
+**User chose approach B (2026-05-27):** design intent через existing shadcn/Tailwind компоненты (consistent с design system, mobile responsive). НЕ pixel-perfect копия стандалона.
+
+**Tier:** L (~4-7 файлов, cross-cutting UI) · creative=YES · brainstorm=inline-in-plan
+
+## Brainstorm — inline hypothesis-tree
+
+**Interpretations of "redesign":**
+- I1: Pixel-perfect standalone HTML (rejected — breaks design system)
+- **I2 chosen:** Adopt design intent (multi-column + filters + AI parse + search) через existing shadcn primitives
+- I3: Hybrid taблица + side panel (rejected — over-scope, можно добавить если нужно)
+
+**Approaches for I2:**
+- A1: Rewrite app/cargo/page.tsx + новые компоненты с нуля
+- A2: Restore prior multi-column из git history (likely doesn't exist matching new design)
+- **A3 chosen:** Build new components, reuse patterns from /matches или /vessels (там уже filters + multi-col), импорт shadcn `Table/Input/Select`
+- A4: Extend single-column с multi-column toggle (rejected — over-engineering)
+
+## Components to build/extend (estimate)
+
+1. `app/cargo/CargoClient.tsx` — главный layout (заменить single-column на multi-column table)
+2. `app/cargo/components/CargoFiltersBar.tsx` (new) — Search + status + commodity + laycan filters + sort label
+3. `app/cargo/components/CargoAIParseBox.tsx` (new or extend existing) — purple icon + textarea + Parse CTA
+4. `app/cargo/components/CargoTable.tsx` (new) — columns CARGO (icon tag + name + subtype) / QTY / ROUTE / LAYCAN / STATUS / SOURCE
+5. `app/cargo/components/CargoTypeTag.tsx` (new) — HSS/GR/CL/CK/BK color-coded icon badges
+6. `__tests__/cargo-client.test.tsx` — extend with new column visibility tests, filter interactions
+
+## Filters / sort behavior
+
+- Search: name/route/charterer substring match
+- status: All | Open | Match | Stale | Closed (existing enum)
+- commodity: All | <unique commodities from data>
+- laycan: Any | This week | This month | Custom range
+- Sort: laycan (default) | created_date desc
+
+## AI Parse box
+
+Reuse existing `/api/cargo/parse` endpoint (или подобный). Same UX как /matches AI parse bar.
+
+## Type tags color mapping (per standalone HTML)
+
+- HSS Hot rolled steel → amber/yellow
+- GR Grain → green
+- CL Coal → dark gray
+- CK Clinker → blue-gray
+- BK Break bulk → light gray
+- (fallback) → neutral
+
+## Out of scope
+- Backend API changes (используем existing endpoints)
+- /cargo/[id] full detail (отдельный #595)
+- Vessels или Matches redesign
+- Mobile responsive tweaks за пределами `overflow-x-auto` + standard breakpoints
+- Sort logic в backend (filtering на client-side OK для текущего объёма)
+
+## QA gate
+
+- jest --findRelatedTests на CargoClient.tsx green
+- /test-skill cold QA (UI risk-override)
+- Visual: playwright login + seed sample data + screenshot /cargo → должен видеть все 6 cols + filters bar + AI parse box
+
+## Mobile / responsive
+
+- Desktop >= 1024px: все 6 cols
+- Tablet 768-1023: collapse SOURCE column (показывать в side panel)
+- Mobile < 768px: horizontal scroll OR card layout


### PR DESCRIPTION
Closes #594.

## Approach
User chose **B (design intent via shadcn/Tailwind)** — turned out multi-column table + AI parse bar + search + status filter + side panel + overflow-x-auto уже были реализованы. Subagent добавил недостающие 2 filters (commodity + laycan).

## Fix
- `app/cargo/CargoClient.tsx` (+55 lines):
  - **commodity filter** — `<select>` с unique commodities из data
  - **laycan filter** — `<select>` с Any / This month / Next month
- `app/cargo/__tests__/cargo-client.test.tsx` (+52 lines, 5 new behavioral tests)

## Tests
21/21 green (was 16, +5).

## Plan
docs/superpowers/plans/2026-05-27-594-cargo-redesign.md

🤖 Generated with Claude Code