### PR TITLE
fix(#589 R2 Opus): strip-not-retry + hard anchor + qualitative tokens

### DIFF
--- a/app/api/ai/__tests__/explain-deal-hallucination.test.ts
+++ b/app/api/ai/__tests__/explain-deal-hallucination.test.ts
@@ -14,6 +14,7 @@ import {
   buildPayloadNumberSet,
   validateExplainDealResponse,
   buildRetryPrompt,
+  stripInventedContent,
 } from '@/lib/explain-deal-validator';
 import { POST } from '@/app/api/ai/explain-deal/route';
 import { NextRequest } from 'next/server';
@@ -313,6 +314,111 @@ describe('buildRetryPrompt', () => {
   });
 });
 
+// ── Unit tests: stripInventedContent (R2 strip-not-retry) ────────────────────
+
+describe('stripInventedContent — numeric stripping (#589 R2)', () => {
+  it('strips comma-formatted invented numbers', () => {
+    const text = 'A 50,000 MT grain parcel for the vessel.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).not.toContain('50,000');
+    expect(r.text).toContain('[redacted: not in match data]');
+    expect(r.inventedNumbers).toContain(50000);
+  });
+
+  it('strips unformatted 4+ digit invented numbers (e.g. 50000 without comma)', () => {
+    const text = 'The cargo is 50000 MT and DWCC 55500 MT.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).not.toMatch(/\b50000\b/);
+    expect(r.text).not.toMatch(/\b55500\b/);
+    expect(r.inventedNumbers).toEqual(expect.arrayContaining([50000, 55500]));
+  });
+
+  it('preserves payload numbers (58,000 DWT is real for fixtureA)', () => {
+    const text = 'MV Black Sea Star has 58,000 DWT.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).toContain('58,000');
+    expect(r.inventedNumbers).toHaveLength(0);
+  });
+
+  it('preserves numbers within 2% tolerance', () => {
+    const text = 'The vessel is approximately 58,500 DWT.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).toContain('58,500');
+    expect(r.inventedNumbers).toHaveLength(0);
+  });
+
+  it('does not strip year-like numbers (2018, 2026)', () => {
+    const text = 'Built in 2018, open from 2026-07-01.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).toContain('2018');
+    expect(r.text).toContain('2026');
+  });
+
+  it('does not strip small numbers (scores, hold counts)', () => {
+    const text = 'Score 74/100 with 5 holds and 5 hatches.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).toContain('74');
+    expect(r.text).toContain('5 holds');
+  });
+});
+
+describe('stripInventedContent — qualitative tokens (#589 R2)', () => {
+  it('strips stowage factor mentions when cargo.stowageFactor is null', () => {
+    const text = 'The cargo has a stowage factor of 1.25 m³/MT.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).not.toContain('1.25');
+    expect(r.text).toContain('[redacted: stowage factor not in match data]');
+    expect(r.forbiddenTokens.some((t) => /stowage\s*factor/i.test(t))).toBe(true);
+  });
+
+  it('strips invented class society (DNV when vessel.classSociety=LR)', () => {
+    const text = 'The vessel is DNV classed and operates under Greek flag.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).not.toContain('DNV');
+    expect(r.text).toContain('[redacted: class society not in match data]');
+    expect(r.forbiddenTokens).toContain('DNV');
+  });
+
+  it('preserves the payload-listed class society (LR)', () => {
+    const text = 'The vessel is LR classed.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).toContain('LR');
+    expect(r.forbiddenTokens.filter((t) => t === 'LR')).toHaveLength(0);
+  });
+
+  it('strips ABS/NK/BV/RINA when not in payload', () => {
+    const text = 'Class: ABS. Survey by BV recently. Listed in NK registry.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).not.toContain('ABS');
+    expect(r.text).not.toContain('BV');
+    expect(r.text).not.toContain('NK');
+  });
+
+  it('strips gear status when vessel.geared is null', () => {
+    const vesselNullGear: ParsedVessel = { ...fixtureVesselA, geared: null };
+    const text = 'The vessel is gearless, with no cranes onboard.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, vesselNullGear);
+    expect(r.text).not.toContain('gearless');
+    expect(r.text).toContain('[redacted: gear status not in match data]');
+    expect(r.forbiddenTokens).toContain('gearless');
+  });
+
+  it('does NOT strip gear status when vessel.geared is explicit (false in fixtureA)', () => {
+    // fixtureVesselA.geared = false — payload provides this field
+    const text = 'The vessel is gearless.';
+    const r = stripInventedContent(text, fixtureMatchA, fixtureCargoA, fixtureVesselA);
+    expect(r.text).toContain('gearless');
+    expect(r.forbiddenTokens).not.toContain('gearless');
+  });
+
+  it('preserves stowage factor when cargo.stowageFactor is provided', () => {
+    const cargoWithSF: ParsedCargo = { ...fixtureCargoA, stowageFactor: '1.30' };
+    const text = 'The cargo stowage factor of 1.30 is typical for coal.';
+    const r = stripInventedContent(text, fixtureMatchA, cargoWithSF, fixtureVesselA);
+    expect(r.text).toContain('1.30');
+  });
+});
+
 // ── Behavioral: route retry flow ──────────────────────────────────────────────
 
 describe('POST /api/ai/explain-deal — hallucination retry (#589)', () => {
@@ -355,41 +461,40 @@ describe('POST /api/ai/explain-deal — hallucination retry (#589)', () => {
     counterparties: [],
   };
 
-  it('retries once when first LLM response contains invented numbers', async () => {
+  it('strips invented numbers from response (R2: no retry, post-process inline)', async () => {
     mockGetSession.mockReturnValue(baseSession);
 
-    // First call: hallucinated response (50,000 MT invented, 55,500 DWCC invented)
+    // Hallucinated response: 50,000 MT and 55,500 MT DWCC are NOT in the payload
+    // (cargoWeight=null, dwcc=null, only dwt=58000 is real).
     const hallucinatedResponse =
       'Market Context\nGrain market is active.\n\n' +
       'Deal Rationale\nThis 50,000 MT grain parcel fits the 55,500 MT DWCC vessel well.\n\n' +
       'Key Risks\n- Tight laycan\n\n' +
       'Recommended Next Steps\nContact owner.';
 
-    // Second call: corrected response (cites actual 58,000 DWT, no invented numbers)
-    const correctedResponse =
-      'Market Context\nGrain market is active in Black Sea.\n\n' +
-      'Deal Rationale\nMV Black Sea Star (58,000 DWT) is suitable. Cargo weight is not specified.\n\n' +
-      'Key Risks\n- Cargo weight not confirmed\n\n' +
-      'Recommended Next Steps\nConfirm cargo quantity before fixing.';
-
-    mockCallAiText
-      .mockResolvedValueOnce(hallucinatedResponse)
-      .mockResolvedValueOnce(correctedResponse);
+    mockCallAiText.mockResolvedValueOnce(hallucinatedResponse);
 
     const req = makeRequest({ matchIndex: 0 }, 'sess-qa');
     const res = await POST(req);
 
     expect(res.status).toBe(200);
-    // Route must have called callAiText twice (initial + retry)
-    expect(mockCallAiText).toHaveBeenCalledTimes(2);
+    // R2: strip-not-retry — exactly one LLM call, then post-process
+    expect(mockCallAiText).toHaveBeenCalledTimes(1);
 
     const body = await res.json();
-    // Response should use the corrected (second) text
     const rationale = body.sections.find(
       (s: { heading: string }) => s.heading === 'Deal Rationale',
     );
-    expect(rationale?.content).toContain('58,000 DWT');
-    expect(rationale?.content).not.toContain('50,000 MT');
+    // Invented numerics replaced with redaction marker; no raw "50,000" or "55,500"
+    expect(rationale?.content).not.toContain('50,000');
+    expect(rationale?.content).not.toContain('55,500');
+    expect(rationale?.content).toContain('[redacted: not in match data]');
+    // Warnings exposed in response metadata
+    expect(body.warnings).toBeDefined();
+    const numericWarning = body.warnings.find(
+      (w: { type: string }) => w.type === 'invented_numerics',
+    );
+    expect(numericWarning?.values).toEqual(expect.arrayContaining([50000, 55500]));
   });
 
   it('does not retry when first LLM response has no invented numbers', async () => {
@@ -410,32 +515,29 @@ describe('POST /api/ai/explain-deal — hallucination retry (#589)', () => {
     expect(mockCallAiText).toHaveBeenCalledTimes(1);
   });
 
-  it('retry prompt contains the invented numbers and correction instruction', async () => {
+  it('anchor prompt includes NOT_PROVIDED markers and FORBIDDEN clause', async () => {
     mockGetSession.mockReturnValue(baseSession);
 
-    const hallucinatedResponse =
-      'Market Context\nGrain market.\n\n' +
-      'Deal Rationale\n50,000 MT grain fits 55,500 DWCC.\n\n' +
-      'Key Risks\n- None\n\n' +
-      'Recommended Next Steps\nFix the deal.';
-
-    const correctedResponse =
+    const validResponse =
       'Market Context\nGrain market.\n\n' +
       'Deal Rationale\nVessel 58,000 DWT suits bulk grain. Weight not specified.\n\n' +
       'Key Risks\n- Weight unknown\n\n' +
       'Recommended Next Steps\nConfirm weight.';
 
-    mockCallAiText
-      .mockResolvedValueOnce(hallucinatedResponse)
-      .mockResolvedValueOnce(correctedResponse);
+    mockCallAiText.mockResolvedValueOnce(validResponse);
 
     const req = makeRequest({ matchIndex: 0 }, 'sess-qa');
     await POST(req);
 
-    // The second callAiText call (retry) must pass the correction prompt
-    const [, , retryUserPrompt] = mockCallAiText.mock.calls[1];
-    expect(retryUserPrompt).toContain('CORRECTION REQUIRED');
-    expect(retryUserPrompt).toContain('50000');
-    expect(retryUserPrompt).toContain('55500');
+    // R2 hard-anchor: prompt must list NOT_PROVIDED for missing fields and
+    // include the FORBIDDEN section so Gemini knows what to skip.
+    const [, , userPrompt] = mockCallAiText.mock.calls[0];
+    expect(userPrompt).toContain('MATCH PAYLOAD');
+    expect(userPrompt).toContain('NOT_PROVIDED');
+    expect(userPrompt).toContain('cargo.weight_mt: NOT_PROVIDED');
+    expect(userPrompt).toContain('vessel.dwcc: NOT_PROVIDED');
+    expect(userPrompt).toContain('cargo.stowage_factor: NOT_PROVIDED');
+    expect(userPrompt).toContain('FORBIDDEN');
+    expect(userPrompt).toContain('vessel.dwt_summer: 58000 MT');
   });
 });

--- a/app/api/ai/explain-deal/route.ts
+++ b/app/api/ai/explain-deal/route.ts
@@ -19,11 +19,7 @@ import {
   EXPLAIN_DEAL_SYSTEM_PROMPT_AR,
 } from '@/lib/prompts';
 import { ExplainDealBodySchema } from '@/lib/api-schemas';
-import {
-  validateExplainDealResponse,
-  buildRetryPrompt,
-  buildPayloadNumberSet,
-} from '@/lib/explain-deal-validator';
+import { stripInventedContent } from '@/lib/explain-deal-validator';
 
 export const maxDuration = 60;
 
@@ -48,10 +44,16 @@ export type ExplainDealSection = {
   content: string;
 };
 
+export type ExplainDealWarning = {
+  type: 'invented_numerics' | 'forbidden_tokens';
+  values: (string | number)[];
+};
+
 export type ExplainDealResponse = {
   sections: ExplainDealSection[];
   language: 'en' | 'ar';
   model: string;
+  warnings?: ExplainDealWarning[];
 };
 
 /**
@@ -176,24 +178,29 @@ export async function POST(request: NextRequest) {
     const llmOpts = { timeoutMs: endpointLlmTimeout(maxDuration), model: modelOverride };
     const rawText = await callAiText('EXPLAIN_DEAL', systemPrompt, userPrompt, llmOpts);
 
-    // A2: post-response numeric validation — retry once if invented numbers found
-    const validation = validateExplainDealResponse(rawText, match, cargo ?? null, vessel ?? null);
-    let finalText = rawText;
-    if (!validation.valid) {
-      const payloadNumbers = buildPayloadNumberSet(match, cargo ?? null, vessel ?? null);
-      const retryPrompt = buildRetryPrompt(userPrompt, validation.inventedNumbers, payloadNumbers);
-      finalText = await callAiText('EXPLAIN_DEAL', systemPrompt, retryPrompt, llmOpts);
-    }
+    // R2 (#589): strip-not-retry — post-process the response by replacing invented
+    // numerics and forbidden qualitative tokens with inline redaction markers.
+    // Retry approach (R1) was ineffective: Gemini re-invents the same values.
+    const stripped = stripInventedContent(rawText, match, cargo ?? null, vessel ?? null);
 
-    const sections = parseSections(finalText, headers);
+    const sections = parseSections(stripped.text, headers);
     const usedModel =
       modelOverride ??
       (process.env.AI_MODEL_HEAVY ?? 'gpt-5.5');
+
+    const warnings: ExplainDealWarning[] = [];
+    if (stripped.inventedNumbers.length > 0) {
+      warnings.push({ type: 'invented_numerics', values: stripped.inventedNumbers });
+    }
+    if (stripped.forbiddenTokens.length > 0) {
+      warnings.push({ type: 'forbidden_tokens', values: stripped.forbiddenTokens });
+    }
 
     const response: ExplainDealResponse = {
       sections,
       language,
       model: usedModel,
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
 
     return NextResponse.json(response);
@@ -220,30 +227,68 @@ function buildUserPrompt(
   vessel: import('@/lib/types').ParsedVessel | null,
   matchIndex: number,
 ): string {
-  // A1: explicit numeric anchor — list key numbers so LLM sees them before the JSON blob
+  // R2 hard-anchor: every field is listed with either its value or "NOT_PROVIDED".
+  // The LLM must NOT mention any NOT_PROVIDED field (FORBIDDEN clause below).
+  const fmt = (v: unknown): string => {
+    if (v === null || v === undefined || v === '') return 'NOT_PROVIDED';
+    if (typeof v === 'object' && 'value' in (v as { value?: unknown })) {
+      const val = (v as { value: unknown }).value;
+      return val === null || val === undefined || val === '' ? 'NOT_PROVIDED' : String(val);
+    }
+    return String(v);
+  };
+
   const cargoWeight =
     cargo?.weightMt?.value ?? cargo?.weightMtMin ?? cargo?.weightMtMax ?? null;
-  const vesselDwt = vessel?.dwtSummer?.value ?? null;
-  const vesselDwcc = vessel?.dwcc?.value ?? null;
-  const totalCost = match.economics?.totalUsd ?? null;
+  const cargoQuantity = (() => {
+    if (!cargo?.quantity) return null;
+    if (typeof cargo.quantity === 'number') return cargo.quantity;
+    if (typeof cargo.quantity === 'object' && 'min' in cargo.quantity) {
+      return `${cargo.quantity.min}–${cargo.quantity.max}`;
+    }
+    return null;
+  })();
 
-  const anchorLines = [
-    `Cargo weight: ${cargoWeight !== null ? `${cargoWeight} MT` : 'not specified'}`,
-    `Vessel DWT: ${vesselDwt !== null ? `${vesselDwt} MT` : 'not specified'}`,
-    vesselDwcc !== null ? `Vessel DWCC: ${vesselDwcc} MT` : null,
-    totalCost !== null ? `Total voyage cost: USD ${totalCost}` : null,
-  ]
-    .filter(Boolean)
-    .join('\n- ');
+  const payloadLines = [
+    `cargo.type: ${fmt(cargo?.cargoType)}`,
+    `cargo.description: ${fmt(cargo?.cargoDescription)}`,
+    `cargo.weight_mt: ${cargoWeight !== null ? `${cargoWeight} MT` : 'NOT_PROVIDED'}`,
+    `cargo.quantity: ${cargoQuantity !== null ? cargoQuantity : 'NOT_PROVIDED'}`,
+    `cargo.stowage_factor: ${fmt(cargo?.stowageFactor)}`,
+    `cargo.origin_port: ${fmt(cargo?.originPort)}`,
+    `cargo.destination_port: ${fmt(cargo?.destinationPort)}`,
+    `cargo.laycan: ${fmt(cargo?.laycan)}`,
+    `vessel.name: ${fmt(vessel?.vesselName)}`,
+    `vessel.imo: ${fmt(vessel?.imo)}`,
+    `vessel.type: ${fmt(vessel?.vesselType)}`,
+    `vessel.flag: ${fmt(vessel?.flag)}`,
+    `vessel.built: ${fmt(vessel?.built)}`,
+    `vessel.dwt_summer: ${vessel?.dwtSummer?.value ? `${vessel.dwtSummer.value} MT` : 'NOT_PROVIDED'}`,
+    `vessel.dwcc: ${vessel?.dwcc?.value ? `${vessel.dwcc.value} MT` : 'NOT_PROVIDED'}`,
+    `vessel.class_society: ${fmt(vessel?.classSociety)}`,
+    `vessel.geared: ${vessel?.geared === null || vessel?.geared === undefined ? 'NOT_PROVIDED' : String(vessel.geared)}`,
+    `vessel.holds_count: ${fmt(vessel?.holdsCount)}`,
+    `vessel.grain_capacity: ${vessel?.grainCapacity ? String(vessel.grainCapacity) : 'NOT_PROVIDED'}`,
+    `vessel.open_position: ${fmt(vessel?.openPosition)}`,
+    `vessel.open_date: ${fmt(vessel?.openDate)}`,
+    `economics.total_usd: ${match.economics?.totalUsd ? `USD ${match.economics.totalUsd}` : 'NOT_PROVIDED'}`,
+  ].join('\n- ');
 
-  return `MATCH DATA (index ${matchIndex}):
+  return `MATCH PAYLOAD (index ${matchIndex}) — use ONLY these values; NEVER infer, estimate, or default:
+- ${payloadLines}
 
-NUMERIC ANCHOR — cite ONLY these values; for anything absent write "not specified":
-- ${anchorLines}
+FORBIDDEN — do NOT mention any field marked NOT_PROVIDED. Do NOT fabricate:
+- Stowage factors in m³/MT or any unit (if cargo.stowage_factor is NOT_PROVIDED)
+- Vessel class societies (DNV, LR, ABS, BV, NK, RINA, CCS, KR, etc.) other than the exact value above
+- Gear status (gearless, geared, crane-fitted) if vessel.geared is NOT_PROVIDED
+- Specific quantities, capacities, DWT, DWCC, or freight rates not listed above
+- Open position history, last cargoes, hold/hatch dimensions not in the payload
 
 Score: ${match.score}/100 (${match.matchLevel.toUpperCase()})
 Match Reasons: ${match.matchReasons.join('; ') || 'none'}
 Issues: ${match.issues.join('; ') || 'none'}
+
+FULL DATA (for context only — do NOT use any value missing from the MATCH PAYLOAD anchor above):
 
 CARGO:
 ${cargo ? JSON.stringify(cargo, null, 2) : 'Not available'}
@@ -257,5 +302,5 @@ ${match.economics ? JSON.stringify(match.economics, null, 2) : 'Not available'}
 SCORE BREAKDOWN:
 ${match.scoreBreakdown ? JSON.stringify(match.scoreBreakdown, null, 2) : 'Not available'}
 
-Please produce the 4-section narrative based on this data.`;
+Please produce the 4-section narrative using ONLY values from the MATCH PAYLOAD anchor.`;
 }

--- a/docs/superpowers/plans/2026-05-27-589-r2-opus.md
+++ b/docs/superpowers/plans/2026-05-27-589-r2-opus.md
@@ -1,0 +1,66 @@
+# Issue #589 — Fix Round 2 (Opus)
+
+**Source:** PR #601 (Sonnet R1) deployed но visual=FAIL via playwright 2026-05-27 17:43 UTC. Gemini продолжает invent: `50000 MT cargo`, `55500 MT DWCC`, `1.25 stowage`, и качественные facts (Singapore open position, DNV class, gearless) которых НЕТ в match payload.
+
+**Tier:** M (~3-5 файлов tuning existing) · creative=YES · brainstorm=inline-in-plan · **Opus 4.7** (DISPATCH_MODEL=claude-opus-4-7, per memory feedback_fix_loop_escalate_to_opus)
+
+## What R1 (Sonnet) did
+- Added NUMERIC ANCHOR section в user prompt
+- Added validator `lib/explain-deal-validator.ts` (regex extract numerics, cross-check, 2% tolerance, one-shot retry)
+- 20 behavioral tests green
+
+## Why R1 failed (RC investigation)
+- **Issue 1 — regex misses unformatted numerics.** Validator likely matches `50,000` с запятой, но Gemini выдаёт `50000` без. Fixture tests могли проверять только comma-formatted strings.
+- **Issue 2 — anchor weak vs free-form generation.** Anchor lists payload values, но Gemini «дополняет» context plausible defaults. Anchor должен explicitly mark missing fields как `NOT_PROVIDED` и forbid mentioning поля без data.
+- **Issue 3 — qualitative facts not constrained.** Gemini инвентирует non-numeric claims ("DNV class", "Singapore position", "gearless") — текущий validator только numeric. Нужно либо tighten system prompt («NEVER mention vessel name/class/equipment не из payload»), либо whitelist подход.
+- **Issue 4 — retry doesn't help.** Retry с corrective prompt не уговаривает Gemini — он re-invents same numbers. Validator должен STRIP invented numbers from response, не retry.
+
+## Hypothesis tree (Opus brainstorm)
+
+- **H1 (most likely):** validator regex `\d{1,3}(,\d{3})*` ловит запятые, не unformatted. Fix: расширить до `\d{1,3}(,\d{3})*|\d{4,}` covering 50000 / 55500. Decimals: `\d+\.\d+` covers 1.25.
+- **H2:** anchor включает только numeric fields. Должен включать ВСЕ relevant fields с `NOT_PROVIDED` для missing. И добавить explicit «do not mention any specification not listed above».
+- **H3:** Gemini ignoring constraints under pressure of "broker-style narrative". Lower temperature, switch на structured output schema (A3 from R1 plan).
+
+## R2 approach: Strip-not-Retry + Hard-anchor + Whitelist
+
+1. **Validator extends regex:**
+   - `\d{1,3}(,\d{3})+(\.\d+)?` — comma-formatted with optional decimal
+   - `\d{4,}(\.\d+)?` — unformatted 4+ digit
+   - `\d+\.\d{2,}` — decimals like 1.25
+   - Filter known whitelist (years 2020-2030, scores ≤100, common ratings)
+2. **Anchor rewrite — be explicit about NOT_PROVIDED:**
+   ```
+   MATCH PAYLOAD (use ONLY these values; NEVER infer, estimate, or default):
+   - cargo.type: BULK
+   - cargo.quantity_mt: NOT_PROVIDED
+   - vessel.dwt: 58000
+   - vessel.dwcc: NOT_PROVIDED
+   - vessel.imo: 9999991
+   - load_port: CNSHA
+   - discharge_port: NLRTM
+   FORBIDDEN: mentioning any field marked NOT_PROVIDED, fabricating stowage factors, vessel class, equipment, or position history.
+   ```
+3. **Strip-not-retry post-processing:**
+   - If validator found invented numerics OR forbidden tokens → replace с `[redacted: not in match data]` ИЛИ remove whole sentence containing
+   - Save invented numerics + forbidden tokens в response metadata для frontend warning ("AI mentioned X but data unavailable — verify manually")
+4. **Behavioral test additions:**
+   - Fixture w/ payload no qty, no DWCC, no stowage → Gemini call → assert response не mentions ANY of {qty, DWCC, stowage, vessel class names DNV/LR/ABS, port names not load/discharge}
+   - Edge regex test: `50000` без запятой = caught, `1.25` decimal = caught
+
+## Out of scope
+- Switch на different LLM (sticking with Gemini 2.5 Pro)
+- UI redesign for AI modal
+- Caching/retry strategy
+
+## QA gate (PI2)
+- jest --findRelatedTests на validator + route — green
+- Real LLM call в behavioral test (no mock) — 3 fixture matches
+- /test-skill cold QA mandatory
+
+## PI3
+- Existing 20 tests из R1 — НЕ удалять, расширять
+- Не trim чрезмерно response (preserve LLM rationale, только strip invented facts)
+
+## Acceptance (round 2)
+- Playwright re-test: open Explain this deal → response не упоминает: invented numerics, vessel class, equipment, position history, stowage factor если не в payload
+- Validator catches "50000 MT" unformatted + "1.25" decimal + qualitative tokens (DNV|LR|ABS|gearless|geared)

--- a/lib/explain-deal-validator.ts
+++ b/lib/explain-deal-validator.ts
@@ -2,6 +2,9 @@
  * Post-response validation for "Explain this deal" (#589).
  * Extracts numeric values from LLM output and cross-checks against the match payload
  * to detect hallucinated cargo quantities, vessel DWT, or freight rates.
+ *
+ * R2 (#589 round 2): also strips invented qualitative tokens (class society,
+ * gear status, stowage factor) when payload doesn't carry that field.
  */
 import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
 import { isRange } from '@/lib/types';
@@ -18,7 +21,10 @@ function isYearLike(n: number): boolean {
 
 /**
  * Extract all "specification-scale" numbers (≥500, non-year) from LLM response text.
- * Handles comma-formatted numbers like "28,000".
+ * Handles comma-formatted numbers ("28,000"), unformatted ("28000"), and decimals.
+ *
+ * R2: explicit handling for unformatted 4+ digit (Gemini sometimes outputs "50000"
+ * without comma) — comma-strip in normalize covers both forms.
  */
 export function extractSpecNumbers(text: string): number[] {
   const normalized = text.replace(/(\d),(\d{3})/g, '$1$2');
@@ -98,6 +104,34 @@ function isWithinTolerance(n: number, allowed: Set<number>): boolean {
   return false;
 }
 
+/** Class society abbreviations Gemini commonly invents when classSociety is null. */
+const CLASS_SOCIETIES = [
+  'DNV',
+  'DNV-GL',
+  'DNV GL',
+  'LR',
+  "Lloyd's Register",
+  'ABS',
+  'BV',
+  'NK',
+  'NKK',
+  'ClassNK',
+  'RINA',
+  'CCS',
+  'KR',
+  'KRS',
+  'IRS',
+];
+
+const REDACTION_NUMBER = '[redacted: not in match data]';
+const REDACTION_CLASS = '[redacted: class society not in match data]';
+const REDACTION_GEAR = '[redacted: gear status not in match data]';
+const REDACTION_STOWAGE = '[redacted: stowage factor not in match data]';
+
+function normalizeClassSocietyToken(raw: string): string {
+  return raw.toUpperCase().replace(/[\s-]/g, '').replace(/[‘’']/g, '');
+}
+
 export type ValidationResult = {
   valid: boolean;
   inventedNumbers: number[];
@@ -121,6 +155,86 @@ export function validateExplainDealResponse(
   );
 
   return { valid: inventedNumbers.length === 0, inventedNumbers };
+}
+
+export type StripResult = {
+  text: string;
+  inventedNumbers: number[];
+  forbiddenTokens: string[];
+};
+
+/**
+ * R2 strip-not-retry: post-process the LLM response by replacing invented
+ * numerics and forbidden qualitative tokens with inline redaction markers.
+ *
+ * Strips:
+ * - Large numbers (≥500) absent from match payload, including unformatted (50000)
+ *   and comma-formatted (50,000) variants
+ * - Class society abbreviations when vessel.classSociety is null OR doesn't match
+ * - Gear status ("gearless", "geared") when vessel.geared is null/undefined
+ * - "stowage factor X.Y" phrases when cargo.stowageFactor is null
+ */
+export function stripInventedContent(
+  text: string,
+  match: Match,
+  cargo: ParsedCargo | null,
+  vessel: ParsedVessel | null,
+): StripResult {
+  const payloadNumbers = buildPayloadNumberSet(match, cargo, vessel);
+  const inventedNumbers: number[] = [];
+  const forbiddenTokens: string[] = [];
+
+  // 1. Strip invented numbers. Pattern covers: comma-formatted (50,000),
+  //    unformatted 4+ digit (50000), and decimals (1.25 — caught for context
+  //    but filtered by threshold below; the stowage factor pass handles SF).
+  let stripped = text.replace(
+    /\b\d{1,3}(?:,\d{3})+(?:\.\d+)?|\b\d{4,}(?:\.\d+)?\b/g,
+    (raw) => {
+      const n = parseFloat(raw.replace(/,/g, ''));
+      if (!Number.isFinite(n)) return raw;
+      if (n < LARGE_NUMBER_THRESHOLD || isYearLike(n)) return raw;
+      if (isWithinTolerance(n, payloadNumbers)) return raw;
+      inventedNumbers.push(n);
+      return REDACTION_NUMBER;
+    },
+  );
+
+  // 2. Strip stowage factor mentions when cargo.stowageFactor is null.
+  //    Catches "stowage factor of 1.25", "SF 1.25 m³/MT", "stowage factor: 1.25".
+  if (!cargo?.stowageFactor) {
+    stripped = stripped.replace(
+      /\b(?:stowage\s*factor|SF)\s*(?:of|is|:|=|approximately|approx\.?|~)?\s*\d+(?:\.\d+)?\s*(?:m³?\/?MT|m3\/MT)?/gi,
+      (raw) => {
+        forbiddenTokens.push(raw.trim());
+        return REDACTION_STOWAGE;
+      },
+    );
+  }
+
+  // 3. Strip class society mentions that don't match vessel.classSociety.
+  const payloadClass = vessel?.classSociety
+    ? normalizeClassSocietyToken(vessel.classSociety)
+    : null;
+  for (const candidate of CLASS_SOCIETIES) {
+    const escaped = candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`\\b${escaped}\\b`, 'g');
+    stripped = stripped.replace(re, (raw) => {
+      const norm = normalizeClassSocietyToken(raw);
+      if (payloadClass && norm === payloadClass) return raw;
+      forbiddenTokens.push(raw);
+      return REDACTION_CLASS;
+    });
+  }
+
+  // 4. Strip gear status when vessel.geared is null/undefined (unknown).
+  if (vessel?.geared === null || vessel?.geared === undefined) {
+    stripped = stripped.replace(/\b(gearless|geared)\b/gi, (raw) => {
+      forbiddenTokens.push(raw);
+      return REDACTION_GEAR;
+    });
+  }
+
+  return { text: stripped, inventedNumbers, forbiddenTokens };
 }
 
 /**

--- a/lib/prompts/explain-deal.ts
+++ b/lib/prompts/explain-deal.ts
@@ -32,11 +32,20 @@ Output format:
 - No markdown formatting in section content — plain text only
 - Do NOT include the section number in the header (write "Market Context" not "1. Market Context")
 
-CRITICAL DATA INTEGRITY — NO INVENTED NUMERICS:
-You MUST use ONLY numeric values explicitly present in the match data provided.
-If a field is null, absent, or marked "Not available" — write "not specified" rather than estimating.
+CRITICAL DATA INTEGRITY — NO INVENTED NUMERICS OR QUALITATIVE FACTS:
+You MUST use ONLY values explicitly present in the match data provided.
+The user prompt contains a "MATCH PAYLOAD" anchor section listing every field with its value.
+Fields marked "NOT_PROVIDED" have no value — do NOT mention them, do NOT estimate, do NOT default.
+
 NEVER substitute cargo quantity, vessel DWT/DWCC, freight rates, or TCE values with "typical" broker estimates or training-data priors.
-If you cannot find a specific number in the data, omit it or state "not specified".`;
+NEVER fabricate qualitative facts not in the payload:
+- Stowage factors (in m³/MT or any unit)
+- Vessel class society (DNV, LR, ABS, BV, NK, RINA, CCS, KR, etc.) unless the payload lists it
+- Gear status (gearless, geared, crane-fitted) unless the payload lists it
+- Open position history, last cargoes, or specific itinerary not in the payload
+- Hold/hatch dimensions, capacities, or equipment not in the payload
+
+If a value is NOT_PROVIDED, write "not specified in the inquiry" or omit the topic entirely.`;
 
 export const EXPLAIN_DEAL_SYSTEM_PROMPT_AR = `أنت محلل وساطة شحن بحري أول تشرح مطابقة بضاعة-سفينة لوسيط مقيم في دبي.
 
@@ -68,7 +77,17 @@ export const EXPLAIN_DEAL_SYSTEM_PROMPT_AR = `أنت محلل وساطة شحن 
 - لا تدرج رقم القسم في العنوان
 - لا تستخدم أي تنسيق markdown (نجوم، علامات #) في عناوين الأقسام — اكتبها كنص عادي
 
-قواعد النزاهة الحرجة — لا تختلق أرقاماً:
-يجب استخدام القيم الرقمية الموجودة صراحةً في بيانات المطابقة المقدمة فقط.
-إذا كان الحقل فارغاً أو غير متوفر — اكتب "غير محدد" بدلاً من التقدير.
-لا تستبدل كمية البضاعة أو DWT/DWCC للسفينة أو أسعار الشحن بتقديرات وسيط نموذجية.`;
+قواعد النزاهة الحرجة — لا تختلق أرقاماً أو حقائق:
+يجب استخدام القيم الموجودة صراحةً في بيانات المطابقة المقدمة فقط.
+يحتوي مطلب المستخدم على قسم "MATCH PAYLOAD" يسرد كل حقل بقيمته.
+الحقول المعلّمة بـ "NOT_PROVIDED" لا تحمل قيمة — لا تذكرها ولا تقدّر ولا تفترض قيماً افتراضية.
+
+لا تستبدل كمية البضاعة أو DWT/DWCC للسفينة أو أسعار الشحن أو TCE بتقديرات وسيط نموذجية.
+لا تختلق حقائق نوعية غير موجودة في البيانات:
+- معامل الرص (stowage factor) بأي وحدة
+- فئة التصنيف للسفينة (DNV, LR, ABS, BV, NK, RINA, CCS, KR إلخ) إلا إذا ذكرتها البيانات
+- حالة التجهيز (gearless, geared) إلا إذا ذكرتها البيانات
+- تاريخ المواقع المفتوحة أو الشحنات السابقة أو خط السير غير الموجود في البيانات
+- أبعاد العنابر أو السعات أو المعدات غير الموجودة في البيانات
+
+إذا كانت القيمة NOT_PROVIDED، اكتب "غير محدد في الاستفسار" أو احذف الموضوع كلياً.`;


### PR DESCRIPTION
Reopens fix for #589 (R1 PR #601 deployed но playwright FAIL 2026-05-27 17:43 UTC).

## R1 failure (PR #601, Sonnet)
- Validator regex ловил comma-formatted (`50,000`) но не unformatted (`50000`)
- Qualitative inventions (DNV class, Singapore position, gearless, 1.25 stowage) не проверялись
- Retry-corrective prompt не убеждал Gemini

## R2 (Opus 4.7) approach
- **Extended validator regex** — unformatted 4+ digit + decimals (1.25) + qualitative tokens (DNV/LR/ABS/gearless/geared/stowage)
- **Hard anchor** — explicit `NOT_PROVIDED` markers per field + `FORBIDDEN` section
- **Strip-not-retry** — replace invented content с `[redacted: not in match data]`, expose `warnings[]` метаданные frontend'у
- **13 new behavioral tests** (PI3 preserved 21 R1 tests, 2 retry-flow reworked для strip)

## Files
- `lib/explain-deal-validator.ts` — `stripInventedContent` function + extended regex
- `lib/prompts/explain-deal.ts` — anchor rewrite
- `app/api/ai/explain-deal/route.ts` — switch retry→strip + warnings metadata
- `__tests__/explain-deal-hallucination.test.ts` — 13 new tests

## Tests
65/65 explain-deal suites · 468/468 related · tsc clean.

## Plan
docs/superpowers/plans/2026-05-27-589-r2-opus.md

🤖 Generated with Claude Code (Opus 4.7 fix round 2)