### PR TITLE
feat(demo): show frozen snapshot on demo login (hydrate from demo-seed.db)

### DIFF
--- a/__tests__/api/auth-login-demo-mode.test.ts
+++ b/__tests__/api/auth-login-demo-mode.test.ts
@@ -1,8 +1,10 @@
 /**
- * Regression test for #573: /matches shows empty state in demo
+ * Regression test for #573 + frozen-snapshot wiring.
  *
- * In DEMO_MODE=true, POST /api/auth/login must auto-create a sample data
- * session and set the session_id cookie so /matches has data immediately.
+ * In DEMO_MODE=true, POST /api/auth/login must auto-create a session hydrated
+ * from the frozen snapshot (demo-seed.db, via hydrateDemoSession) and set the
+ * session_id + csrf_token cookies so /matches shows the audited demo data
+ * immediately and demo /api/ai/* calls pass the CSRF check.
  */
 import { NextRequest } from 'next/server';
 
@@ -23,8 +25,12 @@ describe('POST /api/auth/login — DEMO_MODE session seeding', () => {
       NODE_ENV: 'test',
     };
 
-    jest.doMock('@/lib/sample-data/create-demo-session', () => ({
-      createDemoSession: jest.fn().mockReturnValue(DEMO_SESSION_ID),
+    // Auto-seed now creates a session and hydrates it from the frozen snapshot.
+    jest.doMock('@/lib/session', () => ({
+      createSession: jest.fn().mockReturnValue(DEMO_SESSION_ID),
+    }));
+    jest.doMock('@/lib/demo-mode/hydrate-demo-session', () => ({
+      hydrateDemoSession: jest.fn(),
     }));
   });
 
@@ -49,13 +55,24 @@ describe('POST /api/auth/login — DEMO_MODE session seeding', () => {
     const allCookies = cookies.join('; ');
     expect(allCookies).toContain('session_id=');
     expect(allCookies).toContain(DEMO_SESSION_ID);
+    // The auth cookie must coexist (regression guard: session_id must not clobber it).
+    expect(allCookies).toContain('demo_auth=');
   });
 
-  it('calls createDemoSession on successful login when DEMO_MODE=true', async () => {
-    const { createDemoSession } = await import('@/lib/sample-data/create-demo-session');
+  it('hydrates the session from the frozen snapshot on successful login when DEMO_MODE=true', async () => {
+    const { hydrateDemoSession } = await import('@/lib/demo-mode/hydrate-demo-session');
     const { POST } = await import('@/app/api/auth/login/route');
     await POST(makeFormReq({ user: 'admin', password: 'demo' }));
-    expect(createDemoSession).toHaveBeenCalledTimes(1);
+    expect(hydrateDemoSession).toHaveBeenCalledTimes(1);
+    expect(hydrateDemoSession).toHaveBeenCalledWith(DEMO_SESSION_ID);
+  });
+
+  it('sets a csrf_token cookie on successful demo login (so /api/ai/* passes CSRF)', async () => {
+    const { POST } = await import('@/app/api/auth/login/route');
+    const res = await POST(makeFormReq({ user: 'admin', password: 'demo' }));
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const allCookies = cookies.join('; ');
+    expect(allCookies).toContain('csrf_token=');
   });
 
   it('does NOT set session_id cookie when DEMO_MODE is not set', async () => {
@@ -69,10 +86,10 @@ describe('POST /api/auth/login — DEMO_MODE session seeding', () => {
     expect(allCookies).not.toContain('session_id=');
   });
 
-  it('does NOT call createDemoSession on failed login', async () => {
-    const { createDemoSession } = await import('@/lib/sample-data/create-demo-session');
+  it('does NOT hydrate a session on failed login', async () => {
+    const { hydrateDemoSession } = await import('@/lib/demo-mode/hydrate-demo-session');
     const { POST } = await import('@/app/api/auth/login/route');
     await POST(makeFormReq({ user: 'admin', password: 'wrong-password' }));
-    expect(createDemoSession).not.toHaveBeenCalled();
+    expect(hydrateDemoSession).not.toHaveBeenCalled();
   });
 });

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -76,17 +76,46 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       .join('; '),
   );
 
-  // In DEMO_MODE, auto-seed a sample data session so /matches shows data immediately.
+  // In DEMO_MODE, auto-seed a session from the frozen snapshot (demo-seed.db) so
+  // /matches shows the audited demo data immediately. The legacy "Try sample data"
+  // button still uses createDemoSession via /api/sample — left unchanged.
   if (process.env.DEMO_MODE === 'true') {
-    const { createDemoSession } = await import('@/lib/sample-data/create-demo-session');
-    const sessionId = createDemoSession();
-    response.cookies.set('session_id', sessionId, {
-      httpOnly: true,
-      secure: isProduction,
-      sameSite: 'lax',
-      maxAge: 3600,
-      path: '/',
-    });
+    const { createSession } = await import('@/lib/session');
+    const { hydrateDemoSession } = await import('@/lib/demo-mode/hydrate-demo-session');
+    const { generateCsrfToken } = await import('@/lib/csrf');
+    const sessionId = createSession('demo-seed');
+    hydrateDemoSession(sessionId);
+    // Append (do NOT use response.cookies.set — it would clobber the auth cookie
+    // already set above via headers.set('Set-Cookie', ...)). Separate Set-Cookie
+    // headers coexist, so demo_auth + session_id + csrf_token all survive.
+    response.headers.append(
+      'Set-Cookie',
+      [
+        `session_id=${sessionId}`,
+        'Path=/',
+        'Max-Age=3600',
+        'HttpOnly',
+        isProduction ? 'Secure' : '',
+        'SameSite=Lax',
+      ]
+        .filter(Boolean)
+        .join('; '),
+    );
+    // csrf_token (double-submit, JS-readable) so demo /api/ai/* calls pass the middleware CSRF check.
+    const csrfToken = generateCsrfToken();
+    response.headers.append(
+      'Set-Cookie',
+      [
+        `csrf_token=${csrfToken}`,
+        'Path=/',
+        'Max-Age=3600',
+        isProduction ? 'Secure' : '',
+        'SameSite=Strict',
+      ]
+        .filter(Boolean)
+        .join('; '),
+    );
+    response.headers.set('X-CSRF-Token', csrfToken);
   }
 
   return response;

--- a/docs/superpowers/specs/2026-05-29-demo-seed-session-hydration-design.md
+++ b/docs/superpowers/specs/2026-05-29-demo-seed-session-hydration-design.md
@@ -1,0 +1,70 @@
+# Demo-seed → session hydration (show the frozen snapshot on login)
+
+**Date:** 2026-05-29
+**Status:** Implemented
+**Owner:** Виталий (founder) + Claude session
+
+## Problem
+
+`demo.quantika.org` should display the audited **frozen snapshot** (153 anonymized broker emails
+
+- 436 matches in `data/demo-seed.db`, frozen "today" = 2026-05-28). The snapshot is built, fixed,
+  and deployed to prod, and `DEMO_MODE=true` + `SESSIONS_DB_PATH=data/demo-seed.db` are live. But the
+  UI renders from a per-session blob (`session.emails` / `session.matches`), and the snapshot was
+  never loaded into a session for display.
+
+## Context — what main already has (#611)
+
+Current `main` ships PR #611: in `DEMO_MODE`, `POST /api/auth/login` auto-creates a session on
+successful login (`createDemoSession()` in `lib/sample-data/create-demo-session.ts`) and sets the
+`session_id` cookie — fixing the empty-dashboard state. **But it seeds the legacy
+`lib/sample-data/*.json` sample data, not the frozen snapshot.** So after login the demo shows the
+old sample data, not the audited anonymized corpus.
+
+## Approach (implemented)
+
+Reuse main's existing login auto-seed seam; swap only its **data source**:
+
+1. **`hydrateDemoSession(sessionId)`** (`lib/demo-mode/hydrate-demo-session.ts`, new) — reads the
+   `emails` / `parsed_results` / `matches` tables from the served `demo-seed.db` (via
+   `getStore().getDatabase()`) and writes them into the session blob via `updateSession`. A pure
+   `buildDemoSessionBlob(db)` does the table→`SessionData` mapping (matches loaded as-is, level via
+   the existing `deriveMatchLevel`; `processedEmails` via the existing `buildProcessedEmails`).
+2. **Login route** (`app/api/auth/login/route.ts`) — in the existing `DEMO_MODE` block, replace
+   `createDemoSession()` with `createSession('demo-seed')` + `hydrateDemoSession(sessionId)`, and
+   also set a `csrf_token` cookie + `X-CSRF-Token` header (so demo `/api/ai/*` calls — e.g. the
+   "Explain deal" modal — pass the middleware double-submit CSRF check).
+
+That is the whole change. No new routes, no page edits.
+
+## Non-goals / left unchanged
+
+- The legacy **"Try with sample data"** button (`/api/sample` → `createDemoSession`) keeps showing
+  the legacy sample data — `createDemoSession` is untouched (shared helper).
+- Onboarding (`seedDemoForRegion`) — unchanged.
+- The dashboard/matches "No emails yet" empty state (for expired/no session) — unchanged (main's
+  behavior); login is the entry that seeds.
+- Matches are loaded as-is from the seed (not recomputed); the frozen clock (`lib/clock.ts`) already
+  drives freshness in `DEMO_MODE`.
+
+## Why not a separate `/api/demo/enter` route
+
+An earlier draft added a dedicated entry route + login redirect. But `main` already auto-seeds on
+login (#611), so a parallel route would double-create sessions and conflict. Reusing the #611 seam
+is smaller, conflict-free, and keeps one demo-entry path.
+
+## Testing / acceptance
+
+- Unit: `buildDemoSessionBlob` maps emails/parsed_results/matches correctly; survives malformed
+  `result_json` (`lib/demo-mode/__tests__/hydrate-demo-session.test.ts`).
+- Integration: `POST /api/auth/login` in `DEMO_MODE` hydrates via `hydrateDemoSession`, sets
+  `session_id` + `csrf_token`; does neither on failed login or when `DEMO_MODE` is unset
+  (`__tests__/api/auth-login-demo-mode.test.ts`).
+- Acceptance: after the password gate, `/dashboard` + `/matches` show the frozen snapshot
+  (≥120 matches), dates frozen at 2026-05-28; legacy sample button still works; suite + `tsc` green.
+- Prod verify (post-deploy): log in → dashboard populated with the anonymized corpus; PII spot-check.
+
+## Constraints
+
+Branch off `main`; PR; CI green; **squash-merge** (Rule #14). `data/demo-seed.db` is gitignored +
+already on prod. Prod `.env.local` already has `DEMO_MODE=true` + `SESSIONS_DB_PATH=data/demo-seed.db`.

--- a/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
@@ -1,0 +1,78 @@
+import Database from 'better-sqlite3';
+import { buildDemoSessionBlob } from '../hydrate-demo-session';
+import { logger } from '@/lib/logger';
+
+function makeSeedDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE emails (
+      account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+      from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+      body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+    );
+    CREATE TABLE parsed_results (
+      account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+      result_json TEXT, parsed_at INTEGER
+    );
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+      reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+      reason_structured TEXT
+    );
+  `);
+  db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, from_name, from_email, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+    VALUES ('demo','e1','t1','From A <a@demo.local>','A','a@demo.local','me@demo.local','Cargo X','2026-05-20','body1','snip1','["INBOX"]',0)`).run();
+  db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, from_name, from_email, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+    VALUES ('demo','e2','t2','From B <b@demo.local>','B','b@demo.local','me@demo.local','Vessel Y','2026-05-21','body2','snip2',NULL,0)`).run();
+  db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+    VALUES ('demo','e1','cargo','v1','[{"emailId":"e1","itemIndex":0}]',0)`).run();
+  db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+    VALUES ('demo','e2','vessel','v1','[{"emailId":"e2","itemIndex":0}]',0)`).run();
+  db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+    VALUES ('demo','e1','classify','v1','[{"emailId":"e1","category":"CARGO_INQUIRY","isUnanswered":false,"urgency":"normal","daysWithoutReply":null,"confidence":0.9,"originalSender":"A","originalSenderCompany":"ACME"}]',0)`).run();
+  db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured)
+    VALUES ('e1','e2',88,'Good fit','shortlist',NULL,0,0,NULL)`).run();
+  db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured)
+    VALUES ('e1','e2b',66,'Possible fit','shortlist',NULL,0,0,NULL)`).run();
+  return db;
+}
+
+describe('buildDemoSessionBlob', () => {
+  it('maps emails, parsed_results, and matches into the session blob', () => {
+    const db = makeSeedDb();
+    const blob = buildDemoSessionBlob(db);
+
+    expect(blob.emails).toHaveLength(2);
+    expect(blob.emails[0]).toMatchObject({ id: 'e1', threadId: 't1', fromName: 'A', labelIds: ['INBOX'] });
+    expect(blob.emails[1].labelIds).toEqual([]); // NULL label_ids -> []
+    expect(blob.parsedCargos).toHaveLength(1);
+    expect(blob.parsedVessels).toHaveLength(1);
+    expect(blob.classifications).toHaveLength(1);
+    expect(blob.matches).toHaveLength(2);
+    expect(blob.matches[0]).toMatchObject({
+      cargoEmailId: 'e1', cargoItemIndex: 0, vesselEmailId: 'e2',
+      vesselItemIndex: 0, score: 88, matchLevel: 'good', matchReasons: ['Good fit'],
+    });
+    expect(blob.matches[1].matchLevel).toBe('possible'); // 66 -> possible
+    expect(blob.isSampleData).toBe(true);
+    expect(blob.accountId).toBe('demo');
+    db.close();
+  });
+
+  it('skips a malformed result_json row but keeps the valid rows (and warns)', () => {
+    const db = makeSeedDb();
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e1','cargo','v1','{not json',0)`).run();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => {}) as never);
+
+    const blob = buildDemoSessionBlob(db);
+
+    // The valid cargo row from makeSeedDb survives; only the malformed row is skipped.
+    expect(blob.parsedCargos).toHaveLength(1);
+    // The bad row was logged rather than thrown.
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    db.close();
+  });
+});

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -1,0 +1,122 @@
+import type Database from 'better-sqlite3';
+import { getStore } from '@/lib/session-store';
+import { updateSession } from '@/lib/session';
+import { buildProcessedEmails } from '@/lib/classification-service';
+import { deriveMatchLevel } from '@/lib/sailing/match-scoring';
+import { logger } from '@/lib/logger';
+import type {
+  Email, Classification, ParsedCargo, ParsedVessel, ParsedFixtureRecap, Match, ScoreBreakdown, SessionData,
+} from '@/lib/types';
+
+type DemoBlob = Pick<
+  SessionData,
+  'emails' | 'classifications' | 'parsedCargos' | 'parsedVessels'
+  | 'parsedFixtureRecaps' | 'processedEmails' | 'matches' | 'isSampleData' | 'accountId'
+>;
+
+interface EmailRow {
+  gmail_message_id: string; thread_id: string; from_addr: string; from_name: string | null;
+  from_email: string | null; to_addr: string; subject: string; date: string;
+  body: string; snippet: string; label_ids: string | null;
+}
+interface ParsedRow { parse_type: string; result_json: string; }
+interface MatchRow {
+  cargo_id: string; vessel_id: string; score: number;
+  reason: string | null; reason_structured: string | null;
+}
+
+function safeJsonArray<T>(json: string, ctx: string): T[] {
+  try {
+    const v = JSON.parse(json);
+    return Array.isArray(v) ? (v as T[]) : [];
+  } catch (err) {
+    logger.warn({ err, ctx }, 'demo hydrate: bad result_json, skipping row');
+    return [];
+  }
+}
+
+function safeJsonObject<T>(json: string | null): T | undefined {
+  if (!json) return undefined;
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
+  const emailRows = db.prepare(
+    `SELECT gmail_message_id, thread_id, from_addr, from_name, from_email,
+            to_addr, subject, date, body, snippet, label_ids FROM emails`,
+  ).all() as EmailRow[];
+
+  const emails: Email[] = emailRows.map((r) => ({
+    id: r.gmail_message_id,
+    threadId: r.thread_id,
+    from: r.from_addr,
+    fromName: r.from_name,
+    fromEmail: r.from_email,
+    to: r.to_addr,
+    subject: r.subject,
+    date: r.date,
+    body: r.body,
+    snippet: r.snippet,
+    labelIds: r.label_ids ? safeJsonArray<string>(r.label_ids, 'label_ids') : [],
+  }));
+
+  const parsedRows = db.prepare(
+    `SELECT parse_type, result_json FROM parsed_results`,
+  ).all() as ParsedRow[];
+
+  const parsedCargos: ParsedCargo[] = [];
+  const parsedVessels: ParsedVessel[] = [];
+  const parsedFixtureRecaps: ParsedFixtureRecap[] = [];
+  const classifications: Classification[] = [];
+  for (const row of parsedRows) {
+    switch (row.parse_type) {
+      case 'cargo': parsedCargos.push(...safeJsonArray<ParsedCargo>(row.result_json, 'cargo')); break;
+      case 'vessel': parsedVessels.push(...safeJsonArray<ParsedVessel>(row.result_json, 'vessel')); break;
+      case 'recap': parsedFixtureRecaps.push(...safeJsonArray<ParsedFixtureRecap>(row.result_json, 'recap')); break;
+      case 'classify': classifications.push(...safeJsonArray<Classification>(row.result_json, 'classify')); break;
+    }
+  }
+
+  const matchRows = db.prepare(
+    `SELECT cargo_id, vessel_id, score, reason, reason_structured FROM matches`,
+  ).all() as MatchRow[];
+
+  const matches: Match[] = matchRows.map((r) => ({
+    cargoEmailId: r.cargo_id,
+    cargoItemIndex: 0,
+    vesselEmailId: r.vessel_id,
+    vesselItemIndex: 0,
+    score: r.score,
+    matchLevel: deriveMatchLevel(r.score),
+    matchReasons: r.reason ? [r.reason] : [],
+    issues: [],
+    scoreBreakdown: safeJsonObject<ScoreBreakdown>(r.reason_structured),
+  }));
+
+  const processedEmails = buildProcessedEmails(emails, classifications, parsedCargos, parsedVessels);
+
+  return {
+    emails,
+    classifications,
+    parsedCargos,
+    parsedVessels,
+    parsedFixtureRecaps,
+    processedEmails,
+    matches,
+    isSampleData: true,
+    accountId: 'demo',
+  };
+}
+
+export function hydrateDemoSession(sessionId: string): void {
+  const db = getStore().getDatabase();
+  const blob = buildDemoSessionBlob(db);
+  if (blob.emails.length === 0) {
+    logger.warn({ sessionId }, 'demo hydrate: 0 emails — demo-seed.db may be empty/incomplete');
+  }
+  updateSession(sessionId, blob);
+}


### PR DESCRIPTION
## What
In `DEMO_MODE`, `POST /api/auth/login` now auto-seeds the session from the **frozen snapshot** (`data/demo-seed.db` — 153 anonymized broker emails + 436 audited matches, frozen "today" = 2026-05-28) via a new `hydrateDemoSession`, instead of the legacy `lib/sample-data/*.json` (`createDemoSession`). Also sets a `csrf_token` cookie + `X-CSRF-Token` header so demo `/api/ai/*` calls (e.g. "Explain deal") pass the middleware CSRF check.

Reuses the existing **#611** login auto-seed seam (swaps only the data source). The legacy **"Try with sample data"** button (`/api/sample`, also uses `createDemoSession`) is **unchanged**.

## Why
After the password gate, `demo.quantika.org` currently shows the legacy sample data (real dates, "Sample data" badge). This surfaces the audited **anonymized frozen** corpus instead — the actual demo content.

## Files
- `lib/demo-mode/hydrate-demo-session.ts` (new) — `buildDemoSessionBlob(db)` (pure: seed tables → `SessionData`) + `hydrateDemoSession(sessionId)`.
- `app/api/auth/login/route.ts` — DEMO_MODE auto-seed → hydrate frozen + csrf; cookies set via `headers.append` so `demo_auth` + `session_id` + `csrf_token` coexist.
- `__tests__/api/auth-login-demo-mode.test.ts` — updated #611 test (hydrate + csrf + cookie-coexist guard).
- `lib/demo-mode/__tests__/hydrate-demo-session.test.ts` (new).
- `docs/superpowers/specs/2026-05-29-demo-seed-session-hydration-design.md` (new).

## Verification
- Targeted suites green (hydrate, #611 login, auth, session/clock/demo-mode); `tsc --noEmit` clean. (Full suite OOMs locally — CI runs it.)
- `data/demo-seed.db` is gitignored + already on prod; prod `.env.local` already has `DEMO_MODE=true` + `SESSIONS_DB_PATH=data/demo-seed.db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)