### PR TITLE
fix(matches): full-width table + vessel wraps instead of truncating

### DIFF
--- a/__tests__/matches-polish-490-489-488.test.tsx
+++ b/__tests__/matches-polish-490-489-488.test.tsx
@@ -29,8 +29,9 @@ describe('app/matches/page.tsx — table fits at 1440px (#488)', () => {
 
   it('uses a container ≥ max-w-5xl so table fits without horizontal scroll', () => {
     const src = readSource(pagePath);
-    // max-w-5xl (1024px) or wider accommodates the 970px table at 1440px viewport
-    expect(src).toMatch(/max-w-5xl|max-w-6xl|max-w-7xl|max-w-screen/);
+    // max-w-5xl (1024px) or wider accommodates the 970px table at 1440px viewport;
+    // max-w-[1280px] matches /cargo full-width container
+    expect(src).toMatch(/max-w-5xl|max-w-6xl|max-w-7xl|max-w-screen|max-w-\[1280/);
   });
 });
 

--- a/__tests__/matches-table-layout.test.tsx
+++ b/__tests__/matches-table-layout.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Layout regression tests: /matches table VESSEL column wrapping
+ *
+ * Goal: VESSEL names must wrap inside their column (break-words), not truncate.
+ * Matches /cargo pattern from PR #643 (#636 fix).
+ *
+ * Strategy: static source analysis (testEnvironment: 'node').
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const clientPath = path.join(ROOT, 'app/matches/MatchesClient.tsx');
+const pagePath = path.join(ROOT, 'app/matches/page.tsx');
+
+function readSource(p: string): string {
+  return fs.readFileSync(p, 'utf8');
+}
+
+describe('MatchesClient.tsx — VESSEL column wraps long names (#636 pattern)', () => {
+  let src: string;
+  beforeAll(() => { src = readSource(clientPath); });
+
+  it('table view vessel cells use break-words, not truncate', () => {
+    // Extract the table view section (after "TABLE VIEW" comment)
+    const tableSection = src.slice(src.indexOf('TABLE VIEW'));
+    // All vessel_id spans in table view must use break-words
+    const vesselSpans = [...tableSection.matchAll(/vessel_id[^<]*<\/span>/g)];
+    expect(vesselSpans.length).toBeGreaterThan(0);
+
+    // No vessel_id span in the table section should have truncate class
+    const truncatedVessel = tableSection.match(
+      /className="[^"]*truncate[^"]*"[^>]*>\{match\.vessel_id\}/
+    );
+    expect(truncatedVessel).toBeNull();
+  });
+
+  it('table view vessel cells use break-words class', () => {
+    const tableSection = src.slice(src.indexOf('TABLE VIEW'));
+    expect(tableSection).toMatch(/break-words[^>]*>\{match\.vessel_id\}|className="[^"]*break-words[^"]*"[^>]*>\{match\.vessel_id\}/);
+  });
+
+  it('outer wrapper does not use overflow-x-hidden (which clips scrollable table)', () => {
+    // overflow-x-hidden on parent clips inner overflow-x-auto scroll container
+    // Must not appear on the top-level div wrapping the matches list
+    const topDiv = src.match(/<div className="space-y-4[^"]*">/);
+    expect(topDiv).not.toBeNull();
+    expect(topDiv![0]).not.toContain('overflow-x-hidden');
+  });
+
+  it('table section retains overflow-x-auto for narrow viewport scroll', () => {
+    expect(src).toMatch(/overflow-x-auto/);
+  });
+});
+
+describe('app/matches/page.tsx — full-width container matches /cargo', () => {
+  let src: string;
+  beforeAll(() => { src = readSource(pagePath); });
+
+  it('uses max-w-[1280px] container matching /cargo width', () => {
+    expect(src).toMatch(/max-w-\[1280px\]/);
+  });
+
+  it('does not use overflow-x-hidden at page level', () => {
+    expect(src).not.toMatch(/overflow-x-hidden/);
+  });
+});

--- a/__tests__/ui/matches-vessel-wrap.test.tsx
+++ b/__tests__/ui/matches-vessel-wrap.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral regression test: long vessel names must wrap (break-words), not truncate.
+ * Mirrors cargo-wrap.test.tsx pattern for #636. Criterion #6 for PR 662.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/design-system/patterns/useMode', () => ({
+  useMode: () => ({
+    mode: 'charterer',
+    isCharterer: true,
+    isOwner: false,
+    setMode: jest.fn(),
+    t: (k: string) => k,
+  }),
+}));
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+jest.mock('@/design-system/patterns/useLiveJobs', () => ({
+  useLiveJobs: () => ({ jobs: [], latestMatch: null, dismissMatch: jest.fn() }),
+}));
+
+jest.mock('@/components/ui/toast', () => ({
+  useToast: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    action: jest.fn(),
+  }),
+}));
+
+jest.mock('@/design-system/patterns/LiveStrip', () => ({
+  LiveStrip: () => null,
+}));
+
+jest.mock('@/design-system/patterns/MatchToast', () => ({
+  MatchToast: () => null,
+}));
+
+import MatchesClient from '@/app/matches/MatchesClient';
+import type { StoredMatch } from '@/lib/matching/matches-repository';
+
+const LONG_VESSEL = 'MV Supra-Ultramax Eastern Mediterranean Pacific Star VIII';
+
+const longVesselMatch: StoredMatch = {
+  id: 1,
+  cargo_id: 'cargo:wrap:0',
+  vessel_id: LONG_VESSEL,
+  score: 85,
+  reason: 'test',
+  status: 'shortlist',
+  user_id: null,
+  created_at: Date.now() - 1000,
+  updated_at: Date.now() - 1000,
+  reason_structured: null,
+  cargo_type: 'BULK',
+  load_port: 'Rotterdam',
+  discharge_port: 'Singapore',
+  laycan_start: null,
+  laycan_end: null,
+  vessel_dwt: 58000,
+  tce_usd_per_day: 14500,
+  distance_nm: null,
+  freight_rate_usd_per_mt: null,
+  freight_rate_source: null,
+};
+
+describe('MatchesClient — long vessel name wraps (#662)', () => {
+  it('renders the full long vessel name without truncation', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longVesselMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    expect(screen.getByText(LONG_VESSEL)).toBeInTheDocument();
+  });
+
+  it('vessel name cell uses break-words, not truncate', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longVesselMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    const vesselText = screen.getByText(LONG_VESSEL);
+    expect(vesselText.className).toMatch(/break-words/);
+    expect(vesselText.className).not.toMatch(/truncate/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -584,7 +584,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
           </div>
         ) : density === 'cards' ? (
           /* ===== CARDS VIEW ===== */
-          <>
+          <div className="overflow-x-hidden">
             {/* Select all header */}
             <div className="flex items-center gap-2 px-1 py-1">
               <input
@@ -791,7 +791,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                 </li>
               ))}
             </ul>
