### PR TITLE
feat(ops): post-deploy headless smoke on dev-vps (5 routes × screenshot + DOM check)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,133 @@
+name: Post-Deploy Smoke
+
+# После успешного deploy.yml → SSH dev-vps → headless playwright прогон 5
+# prod routes → JSON+screenshots в ~/orchestrator-state/.../post-deploy-checks/<pr#>/
+# → comment на PR (PASS/FAIL).
+#
+# Smoke выполняется на dev-vps (НЕ outreach-vps), потому что:
+# - PROD_SSH_KEY на outreach-vps locked-down (forced-command /root/deploy.sh)
+# - dev-vps уже имеет playwright + chromium + достаточно ресурсов для headless
+# - smoke read-only через https — prod box смешивать с QA box не нужно
+#
+# Failure НЕ откатывает deploy — это сигнал, не gate. Rollback живёт в deploy.yml
+# (60s health-check + auto-revert). Smoke смотрит шире: visual rendering + DOM.
+#
+# Required secrets: DEV_VPS_SSH_KEY (ed25519, open SSH, не forced-command).
+
+on:
+  workflow_run:
+    workflows: ["Deploy to prod"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR# (для manual re-run)"
+        required: false
+        default: "manual"
+      sha:
+        description: "merge SHA (если PR не указан)"
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: post-deploy-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve PR# + SHA
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR="${{ github.event.inputs.pr }}"
+            SHA="${{ github.event.inputs.sha }}"
+          else
+            SHA="${{ github.event.workflow_run.head_sha }}"
+            PR=$(gh pr list --state merged --search "$SHA" \
+                  --json number --jq '.[0].number' \
+                  --repo "${{ github.repository }}" 2>/dev/null || true)
+            [ -z "$PR" ] && PR="manual"
+          fi
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved: PR=#$PR SHA=$SHA"
+
+      - name: Setup SSH to dev-vps
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "${{ secrets.DEV_VPS_SSH_KEY }}" > ~/.ssh/dev_vps_key
+          chmod 600 ~/.ssh/dev_vps_key
+          ssh-keyscan -H 157.173.124.116 >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Run smoke on dev-vps
+        id: smoke
+        continue-on-error: true
+        run: |
+          PR="${{ steps.resolve.outputs.pr }}"
+          set +e
+          ssh -i ~/.ssh/dev_vps_key \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=15 \
+              root@157.173.124.116 \
+              "bash /root/post-deploy-smoke/run-quantika.sh $PR" \
+              | tee smoke-output.txt
+          RC=${PIPESTATUS[0]}
+          echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          # Pull JSON summary back для downstream parse
+          scp -i ~/.ssh/dev_vps_key \
+              -o StrictHostKeyChecking=accept-new \
+              "root@157.173.124.116:orchestrator-state/quantika-demo/post-deploy-checks/$PR/summary.json" \
+              ./summary.json 2>/dev/null || echo '{"overall":"ERROR","routes_passed":0,"routes_checked":0}' > summary.json
+          exit 0
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-deploy-smoke-${{ steps.resolve.outputs.pr }}
+          path: |
+            summary.json
+            smoke-output.txt
+          retention-days: 30
+
+      - name: Comment on PR
+        if: steps.resolve.outputs.pr != 'manual'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.resolve.outputs.pr }}
+          RC: ${{ steps.smoke.outputs.rc }}
+        run: |
+          OVERALL=$(jq -r .overall summary.json 2>/dev/null || echo "ERROR")
+          PASSED=$(jq -r '.routes_passed // 0' summary.json)
+          TOTAL=$(jq -r '.routes_checked // 0' summary.json)
+          FAILED_ROUTES=$(jq -r '[.results[] | select(.pass==false) | .route] | join(", ")' summary.json 2>/dev/null || echo "")
+
+          if [ "$OVERALL" = "PASS" ]; then ICON="✅"; else ICON="❌"; fi
+
+          BODY="$ICON **Post-deploy smoke**: \`$OVERALL\` ($PASSED/$TOTAL routes)"
+          if [ "$OVERALL" != "PASS" ] && [ -n "$FAILED_ROUTES" ]; then
+            BODY="$BODY
+
+          Failed routes: $FAILED_ROUTES"
+          fi
+          BODY="$BODY
+
+          Artifacts on dev-vps: \`~/orchestrator-state/quantika-demo/post-deploy-checks/$PR/\` (summary.json + 5 screenshots)
+          GH artifact: [post-deploy-smoke-$PR](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+          gh pr comment "$PR" --body "$BODY" --repo "${{ github.repository }}"
+
+      - name: Fail workflow if smoke failed
+        if: steps.smoke.outputs.rc != '0'
+        run: |
+          echo "::error::Smoke failed (exit ${{ steps.smoke.outputs.rc }})"
+          exit 1

--- a/scripts/post-deploy-smoke/README.md
+++ b/scripts/post-deploy-smoke/README.md
@@ -1,0 +1,63 @@
+# Post-Deploy Smoke
+
+Headless playwright check на prod (`https://demo.quantika.org`) после успешного `deploy.yml`. Гоняется на **dev-vps** (`157.173.124.116`) через GitHub Action `.github/workflows/post-deploy-smoke.yml`.
+
+## Что делает
+
+Открывает 5 ключевых routes (`/`, `/cargo`, `/vessel`, `/match`, `/login`) в headless Chromium на dev-vps, проверяет:
+
+- HTTP status 2xx/3xx (4xx/5xx → FAIL)
+- DOM не содержит error-markers (`application error`, `internal server error`, `unhandled`, `stack trace`, `next.js error`)
+- Нет console errors (после фильтрации favicon/sentry/chunk/4xx-resource-probe noise)
+- Полный screenshot каждого route (1280×800 viewport)
+
+Outputs:
+- `~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/summary.json`
+- `~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/<route>.png` (5 файлов)
+
+Exit 0 = все 5 routes PASS · exit 1 = хоть один FAIL.
+
+## Manual run (на dev-vps)
+
+```bash
+ssh root@dev-vps
+bash /root/post-deploy-smoke/run-quantika.sh <pr#>
+# или с custom URL:
+bash /root/post-deploy-smoke/run-quantika.sh manual https://staging.example.com
+```
+
+## CI flow
+
+```
+auto-merge.yml → repository_dispatch (prod-deploy)
+                     ↓
+              deploy.yml → SSH outreach-vps → /root/deploy-quantika-demo.sh
+                     ↓ (success)
+              workflow_run trigger
+                     ↓
+        post-deploy-smoke.yml → SSH dev-vps → run-quantika.sh <pr#>
+                     ↓
+              gh pr comment <pr#> --body "✅/❌ smoke ..."
+```
+
+## Required GH Secrets
+
+| Secret | Что | Где использован |
+|---|---|---|
+| `DEV_VPS_SSH_KEY` | ed25519 private key (открытый SSH, не forced-command) | `post-deploy-smoke.yml` |
+
+`PROD_SSH_KEY` НЕ переиспользуется — он locked-down (forced-command `/root/deploy.sh`), не может запускать произвольный bash.
+
+## Tuning
+
+- Добавить route: edit `ROUTES_DEFAULT` в `smoke.mjs` или передать `SMOKE_ROUTES="/foo,/bar"` env var.
+- Изменить timeout: `SMOKE_TIMEOUT=20000` (ms).
+- Custom base URL: `SMOKE_BASE_URL=https://staging...`.
+- Console-error фильтр в `smoke.mjs` line ~57 — расширь regex для новых noise patterns.
+
+## Phase 3 (orchestrator-day integration)
+
+Orchestrator-day skill v3.15.0+ читает `~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/summary.json` на wake и выдаёт первой строкой:
+
+- PASS → «PR #N prod-check ✅ — открой screenshot тут … далее USER_CHECKLIST (Gate 5)»
+- FAIL → «PR #N prod-check ❌ — упало <routes>, см. screenshot, нужен фикс»

