### PR TITLE
fix(demo): parseLeadingNumber tolerates numeric inputs (frozen-demo dashboard crash)

### DIFF
--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -49,6 +49,15 @@ describe('parseLeadingNumber', () => {
   it('returns 0 for undefined', () => {
     expect(parseLeadingNumber(undefined)).toBe(0);
   });
+
+  it('returns a raw number unchanged (LLM-parsed fields can be numbers, not strings)', () => {
+    expect(parseLeadingNumber(12.5)).toBe(12.5);
+    expect(parseLeadingNumber(0)).toBe(0);
+  });
+
+  it('returns 0 for a non-finite number', () => {
+    expect(parseLeadingNumber(NaN)).toBe(0);
+  });
 });
 
 describe('estimateFreightRate', () => {

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -38,10 +38,12 @@ export interface TceEstimate {
   freight_rate_source: 'estimated' | 'manual';
 }
 
-// Parse a leading number from strings like "12.5 knots", "25 mt/day"
-export function parseLeadingNumber(s: string | null | undefined): number {
-  if (!s) return 0;
-  const m = s.match(/(\d+(?:\.\d+)?)/);
+// Parse a leading number from values like "12.5 knots", "25 mt/day", or a raw
+// number (LLM-parsed fields can arrive as numbers, not strings).
+export function parseLeadingNumber(s: string | number | null | undefined): number {
+  if (s == null) return 0;
+  if (typeof s === 'number') return Number.isFinite(s) ? s : 0;
+  const m = String(s).match(/(\d+(?:\.\d+)?)/);
   return m ? Number(m[1]) : 0;
 }
 


### PR DESCRIPTION
## Bug
Every **fresh** demo login (DEMO_MODE) crashed `/dashboard` with **"Не удалось загрузить Dashboard"** → server `TypeError: s.match is not a function` at `tce-calculator.ts:parseLeadingNumber`, called from `persistSessionMatches`.

## Root cause
The frozen snapshot (`demo-seed.db`) stores LLM-parsed vessel fields `speedLaden` / `consumption` as **numbers**, but `parseLeadingNumber(s)` did `s.match(...)` (string-only). Legacy sample fixtures had these as strings, so the bug only surfaced once login hydrated from the frozen DB (#682).

## Fix
`parseLeadingNumber` now accepts `string | number | null | undefined`: returns finite numbers directly, coerces other input via `String()`. One-line-level change; unit tests added for numeric + non-finite inputs.

## Verification
Reproduced against the real prod `demo-seed.db` (153 emails, 436 matches): full dashboard data path (hydrate → persistSessionMatches → listMatches → filterByCategory → priorityCards) now passes. tce-calculator suite 22/22, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)