-          </>
+          </div>
         ) : (
           /* ===== TABLE VIEW ===== */
           <section className="bg-ds-surface border border-ds-border rounded-[14px] overflow-hidden" aria-label="Matches table">

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -348,7 +348,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   return (
     <>
       <LiveStrip jobs={jobs} />
-      <div className="space-y-4 overflow-x-hidden">
+      <div className="space-y-4">
 
         {nowUtc && (
           <div className="flex justify-end">
@@ -858,7 +858,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                               <span className="w-7 h-7 rounded-[7px] bg-ds-accent text-ds-accent-fg flex-shrink-0 inline-flex items-center justify-center font-mono text-[11.5px] font-medium">
                                 {vesselInitials(match.vessel_id)}
                               </span>
-                              <span className="font-medium text-sm tracking-[-0.005em] truncate">{match.vessel_id}</span>
+                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_id}</span>
                             </div>
                           </td>
                         )}
@@ -893,7 +893,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                               <span className="w-7 h-7 rounded-[7px] bg-ds-accent text-ds-accent-fg flex-shrink-0 inline-flex items-center justify-center font-mono text-[11.5px] font-medium">
                                 {vesselInitials(match.vessel_id)}
                               </span>
-                              <span className="font-medium text-sm tracking-[-0.005em] truncate">{match.vessel_id}</span>
+                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_id}</span>
                             </div>
                           </td>
                         ) : (

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -61,7 +61,7 @@ export default async function MatchesPage() {
 
   return (
     <main className="min-h-screen bg-gray-50 px-4 py-12">
-      <div className="max-w-5xl mx-auto space-y-6">
+      <div className="max-w-[1280px] mx-auto space-y-6">
         <h1 className="text-2xl font-bold">Matches {matches.length} results</h1>
         <Suspense fallback={<PageSkeleton />}>
           <MatchesClient initialMatches={matches} isComputing={isComputing}


### PR DESCRIPTION
Applies /cargo break-words + max-w-[1280px] pattern to /matches. Removes overflow-x-hidden that clipped scroll, fixes truncate on VESSEL cells.