--- a/scripts/post-deploy-smoke/package.json
+++ b/scripts/post-deploy-smoke/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "post-deploy-smoke",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "playwright": "^1.60.0"
+  }
+}

--- a/scripts/post-deploy-smoke/run-quantika.sh
+++ b/scripts/post-deploy-smoke/run-quantika.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# run-quantika.sh — Phase 1b proof: headless post-deploy smoke for quantika-demo.
+# Usage:  run-quantika.sh <pr#> [base-url]
+# Output: ~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/{summary.json, *.png}
+# Exit:   0 = PASS (all routes ok) · 1 = FAIL (any route failed)
+
+set -o pipefail
+PR="${1:?Usage: run-quantika.sh <pr#> [base-url]}"
+BASE="${2:-https://demo.quantika.org}"
+OUTDIR="$HOME/orchestrator-state/quantika-demo/post-deploy-checks/$PR"
+
+mkdir -p "$OUTDIR"
+cd /root/post-deploy-smoke
+
+SMOKE_PR="$PR" SMOKE_BASE_URL="$BASE" SMOKE_OUTDIR="$OUTDIR" \
+  node smoke.mjs > "$OUTDIR/summary.json" 2> "$OUTDIR/stderr.log"
+RC=$?
+
+echo "=== POST-DEPLOY SMOKE · PR #$PR · $BASE ==="
+if command -v jq >/dev/null; then
+  jq -r '"overall=" + .overall + "  passed=" + (.routes_passed|tostring) + "/" + (.routes_checked|tostring) + "  failed=" + (.routes_failed|tostring)' "$OUTDIR/summary.json"
+  echo "--- per-route ---"
+  jq -r '.results[] | "  " + (if .pass then "✓" else "✗" end) + " " + .route + " (status=" + (.status|tostring) + ", " + (.duration_ms|tostring) + "ms)" + (if .error_markers|length>0 then " markers=" + (.error_markers|join(",")) else "" end) + (if .error then " error=" + .error else "" end)' "$OUTDIR/summary.json"
+else
+  cat "$OUTDIR/summary.json"
+fi
+echo "--- artifacts ---"
+ls "$OUTDIR/" | head -20
+exit $RC

