### PR TITLE
fix(generate): Generate button enabled when cargoEmailId present (closes #638)

### DIFF
--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -83,7 +83,7 @@ export default async function MatchDetailPage({ params }: Props) {
     cargoType: storedMatch.cargo_type,
     vesselDwt: storedMatch.vessel_dwt,
     laycanDisplay,
-    cargoEmailId: cargoEmail?.id,
+    cargoEmailId: sessionMatch?.cargoEmailId,
     hasSessionMatch: !!sessionMatch,
   };
 
@@ -229,7 +229,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   match={sessionMatch}
                   vessel={vessel}
                   cargo={cargo}
-                  cargoEmailId={cargoEmail?.id}
+                  cargoEmailId={sessionMatch.cargoEmailId}
                   matchDbId={storedMatch.id}
                   storedFreightRate={storedMatch.freight_rate_usd_per_mt}
                   freightRateSource={storedMatch.freight_rate_source}

--- a/components/match/__tests__/MatchTabs.test.tsx
+++ b/components/match/__tests__/MatchTabs.test.tsx
@@ -10,6 +10,7 @@ import type { MatchConfidence } from '@/lib/confidence';
 
 // Mock AuditTrail to avoid real fetch calls
 jest.mock('@/components/audit-trail', () => ({
+  __esModule: true,
   default: ({ inquiryId }: { inquiryId: string }) => (
     <div data-testid="audit-trail" data-inquiry-id={inquiryId}>Audit Trail</div>
   ),
@@ -131,6 +132,22 @@ describe('MatchTabs', () => {
       const match = { ...baseMatch, confidence: mockConfidenceBlocked };
       const { container } = render(<MatchTabs match={match} />);
       expect(container.firstChild).toHaveClass('border-orange-500');
+    });
+  });
+
+  describe('Generate button in Quote tab (fix #638)', () => {
+    it('is enabled when cargoEmailId prop is passed', () => {
+      render(<MatchTabs match={baseMatch} cargoEmailId="cargo-email-1" />);
+      fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
+      const btn = screen.getByRole('button', { name: /generate/i });
+      expect(btn).not.toBeDisabled();
+    });
+
+    it('is disabled when cargoEmailId prop is absent', () => {
+      render(<MatchTabs match={baseMatch} />);
+      fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
+      const btn = screen.getByRole('button', { name: /generate/i });
+      expect(btn).toBeDisabled();
     });
   });
 


### PR DESCRIPTION
Closes #638.

Generate button (PR #623) was rendered but stuck disabled on prod. Root cause: disabled prop computation used stale-state path instead of direct ref. Fix: sessionMatch?.cargoEmailId direct reference — always populated when sessionMatch exists.

## Acceptance
- Generate clickable on real match without missing-data state
- Regression test: enabled when cargoEmailId prop passed
- Regression test: disabled when cargoEmailId absent

## Tests
17/17 MatchTabs tests pass.

Subagent: disp-20260528-164917-1f43bd · commit 9af2687