### PR TITLE
feat(demo-seed): LLM cache parsing — drive 153 emails through live parsers, cache results, feed into demo-seed pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ lib/sample-data/etms-emails.json
 .test-review-*/
 **/playwright-report-rag/
 .env*.stale*
+
+# Demo-seed LLM cache (Task 1 — feat/demo-llm-cache-parsing)
+scripts/demo-seed/.llm-cache/
+.private/.llm-cache/

--- a/docs/superpowers/plans/2026-05-27-demo-llm-cache-parsing.md
+++ b/docs/superpowers/plans/2026-05-27-demo-llm-cache-parsing.md
@@ -1,0 +1,1147 @@
+# Demo LLM Cache Parsing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+CHAIN_demo_llm_cache=M creative=y writing_plans=docs/superpowers/plans/2026-05-27-demo-llm-cache-parsing.md
+
+**Goal:** Drive 153 real broker emails through this repo's live LLM HTTP endpoints once, cache the structured output, and feed it into demo-seed pipeline so `data/demo-seed.db.matches` row count goes from 0 to >50.
+
+**Architecture:** New `scripts/demo-seed/llm-cache.ts` provides pure helpers for hash + read/write. New `scripts/demo-seed/parse-via-devserver.ts` is the driver — seeds a session into `data/sessions.db`, drives 4 LLM endpoints over HTTP, reads the resulting parsed arrays back, writes a single cache JSON. `scripts/demo-seed/analyze.ts` and `scripts/demo-seed/build.ts` are extended with a cache-prefer code path that falls back to the existing regex logic when no cache file is present (CI-safe).
+
+**Tech Stack:** TypeScript (tsx), better-sqlite3, Node fetch, existing parsers + SessionStore, jest.
+
+**Spec:** [docs/superpowers/specs/2026-05-27-demo-llm-cache-parsing-design.md](../specs/2026-05-27-demo-llm-cache-parsing-design.md)
+
+**Branch:** `feat/demo-llm-cache-parsing` (already created from `89fcba1`).
+
+**Pre-flight for every Bash step:** working directory = repo root.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `scripts/demo-seed/llm-cache.ts` | CREATE | `corpusHash()`, `readCache()`, `writeCache()`, `cachePath()`, type `LlmCache` |
+| `scripts/demo-seed/__tests__/llm-cache.test.ts` | CREATE | Unit tests for hash determinism + round-trip |
+| `scripts/demo-seed/parse-via-devserver.ts` | CREATE | Driver: seed session → HTTP × 4 → write cache |
+| `scripts/demo-seed/analyze.ts` | MODIFY | Prefer cache when present; fall back to regex |
+| `scripts/demo-seed/build.ts` | MODIFY | Write real cargo/vessel/recap rows from cache |
+| `scripts/demo-seed/__tests__/analyze.test.ts` | MODIFY | Add cache-prefer test |
+| `scripts/demo-seed/__tests__/build.test.ts` | MODIFY | Add cache-yields-matches test |
+| `.gitignore` | MODIFY | Add `scripts/demo-seed/.llm-cache/` |
+
+---
+
+## Task 1 — Cache types + helpers (`scripts/demo-seed/llm-cache.ts`)
+
+**Files:**
+- Create: `scripts/demo-seed/llm-cache.ts`
+- Create: `scripts/demo-seed/__tests__/llm-cache.test.ts`
+
+- [ ] **Step 1: Write the failing tests.**
+
+```typescript
+// scripts/demo-seed/__tests__/llm-cache.test.ts
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  corpusHash,
+  cachePath,
+  readCache,
+  writeCache,
+  loadLlmCacheIfAny,
+  type LlmCache,
+} from '../llm-cache';
+
+function makeCorpus(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-cache-test-'));
+  fs.writeFileSync(path.join(dir, 'a.json'), '{"id":"a","body":"alpha"}');
+  fs.writeFileSync(path.join(dir, 'b.json'), '{"id":"b","body":"beta"}');
+  return dir;
+}
+
+describe('corpusHash', () => {
+  it('returns a 64-char hex string', () => {
+    const dir = makeCorpus();
+    expect(corpusHash(dir)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic across calls', () => {
+    const dir = makeCorpus();
+    expect(corpusHash(dir)).toBe(corpusHash(dir));
+  });
+
+  it('changes when any file content changes', () => {
+    const dir = makeCorpus();
+    const h1 = corpusHash(dir);
+    fs.writeFileSync(path.join(dir, 'a.json'), '{"id":"a","body":"ALPHA"}');
+    expect(corpusHash(dir)).not.toBe(h1);
+  });
+
+  it('does not depend on file enumeration order', () => {
+    const dir = makeCorpus();
+    const h1 = corpusHash(dir);
+    // Rewrite same content in opposite order — hash must match
+    const a = fs.readFileSync(path.join(dir, 'a.json'));
+    const b = fs.readFileSync(path.join(dir, 'b.json'));
+    fs.unlinkSync(path.join(dir, 'a.json'));
+    fs.unlinkSync(path.join(dir, 'b.json'));
+    fs.writeFileSync(path.join(dir, 'b.json'), b);
+    fs.writeFileSync(path.join(dir, 'a.json'), a);
+    expect(corpusHash(dir)).toBe(h1);
+  });
+
+  it('ignores non-.json files', () => {
+    const dir = makeCorpus();
+    const h1 = corpusHash(dir);
+    fs.writeFileSync(path.join(dir, 'README.md'), 'docs');
+    expect(corpusHash(dir)).toBe(h1);
+  });
+});
+
+describe('writeCache + readCache', () => {
+  it('round-trips a cache payload', () => {
+    const dir = makeCorpus();
+    const cache: LlmCache = {
+      corpusHash: 'abc',
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [{ emailId: 'a' } as any],
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(dir, cache);
+    const read = readCache(dir, 'abc');
+    expect(read).toEqual(cache);
+  });
+});
+
+describe('loadLlmCacheIfAny', () => {
+  it('returns null when .llm-cache/ does not exist', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-cache-'));
+    expect(loadLlmCacheIfAny(dir)).toBeNull();
+  });
+
+  it('returns null when cache hash does not match corpus hash', () => {
+    const dir = makeCorpus();
+    const cache: LlmCache = {
+      corpusHash: 'stale-hash',
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [], parsedCargos: [], parsedVessels: [], parsedFixtureRecaps: [],
+    };
+    writeCache(dir, cache);
+    expect(loadLlmCacheIfAny(dir)).toBeNull();
+  });
+
+  it('returns cache when hash matches', () => {
+    const dir = makeCorpus();
+    const h = corpusHash(dir);
+    const cache: LlmCache = {
+      corpusHash: h,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [], parsedCargos: [], parsedVessels: [], parsedFixtureRecaps: [],
+    };
+    writeCache(dir, cache);
+    const loaded = loadLlmCacheIfAny(dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.corpusHash).toBe(h);
+  });
+});
+
+describe('cachePath', () => {
+  it('joins the corpus dir + .llm-cache/<hash>.json', () => {
+    expect(cachePath('/x/y', 'abc')).toBe('/x/y/.llm-cache/abc.json');
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL (module not found).**
+
+```bash
+npx jest scripts/demo-seed/__tests__/llm-cache.test.ts
+```
+
+- [ ] **Step 3: Implement `llm-cache.ts`.**
+
+```typescript
+// scripts/demo-seed/llm-cache.ts
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  Classification,
+  ParsedCargo,
+  ParsedVessel,
+  ParsedFixtureRecap,
+} from '@/lib/types';
+
+export interface LlmCache {
+  corpusHash: string;
+  generatedAt: string;
+  classifications: Classification[];
+  parsedCargos: ParsedCargo[];
+  parsedVessels: ParsedVessel[];
+  parsedFixtureRecaps: ParsedFixtureRecap[];
+}
+
+const CACHE_DIR_NAME = '.llm-cache';
+
+/**
+ * Deterministic SHA-256 of every .json file in `rawDir`, joined in
+ * lexicographic filename order so the result is independent of the
+ * underlying filesystem enumeration order.
+ */
+export function corpusHash(rawDir: string): string {
+  const files = fs
+    .readdirSync(rawDir)
+    .filter(f => f.endsWith('.json'))
+    .sort();
+  const hash = crypto.createHash('sha256');
+  for (const f of files) {
+    hash.update(f);
+    hash.update('\0');
+    hash.update(fs.readFileSync(path.join(rawDir, f)));
+    hash.update('\n--FILE--\n');
+  }
+  return hash.digest('hex');
+}
+
+export function cachePath(rawDir: string, hash: string): string {
+  return path.join(rawDir, CACHE_DIR_NAME, `${hash}.json`);
+}
+
+export function writeCache(rawDir: string, cache: LlmCache): void {
+  const dir = path.join(rawDir, CACHE_DIR_NAME);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(cachePath(rawDir, cache.corpusHash), JSON.stringify(cache, null, 2) + '\n');
+}
+
+export function readCache(rawDir: string, hash: string): LlmCache | null {
+  const p = cachePath(rawDir, hash);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8')) as LlmCache;
+}
+
+/**
+ * Returns the cache file whose hash matches the current corpus, or null.
+ * Used by analyze.ts / build.ts to opt into LLM-parsed data when available
+ * without blowing up if it's absent (CI, fresh worktree).
+ */
+export function loadLlmCacheIfAny(rawDir: string): LlmCache | null {
+  const dirExists = fs.existsSync(path.join(rawDir, CACHE_DIR_NAME));
+  if (!dirExists) return null;
+  const h = corpusHash(rawDir);
+  return readCache(rawDir, h);
+}
+```
+
+NOTE: the spec wrote cache files under `scripts/demo-seed/.llm-cache/`, but locating them next to the corpus (`<rawDir>/.llm-cache/`) keeps the hash and the data physically co-located. This is safer for the case where someone moves `.private/`. `.private/` is already gitignored so `.private/.llm-cache/` inherits that.
+
+UPDATE `.gitignore` to make this explicit even if `.private/` were ever un-ignored:
+
+- [ ] **Step 4: Add gitignore entries.**
+
+```bash
+printf '\n# Demo-seed LLM cache\nscripts/demo-seed/.llm-cache/\n.private/.llm-cache/\n' >> .gitignore
+```
+
+- [ ] **Step 5: Run, expect PASS.**
+
+```bash
+npx jest scripts/demo-seed/__tests__/llm-cache.test.ts
+```
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add scripts/demo-seed/llm-cache.ts \
+        scripts/demo-seed/__tests__/llm-cache.test.ts \
+        .gitignore
+git commit --no-verify -m "feat(demo-seed): llm-cache helpers (hash, read/write, load)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 — Driver script (`parse-via-devserver.ts`)
+
+**Files:**
+- Create: `scripts/demo-seed/parse-via-devserver.ts`
+
+This task has no unit test (it's an integration driver that hits a live dev-server). It is verified by Task 5 end-to-end run. We still add a `--dry-run` flag that prints the plan without making network calls — that flag is what a future regression test would assert on.
+
+- [ ] **Step 1: Implement driver skeleton with `--dry-run`.**
+
+```typescript
+// scripts/demo-seed/parse-via-devserver.ts
+/**
+ * Drive the real LLM HTTP endpoints to parse all .private/raw-emails/*.json once,
+ * cache the result, exit. Re-running with same corpus is a no-op (cache hit).
+ *
+ * Usage:
+ *   tsx scripts/demo-seed/parse-via-devserver.ts [--raw-dir DIR] [--base-url URL] [--dry-run]
+ *
+ * Pre-req: dev-server on http://localhost:3000 (`npm run dev` in another terminal).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+import { getStore } from '@/lib/session-store';
+import type { Email } from '@/lib/types';
+import { normalizeRawEmail } from './analyze';
+import {
+  corpusHash,
+  loadLlmCacheIfAny,
+  writeCache,
+  type LlmCache,
+} from './llm-cache';
+
+const DEFAULT_RAW = '.private/raw-emails';
+const DEFAULT_BASE = 'http://localhost:3000';
+const ENDPOINTS = [
+  '/api/ai/classify',
+  '/api/ai/parse-cargo',
+  '/api/ai/parse-vessel',
+  '/api/ai/parse-recap',
+] as const;
+const PER_CALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 min
+
+interface Args {
+  rawDir: string;
+  baseUrl: string;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (k: string) => {
+    const i = argv.indexOf(k);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  return {
+    rawDir: path.resolve(get('--raw-dir') ?? DEFAULT_RAW),
+    baseUrl: get('--base-url') ?? DEFAULT_BASE,
+    dryRun: argv.includes('--dry-run'),
+  };
+}
+
+async function probeServer(baseUrl: string): Promise<boolean> {
+  try {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), 2000);
+    const r = await fetch(baseUrl, { signal: ctl.signal });
+    clearTimeout(t);
+    return r.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+function flatToEmail(flat: ReturnType<typeof normalizeRawEmail>): Email {
+  return {
+    id: flat.messageId,
+    threadId: flat.threadId,
+    from: flat.fromName
+      ? `${flat.fromName} <${flat.fromEmail ?? ''}>`
+      : (flat.fromEmail ?? ''),
+    fromName: flat.fromName ?? null,
+    fromEmail: flat.fromEmail ?? null,
+    to: '',
+    subject: flat.subject ?? '',
+    date: flat.date,
+    body: flat.body,
+    snippet: flat.body.slice(0, 200),
+    labelIds: [],
+  };
+}
+
+async function callEndpoint(
+  baseUrl: string,
+  endpoint: string,
+  sessionId: string,
+): Promise<{ ok: boolean; status: number; body: string }> {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), PER_CALL_TIMEOUT_MS);
+  try {
+    const r = await fetch(`${baseUrl}${endpoint}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Cookie': `session_id=${sessionId}`,
+      },
+      body: '{}',
+      signal: ctl.signal,
+    });
+    const body = await r.text();
+    return { ok: r.ok, status: r.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!fs.existsSync(args.rawDir)) {
+    console.error(`Raw dir does not exist: ${args.rawDir}`);
+    process.exit(2);
+  }
+
+  const hash = corpusHash(args.rawDir);
+  console.log(`[parse-via-devserver] corpus hash: ${hash}`);
+
+  if (loadLlmCacheIfAny(args.rawDir)) {
+    console.log('[parse-via-devserver] cache hit — nothing to do.');
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log('[dry-run] would seed session into data/sessions.db');
+    console.log('[dry-run] would POST sequentially:');
+    for (const ep of ENDPOINTS) console.log(`  ${args.baseUrl}${ep}`);
+    console.log(`[dry-run] would write cache: ${args.rawDir}/.llm-cache/${hash}.json`);
+    return;
+  }
+
+  if (!(await probeServer(args.baseUrl))) {
+    console.error(
+      `[parse-via-devserver] dev-server not reachable at ${args.baseUrl}.\n` +
+        `Run \`npm run dev\` in another terminal and retry.`,
+    );
+    process.exit(2);
+  }
+
+  // Load corpus → Email[]
+  const files = fs.readdirSync(args.rawDir).filter(f => f.endsWith('.json')).sort();
+  const emails: Email[] = files.map(f => {
+    const raw = JSON.parse(fs.readFileSync(path.join(args.rawDir, f), 'utf8'));
+    return flatToEmail(normalizeRawEmail(raw));
+  });
+  console.log(`[parse-via-devserver] loaded ${emails.length} emails`);
+
+  // Seed session via the real SessionStore (writes data/sessions.db)
+  const store = getStore();
+  const sessionId = store.createSession('demo-script-token');
+  store.updateSession(sessionId, { emails });
+  console.log(`[parse-via-devserver] seeded session ${sessionId}`);
+
+  // Drive endpoints sequentially. Each modifies session.<field>, next reads it.
+  try {
+    for (const ep of ENDPOINTS) {
+      console.log(`[parse-via-devserver] POST ${ep} ...`);
+      const t0 = Date.now();
+      const res = await callEndpoint(args.baseUrl, ep, sessionId);
+      const dt = ((Date.now() - t0) / 1000).toFixed(1);
+      console.log(`  ← ${res.status} in ${dt}s — ${res.body.slice(0, 200)}`);
+      if (!res.ok) {
+        console.error(`[parse-via-devserver] ${ep} returned ${res.status}; aborting.`);
+        console.error(res.body);
+        process.exit(3);
+      }
+    }
+  } finally {
+    // Read final session state regardless of outcome
+  }
+
+  // Read back the populated session
+  const final = store.getSession(sessionId);
+  if (!final) {
+    console.error('[parse-via-devserver] session vanished after parsing');
+    process.exit(3);
+  }
+
+  const cache: LlmCache = {
+    corpusHash: hash,
+    generatedAt: new Date().toISOString(),
+    classifications: final.classifications,
+    parsedCargos: final.parsedCargos,
+    parsedVessels: final.parsedVessels,
+    parsedFixtureRecaps: final.parsedFixtureRecaps,
+  };
+
+  writeCache(args.rawDir, cache);
+  const stats = fs.statSync(path.join(args.rawDir, '.llm-cache', `${hash}.json`));
+  console.log(
+    `[parse-via-devserver] wrote cache: ${(stats.size / 1024).toFixed(1)} KB ` +
+      `(classifications=${cache.classifications.length} cargos=${cache.parsedCargos.length} ` +
+      `vessels=${cache.parsedVessels.length} recaps=${cache.parsedFixtureRecaps.length})`,
+  );
+
+  // Best-effort cleanup — don't leak the test session
+  try {
+    store.deleteSession(sessionId);
+  } catch (e) {
+    console.warn('[parse-via-devserver] could not delete seeded session:', e);
+  }
+}
+
+if (require.main === module) {
+  main().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 2: Verify `--dry-run` works (no dev-server needed).**
+
+```bash
+# .private/raw-emails lives in the main worktree only — symlink so the
+# script can find it from this branch worktree.
+if [ ! -e .private ] && [ -d /Users/jarvis/work/quantika-demo/.private ]; then
+  ln -s /Users/jarvis/work/quantika-demo/.private .private
+fi
+npx tsx scripts/demo-seed/parse-via-devserver.ts --dry-run
+```
+
+Expected output: `corpus hash: <64 hex>`, "would seed session", "would POST", "would write cache".
+
+- [ ] **Step 3: Commit (driver only — no real run yet).**
+
+```bash
+git add scripts/demo-seed/parse-via-devserver.ts
+git commit --no-verify -m "feat(demo-seed): parse-via-devserver.ts driver (hash + HTTP × 4 + cache)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 — analyze.ts: cache-prefer integration
+
+**Files:**
+- Modify: `scripts/demo-seed/analyze.ts`
+- Modify: `scripts/demo-seed/__tests__/analyze.test.ts`
+
+The existing `extractFacts(email)` (regex path) stays as fallback. We add `extractFactsFromCache(email, cache)` that pulls from `LlmCache` and returns the same `ParsedFacts` shape so the rest of `analyze()` is unchanged.
+
+- [ ] **Step 1: Append failing test.**
+
+Find the existing `analyze.test.ts` and append:
+
+```typescript
+// scripts/demo-seed/__tests__/analyze.test.ts — APPEND
+import * as fs from 'fs';
+import { analyze } from '../analyze';
+import { writeCache, corpusHash, type LlmCache } from '../llm-cache';
+
+describe('analyze with LLM cache', () => {
+  it('uses cache.classifications.category when cache present', async () => {
+    // Use the existing fixture corpus (5 synthetic emails) located by
+    // the suite's other tests. Read fixture dir from the file at top.
+    // The fixture corpus IS the test corpus for unit tests; we mint a
+    // cache against its current hash so the cache-prefer code path
+    // exercises.
+    const FIXTURE_DIR = require('path').resolve(
+      __dirname,
+      '../../../__tests__/fixtures/demo-seed',
+    );
+    if (!fs.existsSync(FIXTURE_DIR)) return; // skip if PR #599 fixtures not present
+    const hash = corpusHash(FIXTURE_DIR);
+    const cache: LlmCache = {
+      corpusHash: hash,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      // Force every fixture email to "cargo" via cache — regex path would
+      // pick a different category for some; we assert cache wins.
+      classifications: fs
+        .readdirSync(FIXTURE_DIR)
+        .filter(f => f.endsWith('.json'))
+        .map(f => {
+          const raw = JSON.parse(fs.readFileSync(`${FIXTURE_DIR}/${f}`, 'utf8'));
+          const msg = raw.messages?.[0];
+          return {
+            emailId: msg?.id ?? raw.id ?? f.replace('.json', ''),
+            category: 'CARGO_INQUIRY',
+            isUnanswered: false,
+            urgency: 'normal',
+            daysWithoutReply: null,
+            confidence: 1,
+            originalSender: null,
+            originalSenderCompany: null,
+          } as any;
+        }),
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(FIXTURE_DIR, cache);
+    try {
+      const m = await analyze({
+        rawDir: FIXTURE_DIR,
+        frozenDate: '2026-05-20',
+        demoWindowDays: 14,
+      });
+      // Every offset should carry a 'cargo' rationale (from cache classification)
+      // OR fallback rationale — but at least one must mention "cache".
+      const rationales = Object.values(m.offsets).map(o => o.rationale).join('|');
+      expect(rationales.toLowerCase()).toContain('cache');
+    } finally {
+      // Cleanup so the fixture corpus stays clean for the regex-path test
+      fs.unlinkSync(`${FIXTURE_DIR}/.llm-cache/${hash}.json`);
+      fs.rmdirSync(`${FIXTURE_DIR}/.llm-cache`);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+```bash
+npx jest scripts/demo-seed/__tests__/analyze.test.ts
+```
+
+- [ ] **Step 3: Edit `scripts/demo-seed/analyze.ts` — add cache-prefer logic.**
+
+Add this import block at the top:
+
+```typescript
+import { loadLlmCacheIfAny, type LlmCache } from './llm-cache';
+import { cfValue } from '@/lib/types';
+import type { Email } from '@/lib/types';
+```
+
+Add the helper just above `extractFacts`:
+
+```typescript
+/**
+ * Build ParsedFacts for an email from a pre-computed LLM cache.
+ * Returns the same shape as the regex `extractFacts`, populated with
+ * real LLM data when the email was processed.
+ *
+ * When no rows match (email not in cache), returns category='other' and
+ * empty arrays — caller can choose to fall back to `extractFacts`.
+ */
+export function extractFactsFromCache(
+  email: FlatEmail,
+  cache: LlmCache,
+): ParsedFacts {
+  const cls = cache.classifications.find(c => c.emailId === email.messageId);
+  const cargoRows = cache.parsedCargos.filter(c => c.emailId === email.messageId);
+  const vesselRows = cache.parsedVessels.filter(v => v.emailId === email.messageId);
+  const recapRows = cache.parsedFixtureRecaps.filter(r => r.emailId === email.messageId);
+
+  let category: ParsedFacts['category'] = 'other';
+  switch (cls?.category) {
+    case 'CARGO_INQUIRY':   category = 'cargo'; break;
+    case 'VESSEL_POSITION': category = 'vessel'; break;
+    case 'FIXTURE_RECAP':   category = 'recap'; break;
+    default:                category = 'other';
+  }
+
+  const facts: ParsedFacts = {
+    category,
+    vesselNames: [],
+    brokers: email.fromName ? [email.fromName] : [],
+    senderEmails: email.fromEmail ? [email.fromEmail] : [],
+    charterers: [],
+  };
+
+  // Cargo: pull laycan string and parse via existing helper
+  if (category === 'cargo' && cargoRows.length > 0) {
+    const cargo = cargoRows[0];
+    if (cargo.laycan) {
+      const refYear = new Date(email.date).getUTCFullYear();
+      // Reuse the regex laycan parser from existing analyze.ts imports
+      const range = parseLaycan(cargo.laycan, refYear);
+      if (range) {
+        facts.laycanStart = range.start;
+        facts.laycanEnd = range.end;
+      }
+    }
+  }
+
+  // Vessel: openDate is ConfidenceField<string>, value is ISO date
+  if (category === 'vessel' && vesselRows.length > 0) {
+    const vessel = vesselRows[0];
+    const openIso = cfValue(vessel.openDate);
+    if (openIso) {
+      const d = new Date(openIso);
+      if (!isNaN(d.getTime())) facts.openDate = d;
+    }
+    const vName = cfValue(vessel.vesselName);
+    if (vName) facts.vesselNames.push(vName);
+  }
+
+  // Recap: extract charterers (anonymization map source)
+  if (category === 'recap' && recapRows.length > 0) {
+    const ch = cfValue(recapRows[0].charterers);
+    if (ch) facts.charterers.push(ch);
+    const vName = cfValue(recapRows[0].vesselName);
+    if (vName) facts.vesselNames.push(vName);
+  }
+
+  return facts;
+}
+```
+
+Now wire the cache check inside `analyze()`. Replace the existing loop body (the `for (const email of corpus)` block) so it reads cache first:
+
+```typescript
+const llmCache = loadLlmCacheIfAny(opts.rawDir);
+
+const offsets: Record<string, OffsetEntry> = {};
+for (const email of corpus) {
+  const emailD = new Date(email.date);
+  const facts = llmCache
+    ? extractFactsFromCache(email, llmCache)
+    : extractFacts(email);
+
+  // ... existing anonymization map population unchanged ...
+  for (const v of facts.vesselNames) alias('vessels', v, 'M/V DEMO');
+  for (const b of facts.brokers) alias('brokers', b, 'BROKER');
+  for (const e of facts.senderEmails) alias('sender_emails', e, 'SENDER');
+  for (const c of facts.charterers) alias('charterers', c, 'CHARTERER');
+
+  // ... existing offset computation unchanged, except RATIONALE gets a "cache:" prefix
+  //     when llmCache present so tests can detect it ...
+  const sourceTag = llmCache ? 'cache' : 'regex';
+  const shifted: string[] = ['email.date'];
+  let offsetDays: number;
+  let rationale: string;
+
+  if (facts.category === 'cargo' && facts.laycanStart && facts.laycanEnd) {
+    const midLay = new Date((facts.laycanStart.getTime() + facts.laycanEnd.getTime()) / 2);
+    const target = new Date(frozen.getTime() + 7 * 86_400_000);
+    offsetDays = Math.round((target.getTime() - midLay.getTime()) / 86_400_000);
+    shifted.push('laycan_start', 'laycan_end');
+    rationale = `${sourceTag}: laycan midpoint ${midLay.toISOString().slice(0, 10)} → ${target.toISOString().slice(0, 10)}`;
+  } else if (facts.category === 'vessel' && facts.openDate) {
+    const target = new Date(frozen.getTime() + 3 * 86_400_000);
+    offsetDays = Math.round((target.getTime() - facts.openDate.getTime()) / 86_400_000);
+    shifted.push('open_date');
+    rationale = `${sourceTag}: open_date ${facts.openDate.toISOString().slice(0, 10)} → ${target.toISOString().slice(0, 10)}`;
+  } else {
+    const days = Math.round((frozen.getTime() - emailD.getTime()) / 86_400_000);
+    offsetDays = -days + -7;
+    rationale = `${sourceTag}: email.date ${emailD.toISOString().slice(0, 10)} → frozenDate ${opts.frozenDate} (fallback)`;
+  }
+
+  offsets[email.threadId] = { offsetDays, rationale, shifted_fields: shifted };
+}
+```
+
+Important: `parseLaycan` is already imported at top of the file (`import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing'`). The new helper reuses it.
+
+- [ ] **Step 4: Run analyze tests — expect PASS.**
+
+```bash
+npx jest scripts/demo-seed/__tests__/analyze.test.ts
+```
+
+Existing regex-path tests must stay green (they run without a cache file present in the fixture corpus by default).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/demo-seed/analyze.ts scripts/demo-seed/__tests__/analyze.test.ts
+git commit --no-verify -m "feat(demo-seed): analyze prefers llm-cache when present
+
+Adds extractFactsFromCache(email, cache) which pulls category from
+classifications, laycan from parsedCargos, openDate from parsedVessels,
+vesselName/charterer from cache. Falls back to existing regex
+extractFacts when no .llm-cache/<hash>.json is present (CI-safe).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 — build.ts: write real parsed_results from cache
+
+**Files:**
+- Modify: `scripts/demo-seed/build.ts`
+- Modify: `scripts/demo-seed/__tests__/build.test.ts`
+
+The current `build()` loop calls `extractFacts(...)` and inserts at most one `classify` + one sparse `cargo` or `vessel` row per email. With cache, we write the real `Classification`, every `ParsedCargo`, every `ParsedVessel`, every `ParsedFixtureRecap` — and we shift their date fields by `offset.offsetDays` so the match-compute step sees shifted-and-anonymized data.
+
+- [ ] **Step 1: Append failing test.**
+
+```typescript
+// scripts/demo-seed/__tests__/build.test.ts — APPEND
+import { writeCache, corpusHash, type LlmCache } from '../llm-cache';
+
+describe('build with LLM cache → matches table populated', () => {
+  it('writes cargo+vessel parsed_results and produces matches when cache present', async () => {
+    const FIXTURE_DIR = require('path').resolve(
+      __dirname,
+      '../../../__tests__/fixtures/demo-seed',
+    );
+    const FIX_MANIFEST = require('path').resolve(
+      __dirname,
+      'fixtures/manifest.fixture.json',
+    );
+    if (!fs.existsSync(FIXTURE_DIR) || !fs.existsSync(FIX_MANIFEST)) return;
+
+    // Load fixture corpus, pick first 2 as cargo + first 2 as vessel
+    const files = fs.readdirSync(FIXTURE_DIR).filter(f => f.endsWith('.json')).sort();
+    const ids = files.map(f => {
+      const raw = JSON.parse(fs.readFileSync(`${FIXTURE_DIR}/${f}`, 'utf8'));
+      return raw.messages?.[0]?.id ?? raw.id ?? f.replace('.json', '');
+    });
+    const [c1, c2, v1, v2] = ids;
+
+    const hash = corpusHash(FIXTURE_DIR);
+    const cache: LlmCache = {
+      corpusHash: hash,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [
+        ...[c1, c2].map(id => ({ emailId: id, category: 'CARGO_INQUIRY' } as any)),
+        ...[v1, v2].map(id => ({ emailId: id, category: 'VESSEL_POSITION' } as any)),
+      ],
+      parsedCargos: [
+        { emailId: c1, itemIndex: 0, laycan: '10-15 May 2026' } as any,
+        { emailId: c2, itemIndex: 0, laycan: '12-18 May 2026' } as any,
+      ],
+      parsedVessels: [
+        { emailId: v1, itemIndex: 0, openDate: { value: '2026-05-12', confidence: 'high' } } as any,
+        { emailId: v2, itemIndex: 0, openDate: { value: '2026-05-15', confidence: 'high' } } as any,
+      ],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(FIXTURE_DIR, cache);
+
+    const tmpDb = path.join(os.tmpdir(), `demo-seed-cache-${Date.now()}.db`);
+    try {
+      await build({
+        rawDir: FIXTURE_DIR,
+        manifestPath: FIX_MANIFEST,
+        outDb: tmpDb,
+      });
+      const db = new Database(tmpDb);
+      const parsedCount = db.prepare(
+        "SELECT COUNT(*) AS c FROM parsed_results WHERE parse_type IN ('cargo','vessel')",
+      ).get() as { c: number };
+      expect(parsedCount.c).toBeGreaterThanOrEqual(4);
+      const matchCount = db.prepare('SELECT COUNT(*) AS c FROM matches').get() as { c: number };
+      expect(matchCount.c).toBeGreaterThan(0);
+      db.close();
+    } finally {
+      fs.unlinkSync(`${FIXTURE_DIR}/.llm-cache/${hash}.json`);
+      fs.rmdirSync(`${FIXTURE_DIR}/.llm-cache`);
+      if (fs.existsSync(tmpDb)) fs.unlinkSync(tmpDb);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+```bash
+npx jest scripts/demo-seed/__tests__/build.test.ts
+```
+
+- [ ] **Step 3: Edit `scripts/demo-seed/build.ts`.**
+
+Add imports near the top:
+
+```typescript
+import { loadLlmCacheIfAny, type LlmCache } from './llm-cache';
+import { cfValue, type ParsedCargo, type ParsedVessel, type ParsedFixtureRecap, type Classification } from '@/lib/types';
+import { parseLaycan } from '@/lib/sailing/date-parsing';
+```
+
+Add a small helper to shift ISO-date strings inside the parsed objects (mutates a shallow clone):
+
+```typescript
+function shiftIsoDateString(iso: string, offsetDays: number): string {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString();
+}
+
+function shiftedCargo(c: ParsedCargo, offsetDays: number): ParsedCargo {
+  // ParsedCargo.laycan is a free-text string ("10-15 May 2026"); reuse
+  // build.ts's existing shiftBodyDates to convert it.
+  return { ...c, laycan: c.laycan ? shiftBodyDates(c.laycan, offsetDays) : c.laycan };
+}
+
+function shiftedVessel(v: ParsedVessel, offsetDays: number): ParsedVessel {
+  if (!v.openDate) return v;
+  const iso = v.openDate.value;
+  // openDate.value is "YYYY-MM-DD"
+  const shifted = iso.match(/^\d{4}-\d{2}-\d{2}$/)
+    ? shiftIsoDateString(`${iso}T00:00:00Z`, offsetDays).slice(0, 10)
+    : iso;
+  return { ...v, openDate: { ...v.openDate, value: shifted } };
+}
+
+function shiftedRecap(r: ParsedFixtureRecap, offsetDays: number): ParsedFixtureRecap {
+  // ParsedFixtureRecap has many optional date-like fields; for matching
+  // we don't need to shift them — recaps aren't matched. Keep as-is.
+  void offsetDays;
+  return r;
+}
+```
+
+Inside the `build()` transaction, locate the per-email block (after `insertEmail.run(...)` and before the regex `extractFacts` call). Replace the regex insert block with cache-prefer branch:
+
+```typescript
+const llmCache = loadLlmCacheIfAny(opts.rawDir);
+
+// ... inside corpus loop, after insertEmail.run(...) ...
+
+if (llmCache) {
+  const cls = llmCache.classifications.find(c => c.emailId === email.messageId);
+  if (cls) {
+    insertParsed.run(
+      'demo', email.messageId, 'classify', PARSER_VERSION,
+      JSON.stringify(cls), manifest.generated_at,
+    );
+  }
+
+  const cargosForEmail = llmCache.parsedCargos.filter(c => c.emailId === email.messageId);
+  for (const cargo of cargosForEmail) {
+    const shifted = shiftedCargo(cargo, offset.offsetDays);
+    // Pre-compute laycan {start,end} ISO so the later matches loop can read them
+    let laycanRange: { start: string; end: string } | null = null;
+    if (shifted.laycan) {
+      const refYear = new Date(shiftedDate).getUTCFullYear();
+      const r = parseLaycan(shifted.laycan, refYear);
+      if (r) laycanRange = { start: r.start.toISOString(), end: r.end.toISOString() };
+    }
+    insertParsed.run(
+      'demo', email.messageId, 'cargo', PARSER_VERSION,
+      JSON.stringify({ ...shifted, laycan: laycanRange ?? shifted.laycan }),
+      manifest.generated_at,
+    );
+  }
+
+  const vesselsForEmail = llmCache.parsedVessels.filter(v => v.emailId === email.messageId);
+  for (const vessel of vesselsForEmail) {
+    const shifted = shiftedVessel(vessel, offset.offsetDays);
+    const openIso = cfValue(shifted.openDate);
+    insertParsed.run(
+      'demo', email.messageId, 'vessel', PARSER_VERSION,
+      JSON.stringify({ ...shifted, openDate: openIso ? new Date(openIso).toISOString() : null }),
+      manifest.generated_at,
+    );
+  }
+
+  const recapsForEmail = llmCache.parsedFixtureRecaps.filter(r => r.emailId === email.messageId);
+  for (const recap of recapsForEmail) {
+    insertParsed.run(
+      'demo', email.messageId, 'recap', PARSER_VERSION,
+      JSON.stringify(shiftedRecap(recap, offset.offsetDays)),
+      manifest.generated_at,
+    );
+  }
+} else {
+  // === existing regex extractFacts path (unchanged) ===
+  const facts = extractFacts({ /* same as today */ });
+  // ... unchanged code that inserts classify + cargo/vessel rows
+}
+```
+
+The matches loop at the end of `build()` already SELECTs `parse_type='cargo'` and `parse_type='vessel'` and reads `result_json.laycan.{start,end}` and `result_json.openDate`. Our cache branch writes those exact shapes, so the existing matcher works without modification.
+
+- [ ] **Step 4: Run, expect PASS — both new and existing build tests green.**
+
+```bash
+npx jest scripts/demo-seed/__tests__/build.test.ts
+```
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/demo-seed/build.ts scripts/demo-seed/__tests__/build.test.ts
+git commit --no-verify -m "feat(demo-seed): build writes real parsed_results from llm-cache
+
+When .llm-cache/<hash>.json exists, build inserts the real classify/cargo/
+vessel/recap rows (with dates shifted per manifest.offsets) so the match
+compute step at end of build() pairs real data — match count goes from
+0 to dozens. Regex path stays as fallback for CI.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 — Real run + verify acceptance
+
+This task has no automated test — it runs the live pipeline against the real corpus and reads back match counts.
+
+- [ ] **Step 1: Make sure raw emails are accessible.**
+
+```bash
+if [ ! -e .private ] && [ -d /Users/jarvis/work/quantika-demo/.private ]; then
+  ln -s /Users/jarvis/work/quantika-demo/.private .private
+fi
+ls .private/raw-emails | wc -l   # expect: 153
+```
+
+- [ ] **Step 2: Start the dev-server in a background window.**
+
+```bash
+# Either: open another terminal and run `npm run dev`
+# Or one-shot here:
+npm run dev > /tmp/quantika-dev.log 2>&1 &
+DEV_PID=$!
+# Wait for it to bind :3000
+for i in $(seq 1 30); do
+  if curl -s -o /dev/null http://localhost:3000; then break; fi
+  sleep 2
+done
+echo "dev-server pid=$DEV_PID"
+```
+
+- [ ] **Step 3: Run the driver.**
+
+```bash
+npx tsx scripts/demo-seed/parse-via-devserver.ts \
+  --raw-dir .private/raw-emails \
+  --base-url http://localhost:3000
+```
+
+Expected stdout: `corpus hash: ...`, 153 emails loaded, four endpoints each return 200, final "wrote cache" line with non-zero counts. Total wall time: 5-20 minutes (LLM-bound).
+
+- [ ] **Step 4: Inspect the cache.**
+
+```bash
+ls -la .private/raw-emails/.llm-cache/
+jq '{cargos: (.parsedCargos|length), vessels: (.parsedVessels|length), recaps: (.parsedFixtureRecaps|length), classifications: (.classifications|length)}' \
+  .private/raw-emails/.llm-cache/*.json
+```
+
+Expect classifications == 153, cargos+vessels > 50 combined.
+
+- [ ] **Step 5: Re-run analyze + build.**
+
+```bash
+FROZEN=$(date -u -v+1d +%Y-%m-%d 2>/dev/null || date -u -d '+1 day' +%Y-%m-%d)
+npx tsx scripts/demo-seed/analyze.ts \
+  --raw-dir .private/raw-emails \
+  --frozen-date "$FROZEN" \
+  --window 14
+npx tsx scripts/demo-seed/build.ts \
+  --raw-dir .private/raw-emails \
+  --manifest scripts/demo-seed/manifest.json \
+  --out data/demo-seed.db
+```
+
+- [ ] **Step 6: Verify acceptance criteria.**
+
+```bash
+sqlite3 data/demo-seed.db "SELECT COUNT(*) FROM matches;"           # > 50
+sqlite3 data/demo-seed.db "SELECT COUNT(*) FROM emails;"            # = 153
+sqlite3 data/demo-seed.db "SELECT COUNT(*) FROM parsed_results WHERE parse_type='cargo';"   # > 0
+sqlite3 data/demo-seed.db "SELECT COUNT(*) FROM parsed_results WHERE parse_type='vessel';"  # > 0
+jq '{vessels: (.anonymization.vessels|length), charterers: (.anonymization.charterers|length)}' \
+  scripts/demo-seed/manifest.json
+```
+
+If matches count is NOT >50: dump 5 random rows from `parsed_results` for cargo and vessel and inspect whether `laycan` is `{start,end}` shape vs a raw string. Fix accordingly.
+
+- [ ] **Step 7: Kill dev-server.**
+
+```bash
+kill $DEV_PID 2>/dev/null || true
+```
+
+- [ ] **Step 8: Commit the new manifest.json + demo-seed.db.**
+
+```bash
+git add scripts/demo-seed/manifest.json data/demo-seed.db
+git commit --no-verify -m "feat(demo-seed): regenerate manifest + demo-seed.db with LLM-parsed data
+
+Real LLM run via scripts/demo-seed/parse-via-devserver.ts produced
+classifications + cargo/vessel parsed_results for all 153 emails;
+match-compute step now yields N matches (was 0 with regex-only).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6 — Full test suite + pre-merge check
+
+- [ ] **Step 1: Full jest run — all 26+ tests stay green.**
+
+```bash
+npm test -- --silent 2>&1 | tail -20
+```
+
+PI3 requirement: zero test-expectation rewrites. Any unrelated failure → root-cause + fix or document as pre-existing.
+
+- [ ] **Step 2: Typecheck + lint.**
+
+```bash
+npx tsc --noEmit
+npm run lint
+```
+
+- [ ] **Step 3: pre-merge-check (if it exists).**
+
+```bash
+if [ -x ./scripts/pre-merge-check.sh ]; then
+  ./scripts/pre-merge-check.sh
+else
+  echo "no pre-merge-check.sh — skipping"
+fi
+```
+
+- [ ] **Step 4: Push branch + open PR.**
+
+```bash
+git push -u origin feat/demo-llm-cache-parsing
+gh pr create --base main --head feat/demo-llm-cache-parsing \
+  --title "feat(demo-seed): LLM cache parsing — matches table now populated (>50 rows)" \
+  --body "$(cat <<'EOF'
+## What
+
+After PR #599 landed, `data/demo-seed.db.matches` was empty (0 rows) because
+`scripts/demo-seed/analyze.ts` extracted dates with regex literals (`LAYCAN:`
+and `OPEN DATE:`) that real broker emails never use.
+
+This PR adds a driver script that runs the 153 raw emails through this repo's
+live LLM HTTP endpoints once, caches the structured result on disk (gitignored),
+and teaches `analyze.ts` + `build.ts` to prefer the cache when present.
+
+## Pieces
+
+- `scripts/demo-seed/llm-cache.ts` — pure helpers (corpusHash + read/write).
+- `scripts/demo-seed/parse-via-devserver.ts` — driver: seed session → 4× HTTP → cache.
+- `scripts/demo-seed/analyze.ts` — `extractFactsFromCache` path; regex fallback unchanged.
+- `scripts/demo-seed/build.ts` — writes real `parsed_results` rows from cache.
+
+## Auth
+
+The driver seeds a real session into `data/sessions.db` via the existing
+`SessionStore` and sends the `session_id` cookie. `validateCsrf` returns
+true under `NODE_ENV=development`, so no CSRF header is needed. **No prod
+code is touched** — the script authenticates the same way the browser does.
+
+## CI safety
+
+When `.llm-cache/<hash>.json` is absent (CI, fresh worktree), both
+`analyze.ts` and `build.ts` fall back to the existing regex path — all
+26 existing tests stay green.
+
+## Acceptance
+
+- [x] `sqlite3 data/demo-seed.db "SELECT COUNT(*) FROM matches"` > 50
+- [x] cache file populated; classifications=153, cargos+vessels combined > 50
+- [x] `manifest.json` `anonymization.vessels` / `.charterers` populated
+- [x] full test suite green
+
+## Out of scope
+
+- Reactivate DEMO_MODE cache-only guards on `/api/ai/*` (separate PR).
+- Production deploy DEMO_MODE=true on outreach-vps (manual step).
+
+## Plan markers
+CHAIN_demo_llm_cache=M creative=y writing_plans=docs/superpowers/plans/2026-05-27-demo-llm-cache-parsing.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** every section of the spec maps to a task (helpers → T1, driver → T2, analyze → T3, build → T4, real run → T5, suite → T6). 
+- **No placeholders:** every step has code or shell. No "TBD".
+- **Type consistency:** `LlmCache` used identically in all tasks; `extractFactsFromCache` signature stable; `ParsedCargo.laycan` always treated as `string | null`; `ParsedVessel.openDate` always treated as `ConfidenceField<string>`. 
+- **PI3:** No test-expectation rewrites; new tests only ADD assertions; regex path tests untouched.

--- a/docs/superpowers/specs/2026-05-27-demo-llm-cache-parsing-design.md
+++ b/docs/superpowers/specs/2026-05-27-demo-llm-cache-parsing-design.md
@@ -1,0 +1,188 @@
+# Demo LLM Cache Parsing — Design
+
+**Date:** 2026-05-27
+**Status:** Approved, ready for plan
+**Owner:** Виталий (founder)
+**Spec chain:** Builds on `2026-05-27-quantika-demo-frozen-snapshot-design.md` (PR #599 merged as `89fcba1`).
+
+## Problem
+
+After PR #599 merge, `data/demo-seed.db` contains **153 emails but 0 matches**. Root cause: `scripts/demo-seed/analyze.ts` and `scripts/demo-seed/build.ts` use regex-only extraction (`extractFacts` in analyze.ts) that matches literal `LAYCAN:` / `OPEN DATE:` labels — real broker emails don't use those labels, so only 3/153 emails yielded structured dates and 0 cargo↔vessel matches survived the pairing step.
+
+## Goal
+
+Run the 153 raw emails through this repo's **live LLM HTTP parsers** once, cache structured results to disk keyed by corpus hash, and feed them into `analyze.ts` + `build.ts`. Target: `data/demo-seed.db.matches` row count **>50** (current: 0).
+
+## Non-goals
+
+- E2E playwright tests (deferred to PR #599 Task 23).
+- CI fixture-corpus smoke build (deferred to PR #599 Task 24).
+- Reactivating DEMO_MODE guards on `/api/ai/*` endpoints (the user already trimmed those pre-merge).
+- Adding `SCRIPT_AUTH_BYPASS` env flag — prod code stays untouched.
+
+## Architecture (3 changes)
+
+| Component | Action | Responsibility |
+|---|---|---|
+| `scripts/demo-seed/parse-via-devserver.ts` | CREATE | Driver: seed session, drive 4 LLM endpoints, write cache. |
+| `scripts/demo-seed/llm-cache.ts` | CREATE | Pure helpers: `corpusHash()`, `readCache()`, `writeCache()`. |
+| `scripts/demo-seed/analyze.ts` | MODIFY | Prefer LLM cache over regex `extractFacts` when present. |
+| `scripts/demo-seed/build.ts` | MODIFY | Write real cargo/vessel/recap rows into `parsed_results` from cache. |
+| `.gitignore` | MODIFY | Add `scripts/demo-seed/.llm-cache/`. |
+
+## Data flow
+
+```
+.private/raw-emails/*.json (153 Gmail threads)
+        ↓ scripts/demo-seed/parse-via-devserver.ts
+[dev-server on :3000] ←─ POST /api/ai/classify
+                     ←─ POST /api/ai/parse-cargo
+                     ←─ POST /api/ai/parse-vessel
+                     ←─ POST /api/ai/parse-recap
+        ↓ read updated session from data/sessions.db
+scripts/demo-seed/.llm-cache/<sha256>.json (gitignored)
+        ↓ scripts/demo-seed/analyze.ts
+scripts/demo-seed/manifest.json (offsets driven by REAL laycan/open_date)
+        ↓ scripts/demo-seed/build.ts
+data/demo-seed.db (emails + real parsed_results + >50 matches)
+```
+
+## Cache format
+
+`scripts/demo-seed/.llm-cache/<sha256>.json`:
+
+```json
+{
+  "corpusHash": "abc123...",
+  "generatedAt": "2026-05-27T20:00:00.000Z",
+  "classifications": [/* Classification[] from SessionData */],
+  "parsedCargos":    [/* ParsedCargo[] from SessionData */],
+  "parsedVessels":   [/* ParsedVessel[] from SessionData */],
+  "parsedFixtureRecaps": [/* ParsedFixtureRecap[] from SessionData */]
+}
+```
+
+Field shapes match SessionData exactly so analyze.ts/build.ts re-use existing types.
+
+### Corpus hash
+
+```ts
+sha256(
+  sortedFiles.map(f => readFileSync(f)).join('\n--FILE--\n')
+)
+```
+
+Sorting filenames ensures determinism. Any change to any raw email → new hash → cache miss → re-run.
+
+## Driver script (`parse-via-devserver.ts`)
+
+Sequence:
+
+1. **Hash check.** Compute corpus hash. If `.llm-cache/<hash>.json` exists, exit 0 with "cache hit, skipping LLM calls".
+2. **Server probe.** `GET http://localhost:3000/` with 2s timeout. If non-200 → print "Start the dev-server in another terminal: `npm run dev`" and exit 2.
+3. **Load corpus.** Read all 153 raw emails via `normalizeRawEmail()` (already exported from analyze.ts). Map to `Email[]` shape — populate `id` (from `messageId`), `threadId`, `from`/`fromName`/`fromEmail`, `subject`, `date`, `body`, `snippet`, `to=""`, `labelIds=[]`.
+4. **Seed session.** Open `data/sessions.db` via the existing `SessionStore` (`getStore()`), call `createSession('demo-script-token')` → returns session id, then `updateSession(id, { emails })`. Do **not** set `isSampleData=true` — endpoints would early-return cached data.
+5. **Drive endpoints (sequential, with retries on 5xx).** For each of `/api/ai/classify`, `/api/ai/parse-cargo`, `/api/ai/parse-vessel`, `/api/ai/parse-recap`:
+   - `POST http://localhost:3000/<path>` with header `Cookie: session_id=<id>`.
+   - In dev `validateCsrf` returns `true` unconditionally → no CSRF header needed.
+   - Body: empty JSON `{}` (endpoints read session, not body).
+   - Timeout: 300s per call (parse endpoints have `maxDuration` 55-120s and process in batches).
+   - Retry once on 5xx / network error.
+6. **Read result.** After all 4 succeed, read session row directly from sessions.db, deserialize the `data` JSON blob, extract the 4 arrays.
+7. **Write cache.** `mkdir -p .llm-cache`, write `<hash>.json` with the 4 arrays.
+8. **Cleanup.** Best-effort `DELETE FROM sessions WHERE id = ?` so we don't pollute dev sessions.db.
+
+**Auth model summary:** Session is real (lives in sessions.db). CSRF is bypassed by NODE_ENV=development. No prod code changes; the driver is just an HTTP client that authenticates the same way the browser does.
+
+## analyze.ts integration
+
+Add `loadLlmCacheIfAny(rawDir): LlmCache | null` helper. In `analyze()`:
+
+```ts
+const llmCache = loadLlmCacheIfAny(opts.rawDir);
+// inside loop over corpus:
+const facts = llmCache
+  ? extractFactsFromCache(email, llmCache)
+  : extractFacts(email);  // existing regex path
+```
+
+`extractFactsFromCache` produces the same `ParsedFacts` shape but populates:
+- `category` from `classifications.find(c => c.emailId === email.id).category` mapped to `'cargo'|'vessel'|'recap'|'other'`.
+- `laycanStart/End` from `parsedCargos.find(p => p.emailId === email.id).laycan`.
+- `openDate` from `parsedVessels.find(p => p.emailId === email.id).openDate`.
+- `vesselNames` from `parsedVessels[].vesselName` (real names → richer anonymization map).
+- `charterers` from `parsedCargos[].charterer` (previously empty in regex path).
+- `brokers`, `senderEmails` from email header (unchanged).
+
+**Backward compatibility:** When no cache present (CI, fresh worktree), regex path runs identically to today → existing tests stay green.
+
+## build.ts integration
+
+Currently `build()` calls `extractFacts(email)` and inserts only sparse `parsed_results` rows. Change:
+
+```ts
+const llmCache = loadLlmCacheIfAny(opts.rawDir);
+// per email:
+if (llmCache) {
+  // Real classify row
+  const cls = llmCache.classifications.find(c => c.emailId === email.messageId);
+  if (cls) insertParsed.run('demo', email.messageId, 'classify', PARSER_VERSION,
+    JSON.stringify(cls), manifest.generated_at);
+
+  // Real cargo rows (may be >1 per email — multi-cargo)
+  for (const c of llmCache.parsedCargos.filter(c => c.emailId === email.messageId)) {
+    // shift c.laycan dates by offset before persisting
+    insertParsed.run('demo', email.messageId, 'cargo', PARSER_VERSION,
+      JSON.stringify(shiftCargoDates(c, offset)), manifest.generated_at);
+  }
+
+  // Real vessel rows
+  for (const v of llmCache.parsedVessels.filter(v => v.emailId === email.messageId)) {
+    insertParsed.run('demo', email.messageId, 'vessel', PARSER_VERSION,
+      JSON.stringify(shiftVesselDates(v, offset)), manifest.generated_at);
+  }
+
+  // Real recap rows
+  // ... similar
+} else {
+  // existing regex extractFacts path
+}
+```
+
+The match-compute step at end of `build()` already reads `parse_type='cargo'` and `parse_type='vessel'` rows and pairs by laycan/open_date. With real data → >50 matches naturally.
+
+## Edge cases
+
+| Case | Behaviour |
+|---|---|
+| Cache file exists for a different corpus hash (stale cache) | Treat as cache miss — analyze/build see no matching cache. parse-via-devserver script reruns (new hash, new file). Stale files never auto-pruned — operator deletes `.llm-cache/` manually if needed. |
+| Dev-server not running | parse-via-devserver exits 2 with explicit message; never tries to start the server itself. |
+| LLM call returns non-200 | One retry on 5xx, then fail with stderr dump of response body. No partial cache writes. |
+| `parsed_results` already populated with regex data | build.ts always recreates `data/demo-seed.db` from scratch (existing behaviour: `unlinkSync` then re-migrate). Cache integration is just a different code path for the same step. |
+| Cache present but raw email IDs don't match anymore | `extractFactsFromCache` falls back to `other` category if no classification row found → analyze.ts treats as fallback offset. |
+| Anonymization leak: real vessel/charterer name in body that wasn't in cache | build.ts's existing `forbiddenSubstrings` validator throws — operator regenerates manifest with updated anonymization map. |
+
+## Testing
+
+| Layer | What |
+|---|---|
+| `scripts/demo-seed/__tests__/llm-cache.test.ts` (unit) | `corpusHash()` is deterministic + changes when any file changes; `readCache/writeCache` round-trip preserves shape; `loadLlmCacheIfAny` returns null when no cache file or hash mismatch. |
+| `scripts/demo-seed/__tests__/analyze.test.ts` (extend) | When cache fixture present, `analyze()` uses `category`/`laycan` from cache, not regex; when absent, falls back to regex (existing tests stay green). |
+| `scripts/demo-seed/__tests__/build.test.ts` (extend) | With cache fixture providing 2 cargo + 2 vessel rows → `matches` table contains >0 rows. |
+| Integration | One real run of `parse-via-devserver.ts` against the local dev-server — proof that the script works end-to-end. Output cache file checked in NOT committed (gitignored). |
+
+Existing 26 tests must stay green (PI3: no test-expectation rewrites).
+
+## Acceptance
+
+- `scripts/demo-seed/parse-via-devserver.ts` exists and dry-runs cleanly (`--dry-run` flag prints what it would do).
+- After one real run, `.llm-cache/<hash>.json` exists with non-zero classifications + parsedCargos + parsedVessels.
+- After `npm run demo-seed:analyze` + `npm run demo-seed:build`, `sqlite3 data/demo-seed.db "SELECT COUNT(*) FROM matches"` returns **>50**.
+- `manifest.json` `anonymization` map contains real-looking vessel + charterer aliases (e.g. `M/V DEMO 1`, `CHARTERER 1`).
+- `npm test` — all existing tests green.
+- `./scripts/pre-merge-check.sh` (or repo equivalent) passes.
+
+## Out-of-scope follow-ups
+
+- Reactivate DEMO_MODE cache-only guards on parse-* endpoints (separate PR).
+- Production deploy DEMO_MODE=true on outreach-vps (manual step after PR merges).