--- a/scripts/post-deploy-smoke/smoke.mjs
+++ b/scripts/post-deploy-smoke/smoke.mjs
@@ -1,0 +1,92 @@
+import { chromium } from 'playwright';
+import fs from 'fs';
+import path from 'path';
+
+const BASE = process.env.SMOKE_BASE_URL || 'https://demo.quantika.org';
+const OUTDIR = process.env.SMOKE_OUTDIR || '/tmp/smoke-out';
+const PR = process.env.SMOKE_PR || 'manual';
+const TIMEOUT = parseInt(process.env.SMOKE_TIMEOUT || '15000', 10);
+
+const ROUTES_DEFAULT = [
+  { p: '/',       n: 'landing' },
+  { p: '/cargo',  n: 'cargo'   },
+  { p: '/vessel', n: 'vessel'  },
+  { p: '/match',  n: 'match'   },
+  { p: '/login',  n: 'login'   },
+];
+const ROUTES = process.env.SMOKE_ROUTES
+  ? process.env.SMOKE_ROUTES.split(',').map(s => ({ p: s.trim(), n: s.trim().replace(/[\/]/g,'_') || 'root' }))
+  : ROUTES_DEFAULT;
+
+const ERROR_MARKERS = [
+  'application error',
+  'internal server error',
+  'unhandled',
+  'stack trace',
+  'this page could not be found',
+  'next.js error',
+];
+
+fs.mkdirSync(OUTDIR, { recursive: true });
+
+const browser = await chromium.launch({ args: ['--no-sandbox'] });
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const results = [];
+
+for (const r of ROUTES) {
+  const page = await ctx.newPage();
+  const consoleErrors = [];
+  page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+
+  const start = Date.now();
+  let status = 0, error = null, bodyText = '', markers = [], shotPath = null;
+  try {
+    const resp = await page.goto(BASE + r.p, { waitUntil: 'networkidle', timeout: TIMEOUT });
+    status = resp ? resp.status() : 0;
+    bodyText = await page.evaluate(() => document.body ? document.body.innerText.slice(0, 4000) : '');
+    const lower = bodyText.toLowerCase();
+    markers = ERROR_MARKERS.filter(m => lower.includes(m));
+    shotPath = path.join(OUTDIR, r.n + '.png');
+    await page.screenshot({ path: shotPath, fullPage: true });
+  } catch (e) {
+    error = String(e.message || e);
+  }
+  const duration = Date.now() - start;
+
+  const consoleErrorsFiltered = consoleErrors.filter(e =>
+    !/favicon|sentry|chunk|Failed to load resource: the server responded with a status of 4\d{2}/i.test(e)
+  );
+  const statusOK = status >= 200 && status < 400;
+  const pass = !error && statusOK && markers.length === 0 && consoleErrorsFiltered.length === 0;
+
+  results.push({
+    route: r.p,
+    name: r.n,
+    status,
+    duration_ms: duration,
+    pass,
+    error,
+    error_markers: markers,
+    console_errors: consoleErrorsFiltered.slice(0, 5),
+    screenshot: shotPath,
+    body_preview: bodyText.slice(0, 200),
+  });
+  await page.close();
+}
+
+await browser.close();
+
+const summary = {
+  pr: PR,
+  base_url: BASE,
+  timestamp: new Date().toISOString(),
+  routes_checked: results.length,
+  routes_passed: results.filter(r => r.pass).length,
+  routes_failed: results.filter(r => !r.pass).length,
+  overall: results.every(r => r.pass) ? 'PASS' : 'FAIL',
+  results,
+};
+
+fs.writeFileSync(path.join(OUTDIR, 'summary.json'), JSON.stringify(summary, null, 2));
+console.log(JSON.stringify(summary, null, 2));
+process.exit(summary.overall === 'PASS' ? 0 : 1);


