### PR TITLE
fix(#604 BC7): vessel-name false positive — preserve class society token if part of vessel.name

### DIFF
--- a/__tests__/progonq-explain-deal-regression.test.ts
+++ b/__tests__/progonq-explain-deal-regression.test.ts
@@ -138,6 +138,14 @@ const nullClassVessel: ParsedVessel = {
   specialFeatures: [],
 };
 
+// ── BC7 — vessel-name false positive fixtures ─────────────────────────────────
+
+const dnvNameVessel: ParsedVessel = {
+  ...nullClassVessel,
+  vesselName: { value: 'MV DNV Star', confidence: 'confirmed' },
+  classSociety: 'LR', // different society — DNV is NOT the class
+};
+
 // ── R3 regression: buildPayloadNumberSet improvements ─────────────────────────
 
 describe('buildPayloadNumberSet — R3 regression (#589)', () => {
@@ -351,5 +359,51 @@ describe('POST /api/ai/explain-deal — R3 temperature + strip (#589)', () => {
     // 1500 MTPD is from payload loadingRate — must NOT be stripped
     expect(steps?.content).toContain('1500');
     expect(body.warnings).toBeUndefined();
+  });
+});
+
+// ── BC7 — vessel-name false positive (#604) ───────────────────────────────────
+
+describe('stripInventedContent — BC7 vessel-name false positive (#604)', () => {
+  it('does NOT strip class-society token when it appears as part of vessel.name', () => {
+    // vessel.name = "MV DNV Star", classSociety = "LR"
+    // LLM correctly cites the vessel by name — DNV is part of the name, not an invented class
+    const result = stripInventedContent(
+      'The vessel MV DNV Star has been LR classed and is suitable for this voyage.',
+      nullWeightMatch,
+      nullWeightCargo,
+      dnvNameVessel,
+    );
+    // DNV is in vessel.name → must be preserved
+    expect(result.text).toContain('DNV Star');
+    expect(result.forbiddenTokens).not.toContain('DNV');
+  });
+
+  it('still strips class-society token when NOT part of vessel.name', () => {
+    // vessel.name = "MV DNV Star", but response invents "ABS classed"
+    const result = stripInventedContent(
+      'The vessel MV DNV Star is ABS classed.',
+      nullWeightMatch,
+      nullWeightCargo,
+      dnvNameVessel,
+    );
+    // ABS is not in vessel.name and not the payload class (LR) → must be stripped
+    expect(result.text).not.toContain('ABS');
+    expect(result.forbiddenTokens).toContain('ABS');
+    // DNV (from vessel name) must remain intact
+    expect(result.text).toContain('DNV Star');
+  });
+
+  it('allows payload classSociety token regardless of vessel.name', () => {
+    // vessel.classSociety = "LR" → LR mention in response is always OK
+    const result = stripInventedContent(
+      'MV DNV Star is LR classed.',
+      nullWeightMatch,
+      nullWeightCargo,
+      dnvNameVessel,
+    );
+    expect(result.text).toContain('LR');
+    expect(result.forbiddenTokens).not.toContain('LR');
+    expect(result.text).toContain('DNV');
   });
 });

--- a/lib/explain-deal-validator.ts
+++ b/lib/explain-deal-validator.ts
@@ -246,15 +246,18 @@ export function stripInventedContent(
   }
 
   // 3. Strip class society mentions that don't match vessel.classSociety.
+  //    Exception: preserve token if it's a substring of vessel.name (vessel named after society).
   const payloadClass = vessel?.classSociety
     ? normalizeClassSocietyToken(vessel.classSociety)
     : null;
+  const vesselNameUpper = (vessel?.vesselName?.value ?? '').toUpperCase();
   for (const candidate of CLASS_SOCIETIES) {
     const escaped = candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const re = new RegExp(`\\b${escaped}\\b`, 'g');
     stripped = stripped.replace(re, (raw) => {
       const norm = normalizeClassSocietyToken(raw);
       if (payloadClass && norm === payloadClass) return raw;
+      if (vesselNameUpper.includes(raw.toUpperCase())) return raw;
       forbiddenTokens.push(raw);
       return REDACTION_CLASS;
     });


### PR DESCRIPTION
Closes #604 (BC7).
BC2 (D.N.V./DNV-GL dotted variants) already fixed by R3b #608.

## Root cause
`stripInventedContent` блокировал любой class-society токен (DNV/LR/etc) даже когда он валидно part of vessel.name из payload — e.g., `MV DNV Star`.

## Fix
- `lib/explain-deal-validator.ts` (+5 lines): added `vesselNameUpper` from `vessel.vesselName.value`; в class-society loop return `raw` (no strip) when `vesselNameUpper.includes(raw.toUpperCase())`.
- `__tests__/progonq-explain-deal-regression.test.ts` (+57 lines): 3 regression tests.

## Tests
87/87 green (22 → 25 in regression suite + related).

🤖 Subagent: disp-20260527-231542-6b5201 (PASS, 10min)