### PR TITLE
fix(#626): /api/jobs/stream 503 — Caddy gzip-buffers SSE + signal guard

### DIFF
--- a/__tests__/api/jobs-stream.test.ts
+++ b/__tests__/api/jobs-stream.test.ts
@@ -36,4 +36,29 @@ describe('GET /api/jobs/stream', () => {
     expect(res.headers.get('x-accel-buffering')).toBe('no');
     controller.abort();
   });
+
+  it('returns 200 even when signal is already aborted (regression #626 — no 503)', async () => {
+    mockRequireSession.mockReturnValue({ session: {}, sessionId: 'test-sid-3' });
+    const controller = new AbortController();
+    controller.abort(); // abort BEFORE the handler runs
+    const req = new NextRequest('http://localhost/api/jobs/stream', { signal: controller.signal });
+    const res = await GET(req);
+    // Route must return a valid Response (200+SSE), never throw/503
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+  });
+
+  it('stream body starts with SSE connected comment when not pre-aborted', async () => {
+    mockRequireSession.mockReturnValue({ session: {}, sessionId: 'test-sid-4' });
+    const controller = new AbortController();
+    const req = new NextRequest('http://localhost/api/jobs/stream', { signal: controller.signal });
+    const res = await GET(req);
+    expect(res.body).not.toBeNull();
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain(': connected');
+    controller.abort();
+    reader.cancel();
+  });
 });

--- a/app/api/jobs/stream/route.ts
+++ b/app/api/jobs/stream/route.ts
@@ -12,6 +12,8 @@ export async function GET(req: NextRequest) {
 
   const encoder = new TextEncoder();
 
+  let cleanup: (() => void) | null = null;
+
   const stream = new ReadableStream({
     start(controller) {
       const send = (event: { type: string; data: unknown }) => {
@@ -24,7 +26,18 @@ export async function GET(req: NextRequest) {
         }
       };
 
-      controller.enqueue(encoder.encode(': connected\n\n'));
+      // Guard: if request was already aborted before stream setup, close immediately.
+      if (req.signal.aborted) {
+        try { controller.close(); } catch { /* already closed */ }
+        return;
+      }
+
+      try {
+        controller.enqueue(encoder.encode(': connected\n\n'));
+      } catch {
+        // stream already closed before first write
+        return;
+      }
 
       const off = jobEvents.subscribe(sessionId, send);
 
@@ -36,15 +49,20 @@ export async function GET(req: NextRequest) {
         }
       }, 25000);
 
-      req.signal.addEventListener('abort', () => {
+      cleanup = () => {
         off();
         clearInterval(hb);
-        try {
-          controller.close();
-        } catch {
-          // already closed
-        }
+        try { controller.close(); } catch { /* already closed */ }
+      };
+
+      req.signal.addEventListener('abort', () => {
+        cleanup?.();
+        cleanup = null;
       });
+    },
+    cancel() {
+      cleanup?.();
+      cleanup = null;
     },
   });
 

--- a/ops/caddy/Caddyfile.demo
+++ b/ops/caddy/Caddyfile.demo
@@ -1,5 +1,15 @@
 demo.quantika.org {
-    encode gzip zstd
+    # Exclude SSE path from compression — gzip/zstd buffers the infinite stream
+    # before flushing, causing a proxy timeout → HTTP 503. (#626)
+    @compressible {
+        not path /api/jobs/stream
+    }
+    encode @compressible gzip zstd
     header /api/* Cache-Control "no-store"
-    reverse_proxy localhost:3000
+    # flush_interval -1: stream bytes to client immediately, no proxy buffering.
+    # Required for SSE — without this, events are held in the upstream buffer
+    # and clients never receive them.
+    reverse_proxy localhost:3000 {
+        flush_interval -1
+    }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `encode gzip zstd` in Caddy's `Caddyfile.demo` buffers the infinite SSE response before flushing → proxy timeout → HTTP 503
- **Caddy fix**: `@compressible` named matcher excludes `/api/jobs/stream` from compression; `flush_interval -1` disables reverse-proxy buffering so events stream immediately
- **Route hardening**: already-aborted signal guard (H3 race condition), try-catch on initial enqueue, shared `cleanup` closure invoked from both `abort` handler and `ReadableStream.cancel()`

## Test plan

- [ ] `npx jest __tests__/api/jobs-stream.test.ts --maxWorkers=1` → 5/5 pass (2 new tests added)
- [ ] Smoke: `curl -N -H "Cookie: session_id=<valid>" https://demo.quantika.org/api/jobs/stream` → HTTP 200 + `text/event-stream`, first line `: connected`
- [ ] After VPS deploy: `systemctl reload caddy` to pick up `Caddyfile.demo` changes (see RUNBOOK-CADDY-DOMAINS.md)

## Acceptance criteria (#626)

| Issue | Criterion | Status | Evidence |
|-------|-----------|--------|----------|
| #626 | `GET /api/jobs/stream` returns 200 + `text/event-stream` | ✓ | `jobs-stream.test.ts:25–29` |
| #626 | No 503 when signal already aborted | ✓ | `jobs-stream.test.ts:43–52` (regression test) |
| #626 | Caddy stops buffering SSE stream | ✓ | `ops/caddy/Caddyfile.demo`: `flush_interval -1` + `@compressible` matcher |

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)