### PR TITLE
fix(test): knowledge-phase1 source counts (17→18 fresh, 16→17 stale)

### DIFF
--- a/__tests__/integration/knowledge-phase1.test.ts
+++ b/__tests__/integration/knowledge-phase1.test.ts
@@ -234,7 +234,7 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe('healthy');
-    expect(json.sources_fresh).toBe(17);
+    expect(json.sources_fresh).toBe(18);
     expect(json.sources_failed).toBe(0);
   });
 
@@ -269,6 +269,6 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     // Since OFAC is fresh but others are never_synced, status should be degraded
     // (never_synced sources don't fail health check but are counted as stale)
     expect(json.sources_fresh).toBe(1); // Only OFAC
-    expect(json.sources_stale).toBe(16); // Others never synced
+    expect(json.sources_stale).toBe(17); // Others never synced
   });
 });

--- a/__tests__/integration/knowledge-phase1.test.ts
+++ b/__tests__/integration/knowledge-phase1.test.ts
@@ -11,7 +11,7 @@
  *
  * Input Contract (integration level):
  * - All migrations must run without errors
- * - Bootstrap must register exactly 17 sources from KNOWLEDGE_REGISTRY
+ * - Bootstrap must register exactly 18 sources from KNOWLEDGE_REGISTRY
  * - OFAC refresh with valid XML must result in status='fresh', consecutive_failures=0
  * - getDistance must cache results and return { distanceNm, source: 'cache' } on second call
  * - listSources must return SourceRow[] with health_signal computed correctly
@@ -105,7 +105,7 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     expect(tableNames).toContain('eca_zones');
   });
 
-  it('bootstraps registry with exactly 17 sources from KNOWLEDGE_REGISTRY', () => {
+  it('bootstraps registry with exactly 18 sources from KNOWLEDGE_REGISTRY', () => {
     migration013.up(db);
 
     bootstrapKnowledgeSources(db);
@@ -113,11 +113,11 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     const count = (
       db.prepare('SELECT COUNT(*) AS c FROM knowledge_sources').get() as any
     ).c;
-    expect(count).toBe(17);
-    expect(KNOWLEDGE_REGISTRY).toHaveLength(17);
+    expect(count).toBe(18);
+    expect(KNOWLEDGE_REGISTRY).toHaveLength(18);
 
     const sources = listSources(db);
-    expect(sources).toHaveLength(17);
+    expect(sources).toHaveLength(18);
 
     // Verify Phase 1 sources are registered
     const slugs = sources.map((s) => s.slug);


### PR DESCRIPTION
## Summary

KNOWLEDGE_REGISTRY вырос на 1 (market-bci добавлен в #612), integration test проверяющий health endpoint count не обновлён → main CI красный последние 3 коммита.

Bump 2 hardcoded counts to match current registry size:
- `__tests__/integration/knowledge-phase1.test.ts:237` — `sources_fresh: 17 → 18`
- `__tests__/integration/knowledge-phase1.test.ts:272` — `sources_stale: 16 → 17`

## Why this is NOT PI3 violation

PI3 запрещает переписывать test expectations чтобы замаскировать сломанный код. Здесь обратное: registry легитимно вырос (новая фича market-bci в PR #612), test просто отстал от реальности. Counts отражают актуальный production registry — тест восстанавливает alignment, не маскирует баг.

## Follow-up (отдельный PR, опционально)

Заменить magic numbers на dynamic:
```ts
expect(json.sources_fresh).toBe(Object.keys(KNOWLEDGE_REGISTRY).length)
```

Перестанет ломаться при каждом расширении registry. Не делаю в этом PR — surgical-changes принцип (правлю только то, что красное).

## Test plan

- [ ] CI Test job → PASS (1/1 failing suite зелёный)
- [ ] No new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)