### PR TITLE
fix(pages): #572 /about + /pricing 404 — create marketing pages

### DIFF
--- a/__tests__/app/about-pricing.test.tsx
+++ b/__tests__/app/about-pricing.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/link', () => {
+  const MockLink = ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'Link';
+  return MockLink;
+});
+
+import AboutPage from '../../app/about/page';
+import PricingPage from '../../app/pricing/page';
+
+describe('/about page', () => {
+  it('renders without crashing', () => {
+    render(<AboutPage />);
+  });
+
+  it('displays Quantika heading', () => {
+    render(<AboutPage />);
+    expect(screen.getByRole('heading', { name: /About Quantika/i })).toBeInTheDocument();
+  });
+
+  it('contains link to /pricing', () => {
+    render(<AboutPage />);
+    const link = screen.getByRole('link', { name: /Pricing/i });
+    expect(link).toHaveAttribute('href', '/pricing');
+  });
+
+  it('contains contact email link', () => {
+    render(<AboutPage />);
+    const contactLink = screen.getByRole('link', { name: /Contact us/i });
+    expect(contactLink).toHaveAttribute('href', 'mailto:hello@quantika.org');
+  });
+});
+
+describe('/pricing page', () => {
+  it('renders without crashing', () => {
+    render(<PricingPage />);
+  });
+
+  it('displays pricing heading', () => {
+    render(<PricingPage />);
+    expect(screen.getByRole('heading', { name: /pricing/i, level: 1 })).toBeInTheDocument();
+  });
+
+  it('shows three plan tiers', () => {
+    render(<PricingPage />);
+    expect(screen.getByRole('heading', { name: /Starter/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Pro/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Enterprise/i })).toBeInTheDocument();
+  });
+
+  it('contains link to /about', () => {
+    render(<PricingPage />);
+    const link = screen.getByRole('link', { name: /About/i });
+    expect(link).toHaveAttribute('href', '/about');
+  });
+});
+
+describe('middleware bypass for /about and /pricing', () => {
+  it('/about is in AUTH_BYPASS_PATHS', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../middleware.ts'),
+      'utf-8'
+    );
+    expect(src).toContain("'/about'");
+    expect(src).toContain("'/pricing'");
+  });
+});