--- a/scripts/demo-seed/__tests__/analyze.test.ts
+++ b/scripts/demo-seed/__tests__/analyze.test.ts
@@ -82,3 +82,89 @@ describe('analyze (Phase 0)', () => {
     expect(vesselKeys.some(k => /FIXTURE WIND/i.test(k))).toBe(true);
   });
 });
+
+describe('analyze with LLM cache', () => {
+  // Lazily import to avoid loading llm-cache helpers during regex-path tests
+  // (those tests run in CI where the cache file is never present).
+  const fs = require('fs') as typeof import('fs');
+  const { writeCache, corpusHash } = require('../llm-cache') as typeof import('../llm-cache');
+
+  function readFixtureEmailIds(): string[] {
+    return fs
+      .readdirSync(FIXTURES)
+      .filter((f: string) => f.endsWith('.json'))
+      .map((f: string) => {
+        const raw = JSON.parse(fs.readFileSync(`${FIXTURES}/${f}`, 'utf8'));
+        return raw.messages?.[0]?.id ?? raw.id ?? f.replace('.json', '');
+      });
+  }
+
+  it('rationales contain "cache:" prefix when LLM cache is present', async () => {
+    const hash = corpusHash(FIXTURES);
+    const ids = readFixtureEmailIds();
+    const cache = {
+      corpusHash: hash,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: ids.map((id: string) => ({
+        emailId: id,
+        category: 'CARGO_INQUIRY',
+        isUnanswered: false,
+        urgency: 'normal',
+        daysWithoutReply: null,
+        confidence: 1,
+        originalSender: null,
+        originalSenderCompany: null,
+      })),
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(FIXTURES, cache);
+    try {
+      const m = await analyze({ rawDir: FIXTURES, frozenDate: '2026-05-20', demoWindowDays: 14 });
+      const rationales = Object.values(m.offsets).map((o) => o.rationale).join('|');
+      expect(rationales).toMatch(/cache:/);
+    } finally {
+      fs.unlinkSync(`${FIXTURES}/.llm-cache/${hash}.json`);
+      fs.rmdirSync(`${FIXTURES}/.llm-cache`);
+    }
+  });
+
+  it('pulls laycan from cache.parsedCargos when present', async () => {
+    const hash = corpusHash(FIXTURES);
+    const ids = readFixtureEmailIds();
+    const firstId = ids[0];
+    const cache = {
+      corpusHash: hash,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [{
+        emailId: firstId,
+        category: 'CARGO_INQUIRY',
+        isUnanswered: false,
+        urgency: 'normal',
+        daysWithoutReply: null,
+        confidence: 1,
+        originalSender: null,
+        originalSenderCompany: null,
+      }],
+      parsedCargos: [{ emailId: firstId, itemIndex: 0, laycan: '10-15 May 2026' }],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(FIXTURES, cache);
+    try {
+      const m = await analyze({ rawDir: FIXTURES, frozenDate: '2026-05-20', demoWindowDays: 14 });
+      // The threadId for firstId — find it via offsets values that mention laycan midpoint
+      const matchingEntry = Object.values(m.offsets).find((o) =>
+        /cache: laycan midpoint/.test(o.rationale),
+      );
+      expect(matchingEntry).toBeDefined();
+      expect(matchingEntry!.shifted_fields).toEqual(
+        expect.arrayContaining(['laycan_start', 'laycan_end']),
+      );
+    } finally {
+      fs.unlinkSync(`${FIXTURES}/.llm-cache/${hash}.json`);
+      fs.rmdirSync(`${FIXTURES}/.llm-cache`);
+    }
+  });
+});

--- a/scripts/demo-seed/__tests__/build.test.ts
+++ b/scripts/demo-seed/__tests__/build.test.ts
@@ -130,3 +130,59 @@ describe('build (Task 18) — pre-compute matches', () => {
     db.close();
   });
 });
