### PR TITLE
fix(#627): dashboard greeting drop broken There fallback

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -115,8 +115,8 @@ export default async function DashboardPage() {
       id: matchIdMap.get(`${m.cargoEmailId}|${m.vesselEmailId}`)!,
     }));
 
-  const rawName = session.accountId?.split('@')[0] ?? 'there';
-  const userName = rawName.charAt(0).toUpperCase() + rawName.slice(1);
+  const rawName = session.accountId?.split('@')[0] ?? '';
+  const userName = rawName ? rawName.charAt(0).toUpperCase() + rawName.slice(1) : '';
 
   return (
     <div className="bg-ds-bg min-h-screen">

--- a/components/dashboard/MorningHeader.tsx
+++ b/components/dashboard/MorningHeader.tsx
@@ -1,5 +1,5 @@
 interface MorningHeaderProps {
-  userName: string;
+  userName?: string;
   alertCount: number;
 }
 
@@ -16,12 +16,13 @@ const dateFormatter = new Intl.DateTimeFormat('en-GB', {
 
 export function MorningHeader({ userName, alertCount }: MorningHeaderProps) {
   const today = dateFormatter.format(new Date());
+  const greeting = userName ? `Good morning, ${userName} 👋` : 'Good morning! 👋';
 
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-3">
         <h1 className="text-xl font-bold text-gray-900">
-          Good morning, {userName} 👋
+          {greeting}
         </h1>
         {alertCount > 0 && (
           <span className="inline-flex items-center justify-center h-6 min-w-6 px-1.5 rounded-full bg-red-500 text-white text-xs font-bold">

--- a/components/dashboard/__tests__/MorningHeader.test.tsx
+++ b/components/dashboard/__tests__/MorningHeader.test.tsx
@@ -30,4 +30,19 @@ describe('MorningHeader', () => {
     const text = JSON.stringify(el);
     expect(text).toMatch(/[Gg]ood morning/);
   });
+
+  it('shows "Good morning!" without name when userName is omitted — no "There" fallback (#627)', () => {
+    const el = MorningHeader({ alertCount: 0 });
+    const text = JSON.stringify(el);
+    expect(text).toMatch(/Good morning!/);
+    expect(text).not.toContain('There');
+    expect(text).not.toMatch(/Good morning, 👋/);
+  });
+
+  it('shows "Good morning!" without name when userName is empty string — no "There" fallback (#627)', () => {
+    const el = MorningHeader({ userName: '', alertCount: 0 });
+    const text = JSON.stringify(el);
+    expect(text).toMatch(/Good morning!/);
+    expect(text).not.toContain('There');
+  });
 });


### PR DESCRIPTION
Closes #627. Dashboard MorningHeader showed Good morning There when user name absent. Removed literal there fallback - now renders Good morning if no name. 7/7 tests pass. Subagent disp-978731 commit 556b6cc.