--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -68,6 +68,8 @@ describe('middleware auth guard', () => {
       '/design',
       '/api/market/baltic-kpi',
       '/api/market/bunker-kpi',
+      '/about',
+      '/pricing',
     ];
 
     for (const path of bypassPaths) {

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'About — Quantika',
+  description: 'Quantika — AI-powered freight intelligence for dry bulk shipping',
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-12">
+      <div className="max-w-2xl mx-auto space-y-10">
+        <div>
+          <Link href="/" className="text-sm text-slate-500 hover:text-ds-accent transition-colors">
+            ← Home
+          </Link>
+        </div>
+
+        <header className="space-y-3">
+          <h1 className="text-3xl font-bold text-slate-900">About Quantika</h1>
+          <p className="text-lg text-slate-600">
+            AI-powered freight intelligence for dry bulk shipping.
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold text-slate-900">What we do</h2>
+          <p className="text-slate-600 leading-relaxed">
+            Quantika helps freight traders and chartering teams cut through the noise of daily email traffic.
+            Our platform automatically parses cargo inquiries, vessel positions, and fixture recaps —
+            then surfaces the best vessel-cargo matches ranked by compatibility score, route economics, and laycan fit.
+          </p>
+          <p className="text-slate-600 leading-relaxed">
+            Instead of manually cross-referencing dozens of emails, your team sees a ranked shortlist of
+            actionable opportunities within seconds of an email arriving.
+          </p>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold text-slate-900">Key capabilities</h2>
+          <ul className="space-y-3">
+            {[
+              { icon: '📧', title: 'Email parsing', desc: 'Extracts cargo specs, vessel details, and laycan windows from plain-text emails using LLMs trained on shipping industry language.' },
+              { icon: '🤝', title: 'Smart matching', desc: 'Scores vessel-cargo pairs on DWT compatibility, route fit, laycan overlap, and TCE economics — ranked by overall match quality.' },
+              { icon: '📊', title: 'Market intelligence', desc: 'Live Baltic Exchange indices (BDI, BCI, BSI, BHSI), TCE estimates for major tradelanes, and bunker price feeds.' },
+              { icon: '🔒', title: 'Compliance checks', desc: 'Automatic OFAC and EU sanctions screening on all counterparties before a fixture goes firm.' },
+            ].map(({ icon, title, desc }) => (
+              <li key={title} className="flex gap-3">
+                <span className="text-xl flex-shrink-0">{icon}</span>
+                <div>
+                  <span className="font-medium text-slate-900">{title} — </span>
+                  <span className="text-slate-600">{desc}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold text-slate-900">Who we serve</h2>
+          <p className="text-slate-600 leading-relaxed">
+            Quantika is built for dry bulk chartering desks, commodity traders, and shipowners managing
+            Supramax, Capesize, and Handysize fleets across the Mediterranean, Black Sea, and West African corridors.
+          </p>
+        </section>
+
+        <section className="bg-white rounded-2xl border border-slate-200 p-6 space-y-3">
+          <h2 className="text-base font-semibold text-slate-900">Get in touch</h2>
+          <p className="text-slate-600 text-sm">
+            Interested in a live demo or a pilot for your team?
+          </p>
+          <a
+            href="mailto:hello@quantika.org"
+            className="inline-block px-5 py-2.5 bg-ds-accent text-ds-accent-fg text-sm font-medium rounded-lg hover:bg-ds-accent/90 transition-colors"
+          >
+            Contact us
+          </a>
+        </section>
+
+        <nav className="flex gap-4 text-sm">
+          <Link href="/pricing" className="text-ds-accent hover:underline">Pricing →</Link>
+          <Link href="/market" className="text-slate-500 hover:text-ds-accent transition-colors">Market data →</Link>
+        </nav>
+      </div>
+    </main>
+  );
+}

--- a/app/more/page.tsx
+++ b/app/more/page.tsx
@@ -42,6 +42,24 @@ export default function MorePage() {
               </span>
             </li>
             <li>
+              <Link
+                href="/about"
+                className="flex items-center justify-between w-full rounded-ds-md px-4 py-3 text-sm font-medium text-ds-text hover:bg-ds-surface-muted transition-colors duration-ds-fast min-h-[44px]"
+              >
+                About Quantika
+                <span className="text-ds-text-muted text-xs">→</span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/pricing"
+                className="flex items-center justify-between w-full rounded-ds-md px-4 py-3 text-sm font-medium text-ds-text hover:bg-ds-surface-muted transition-colors duration-ds-fast min-h-[44px]"
+              >
+                Pricing
+                <span className="text-ds-text-muted text-xs">→</span>
+              </Link>
+            </li>
+            <li>
               <span className="flex items-center justify-between w-full rounded-ds-md px-4 py-3 text-sm font-medium text-ds-text-muted min-h-[44px]">
                 Help &amp; FAQ
                 <span className="text-xs">Coming soon</span>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Pricing — Quantika',
+  description: 'Quantika pricing plans for freight chartering teams',
+};
+
+interface PlanFeature {
+  text: string;
+  included: boolean;
+}
+
+interface Plan {
+  name: string;
+  price: string;
+  period: string;
+  description: string;
+  features: PlanFeature[];
+  cta: string;
+  highlighted: boolean;
+}
+
+const PLANS: Plan[] = [
+  {
+    name: 'Starter',
+    price: 'Free',
+    period: 'demo',
+    description: 'Try the full platform with sample data. No credit card required.',
+    features: [
+      { text: 'Sample email dataset', included: true },
+      { text: 'Cargo & vessel parsing', included: true },
+      { text: 'Match scoring & ranking', included: true },
+      { text: 'Market indices (BDI / BSI / BCI)', included: true },
+      { text: 'Live email inbox', included: false },
+      { text: 'Sanctions screening', included: false },
+      { text: 'Team seats', included: false },
+    ],
+    cta: 'Try demo',
+    highlighted: false,
+  },
+  {
+    name: 'Pro',
+    price: '$890',
+    period: 'per month',
+    description: 'For active chartering desks processing 50–200 emails per day.',
+    features: [
+      { text: 'Gmail / Outlook integration', included: true },
+      { text: 'Cargo & vessel parsing', included: true },
+      { text: 'Match scoring & ranking', included: true },
+      { text: 'Market indices (BDI / BSI / BCI / BHSI)', included: true },
+      { text: 'OFAC & EU sanctions screening', included: true },
+      { text: 'TCE economics calculator', included: true },
+      { text: '3 team seats', included: true },
+    ],
+    cta: 'Contact sales',
+    highlighted: true,
+  },
+  {
+    name: 'Enterprise',
+    price: 'Custom',
+    period: 'annual contract',
+    description: 'For trading houses and operators with high-volume, multi-desk needs.',
+    features: [
+      { text: 'Everything in Pro', included: true },
+      { text: 'Unlimited email volume', included: true },
+      { text: 'Unlimited team seats', included: true },
+      { text: 'Dedicated onboarding & support', included: true },
+      { text: 'WhatsApp integration', included: true },
+      { text: 'Pipedrive CRM sync', included: true },
+      { text: 'Custom data integrations', included: true },
+    ],
+    cta: 'Talk to us',
+    highlighted: false,
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 px-4 py-12">
+      <div className="max-w-5xl mx-auto space-y-10">
+        <div>
+          <Link href="/" className="text-sm text-slate-500 hover:text-ds-accent transition-colors">
+            ← Home
+          </Link>
+        </div>
+
+        <header className="text-center space-y-3 max-w-xl mx-auto">
+          <h1 className="text-3xl font-bold text-slate-900">Simple, transparent pricing</h1>
+          <p className="text-slate-600">
+            Start with the free demo. Upgrade when you&apos;re ready to connect your live inbox.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {PLANS.map((plan) => (
+            <div
+              key={plan.name}
+              className={`bg-white rounded-2xl border p-6 flex flex-col space-y-5 ${
+                plan.highlighted
+                  ? 'border-ds-accent shadow-md ring-1 ring-ds-accent/20'
+                  : 'border-slate-200'
+              }`}
+            >
+              {plan.highlighted && (
+                <div className="text-center">
+                  <span className="inline-block bg-ds-accent text-ds-accent-fg text-xs font-semibold px-3 py-0.5 rounded-full">
+                    Most popular
+                  </span>
+                </div>
+              )}
+              <div>
+                <h2 className="text-lg font-semibold text-slate-900">{plan.name}</h2>
+                <div className="mt-1 flex items-baseline gap-1">
+                  <span className="text-3xl font-bold text-slate-900">{plan.price}</span>
+                  <span className="text-sm text-slate-500">{plan.period}</span>
+                </div>
+                <p className="mt-2 text-sm text-slate-500">{plan.description}</p>
+              </div>
+
+              <ul className="space-y-2 flex-1">
+                {plan.features.map((f) => (
+                  <li key={f.text} className="flex items-start gap-2 text-sm">
+                    <span className={f.included ? 'text-green-500' : 'text-slate-300'}>
+                      {f.included ? '✓' : '✗'}
+                    </span>
+                    <span className={f.included ? 'text-slate-700' : 'text-slate-400'}>
+                      {f.text}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              <a
+                href="mailto:hello@quantika.org"
+                className={`block text-center px-5 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                  plan.highlighted
+                    ? 'bg-ds-accent text-ds-accent-fg hover:bg-ds-accent/90'
+                    : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                }`}
+              >
+                {plan.cta}
+              </a>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-center text-sm text-slate-400">
+          All prices exclude VAT · Annual billing available at 20% discount · Questions?{' '}
+          <a href="mailto:hello@quantika.org" className="text-ds-accent hover:underline">
+            hello@quantika.org
+          </a>
+        </p>
+
+        <nav className="flex justify-center gap-4 text-sm">
+          <Link href="/about" className="text-slate-500 hover:text-ds-accent transition-colors">About →</Link>
+          <Link href="/market" className="text-slate-500 hover:text-ds-accent transition-colors">Market data →</Link>
+        </nav>
+      </div>
+    </main>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,6 +32,9 @@ const AUTH_BYPASS_PATHS = new Set([
   '/robots.txt',
   // Design preview page — internal gallery, no sensitive data
   '/design',
+  // Public marketing pages — accessible without login for prospects
+  '/about',
+  '/pricing',
   // Market KPI endpoints — public index data (BDI/BHSI/bunker prices), safe for anonymous
   '/api/market/baltic-kpi',
   '/api/market/bunker-kpi',


### PR DESCRIPTION
## Summary
- Creates `app/about/page.tsx` — Quantika pitch, capabilities list, contact CTA
- Creates `app/pricing/page.tsx` — Starter / Pro / Enterprise tier pricing cards
- Adds `/about` and `/pricing` to `AUTH_BYPASS_PATHS` (public, no login required)
- Adds links to both pages in `app/more/page.tsx` More navigation
- Updates `__tests__/middleware-auth.test.ts` bypassPaths array

## Issues
Closes #572

## Acceptance
| Criterion | Status |
|-----------|--------|
| /about renders with content (no 404) | ✓ |
| /pricing renders with content (no 404) | ✓ |
| Both accessible without login | ✓ |
| More dropdown links to /about and /pricing | ✓ |

## Test plan
- [ ] Navigate to /about → marketing page renders with capabilities list
- [ ] Navigate to /pricing → 3-tier pricing cards render
- [ ] Navigate to /more → "About Quantika" and "Pricing" links visible
- [ ] Access /about and /pricing without auth cookie → no redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)