### PR TITLE
fix(#635): matches filter result count updates

### DIFF
--- a/__tests__/matches-filter-count-635.test.tsx
+++ b/__tests__/matches-filter-count-635.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Regression tests — #635: cargo filter applied but result count doesn't update
+ *
+ * Strategy: static JSX source analysis (testEnvironment: 'node').
+ *
+ * Covers:
+ *  1. "All" chip count is NOT hardwired to modeFiltered.length (stale path)
+ *  2. allChipCount variable exists and includes cargoTypes in its derivation
+ *  3. allChipCount is used as the count prop for the "All" quick-filter chip
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const clientPath = path.join(ROOT, 'app/matches/MatchesClient.tsx');
+
+function readSource(): string {
+  return fs.readFileSync(clientPath, 'utf8');
+}
+
+describe('MatchesClient.tsx — All chip count reactive to advanced filters (#635)', () => {
+  it('All chip count is NOT modeFiltered.length (stale — ignores cargoTypes)', () => {
+    const src = readSource();
+    // Find the "All" chip config — must not reference modeFiltered.length as count
+    const allChipLine = src.match(/id:\s*['"]all['"][\s\S]{0,300}/)?.[0] ?? '';
+    expect(allChipLine).not.toMatch(/count:\s*modeFiltered\.length/);
+  });
+
+  it('allChipCount variable is declared and derived from modeFiltered + cargoTypes', () => {
+    const src = readSource();
+    // Variable must exist
+    expect(src).toMatch(/allChipCount/);
+    // It must filter by cargoTypes
+    const countBlock = src.match(/allChipCount[\s\S]{0,400}/)?.[0] ?? '';
+    expect(countBlock).toMatch(/cargoTypes/);
+  });
+
+  it('All chip count prop references allChipCount (not raw matches.length)', () => {
+    const src = readSource();
+    const allChipLine = src.match(/id:\s*['"]all['"][\s\S]{0,300}/)?.[0] ?? '';
+    expect(allChipLine).toMatch(/count:\s*allChipCount/);
+  });
+
+  it('allChipCount also filters by filterStatus (status filter reactive)', () => {
+    const src = readSource();
+    const countBlock = src.match(/allChipCount[\s\S]{0,400}/)?.[0] ?? '';
+    expect(countBlock).toMatch(/filterStatus/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -303,6 +303,14 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   // Mode-based count for "All" chip: charterer sees cargo-side, owner sees vessel-side
   const modeFiltered = filterMatchesByMode(matches, isOwner, cargoEmailIds, vesselEmailIds);
 
+  // All-chip count: mode + status + advanced filters (excluding quick-filter so the badge
+  // reflects "how many match your current advanced criteria" regardless of quick-filter tab)
+  const allChipCount = modeFiltered.filter(
+    (m) =>
+      (!filterStatus || m.status === filterStatus) &&
+      (cargoTypes.length === 0 || cargoTypes.includes(m.cargo_type ?? ''))
+  ).length;
+
   // Client-side filter: mode + status + cargo_type + quick filter; then sort
   const filtered = matches
     .filter(
@@ -353,7 +361,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
           {/* Quick filter chips */}
           <div className="flex items-center gap-2 flex-wrap" role="tablist" aria-label="Filter">
             {([
-              { id: 'all' as QuickFilter, label: 'All', count: modeFiltered.length },
+              { id: 'all' as QuickFilter, label: 'All', count: allChipCount },
               { id: 'fresh' as QuickFilter, label: 'Fresh', count: undefined },
               { id: 'score80' as QuickFilter, label: 'Score 80+', count: undefined },
               { id: 'dwt50_60' as QuickFilter, label: 'DWT 50–60k', count: undefined },


### PR DESCRIPTION
Closes #635. /matches result count did not update when cargo filter applied. Count now derived from filtered array. Tests pass.