### PR DESCRIPTION
## Summary

После успешного `deploy.yml` SSH-сессия на dev-vps запускает headless playwright против `https://demo.quantika.org`, проверяет 5 prod routes (2xx/3xx + DOM error-markers + filtered console errors + full screenshot), пишет результат в `~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/` и комментит PR.

Закрывает разрыв из 2026-05-28 audit: 5 UI PR (#619/#621/#622/#623/#624) смержены + задеплоены без visual проверки, регрессии нашёл user через 30 минут. Совместно с orchestrator-day v3.14.0 (pre-merge Gate 3 mechanical) это автоматизирует post-deploy half (Gate 5 prerequisite).

## Why dev-vps, not outreach-vps

- `PROD_SSH_KEY` использует forced-command `/root/deploy.sh` — не может запускать произвольный bash
- dev-vps уже имеет playwright 1.60 + chromium 1223 + reach to prod URL (verified 200)
- smoke read-only через https — prod box смешивать с QA box не нужно

## Files

| File | Purpose |
|---|---|
| `scripts/post-deploy-smoke/smoke.mjs` | playwright runner (92 lines pure Node) |
| `scripts/post-deploy-smoke/run-quantika.sh` | wrapper, writes `~/orchestrator-state/...` |
| `scripts/post-deploy-smoke/package.json` | playwright dep |
| `scripts/post-deploy-smoke/README.md` | flow diagram + manual run |
| `.github/workflows/post-deploy-smoke.yml` | workflow_run on Deploy to prod success |

## New GH Secret added in this PR setup

| Secret | Что |
|---|---|
| `DEV_VPS_SSH_KEY` | ed25519, открытый SSH (не forced-command), comment `gh-actions-post-deploy-smoke-2026-05-28` |

Setup performed before PR:
- ed25519 keypair generated locally
- pubkey appended to `dev-vps:/root/.ssh/authorized_keys`
- privkey uploaded as GH secret `DEV_VPS_SSH_KEY`
- smoke-tested from local mac (`ssh -i <key> root@dev-vps echo SSH_OK` ✓)
- local privkey shredded

## Verified

- **Phase 1a**: playwright screenshot of `demo.quantika.org/` → 52KB PNG ✓ (рендерит BDI/BHSI/VLSFO widgets + CTAs + trusted-by footer)
- **Phase 1b**: 5/5 routes PASS on https://demo.quantika.org, 12s total run ✓
- **SSH**: ed25519 key installed, GH secret set, smoke SSH from runner-equivalent works ✓

## Test plan

- [ ] Merge PR → triggers noop deploy (no app code changed) → `deploy.yml` green
- [ ] `post-deploy-smoke.yml` fires via `workflow_run` trigger
- [ ] SSH dev-vps step: passes (новый key works)
- [ ] Smoke run: 5/5 PASS on current prod
- [ ] Auto-comment on this PR: `✅ Post-deploy smoke: PASS (5/5 routes)`
- [ ] Artifacts uploaded to GH Actions (30d retention)

## Follow-ups (separate PRs)

- Allegro variant (`run-allegro.sh`): basic_auth via `BASIC_AUTH_USER/PASS` env (allegro.quantika.org returns 401 без creds — выяснено в Phase 1a probe)
- **Phase 3** orchestrator-day SKILL.md: wake-hook reads `summary.json`, surfaces PR-prod-status before USER_CHECKLIST (Gate 5)
- Optional: add `scripts/post-deploy-smoke/` to `auto-merge.yml` path-ignore (smoke-only PRs не должны триггерить noop deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)