### PR TITLE
feat(demo): freeze client-side relative dates in DEMO_MODE

### DIFF
--- a/__tests__/components/use-now.test.tsx
+++ b/__tests__/components/use-now.test.tsx
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { DemoClockProvider, useNow } from '@/lib/demo-clock-context';
+
+function wrapper(frozenMs: number | null) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <DemoClockProvider frozenMs={frozenMs}>{children}</DemoClockProvider>
+  );
+  Wrapper.displayName = 'TestDemoClockWrapper';
+  return Wrapper;
+}
+
+describe('useNow (demo clock)', () => {
+  it('DEMO_MODE: returns the frozen ms, available immediately (no flash, no decay)', () => {
+    const frozen = Date.UTC(2026, 4, 28); // 2026-05-28
+    const { result } = renderHook(() => useNow(), { wrapper: wrapper(frozen) });
+    expect(result.current).toBe(frozen);
+  });
+
+  it('DEMO_MODE: stays constant even with a tick interval requested', () => {
+    const frozen = 1_700_000_000_000;
+    const { result } = renderHook(() => useNow(1000), { wrapper: wrapper(frozen) });
+    expect(result.current).toBe(frozen);
+  });
+
+  it('live mode: resolves to a real timestamp after mount', async () => {
+    const before = Date.now();
+    const { result } = renderHook(() => useNow(), { wrapper: wrapper(null) });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(typeof result.current).toBe('number');
+    expect(result.current as number).toBeGreaterThanOrEqual(before);
+  });
+
+  it('no provider (default null context): behaves as live mode', async () => {
+    const { result } = renderHook(() => useNow());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(typeof result.current).toBe('number');
+  });
+});

--- a/__tests__/matches-hydration-418.test.ts
+++ b/__tests__/matches-hydration-418.test.ts
@@ -31,24 +31,20 @@ describe('MatchesClient hydration safety (#543 regression)', () => {
     expect(src()).toMatch(/if\s*\(\s*now\s*===\s*0\s*\)\s*return false/);
   });
 
