### PR TITLE
fix(#615): Quote tab — add Generate button + disable Send when empty

### DIFF
--- a/components/__tests__/quote-tab-generate-draft.test.tsx
+++ b/components/__tests__/quote-tab-generate-draft.test.tsx
@@ -38,10 +38,12 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
     expect(screen.getByRole('button', { name: /generate/i })).toBeInTheDocument();
   });
 
-  it('does NOT show Generate button when cargoEmailId is absent', () => {
+  it('shows Generate button as disabled when cargoEmailId is absent', () => {
     mockFetchResponses('');
     render(<QuoteTab />);
-    expect(screen.queryByRole('button', { name: /generate/i })).toBeNull();
+    const btn = screen.getByRole('button', { name: /generate/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeDisabled();
   });
 
   it('POSTs to /api/ai/draft-quote with emailId on click', async () => {
@@ -92,5 +94,20 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
     await waitFor(() => {
       expect(screen.getByText('Service unavailable')).toBeInTheDocument();
     });
+  });
+
+  it('Send Quote is disabled when draft textarea is empty', () => {
+    mockFetchResponses('');
+    render(<QuoteTab cargoEmailId="email-001" />);
+    const sendBtn = screen.getByRole('button', { name: /send quote/i });
+    expect(sendBtn).toBeDisabled();
+  });
+
+  it('Send Quote is enabled after draft textarea is filled', () => {
+    mockFetchResponses('');
+    render(<QuoteTab cargoEmailId="email-001" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT' } });
+    const sendBtn = screen.getByRole('button', { name: /send quote/i });
+    expect(sendBtn).not.toBeDisabled();
   });
 });

--- a/components/match/QuoteTab.tsx
+++ b/components/match/QuoteTab.tsx
@@ -56,15 +56,13 @@ export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <label className="block text-xs font-medium text-gray-600">Draft Quote</label>
-          {cargoEmailId && (
-            <button
-              onClick={generateDraft}
-              disabled={generating}
-              className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-200 disabled:opacity-50"
-            >
-              {generating ? 'Generating…' : 'Generate'}
-            </button>
-          )}
+          <button
+            onClick={generateDraft}
+            disabled={generating || !cargoEmailId}
+            className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-200 disabled:opacity-50"
+          >
+            {generating ? 'Generating…' : 'Generate'}
+          </button>
         </div>
         {generateError && (
           <p className="text-xs text-red-600">{generateError}</p>
@@ -80,7 +78,7 @@ export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
       <div className="flex gap-2">
         <button
           className="rounded bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
-          disabled={blockSend}
+          disabled={blockSend || !draft.trim()}
           title={blockSend ? `${blockedFields.length} critical field(s) uncertain: ${blockedFields.join(', ')}` : undefined}
         >
           Send Quote

--- a/components/match/__tests__/MatchTabs.test.tsx
+++ b/components/match/__tests__/MatchTabs.test.tsx
@@ -135,18 +135,28 @@ describe('MatchTabs', () => {
   });
 
   describe('Send Quote button', () => {
-    it('is enabled when blockSend is false', () => {
+    it('is disabled when draft is empty (blockSend=false)', () => {
       const match = { ...baseMatch, confidence: mockConfidenceVerified };
       render(<MatchTabs match={match} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       const btn = screen.getByRole('button', { name: /send quote/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it('is enabled when draft has content and blockSend is false', () => {
+      const match = { ...baseMatch, confidence: mockConfidenceVerified };
+      render(<MatchTabs match={match} />);
+      fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT offer' } });
+      const btn = screen.getByRole('button', { name: /send quote/i });
       expect(btn).not.toBeDisabled();
     });
 
-    it('is disabled when blockSend is true', () => {
+    it('is disabled when blockSend is true even with draft content', () => {
       const match = { ...baseMatch, confidence: mockConfidenceBlocked };
       render(<MatchTabs match={match} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT offer' } });
       const btn = screen.getByRole('button', { name: /send quote/i });
       expect(btn).toBeDisabled();
     });


### PR DESCRIPTION
Closes #615.

## Root cause
Quote tab placeholder говорил 'Click Generate to create an AI draft quote...' но кнопки Generate не было в DOM. Send Quote enabled даже при пустом textarea (UI validation gap).

## Fix
- Added Generate button → calls AI quote-draft endpoint, fills textarea
- Disabled Send Quote when textarea empty (UI validation)

🤖 Subagent: disp-20260528-115809-fd8839 (PASS, 9min)