+
+describe('build with LLM cache → parsed_results from cache + matches', () => {
+  let tmpDb: string;
+  beforeEach(() => { tmpDb = path.join(os.tmpdir(), `demo-seed-cache-${Date.now()}.db`); });
+  afterEach(() => { if (fs.existsSync(tmpDb)) fs.unlinkSync(tmpDb); });
+
+  it('writes real cargo+vessel parsed_results from cache and produces matches', async () => {
+    const { writeCache, corpusHash } = require('../llm-cache') as typeof import('../llm-cache');
+
+    const files = fs.readdirSync(FIXTURES).filter(f => f.endsWith('.json')).sort();
+    const ids = files.map(f => {
+      const raw = JSON.parse(fs.readFileSync(`${FIXTURES}/${f}`, 'utf8'));
+      return raw.messages?.[0]?.id ?? raw.id ?? f.replace('.json', '');
+    });
+    // 2 cargo + 2 vessel emails
+    const [c1, c2, v1, v2] = ids;
+
+    const hash = corpusHash(FIXTURES);
+    const cache = {
+      corpusHash: hash,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [
+        { emailId: c1, category: 'CARGO_INQUIRY' },
+        { emailId: c2, category: 'CARGO_INQUIRY' },
+        { emailId: v1, category: 'VESSEL_POSITION' },
+        { emailId: v2, category: 'VESSEL_POSITION' },
+      ],
+      parsedCargos: [
+        { emailId: c1, itemIndex: 0, laycan: '10-15 May 2026' },
+        { emailId: c2, itemIndex: 0, laycan: '12-18 May 2026' },
+      ],
+      parsedVessels: [
+        { emailId: v1, itemIndex: 0, openDate: { value: '2026-05-12', confidence: 'high' } },
+        { emailId: v2, itemIndex: 0, openDate: { value: '2026-05-15', confidence: 'high' } },
+      ],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(FIXTURES, cache as any);
+
+    try {
+      await build({ rawDir: FIXTURES, manifestPath: FIX_MANIFEST, outDb: tmpDb });
+      const db = new Database(tmpDb);
+      sqliteVec.load(db);
+      const parsedCount = db.prepare(
+        "SELECT COUNT(*) AS c FROM parsed_results WHERE parse_type IN ('cargo','vessel')",
+      ).get() as { c: number };
+      expect(parsedCount.c).toBeGreaterThanOrEqual(4);
+      const matchCount = db.prepare('SELECT COUNT(*) AS c FROM matches').get() as { c: number };
+      expect(matchCount.c).toBeGreaterThan(0);
+      db.close();
+    } finally {
+      fs.unlinkSync(`${FIXTURES}/.llm-cache/${hash}.json`);
+      fs.rmdirSync(`${FIXTURES}/.llm-cache`);
+    }
+  });
+});

--- a/scripts/demo-seed/__tests__/llm-cache.test.ts
+++ b/scripts/demo-seed/__tests__/llm-cache.test.ts
@@ -1,0 +1,119 @@
+// scripts/demo-seed/__tests__/llm-cache.test.ts
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  corpusHash,
+  cachePath,
+  readCache,
+  writeCache,
+  loadLlmCacheIfAny,
+  type LlmCache,
+} from '../llm-cache';
+
+function makeCorpus(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-cache-test-'));
+  fs.writeFileSync(path.join(dir, 'a.json'), '{"id":"a","body":"alpha"}');
+  fs.writeFileSync(path.join(dir, 'b.json'), '{"id":"b","body":"beta"}');
+  return dir;
+}
+
+describe('corpusHash', () => {
+  it('returns a 64-char hex string', () => {
+    const dir = makeCorpus();
+    expect(corpusHash(dir)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic across calls', () => {
+    const dir = makeCorpus();
+    expect(corpusHash(dir)).toBe(corpusHash(dir));
+  });
+
+  it('changes when any file content changes', () => {
+    const dir = makeCorpus();
+    const h1 = corpusHash(dir);
+    fs.writeFileSync(path.join(dir, 'a.json'), '{"id":"a","body":"ALPHA"}');
+    expect(corpusHash(dir)).not.toBe(h1);
+  });
+
+  it('does not depend on file enumeration order', () => {
+    const dir = makeCorpus();
+    const h1 = corpusHash(dir);
+    const a = fs.readFileSync(path.join(dir, 'a.json'));
+    const b = fs.readFileSync(path.join(dir, 'b.json'));
+    fs.unlinkSync(path.join(dir, 'a.json'));
+    fs.unlinkSync(path.join(dir, 'b.json'));
+    fs.writeFileSync(path.join(dir, 'b.json'), b);
+    fs.writeFileSync(path.join(dir, 'a.json'), a);
+    expect(corpusHash(dir)).toBe(h1);
+  });
+
+  it('ignores non-.json files', () => {
+    const dir = makeCorpus();
+    const h1 = corpusHash(dir);
+    fs.writeFileSync(path.join(dir, 'README.md'), 'docs');
+    expect(corpusHash(dir)).toBe(h1);
+  });
+});
+
+describe('writeCache + readCache', () => {
+  it('round-trips a cache payload', () => {
+    const dir = makeCorpus();
+    const cache: LlmCache = {
+      corpusHash: 'abc',
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      classifications: [{ emailId: 'a' } as any],
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(dir, cache);
+    const read = readCache(dir, 'abc');
+    expect(read).toEqual(cache);
+  });
+});
+
+describe('loadLlmCacheIfAny', () => {
+  it('returns null when .llm-cache/ does not exist', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-cache-'));
+    expect(loadLlmCacheIfAny(dir)).toBeNull();
+  });
+
+  it('returns null when cache hash does not match corpus hash', () => {
+    const dir = makeCorpus();
+    const cache: LlmCache = {
+      corpusHash: 'stale-hash',
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [],
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(dir, cache);
+    expect(loadLlmCacheIfAny(dir)).toBeNull();
+  });
+
+  it('returns cache when hash matches', () => {
+    const dir = makeCorpus();
+    const h = corpusHash(dir);
+    const cache: LlmCache = {
+      corpusHash: h,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [],
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(dir, cache);
+    const loaded = loadLlmCacheIfAny(dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.corpusHash).toBe(h);
+  });
+});
+
+describe('cachePath', () => {
+  it('joins the corpus dir + .llm-cache/<hash>.json', () => {
+    expect(cachePath('/x/y', 'abc')).toBe('/x/y/.llm-cache/abc.json');
+  });
+});

--- a/scripts/demo-seed/analyze.ts
+++ b/scripts/demo-seed/analyze.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Manifest, OffsetEntry } from './manifest-schema';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
+import { cfValue } from '@/lib/types';
+import { loadLlmCacheIfAny, type LlmCache } from './llm-cache';
 
 export interface AnalyzeOptions {
   rawDir: string;
@@ -198,6 +200,78 @@ export function extractFacts(email: FlatEmail): ParsedFacts {
   return facts;
 }
 
+/**
+ * Build ParsedFacts for an email from a pre-computed LLM cache.
+ * Returns the same shape as the regex `extractFacts`, populated with
+ * real LLM data when the email was processed. When the cache contains
+ * no rows for this email, returns category='other' so the offset logic
+ * falls back to the email-date heuristic.
+ */
+export function extractFactsFromCache(
+  email: FlatEmail,
+  cache: LlmCache,
+): ParsedFacts {
+  const cls = cache.classifications.find((c) => c.emailId === email.messageId);
+  const cargoRows = cache.parsedCargos.filter((c) => c.emailId === email.messageId);
+  const vesselRows = cache.parsedVessels.filter((v) => v.emailId === email.messageId);
+  const recapRows = cache.parsedFixtureRecaps.filter((r) => r.emailId === email.messageId);
+
+  let category: ParsedFacts['category'] = 'other';
+  switch (cls?.category) {
+    case 'CARGO_INQUIRY':
+      category = 'cargo';
+      break;
+    case 'VESSEL_POSITION':
+      category = 'vessel';
+      break;
+    case 'FIXTURE_RECAP':
+      category = 'recap';
+      break;
+    default:
+      category = 'other';
+  }
+
+  const facts: ParsedFacts = {
+    category,
+    vesselNames: [],
+    brokers: email.fromName ? [email.fromName] : [],
+    senderEmails: email.fromEmail ? [email.fromEmail] : [],
+    charterers: [],
+  };
+
+  if (category === 'cargo' && cargoRows.length > 0) {
+    const cargo = cargoRows[0];
+    if (cargo.laycan) {
+      const refYear = new Date(email.date).getUTCFullYear();
+      const range = parseLaycan(cargo.laycan, refYear);
+      if (range) {
+        facts.laycanStart = range.start;
+        facts.laycanEnd = range.end;
+      }
+    }
+  }
+
+  if (category === 'vessel' && vesselRows.length > 0) {
+    const vessel = vesselRows[0];
+    const openIso = cfValue(vessel.openDate);
+    if (openIso) {
+      const d = new Date(openIso);
+      if (!isNaN(d.getTime())) facts.openDate = d;
+    }
+    const vName = cfValue(vessel.vesselName);
+    if (vName) facts.vesselNames.push(vName);
+  }
+
+  if (category === 'recap' && recapRows.length > 0) {
+    const ch = cfValue(recapRows[0].charterers);
+    if (ch) facts.charterers.push(ch);
+    const vName = cfValue(recapRows[0].vesselName);
+    if (vName) facts.vesselNames.push(vName);
+  }
+
+  return facts;
+}
+
 export async function analyze(opts: AnalyzeOptions): Promise<Manifest> {
   // Sort corpus by threadId for deterministic counter assignment
   const corpus = readCorpus(opts.rawDir).sort((a, b) => a.threadId.localeCompare(b.threadId));
@@ -224,10 +298,17 @@ export async function analyze(opts: AnalyzeOptions): Promise<Manifest> {
     anonymization[kind][real] = `${prefix} ${counters[kind]}`;
   }
 
+  // Prefer LLM cache when present; fall back to regex extractFacts otherwise.
+  // This is the only knob distinguishing analyze() with and without LLM data.
+  const llmCache = loadLlmCacheIfAny(opts.rawDir);
+  const sourceTag = llmCache ? 'cache' : 'regex';
+
   const offsets: Record<string, OffsetEntry> = {};
   for (const email of corpus) {
     const emailD = new Date(email.date);
-    const facts = extractFacts(email);
+    const facts = llmCache
+      ? extractFactsFromCache(email, llmCache)
+      : extractFacts(email);
 
     // Populate anonymization map from extracted names
     for (const v of facts.vesselNames) alias('vessels', v, 'M/V DEMO');
@@ -245,18 +326,18 @@ export async function analyze(opts: AnalyzeOptions): Promise<Manifest> {
       const target = new Date(frozen.getTime() + 7 * 86_400_000);
       offsetDays = Math.round((target.getTime() - midLay.getTime()) / 86_400_000);
       shifted.push('laycan_start', 'laycan_end');
-      rationale = `laycan midpoint ${midLay.toISOString().slice(0, 10)} → ${target.toISOString().slice(0, 10)}`;
+      rationale = `${sourceTag}: laycan midpoint ${midLay.toISOString().slice(0, 10)} → ${target.toISOString().slice(0, 10)}`;
     } else if (facts.category === 'vessel' && facts.openDate) {
       // Place open_date at frozenDate + 3d
       const target = new Date(frozen.getTime() + 3 * 86_400_000);
       offsetDays = Math.round((target.getTime() - facts.openDate.getTime()) / 86_400_000);
       shifted.push('open_date');
-      rationale = `open_date ${facts.openDate.toISOString().slice(0, 10)} → ${target.toISOString().slice(0, 10)}`;
+      rationale = `${sourceTag}: open_date ${facts.openDate.toISOString().slice(0, 10)} → ${target.toISOString().slice(0, 10)}`;
     } else {
       // Fallback: place email ~7 days before frozenDate
       const days = Math.round((frozen.getTime() - emailD.getTime()) / 86_400_000);
       offsetDays = -days + -7;
-      rationale = `email.date ${emailD.toISOString().slice(0, 10)} → frozenDate ${opts.frozenDate} (fallback)`;
+      rationale = `${sourceTag}: email.date ${emailD.toISOString().slice(0, 10)} → frozenDate ${opts.frozenDate} (fallback)`;
     }
 
     offsets[email.threadId] = { offsetDays, rationale, shifted_fields: shifted };

--- a/scripts/demo-seed/build.ts
+++ b/scripts/demo-seed/build.ts
@@ -7,6 +7,14 @@ import { runMigrations } from '@/lib/migrations/runner';
 import { allMigrations } from '@/lib/migrations/index';
 import { ManifestSchema, type Manifest } from './manifest-schema';
 import { normalizeRawEmail, extractFacts, type FlatEmail } from './analyze';
+import { loadLlmCacheIfAny } from './llm-cache';
+import {
+  cfValue,
+  type ParsedCargo,
+  type ParsedVessel,
+  type ParsedFixtureRecap,
+} from '@/lib/types';
+import { parseLaycan } from '@/lib/sailing/date-parsing';
 
 const PARSER_VERSION = 'demo-seed-v1';
 
@@ -58,6 +66,35 @@ function shiftBodyDates(body: string, offsetDays: number): string {
   return out;
 }
 
+// Shift the dates inside an LLM-parsed ParsedCargo: only the free-text
+// `laycan` field carries dates. We push it through the same body-date
+// shifter so "10-15 May 2026" → "25-30 May 2026" (offset = +15d).
+function shiftedCargo(c: ParsedCargo, offsetDays: number): ParsedCargo {
+  return {
+    ...c,
+    laycan: c.laycan ? shiftBodyDates(c.laycan, offsetDays) : c.laycan,
+  };
+}
+
+// Shift the dates inside an LLM-parsed ParsedVessel: only openDate.value
+// (ISO yyyy-mm-dd) is shifted.
+function shiftedVessel(v: ParsedVessel, offsetDays: number): ParsedVessel {
+  if (!v.openDate) return v;
+  const iso = v.openDate.value;
+  if (!iso.match(/^\d{4}-\d{2}-\d{2}/)) return v;
+  const d = new Date(iso + (iso.length === 10 ? 'T00:00:00Z' : ''));
+  if (isNaN(d.getTime())) return v;
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  const shifted = d.toISOString().slice(0, 10);
+  return { ...v, openDate: { ...v.openDate, value: shifted } };
+}
+
+// Recaps aren't matched, so no shift is required for the matches loop
+// to work. Keep as identity for the symmetry of the per-email block.
+function shiftedRecap(r: ParsedFixtureRecap, _offsetDays: number): ParsedFixtureRecap {
+  return r;
+}
+
 export interface BuildOptions {
   rawDir: string;
   manifestPath: string;
@@ -106,6 +143,9 @@ function hashManifest(m: Manifest): string {
 export async function build(opts: BuildOptions): Promise<void> {
   const manifest = loadManifest(opts.manifestPath);
   const corpus = loadCorpus(opts.rawDir);
+  // Prefer real LLM-parsed data when a hash-matching cache is present.
+  // Falls back to regex extractFacts when absent (CI-safe).
+  const llmCache = loadLlmCacheIfAny(opts.rawDir);
 
   if (fs.existsSync(opts.outDb)) fs.unlinkSync(opts.outDb);
   const db = new Database(opts.outDb);
@@ -193,34 +233,90 @@ export async function build(opts: BuildOptions): Promise<void> {
         fetched_at: manifest.generated_at,
       });
 
-      // Populate parsed_results using regex-based extractFacts (LLM-free)
-      const facts = extractFacts({
-        threadId: email.threadId,
-        messageId: email.messageId,
-        fromName: anonFromName,
-        fromEmail: anonFromEmail,
-        subject: anonSubject,
-        date: shiftedDate,
-        body: anonBody,
-      });
+      // Populate parsed_results. Cache-prefer: write real LLM rows when a
+      // matching .llm-cache/<hash>.json is present, fall back to the regex
+      // extractFacts path otherwise (CI-safe — fixture corpus uses regex).
+      if (llmCache) {
+        const cls = llmCache.classifications.find((c) => c.emailId === email.messageId);
+        if (cls) {
+          insertParsed.run(
+            'demo', email.messageId, 'classify', PARSER_VERSION,
+            JSON.stringify(cls), manifest.generated_at,
+          );
+        }
 
-      // Always insert classify row
-      insertParsed.run('demo', email.messageId, 'classify', PARSER_VERSION,
-        JSON.stringify({ category: facts.category }), manifest.generated_at);
+        for (const cargo of llmCache.parsedCargos.filter((c) => c.emailId === email.messageId)) {
+          const shifted = shiftedCargo(cargo, offset.offsetDays);
+          // Pre-compute laycan {start,end} ISO so the matches loop below can
+          // read structured dates directly. parseLaycan is the same helper
+          // used by the matching engine in prod.
+          let laycanRange: { start: string; end: string } | null = null;
+          if (shifted.laycan) {
+            const refYear = new Date(shiftedDate).getUTCFullYear();
+            const r = parseLaycan(shifted.laycan, refYear);
+            if (r) laycanRange = { start: r.start.toISOString(), end: r.end.toISOString() };
+          }
+          insertParsed.run(
+            'demo', email.messageId, 'cargo', PARSER_VERSION,
+            JSON.stringify({ ...shifted, laycan: laycanRange ?? shifted.laycan }),
+            manifest.generated_at,
+          );
+        }
 
-      // Insert category-specific row if relevant dates extracted
-      if (facts.category === 'cargo' && (facts.laycanStart || facts.laycanEnd)) {
-        insertParsed.run('demo', email.messageId, 'cargo', PARSER_VERSION,
-          JSON.stringify({
-            laycan: facts.laycanStart && facts.laycanEnd
-              ? { start: facts.laycanStart.toISOString(), end: facts.laycanEnd.toISOString() }
-              : null,
-          }),
-          manifest.generated_at);
-      } else if (facts.category === 'vessel' && facts.openDate) {
-        insertParsed.run('demo', email.messageId, 'vessel', PARSER_VERSION,
-          JSON.stringify({ openDate: facts.openDate.toISOString() }),
-          manifest.generated_at);
+        for (const vessel of llmCache.parsedVessels.filter((v) => v.emailId === email.messageId)) {
+          const shifted = shiftedVessel(vessel, offset.offsetDays);
+          const openIso = cfValue(shifted.openDate);
+          // Persist openDate as a top-level ISO string (matches the regex
+          // path shape that the matches loop already reads).
+          insertParsed.run(
+            'demo', email.messageId, 'vessel', PARSER_VERSION,
+            JSON.stringify({
+              ...shifted,
+              openDate: openIso
+                ? new Date(
+                    openIso.length === 10 ? openIso + 'T00:00:00Z' : openIso,
+                  ).toISOString()
+                : null,
+            }),
+            manifest.generated_at,
+          );
+        }
+
+        for (const recap of llmCache.parsedFixtureRecaps.filter((r) => r.emailId === email.messageId)) {
+          insertParsed.run(
+            'demo', email.messageId, 'recap', PARSER_VERSION,
+            JSON.stringify(shiftedRecap(recap, offset.offsetDays)),
+            manifest.generated_at,
+          );
+        }
+      } else {
+        // Regex fallback — original LLM-free path. Kept for CI and fresh worktrees.
+        const facts = extractFacts({
+          threadId: email.threadId,
+          messageId: email.messageId,
+          fromName: anonFromName,
+          fromEmail: anonFromEmail,
+          subject: anonSubject,
+          date: shiftedDate,
+          body: anonBody,
+        });
+
+        insertParsed.run('demo', email.messageId, 'classify', PARSER_VERSION,
+          JSON.stringify({ category: facts.category }), manifest.generated_at);
+
+        if (facts.category === 'cargo' && (facts.laycanStart || facts.laycanEnd)) {
+          insertParsed.run('demo', email.messageId, 'cargo', PARSER_VERSION,
+            JSON.stringify({
+              laycan: facts.laycanStart && facts.laycanEnd
+                ? { start: facts.laycanStart.toISOString(), end: facts.laycanEnd.toISOString() }
+                : null,
+            }),
+            manifest.generated_at);
+        } else if (facts.category === 'vessel' && facts.openDate) {
+          insertParsed.run('demo', email.messageId, 'vessel', PARSER_VERSION,
+            JSON.stringify({ openDate: facts.openDate.toISOString() }),
+            manifest.generated_at);
+        }
       }
     }
 

--- a/scripts/demo-seed/llm-cache.ts
+++ b/scripts/demo-seed/llm-cache.ts
@@ -1,0 +1,82 @@
+// scripts/demo-seed/llm-cache.ts
+/**
+ * Pure helpers for the LLM-parse cache.
+ *
+ *   corpusHash(rawDir)     — deterministic SHA256 of every .json in rawDir.
+ *   cachePath(rawDir, h)   — <rawDir>/.llm-cache/<h>.json
+ *   readCache(rawDir, h)   — JSON parse, or null if absent.
+ *   writeCache(rawDir, c)  — mkdir + atomic-ish write.
+ *   loadLlmCacheIfAny(dir) — read the cache file whose hash matches the
+ *                            current corpus, or null. Used by analyze.ts
+ *                            and build.ts to opt into LLM-parsed data.
+ *
+ * Cache files are gitignored (.llm-cache/ under any path).
+ */
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  Classification,
+  ParsedCargo,
+  ParsedVessel,
+  ParsedFixtureRecap,
+} from '@/lib/types';
+
+export interface LlmCache {
+  corpusHash: string;
+  generatedAt: string;
+  classifications: Classification[];
+  parsedCargos: ParsedCargo[];
+  parsedVessels: ParsedVessel[];
+  parsedFixtureRecaps: ParsedFixtureRecap[];
+}
+
+const CACHE_DIR_NAME = '.llm-cache';
+
+/**
+ * Deterministic SHA-256 of every .json file in `rawDir`, joined in
+ * lexicographic filename order so the result is independent of the
+ * underlying filesystem enumeration order. Non-.json files are ignored.
+ */
+export function corpusHash(rawDir: string): string {
+  const files = fs
+    .readdirSync(rawDir)
+    .filter((f) => f.endsWith('.json'))
+    .sort();
+  const hash = crypto.createHash('sha256');
+  for (const f of files) {
+    hash.update(f);
+    hash.update('\0');
+    hash.update(fs.readFileSync(path.join(rawDir, f)));
+    hash.update('\n--FILE--\n');
+  }
+  return hash.digest('hex');
+}
+
+export function cachePath(rawDir: string, hash: string): string {
+  return path.join(rawDir, CACHE_DIR_NAME, `${hash}.json`);
+}
+
+export function writeCache(rawDir: string, cache: LlmCache): void {
+  const dir = path.join(rawDir, CACHE_DIR_NAME);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(cachePath(rawDir, cache.corpusHash), JSON.stringify(cache, null, 2) + '\n');
+}
+
+export function readCache(rawDir: string, hash: string): LlmCache | null {
+  const p = cachePath(rawDir, hash);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8')) as LlmCache;
+}
+
+/**
+ * Returns the cache file whose hash matches the current corpus, or null.
+ * Used by analyze.ts / build.ts to opt into LLM-parsed data when available
+ * without blowing up if it's absent (CI, fresh worktree).
+ */
+export function loadLlmCacheIfAny(rawDir: string): LlmCache | null {
+  const dirExists = fs.existsSync(path.join(rawDir, CACHE_DIR_NAME));
+  if (!dirExists) return null;
+  const h = corpusHash(rawDir);
+  return readCache(rawDir, h);
+}

--- a/scripts/demo-seed/parse-via-devserver.ts
+++ b/scripts/demo-seed/parse-via-devserver.ts
@@ -18,7 +18,14 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+// Next.js auto-loads .env.local in the dev-server, but this CLI runs under
+// `tsx` which doesn't — load it manually so DEMO_AUTH_SECRET etc. are visible.
+import 'dotenv/config';
+import dotenv from 'dotenv';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local'), override: false });
 import { getStore } from '@/lib/session-store';
+import { signAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { generateCsrfToken } from '@/lib/csrf';
 import type { Email } from '@/lib/types';
 import { normalizeRawEmail, type FlatEmail } from './analyze';
 import {
@@ -86,10 +93,34 @@ function flatToEmail(flat: FlatEmail): Email {
   };
 }
 
+interface AuthCookies {
+  demoAuth: string;
+  csrfToken: string;
+}
+
+async function buildAuthCookies(): Promise<AuthCookies> {
+  // DEMO_AUTH cookie — middleware verifies this first. We sign it locally
+  // using the same secret + helper as /api/auth/login.
+  const secret = process.env.DEMO_AUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      'DEMO_AUTH_SECRET is not set in process.env — load .env.local before running this script ' +
+        '(npx tsx already does this; check that the file exists).',
+    );
+  }
+  const user = process.env.DEMO_AUTH_USER ?? 'admin';
+  const days = parseInt(process.env.DEMO_AUTH_COOKIE_DAYS ?? '30', 10);
+  const demoAuth = await signAuthCookie(user, secret, days);
+  // CSRF — middleware enforces double-submit (cookie matches header)
+  const csrfToken = generateCsrfToken();
+  return { demoAuth, csrfToken };
+}
+
 async function callEndpoint(
   baseUrl: string,
   endpoint: string,
   sessionId: string,
+  auth: AuthCookies,
 ): Promise<{ ok: boolean; status: number; body: string }> {
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), PER_CALL_TIMEOUT_MS);
@@ -98,7 +129,9 @@ async function callEndpoint(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Cookie: `session_id=${sessionId}`,
+        // Three cookies: session, demo_auth (middleware), csrf (CSRF guard)
+        Cookie: `session_id=${sessionId}; ${AUTH_COOKIE_NAME}=${auth.demoAuth}; csrf_token=${auth.csrfToken}`,
+        'X-CSRF-Token': auth.csrfToken,
       },
       body: '{}',
       signal: ctl.signal,
@@ -153,11 +186,14 @@ async function main() {
   store.updateSession(sessionId, { emails });
   console.log(`[parse-via-devserver] seeded session ${sessionId}`);
 
+  const auth = await buildAuthCookies();
+  console.log('[parse-via-devserver] signed demo_auth cookie + csrf token');
+
   try {
     for (const ep of ENDPOINTS) {
       console.log(`[parse-via-devserver] POST ${ep} ...`);
       const t0 = Date.now();
-      const res = await callEndpoint(args.baseUrl, ep, sessionId);
+      const res = await callEndpoint(args.baseUrl, ep, sessionId, auth);
       const dt = ((Date.now() - t0) / 1000).toFixed(1);
       console.log(`  ← ${res.status} in ${dt}s — ${res.body.slice(0, 200)}`);
       if (!res.ok) {

--- a/scripts/demo-seed/parse-via-devserver.ts
+++ b/scripts/demo-seed/parse-via-devserver.ts
@@ -1,0 +1,206 @@
+// scripts/demo-seed/parse-via-devserver.ts
+/**
+ * Drive the real LLM HTTP endpoints to parse all .private/raw-emails/*.json once,
+ * cache the result, exit. Re-running with same corpus is a no-op (cache hit).
+ *
+ * Usage:
+ *   npx tsx scripts/demo-seed/parse-via-devserver.ts \
+ *     [--raw-dir DIR] [--base-url URL] [--dry-run]
+ *
+ * Pre-req: dev-server reachable at --base-url (default http://localhost:3000)
+ *          → run `npm run dev` in another terminal.
+ *
+ * Auth model:
+ *   - Seeds a real session into data/sessions.db via the existing
+ *     SessionStore. Cookie session_id=<id> is sent on each POST.
+ *   - validateCsrf returns true in NODE_ENV=development → no CSRF header
+ *     needed. No prod-code changes.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { getStore } from '@/lib/session-store';
+import type { Email } from '@/lib/types';
+import { normalizeRawEmail, type FlatEmail } from './analyze';
+import {
+  corpusHash,
+  loadLlmCacheIfAny,
+  writeCache,
+  type LlmCache,
+} from './llm-cache';
+
+const DEFAULT_RAW = '.private/raw-emails';
+const DEFAULT_BASE = 'http://localhost:3000';
+const ENDPOINTS = [
+  '/api/ai/classify',
+  '/api/ai/parse-cargo',
+  '/api/ai/parse-vessel',
+  '/api/ai/parse-recap',
+] as const;
+const PER_CALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface Args {
+  rawDir: string;
+  baseUrl: string;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (k: string) => {
+    const i = argv.indexOf(k);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  return {
+    rawDir: path.resolve(get('--raw-dir') ?? DEFAULT_RAW),
+    baseUrl: get('--base-url') ?? DEFAULT_BASE,
+    dryRun: argv.includes('--dry-run'),
+  };
+}
+
+async function probeServer(baseUrl: string): Promise<boolean> {
+  try {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), 2000);
+    const r = await fetch(baseUrl, { signal: ctl.signal });
+    clearTimeout(t);
+    return r.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+function flatToEmail(flat: FlatEmail): Email {
+  return {
+    id: flat.messageId,
+    threadId: flat.threadId,
+    from: flat.fromName
+      ? `${flat.fromName} <${flat.fromEmail ?? ''}>`
+      : (flat.fromEmail ?? ''),
+    fromName: flat.fromName ?? null,
+    fromEmail: flat.fromEmail ?? null,
+    to: '',
+    subject: flat.subject ?? '',
+    date: flat.date,
+    body: flat.body,
+    snippet: flat.body.slice(0, 200),
+    labelIds: [],
+  };
+}
+
+async function callEndpoint(
+  baseUrl: string,
+  endpoint: string,
+  sessionId: string,
+): Promise<{ ok: boolean; status: number; body: string }> {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), PER_CALL_TIMEOUT_MS);
+  try {
+    const r = await fetch(`${baseUrl}${endpoint}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `session_id=${sessionId}`,
+      },
+      body: '{}',
+      signal: ctl.signal,
+    });
+    const body = await r.text();
+    return { ok: r.ok, status: r.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!fs.existsSync(args.rawDir)) {
+    console.error(`Raw dir does not exist: ${args.rawDir}`);
+    process.exit(2);
+  }
+
+  const hash = corpusHash(args.rawDir);
+  console.log(`[parse-via-devserver] corpus hash: ${hash}`);
+
+  if (loadLlmCacheIfAny(args.rawDir)) {
+    console.log('[parse-via-devserver] cache hit — nothing to do.');
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log('[dry-run] would seed session into data/sessions.db');
+    console.log('[dry-run] would POST sequentially:');
+    for (const ep of ENDPOINTS) console.log(`  ${args.baseUrl}${ep}`);
+    console.log(`[dry-run] would write cache: ${args.rawDir}/.llm-cache/${hash}.json`);
+    return;
+  }
+
+  if (!(await probeServer(args.baseUrl))) {
+    console.error(
+      `[parse-via-devserver] dev-server not reachable at ${args.baseUrl}.\n` +
+        `Run \`npm run dev\` in another terminal and retry.`,
+    );
+    process.exit(2);
+  }
+
+  const files = fs.readdirSync(args.rawDir).filter((f) => f.endsWith('.json')).sort();
+  const emails: Email[] = files.map((f) => {
+    const raw = JSON.parse(fs.readFileSync(path.join(args.rawDir, f), 'utf8'));
+    return flatToEmail(normalizeRawEmail(raw));
+  });
+  console.log(`[parse-via-devserver] loaded ${emails.length} emails`);
+
+  const store = getStore();
+  const sessionId = store.createSession('demo-script-token');
+  store.updateSession(sessionId, { emails });
+  console.log(`[parse-via-devserver] seeded session ${sessionId}`);
+
+  try {
+    for (const ep of ENDPOINTS) {
+      console.log(`[parse-via-devserver] POST ${ep} ...`);
+      const t0 = Date.now();
+      const res = await callEndpoint(args.baseUrl, ep, sessionId);
+      const dt = ((Date.now() - t0) / 1000).toFixed(1);
+      console.log(`  ← ${res.status} in ${dt}s — ${res.body.slice(0, 200)}`);
+      if (!res.ok) {
+        console.error(`[parse-via-devserver] ${ep} returned ${res.status}; aborting.`);
+        console.error(res.body);
+        process.exit(3);
+      }
+    }
+
+    const final = store.getSession(sessionId);
+    if (!final) {
+      console.error('[parse-via-devserver] session vanished after parsing');
+      process.exit(3);
+    }
+
+    const cache: LlmCache = {
+      corpusHash: hash,
+      generatedAt: new Date().toISOString(),
+      classifications: final.classifications,
+      parsedCargos: final.parsedCargos,
+      parsedVessels: final.parsedVessels,
+      parsedFixtureRecaps: final.parsedFixtureRecaps,
+    };
+
+    writeCache(args.rawDir, cache);
+    const stats = fs.statSync(path.join(args.rawDir, '.llm-cache', `${hash}.json`));
+    console.log(
+      `[parse-via-devserver] wrote cache: ${(stats.size / 1024).toFixed(1)} KB ` +
+        `(classifications=${cache.classifications.length} cargos=${cache.parsedCargos.length} ` +
+        `vessels=${cache.parsedVessels.length} recaps=${cache.parsedFixtureRecaps.length})`,
+    );
+  } finally {
+    try {
+      store.deleteSession(sessionId);
+    } catch (e) {
+      console.warn('[parse-via-devserver] could not delete seeded session:', e);
+    }
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## What

After PR #599 merged, `data/demo-seed.db.matches` contained 0 rows: `scripts/demo-seed/analyze.ts` extracts dates with regex literals (`LAYCAN:` / `OPEN DATE:`) that real broker emails almost never use (3/153 hits in our corpus).

This PR adds a driver script that runs the 153 raw broker emails through this repo's live LLM HTTP endpoints once, caches the structured output, and teaches `analyze.ts` + `build.ts` to prefer the cache when present. Outcome: realistic anonymization map + dozens of cargo×vessel matches in the snapshot.

## Pieces

- `scripts/demo-seed/llm-cache.ts` — pure helpers: `corpusHash()`, `readCache/writeCache`, `loadLlmCacheIfAny()`.
- `scripts/demo-seed/parse-via-devserver.ts` — driver: seed a real session into `data/sessions.db`, sign `demo_auth` cookie locally, drive 4× POST `/api/ai/*`, read final session, write cache.
- `scripts/demo-seed/analyze.ts` — adds `extractFactsFromCache()` (category from `classifications`, laycan from `parsedCargos`, openDate from `parsedVessels`, vesselName/charterer for anonymization). Regex `extractFacts` stays as fallback.
- `scripts/demo-seed/build.ts` — when `.llm-cache/<hash>.json` exists, writes real classify/cargo/vessel/recap rows into `parsed_results` with dates shifted by `manifest.offsets`. Match-compute step at end of `build()` is unchanged — it now operates on real laycans/openDates → dozens of matches.
- `.gitignore` — adds `scripts/demo-seed/.llm-cache/` and `.private/.llm-cache/`.

## Auth model

The driver authenticates exactly the way the browser does:

1. Seeds a real session via the existing `SessionStore` (same code path as `/api/auth/login`).
2. Signs the `demo_auth` cookie locally with `signAuthCookie(user, DEMO_AUTH_SECRET, days)` — same helper the login route uses.
3. Generates a CSRF token and sends both the `csrf_token` cookie and the `X-CSRF-Token` header so middleware's `checkCsrfRequest` passes.

**No prod-code changes.** No `SCRIPT_AUTH_BYPASS` env flag added. No guard removed.

## CI safety

When `.llm-cache/<hash>.json` is absent (CI, fresh worktree, fixture-only corpus), both `analyze.ts` and `build.ts` fall back to the existing regex path. All 7495 existing tests stay green.

## Tests added

- `scripts/demo-seed/__tests__/llm-cache.test.ts` — 10 tests covering deterministic hash + cache round-trip + hash-mismatch detection.
- `scripts/demo-seed/__tests__/analyze.test.ts` — 2 new cases proving the cache-prefer code path is used and pulls laycan from `parsedCargos`.
- `scripts/demo-seed/__tests__/build.test.ts` — 1 new case proving cache yields >=4 `parsed_results` rows and >0 matches.

Full jest run: **685 suites passed, 7495 tests passed, 27 skipped, 0 failed.**

## Blocker reached during real-run verification

Local Mac is missing the Vertex AI service-account JSON — `.env.local` points to `/root/.config/gcp/quantika-vertex-ai.json` which is a VPS path (file does not exist locally). The first call returned `Error: ENOENT '/root'` from `lib/ai-provider.ts:551`. Per the task spec ("If anything blocks (e.g. Gemini creds missing locally, dev-server crash...), STOP and report the blocker"), this run was not executed end-to-end here.

**To complete acceptance**, the operator must run `npx tsx scripts/demo-seed/parse-via-devserver.ts` either:
- On the dev-VPS (157.173.124.116) where the credentials file exists, OR
- Locally after copying the Vertex service-account JSON down from VPS and updating `GOOGLE_APPLICATION_CREDENTIALS` in `.env.local`.

After that one run, `npm run-script demo-seed:analyze` then `demo-seed:build` (or whatever the package.json scripts are named) will produce `data/demo-seed.db` with `SELECT COUNT(*) FROM matches > 50`.

## Acceptance status

- [x] `scripts/demo-seed/parse-via-devserver.ts` exists, dry-runs cleanly.
- [x] `scripts/demo-seed/llm-cache.ts` + helpers unit-tested (10 cases).
- [x] `analyze.ts` + `build.ts` cache-prefer code paths unit-tested.
- [x] All 7495 existing tests stay green (PI3).
- [ ] **Pending operator run**: `.llm-cache/<hash>.json` populated → `SELECT COUNT(*) FROM matches > 50` (blocked on Vertex creds locally — see above).

## Out of scope

- Reactivate DEMO_MODE cache-only guards on `/api/ai/*` endpoints (separate PR per PR #599 Task 21).
- E2E playwright smoke (PR #599 Task 23).
- CI fixture-corpus smoke build (PR #599 Task 24).
- Deploy `DEMO_MODE=true` to outreach-vps (manual step after the LLM cache populates a fresh `data/demo-seed.db`).

## Plan markers
CHAIN_demo_llm_cache=M creative=y writing_plans=docs/superpowers/plans/2026-05-27-demo-llm-cache-parsing.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)