### PR TITLE
fix(demo): hydrate only seeded matches (user_id IS NULL)

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
@@ -34,6 +34,10 @@ function makeSeedDb(): Database.Database {
     VALUES ('e1','e2',88,'Good fit','shortlist',NULL,0,0,NULL)`).run();
   db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured)
     VALUES ('e1','e2b',66,'Possible fit','shortlist',NULL,0,0,NULL)`).run();
+  // A per-session copy (user_id != NULL), as persistSessionMatches writes on prod.
+  // buildDemoSessionBlob must IGNORE these and read only the seeded (NULL) rows.
+  db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured)
+    VALUES ('e1','e2',88,'session copy','shortlist','sess-xyz',0,0,NULL)`).run();
   return db;
 }
 
@@ -48,7 +52,8 @@ describe('buildDemoSessionBlob', () => {
     expect(blob.parsedCargos).toHaveLength(1);
     expect(blob.parsedVessels).toHaveLength(1);
     expect(blob.classifications).toHaveLength(1);
-    expect(blob.matches).toHaveLength(2);
+    expect(blob.matches).toHaveLength(2); // only seeded (user_id NULL) rows; the session copy is excluded
+    expect(blob.matches.every((m) => m.matchReasons[0] !== 'session copy')).toBe(true);
     expect(blob.matches[0]).toMatchObject({
       cargoEmailId: 'e1', cargoItemIndex: 0, vesselEmailId: 'e2',
       vesselItemIndex: 0, score: 88, matchLevel: 'good', matchReasons: ['Good fit'],

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -82,7 +82,10 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   }
 
   const matchRows = db.prepare(
-    `SELECT cargo_id, vessel_id, score, reason, reason_structured FROM matches`,
+    // Only the seeded snapshot rows (user_id IS NULL). Per-session copies that
+    // persistSessionMatches writes (user_id = sessionId) must NOT be re-read here,
+    // or the demo's match set would grow/duplicate with every login.
+    `SELECT cargo_id, vessel_id, score, reason, reason_structured FROM matches WHERE user_id IS NULL`,
   ).all() as MatchRow[];
 
   const matches: Match[] = matchRows.map((r) => ({


### PR DESCRIPTION
## What
`buildDemoSessionBlob` (the demo-login hydration from #682) read **all** rows from `matches`. But `app/dashboard/page.tsx` / `app/matches/page.tsx` call `persistSessionMatches` which writes **per-session copies** (`user_id = sessionId`) on every render. So each demo login re-read prior sessions' copies → the match set **grew and duplicated** with every login (prod already had 436 seeded + 4 stray session copies).

## Fix
One line: `buildDemoSessionBlob` now selects `FROM matches WHERE user_id IS NULL` — only the seeded snapshot rows. The frozen demo stays a stable **436** regardless of how many people log in.

## Verification
- Unit test extended with a `user_id != NULL` session-copy row; asserts it is excluded (matches stays 2). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)