-  it('clientNow state is initialised to 0 (not Date.now())', () => {
-    // useState(0) ensures the server-rendered initial value matches the
-    // client's initial render — React #418 is impossible when both start
-    // from the same sentinel.
-    expect(src()).toMatch(/clientNow.*useState.*0/);
-    expect(src()).not.toMatch(/clientNow.*useState.*Date\.now/);
+  it('clientNow falls back to the 0 sentinel (not Date.now()) for SSR safety', () => {
+    // The clock now comes from useNow(): in live mode it yields null pre-mount so
+    // clientNow resolves to the 0 sentinel — server and client first paint match,
+    // making React #418 impossible. (In DEMO_MODE useNow returns a frozen constant,
+    // also SSR-safe.)
+    expect(src()).toMatch(/clientNow\s*=\s*nowMs\s*\?\?\s*0/);
+    expect(src()).not.toMatch(/clientNow.*=.*Date\.now/);
   });
 
-  it('setClientNow is called inside useEffect, not during render', () => {
-    // The actual Date.now() must only run after mount (in useEffect) so it
-    // never executes during SSR or the synchronous hydration pass.
-    expect(src()).toMatch(/setClientNow\(Date\.now\(\)\)/);
-    // Verify useEffect wraps the call (setClientNow should not appear before
-    // the first useEffect in the source file)
-    const setIdx = src().indexOf('setClientNow(Date.now())');
-    const effectIdx = src().indexOf('useEffect(');
-    expect(effectIdx).toBeGreaterThan(-1);
-    expect(setIdx).toBeGreaterThan(effectIdx);
+  it('sources its clock from the hydration-safe useNow hook (no render-time Date.now for the badge)', () => {
+    // Date.now() deferral to post-mount now lives inside useNow (verified by
+    // use-now.test.tsx). MatchesClient must consume the hook, never read the wall
+    // clock during render.
+    expect(src()).toMatch(/const nowMs = useNow\(\s*60000\s*\)/);
   });
 
   it('isFreshMatch in JSX row loop receives clientNow argument', () => {

--- a/__tests__/matches-polish-490-489-488.test.tsx
+++ b/__tests__/matches-polish-490-489-488.test.tsx
@@ -74,15 +74,16 @@ describe('app/matches/MatchesClient.tsx — AUTO-REFRESH UTC indicator (#490)', 
     expect(src).toMatch(/UTC/);
   });
 
-  it('uses setInterval to update time every 60s', () => {
+  it('refreshes on a 60s cadence via the hydration-safe useNow clock', () => {
     const src = readSource(clientPath);
-    expect(src).toMatch(/setInterval.*60000|60000.*setInterval/);
+    // The 60s tick now lives inside useNow(60000) (no inline setInterval).
+    expect(src).toMatch(/useNow\(\s*60000\s*\)/);
   });
 
   it('uses SSR-safe empty initial state (no server/client mismatch)', () => {
     const src = readSource(clientPath);
-    // Empty string initial state prevents hydration mismatch
-    expect(src).toMatch(/useState.*""\s*\)|useState\(""\)/);
+    // nowUtc falls back to '' until the clock resolves → server and client first paint match
+    expect(src).toMatch(/nowUtc[\s\S]{0,300}:\s*''/);
   });
 
   it('renders indicator conditionally only when time is set (no flash on SSR)', () => {

--- a/app/api/market/benchmark/route.ts
+++ b/app/api/market/benchmark/route.ts
@@ -5,6 +5,7 @@ import { getLatestIndex } from '@/lib/market/market-indices-repository';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { getStore } from '@/lib/session-store';
+import { now as clockNow } from '@/lib/clock';
 
 const VALID_INDICATORS: ReadonlySet<string> = new Set<MarketIndicator>([
   'TOEPFER_TMI',
@@ -50,7 +51,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     if (indexName) {
       const row = getLatestIndex(db, indexName);
       if (row) {
-        const ageMs = Date.now() - new Date(row.index_date).getTime();
+        const ageMs = clockNow().getTime() - new Date(row.index_date).getTime();
         benchmark = {
           indicator: typedIndicator,
           value: row.value,
@@ -79,7 +80,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     const db = getStore().getDatabase();
     const row = getLatestEuaPrice(db);
     if (row) {
-      const ageMs = Date.now() - new Date(row.price_date).getTime();
+      const ageMs = clockNow().getTime() - new Date(row.price_date).getTime();
       benchmark = {
         indicator: typedIndicator,
         value: row.price_eur_per_tco2,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,9 @@ import { verifyAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
 import { getStore } from '@/lib/session-store';
 import { ModeProvider, AppShell } from '@/design-system/patterns';
 import type { Mode } from '@/design-system/patterns';
+import { isDemoMode } from '@/lib/demo-mode';
+import { now as clockNow } from '@/lib/clock';
+import { DemoClockProvider } from '@/lib/demo-clock-context';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -127,6 +130,18 @@ export default async function RootLayout({
     }
   }
 
+  // Frozen "now" (ms) for client relative-date displays in DEMO_MODE; null in
+  // live mode so the client uses the real browser clock. Reuses clock.now() as
+  // the single source; tolerant if demo_seed_meta is absent.
+  let demoFrozenMs: number | null = null;
+  if (isDemoMode()) {
+    try {
+      demoFrozenMs = clockNow().getTime();
+    } catch {
+      demoFrozenMs = null;
+    }
+  }
+
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
       <head>
@@ -138,9 +153,11 @@ export default async function RootLayout({
             <TrialBannerWrapper sessionId={sessionId} />
           </Suspense>
         )}
-        <ModeProvider initial={initialMode}>
-          <AppShell>{children}</AppShell>
-        </ModeProvider>
+        <DemoClockProvider frozenMs={demoFrozenMs}>
+          <ModeProvider initial={initialMode}>
+            <AppShell>{children}</AppShell>
+          </ModeProvider>
+        </DemoClockProvider>
       </body>
     </html>
   );

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useNow } from '@/lib/demo-clock-context';
 import { MarketKpiTile } from '@/components/market/MarketKpiTile';
 import { MetricHistoryPanel } from '@/components/market/MetricHistoryPanel';
 import { RoutesSection } from '@/components/market/RoutesSection';
@@ -105,13 +106,9 @@ export default function MarketPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeKpi, setActiveKpi] = useState<string | null>(null);
-  const [now, setNow] = useState<number>(0);
-
-  useEffect(() => {
-    // Hydration-safe: capture clock on mount so render stays pure.
-    const raf = requestAnimationFrame(() => setNow(Date.now()));
-    return () => cancelAnimationFrame(raf);
-  }, []);
+  // DEMO_MODE → frozen snapshot time (constant, SSR-safe); live → 0 until
+  // post-mount, then the real clock. Keeps render pure / hydration-safe.
+  const now = useNow() ?? 0;
 
   useEffect(() => {
     async function loadData() {

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from 'react';
+import { useNow } from '@/lib/demo-clock-context';
 import Link from 'next/link';
 import { useSearchParams, useRouter } from 'next/navigation';
 import type { StoredMatch, MatchStatus } from '@/lib/matching/matches-repository';
@@ -126,20 +127,15 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
 
   // CD design state
   const [density, setDensity] = useState<Density>('table');
-  const [nowUtc, setNowUtc] = useState<string>("");
-  // Hydration-safe clock: starts at 0 (matches SSR), set post-mount to avoid
-  // React #418 text-content mismatch on the "fresh" badge (#543).
-  const [clientNow, setClientNow] = useState<number>(0);
-  useEffect(() => {
-    const tick = () => {
-      const d = new Date();
-      setNowUtc(`${String(d.getUTCHours()).padStart(2, "0")}:${String(d.getUTCMinutes()).padStart(2, "0")}`);
-      setClientNow(Date.now());
-    };
-    tick();
-    const id = setInterval(tick, 60000);
-    return () => clearInterval(id);
-  }, []);
+  // Single source of "now": DEMO_MODE → frozen snapshot ms (constant, SSR-safe,
+  // never decays); live → 0/"" sentinels until post-mount (no React #418 on the
+  // "fresh" badge, #543), then a real clock ticking every 60s.
+  const nowMs = useNow(60000);
+  const clientNow = nowMs ?? 0;
+  const nowUtc =
+    nowMs !== null
+      ? `${String(new Date(nowMs).getUTCHours()).padStart(2, '0')}:${String(new Date(nowMs).getUTCMinutes()).padStart(2, '0')}`
+      : '';
   const [quickFilter, setQuickFilter] = useState<QuickFilter>('all');
 
   // Auto-switch to cards on mobile after mount
@@ -171,7 +167,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   const [dwt_max, setDwtMax] = useState(() => searchParams.get('dwt_max') ?? '');
 
   // Apply Filters handler
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- pre-existing async useCallback, refactor in R5
+   
   const handleApplyFilters = useCallback(async () => {
     const params = new URLSearchParams();
     for (const ct of cargoTypes) params.append('cargo_type', ct);
@@ -194,7 +190,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   }, [cargoTypes, route, laycan_from, laycan_to, score_min, dwt_min, dwt_max, filterStatus, router]);
 
   // Clear Filters handler
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- pre-existing async useCallback, refactor in R5
+   
   const handleClearFilters = useCallback(async () => {
     setCargoTypes([]);
     setRoute('');

--- a/components/deadlines/SubsCountdown.tsx
+++ b/components/deadlines/SubsCountdown.tsx
@@ -8,7 +8,8 @@
  * CTA «Draft extension request» (β-11 plan-first или mailto fallback).
  */
 
-import { useEffect, useState, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
+import { useNow } from '@/lib/demo-clock-context';
 import {
   computeStage,
   type EscalationStage,
@@ -43,20 +44,11 @@ function formatRemaining(ms: number): string {
 }
 
 export function SubsCountdown(props: SubsCountdownProps): ReactElement {
-  // Defer `new Date()` to post-mount: SSR and client first paint must produce
-  // identical HTML, otherwise React #418 hydration mismatch fires. We use a
-  // null sentinel and render a deterministic placeholder until useEffect runs.
-  const [now, setNow] = useState<Date | null>(null);
-
-  useEffect(() => {
-    // Intentional cascading render: the first `setNow` flips from the null
-    // SSR placeholder to a real Date post-mount, which is the canonical
-    // React fix for hydration mismatches with time-based content.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setNow(new Date());
-    const id = setInterval(() => setNow(new Date()), 1000);
-    return () => clearInterval(id);
-  }, []);
+  // Single source of "now": in DEMO_MODE useNow() returns the frozen snapshot
+  // time (constant, SSR-safe, no decay); in live mode it returns null until
+  // post-mount (deterministic placeholder, no #418), then a ticking real clock.
+  const nowMs = useNow(1000);
+  const now = nowMs !== null ? new Date(nowMs) : null;
 
   // Pre-mount placeholder — deterministic, no Date(), no #418.
   if (now === null) {

--- a/components/deals/SubsCountdownWidget.tsx
+++ b/components/deals/SubsCountdownWidget.tsx
@@ -7,8 +7,9 @@
 
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { getChartererGraceDays, normalizeDeadline } from '@/lib/deadlines/subs-guardian';
+import { useNow } from '@/lib/demo-clock-context';
 
 export interface SubsCountdownWidgetProps {
   dealId: string;
@@ -16,9 +17,9 @@ export interface SubsCountdownWidgetProps {
   chartererTier?: 'blue-chip' | 'second' | 'weak';
 }
 
-function computeRemaining(subsDeadline: string | number): number {
+function computeRemaining(subsDeadline: string | number, nowMs: number): number {
   const deadline = normalizeDeadline(subsDeadline);
-  return deadline.getTime() - Date.now();
+  return deadline.getTime() - nowMs;
 }
 
 // Inner component holds hooks; only mounted when flag is enabled.
@@ -27,19 +28,11 @@ function SubsCountdownInner({
   subsDeadline,
   chartererTier,
 }: SubsCountdownWidgetProps) {
-  // Defer Date.now() to post-mount: SSR and first client paint must produce
-  // identical HTML, otherwise React #418 hydration mismatch fires (same fix
-  // pattern as SubsCountdown — null sentinel → placeholder until useEffect).
-  const [remaining, setRemaining] = useState<number | null>(null);
-
-  useEffect(() => {
-    // Initial compute is sync (tests use fake-timers, can't wait async deferral).
-    // Hydration safety (#408) is preserved by null initial state + suppressHydrationWarning.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRemaining(computeRemaining(subsDeadline));
-    const id = setInterval(() => setRemaining(computeRemaining(subsDeadline)), 60_000);
-    return () => clearInterval(id);
-  }, [subsDeadline]);
+  // Single source of "now": DEMO_MODE → frozen snapshot time (constant, SSR-safe);
+  // live → null until post-mount (deterministic placeholder, no #418), then a real
+  // clock ticking every 60s. Hydration safety preserved by the null sentinel below.
+  const nowMs = useNow(60_000);
+  const remaining = nowMs !== null ? computeRemaining(subsDeadline, nowMs) : null;
 
   if (remaining === null) {
     return (

--- a/lib/demo-clock-context.tsx
+++ b/lib/demo-clock-context.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+/**
+ * Client-side companion to lib/clock.ts. Exposes the frozen snapshot time to
+ * client components so relative-date displays ("X ago", countdowns) don't drift
+ * against the real browser clock in DEMO_MODE.
+ *
+ * The server (app/layout.tsx) reads getDemoFrozenDate() in DEMO_MODE and feeds
+ * the frozen ms into DemoClockProvider; in live mode it passes null.
+ *
+ * See docs/superpowers/specs/2026-05-27-quantika-demo-frozen-snapshot-design.md
+ */
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+// Frozen "now" in epoch ms for DEMO_MODE; null in live (real-clock) mode.
+const DemoClockContext = createContext<number | null>(null);
+
+export function DemoClockProvider({
+  frozenMs,
+  children,
+}: {
+  frozenMs: number | null;
+  children: ReactNode;
+}) {
+  return <DemoClockContext.Provider value={frozenMs}>{children}</DemoClockContext.Provider>;
+}
+
+/**
+ * Single source of "now" (epoch ms) for client relative-date displays.
+ *
+ * - DEMO_MODE (provider supplied a frozen ms): returns that constant. It is known
+ *   at SSR time, so server and client render identically — no hydration mismatch,
+ *   no placeholder flash, and the value never decays.
+ * - Live mode (provider value is null): returns null until post-mount (preserving
+ *   the existing SSR-deferral that avoids hydration mismatch), then the real
+ *   Date.now(), re-ticking every `tickMs` if provided (e.g. 1000 for a countdown).
+ */
+export function useNow(tickMs?: number): number | null {
+  const frozenMs = useContext(DemoClockContext);
+  const [liveNow, setLiveNow] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (frozenMs !== null) return; // frozen — constant, never ticks
+    // Intentional post-mount setState: flips the null SSR sentinel to the real
+    // clock only after hydration — the canonical React fix for #418 time-mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLiveNow(Date.now());
+    if (tickMs && tickMs > 0) {
+      const id = setInterval(() => setLiveNow(Date.now()), tickMs);
+      return () => clearInterval(id);
+    }
+  }, [frozenMs, tickMs]);
+
+  return frozenMs !== null ? frozenMs : liveNow;
+}


### PR DESCRIPTION
## Что это (по-человечески)

Завершает «заморозку» демо. Сервер уже считал «сегодня = frozenDate» (матчи/свежесть не протухают), но клиентские компоненты брали относительное время из **браузерных часов** — поэтому «2h ago» и subs-таймеры «плыли» бы по реальному времени. Теперь и клиент заморожен: демо выглядит свежим **навсегда** при `DEMO_MODE=true`.

## Изменения (~7 файлов)

- **`lib/demo-clock-context.tsx`** (новый): `DemoClockProvider` + хук `useNow(tickMs?)`. DEMO_MODE → frozen ms с сервера (константа, SSR-safe, без flash, без decay); live → null до post-mount (сохраняет #418-deferral), потом реальные часы с тиком `tickMs`. + `use-now.test.tsx` (4 кейса).
- **`app/layout.tsx`**: оборачивает контент в `<DemoClockProvider frozenMs={clock.now() в DEMO_MODE, иначе null}>` (переиспользует `clock.now()`, терпим к отсутствию `demo_seed_meta`).
- **Переведены на `useNow()`**: `MatchesClient` (clientNow/nowUtc), `market/page` (now), `SubsCountdown` (тик 1s), `SubsCountdownWidget` (тик 60s) — все сохраняют SSR-sentinels (`0`/`""`/`null`) и live-поведение.
- **`api/market/benchmark`**: возраст рыночных данных через `clock.now()` — staleness тоже замораживается.

## Тесты

- 127 suites / **1643 тестов pass**, tsc + eslint чисто.
- Обновлены 4 регресс-теста #543/#490: они string-match'или старый inline-clock (`useState(0)`, `setClientNow`, `setInterval 60000`, `useState("")`), который переехал в `useNow`. Гарантия гидрации сохранена — тесты теперь проверяют, что компонент берёт часы из `useNow` + держит SSR-sentinels.

## Browser smoke (за тобой)

Открыть с `DEMO_MODE=true`:
- [ ] `/matches` — freshness-теги/«AUTO-REFRESH HH:MM UTC» показывают frozen-значения (не дрейфуют, нет flash при загрузке).
- [ ] `/market` — as-of/staleness в окне frozenDate.
- [ ] subs-countdown'ы — фиксированные (не уходят в минус со временем).
- [ ] Live-режим (без DEMO_MODE) — относительное время по-прежнему тикает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)