### PR TITLE
fix(dw-wave): remediate 6 audits — security/ai-provider/rsc/parser + honest tests (#651 #663 #674 #675 #676 #679)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,6 +9,17 @@ SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_POSTHOG_KEY=
 
+# Rate-limit client-IP source for the login/admin brute-force throttles.
+# REQUIRED in prod for per-IP limiting. If unset, the limiter FAIL-CLOSES to one
+# shared bucket (coarse, never bypassable) — it will NEVER trust a client-settable
+# header. Values:
+#   cf          → Cloudflare CF-Connecting-IP (use behind Cloudflare; demo.quantika.org)
+#   xff-trusted → X-Forwarded-For at a trusted-hop offset; also set TRUSTED_PROXY_COUNT
+#   xrealip     → X-Real-IP, ONLY if the proxy overwrites it (a bare reverse_proxy does not)
+RATE_LIMIT_CLIENT_IP_SOURCE=cf
+# Trusted appending proxy hops (only for xff-trusted mode), e.g. Caddy=1, CF+Caddy=2.
+TRUSTED_PROXY_COUNT=2
+
 # WhatsApp Business Cloud API (spec-alpha-04)
 # Obtain from Meta Developer Console → WhatsApp → API Setup
 WHATSAPP_TOKEN=your_whatsapp_access_token_here

--- a/__tests__/api/admin/admin-timing-length-independent.test.ts
+++ b/__tests__/api/admin/admin-timing-length-independent.test.ts
@@ -1,0 +1,95 @@
+/**
+ * BUG-4 (LOW) — requireAdmin's constant-time compare must be LENGTH-INDEPENDENT.
+ *
+ * The previous implementation padded both sides to max(len) before timingSafeEqual,
+ * so the work (and the buffers handed to timingSafeEqual) scaled with the candidate
+ * length — a length timing oracle on the admin secret. Hashing both sides to a
+ * fixed-width sha256 digest first makes the comparison constant-width regardless of
+ * input length.
+ *
+ * We can't measure wall-clock timing reliably in CI, so the mutation-honest proof is
+ * structural: the buffers passed to crypto.timingSafeEqual are ALWAYS 32 bytes (the
+ * sha256 digest width), no matter how long the candidate is. Reverting to the pad
+ * approach makes timingSafeEqual receive variable-width buffers → this test goes red,
+ * while the behaviour tests stay green.
+ */
+import { NextRequest } from 'next/server';
+import * as cryptoNs from 'crypto';
+
+const ADMIN_TOKEN = 'super-secret-admin-token-1234567890'; // 34 chars
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.resetModules();
+  jest.dontMock('crypto');
+  process.env = { ...ORIGINAL_ENV, ADMIN_TOKEN };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function reqWithToken(token?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) headers['X-Admin-Token'] = token;
+  return new NextRequest('http://localhost/api/admin/whatever', { method: 'POST', headers });
+}
+
+/** Run requireAdmin with timingSafeEqual spied; return the byte-lengths of each call's args. */
+function widthsPassedToTimingSafeEqual(token: string): Array<[number, number]> {
+  jest.resetModules();
+  const actual = jest.requireActual('crypto') as typeof cryptoNs;
+  const captured: Array<[number, number]> = [];
+  const mock = jest.fn((a: NodeJS.ArrayBufferView, b: NodeJS.ArrayBufferView) => {
+    captured.push([a.byteLength, b.byteLength]);
+    return actual.timingSafeEqual(a, b);
+  });
+  jest.doMock('crypto', () => ({ ...actual, timingSafeEqual: mock }));
+  const { requireAdmin } = require('@/lib/auth/admin');
+  requireAdmin(reqWithToken(token));
+  jest.dontMock('crypto');
+  return captured;
+}
+
+describe('BUG-4 — constant-WIDTH comparison (length-independence)', () => {
+  it('hands timingSafeEqual fixed 32-byte buffers regardless of candidate length', () => {
+    const oneChar = widthsPassedToTimingSafeEqual('x'); // far shorter than the secret
+    const fiveHundred = widthsPassedToTimingSafeEqual('q'.repeat(500)); // far longer
+
+    for (const calls of [oneChar, fiveHundred]) {
+      expect(calls.length).toBeGreaterThan(0);
+      for (const [a, b] of calls) {
+        // sha256 digest width — independent of the input length
+        expect(a).toBe(32);
+        expect(b).toBe(32);
+      }
+    }
+  });
+});
+
+describe('BUG-4 — auth contract preserved across candidate shapes', () => {
+  it.each([
+    ['a prefix of the real token', ADMIN_TOKEN.slice(0, 10)],
+    ['the real token with trailing extra', `${ADMIN_TOKEN}EXTRA`],
+    ['a wrong token of the same length', 'z'.repeat(ADMIN_TOKEN.length)],
+    ['a 500-byte candidate', 'q'.repeat(500)],
+    ['an empty candidate', ''],
+  ])('returns 401 for %s', (_label, token) => {
+    const { requireAdmin } = require('@/lib/auth/admin');
+    const res = requireAdmin(reqWithToken(token));
+    expect(res).not.toBeNull();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns null for the exact token', () => {
+    const { requireAdmin } = require('@/lib/auth/admin');
+    expect(requireAdmin(reqWithToken(ADMIN_TOKEN))).toBeNull();
+  });
+
+  it('returns 500 when ADMIN_TOKEN is unset', () => {
+    delete process.env.ADMIN_TOKEN;
+    const { requireAdmin } = require('@/lib/auth/admin');
+    expect(requireAdmin(reqWithToken('anything')).status).toBe(500);
+  });
+});

--- a/__tests__/api/admin/admin-timing-safe.test.ts
+++ b/__tests__/api/admin/admin-timing-safe.test.ts
@@ -1,0 +1,85 @@
+/**
+ * U1 / #651 — L-3: requireAdmin must compare X-Admin-Token in constant time
+ * and reject non-admins.
+ *
+ * We can't reliably measure wall-clock timing in CI, so the mutation-honest
+ * guarantee here is two-fold:
+ *   1. Behaviour: correct token → null (pass); wrong/missing → 401; unset → 500.
+ *   2. Constant-time: requireAdmin must route through crypto.timingSafeEqual.
+ *      We spy on the crypto module and assert it is invoked, so reverting the
+ *      fix to `provided !== expected` makes the test fail.
+ */
+import { NextRequest } from 'next/server';
+import * as crypto from 'crypto';
+
+const ADMIN_TOKEN = 'super-secret-admin-token-1234567890';
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.resetModules();
+  jest.dontMock('crypto');
+  process.env = { ...ORIGINAL_ENV, ADMIN_TOKEN };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function reqWithToken(token?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) headers['X-Admin-Token'] = token;
+  return new NextRequest('http://localhost/api/admin/whatever', { method: 'POST', headers });
+}
+
+describe('requireAdmin — L-3 constant-time + auth contract', () => {
+  it('returns null (caller proceeds) for the correct token', () => {
+    const { requireAdmin } = require('@/lib/auth/admin');
+    expect(requireAdmin(reqWithToken(ADMIN_TOKEN))).toBeNull();
+  });
+
+  it('returns 401 for a wrong token of equal length', () => {
+    const { requireAdmin } = require('@/lib/auth/admin');
+    const wrong = 'x'.repeat(ADMIN_TOKEN.length);
+    const res = requireAdmin(reqWithToken(wrong));
+    expect(res).not.toBeNull();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a wrong token of different length', () => {
+    const { requireAdmin } = require('@/lib/auth/admin');
+    const res = requireAdmin(reqWithToken('short'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when the header is missing', () => {
+    const { requireAdmin } = require('@/lib/auth/admin');
+    const res = requireAdmin(reqWithToken(undefined));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 500 when ADMIN_TOKEN is not configured', () => {
+    delete process.env.ADMIN_TOKEN;
+    const { requireAdmin } = require('@/lib/auth/admin');
+    const res = requireAdmin(reqWithToken('anything'));
+    expect(res.status).toBe(500);
+  });
+
+  it('uses crypto.timingSafeEqual for the comparison (mutation guard)', () => {
+    // Replace the crypto module so admin.ts (which imports timingSafeEqual at
+    // module load) picks up the tracked mock when it is freshly required.
+    jest.resetModules();
+    const timingSafeEqualMock = jest.fn(
+      (a: NodeJS.ArrayBufferView, b: NodeJS.ArrayBufferView) =>
+        crypto.timingSafeEqual(a, b),
+    );
+    jest.doMock('crypto', () => ({
+      ...jest.requireActual('crypto'),
+      timingSafeEqual: timingSafeEqualMock,
+    }));
+    const { requireAdmin } = require('@/lib/auth/admin');
+    requireAdmin(reqWithToken('some-candidate-token'));
+    expect(timingSafeEqualMock).toHaveBeenCalled();
+    jest.dontMock('crypto');
+  });
+});

--- a/__tests__/api/analytics/roi-auth.test.ts
+++ b/__tests__/api/analytics/roi-auth.test.ts
@@ -1,0 +1,85 @@
+/**
+ * U5 / #679 — HONEST ROI auth guard (replaces tests/regression/.../gamma-18-F10).
+ *
+ * The prior regression lock had TWO defects:
+ *   1. It lived under `tests/regression/`, which jest.config.mjs ignores
+ *      (testPathIgnorePatterns) — so it NEVER RAN. Zero protection.
+ *   2. Even if run, it `jest.mock`'d `@/lib/session` so `requireSession` was the
+ *      MOCK, not the real guard. Deleting `requireSession(request)` from the
+ *      route would still leave the test green (the mock simply never fires, the
+ *      route returns data → the over-mocked test's 401 expectation came from the
+ *      mock's own re-implemented logic, not the SUT).
+ *
+ * This test runs under `__tests__/` (jest DOES run it), exercises the REAL
+ * `requireSession` against a REAL in-memory session store, and calls the REAL
+ * route handler. Mutation contract: remove `requireSession(request)` (or its
+ * `instanceof NextResponse` early-return) from app/api/analytics/roi/route.ts
+ * and the "unauthenticated → 401" / "unknown session → 401" cases go RED while
+ * the authenticated case still passes.
+ */
+
+import { NextRequest } from 'next/server';
+
+// IMPORTANT: do NOT mock @/lib/session — that is the SUT guard. The global jest
+// setup points SESSIONS_DB_PATH at ':memory:', so getStore() builds a fresh real
+// SQLite-backed store with the real schema.
+
+describe('GET /api/analytics/roi — real requireSession auth guard', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.ROI_GUARANTEE_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.ROI_GUARANTEE_ENABLED;
+  });
+
+  it('returns 401 for an unauthenticated request (no session cookie) via the REAL guard', async () => {
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi?days=90');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('No session');
+  });
+
+  it('returns 401 when the session_id cookie points to a non-existent session', async () => {
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi?days=90', {
+      headers: { Cookie: 'session_id=this-session-does-not-exist' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Session expired');
+  });
+
+  it('does NOT leak feature state to unauthenticated callers (auth precedes flag check)', async () => {
+    // Even with the feature flag OFF, an unauthenticated request must get 401,
+    // never the 503 "Feature not enabled" — proving auth is checked FIRST.
+    delete process.env.ROI_GUARANTEE_ENABLED;
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with real ROI data for an authenticated request (valid session in the real store)', async () => {
+    const { getStore } = await import('@/lib/session-store');
+    const { createSession } = await import('@/lib/session');
+    // Create a real session in the real in-memory store.
+    const sessionId = createSession('test-access-token');
+    expect(getStore().getSession(sessionId)).toBeTruthy();
+
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi?days=90', {
+      headers: { Cookie: `session_id=${sessionId}` },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Real getRoiSummary runs against the empty roi_metrics table → zeroes.
+    expect(body).toHaveProperty('totalVoyages');
+    expect(body.totalVoyages).toBe(0);
+  });
+});

--- a/__tests__/api/economics.test.ts
+++ b/__tests__/api/economics.test.ts
@@ -68,7 +68,9 @@ describe('POST /api/economics', () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toMatch(/Economics calculation failed/i);
-    expect(json.detail).toMatch(/external API failure/i);
+    // L-8: the raw internal error message must NOT be reflected to the client.
+    expect(json.detail).toBeUndefined();
+    expect(JSON.stringify(json)).not.toMatch(/external API failure/i);
   });
 
   it('returns 200 with mocked result on happy path', async () => {

--- a/__tests__/api/l8-error-leak.test.ts
+++ b/__tests__/api/l8-error-leak.test.ts
@@ -1,0 +1,76 @@
+/**
+ * U1 / #651 — L-8: API 500 handlers must NOT reflect the raw internal error
+ * message to the client. We mock the underlying lib to throw an error carrying a
+ * recognizable secret-like marker, then assert the marker never appears in the
+ * JSON response body. Mutation-honest: reverting any route to `error.message`
+ * makes the corresponding assertion fail.
+ */
+import { NextRequest } from 'next/server';
+
+const SECRET_MARKER = 'SECRET_DB_PATH_/var/secrets/leak.sqlite';
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe('L-8 — canal route does not leak raw error message', () => {
+  it('returns a generic 500 body for a Suez quote failure', async () => {
+    jest.doMock('@/lib/economics/canals/index', () => ({
+      quoteCanal: jest.fn(() => {
+        throw new Error(SECRET_MARKER);
+      }),
+    }));
+    const { GET } = await import('@/app/api/canal/[canal_code]/route');
+    const req = new NextRequest(
+      'http://localhost/api/canal/suez?vessel_dwt=50000&vessel_nt=30000&vessel_type=tanker',
+    );
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await GET(req, { params: Promise.resolve({ canal_code: 'suez' }) });
+    expect(res.status).toBe(500);
+    const text = await res.text();
+    expect(text).not.toContain(SECRET_MARKER);
+    expect(JSON.parse(text).error).toBe('Internal server error');
+    errSpy.mockRestore();
+  });
+
+  it('returns a generic 500 body for a non-Suez (Panama) quote failure', async () => {
+    jest.doMock('@/lib/economics/canals/index', () => ({
+      quoteCanal: jest.fn(() => {
+        throw new Error(SECRET_MARKER);
+      }),
+    }));
+    const { GET } = await import('@/app/api/canal/[canal_code]/route');
+    const req = new NextRequest(
+      'http://localhost/api/canal/panama?vessel_dwt=50000&vessel_type=bulker',
+    );
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await GET(req, { params: Promise.resolve({ canal_code: 'panama' }) });
+    expect(res.status).toBe(500);
+    const text = await res.text();
+    expect(text).not.toContain(SECRET_MARKER);
+    expect(JSON.parse(text).error).toBe('Internal server error');
+    errSpy.mockRestore();
+  });
+});
+
+describe('L-8 — charterers route does not leak raw error message', () => {
+  it('returns a generic 500 body when the repository throws on GET', async () => {
+    process.env.CHARTERER_CREDIT_ENABLED = 'true';
+    jest.doMock('@/lib/market/charterers-repository', () => ({
+      listCharterers: jest.fn(() => {
+        throw new Error(SECRET_MARKER);
+      }),
+      upsertCharterer: jest.fn(),
+    }));
+    const { GET } = await import('@/app/api/charterers/route');
+    const req = new NextRequest('http://localhost/api/charterers');
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    const text = await res.text();
+    expect(text).not.toContain(SECRET_MARKER);
+    expect(JSON.parse(text).error).toBe('Internal server error');
+    errSpy.mockRestore();
+  });
+});

--- a/__tests__/api/llm-timeout-alignment.test.ts
+++ b/__tests__/api/llm-timeout-alignment.test.ts
@@ -146,6 +146,10 @@ beforeEach(() => {
   mockCallAiJson.mockReset();
   mockCallAiText.mockResolvedValue('AI response text');
   mockCallAiJson.mockResolvedValue({});
+  // U2: these routes/sub-calls go through @/lib/ai-provider. Pin
+  // AI_PROVIDER=openai so the shim delegates to the mocked @/lib/openai layer
+  // asserted below (ambient .env sets AI_PROVIDER=gemini).
+  process.env.AI_PROVIDER = 'openai';
 });
 
 // ── 1. draft-quote (maxDuration=30 → 25_000) ──────────────────────────────

--- a/__tests__/api/llm-timeout-missed-callers.test.ts
+++ b/__tests__/api/llm-timeout-missed-callers.test.ts
@@ -31,6 +31,10 @@ const mockJson = callAiJson as jest.MockedFunction<typeof callAiJson>;
 beforeEach(() => {
   mockText.mockReset();
   mockJson.mockReset();
+  // U2: these call sites now route through @/lib/ai-provider. Pin
+  // AI_PROVIDER=openai so the shim delegates to the mocked @/lib/openai layer
+  // asserted below (ambient .env sets AI_PROVIDER=gemini).
+  process.env.AI_PROVIDER = 'openai';
 });
 
 describe('route-decision.llmReason — bounded LLM timeout', () => {

--- a/__tests__/api/pipedrive-oauth-cookie.test.ts
+++ b/__tests__/api/pipedrive-oauth-cookie.test.ts
@@ -1,0 +1,65 @@
+/**
+ * U1 / #651 — L-4: the Pipedrive OAuth CSRF-state cookie must carry Max-Age and
+ * (in production) the Secure attribute. Invokes the real GET handler.
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/integrations/pipedrive/tokens', () => ({ saveTokens: jest.fn() }));
+
+const ORIGINAL_ENV = process.env;
+
+function initReq(): NextRequest {
+  const url = new URL('http://localhost/api/integrations/pipedrive/oauth');
+  url.searchParams.set('action', 'init');
+  return new NextRequest(url.toString());
+}
+
+async function setCookieOnInit(): Promise<string> {
+  jest.resetModules();
+  const { GET } = await import('@/app/api/integrations/pipedrive/oauth/route');
+  const res = await GET(initReq());
+  expect(res.status).toBe(302);
+  return res.headers.get('set-cookie') ?? '';
+}
+
+function setEnv(nodeEnv: 'development' | 'production' | 'test'): void {
+  // process.env.NODE_ENV is typed read-only; replace the whole object instead
+  // (same pattern as the other auth/middleware tests).
+  process.env = {
+    ...ORIGINAL_ENV,
+    PIPEDRIVE_CLIENT_ID: 'test-client-id',
+    PIPEDRIVE_CLIENT_SECRET: 'test-client-secret',
+    PIPEDRIVE_REDIRECT_URI: 'http://localhost/api/integrations/pipedrive/oauth',
+    NODE_ENV: nodeEnv,
+  };
+}
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+  jest.clearAllMocks();
+});
+
+describe('Pipedrive OAuth state cookie — L-4', () => {
+  it('sets the state cookie with HttpOnly and a bounded Max-Age', async () => {
+    setEnv('test');
+    const cookie = await setCookieOnInit();
+    expect(cookie).toContain('pipedrive_oauth_state=');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toMatch(/Max-Age=\d+/);
+  });
+
+  it('marks the cookie Secure in production', async () => {
+    setEnv('production');
+    const cookie = await setCookieOnInit();
+    expect(cookie).toContain('Secure');
+    expect(cookie).toMatch(/Max-Age=\d+/);
+  });
+
+  it('does not mark the cookie Secure outside production (dev/localhost)', async () => {
+    setEnv('development');
+    const cookie = await setCookieOnInit();
+    // Still bounded with Max-Age even in dev.
+    expect(cookie).toMatch(/Max-Age=\d+/);
+    expect(cookie).not.toContain('Secure');
+  });
+});

--- a/__tests__/auth/redirect-url-l1.test.ts
+++ b/__tests__/auth/redirect-url-l1.test.ts
@@ -1,0 +1,77 @@
+/**
+ * U1 / #651 — L-1: getRequestBaseUrl must not trust a client-supplied
+ * X-Forwarded-Host header by default (host-header poisoning / open-redirect).
+ *
+ * Resolution contract after the fix:
+ *   - NEXT_PUBLIC_APP_URL set                       → always used.
+ *   - X-Forwarded-Host present, TRUST_PROXY_HEADERS unset → IGNORED (use Host).
+ *   - X-Forwarded-Host present, TRUST_PROXY_HEADERS=true  → honoured (Caddy).
+ */
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  delete process.env.TRUST_PROXY_HEADERS;
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(url, { headers });
+}
+
+async function baseUrl(req: NextRequest): Promise<string> {
+  const { getRequestBaseUrl } = await import('@/lib/auth/redirect-url');
+  return getRequestBaseUrl(req);
+}
+
+describe('getRequestBaseUrl — L-1 host-header hardening', () => {
+  it('IGNORES a malicious X-Forwarded-Host when TRUST_PROXY_HEADERS is not set', async () => {
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      'x-forwarded-host': 'evil.attacker.example',
+      'x-forwarded-proto': 'https',
+      host: 'demo.quantika.org',
+    });
+    const result = await baseUrl(req);
+    expect(result).not.toContain('evil.attacker.example');
+    expect(result).toBe('https://demo.quantika.org');
+  });
+
+  it('prefers NEXT_PUBLIC_APP_URL over any header, including forwarded ones', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://demo.quantika.org';
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      'x-forwarded-host': 'evil.attacker.example',
+      'x-forwarded-proto': 'https',
+      host: 'evil.attacker.example',
+    });
+    const result = await baseUrl(req);
+    expect(result).toBe('https://demo.quantika.org');
+  });
+
+  it('strips trailing slashes from NEXT_PUBLIC_APP_URL', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://demo.quantika.org/';
+    const req = makeReq('http://localhost:3000/api/auth/login', { host: 'localhost:3000' });
+    expect(await baseUrl(req)).toBe('https://demo.quantika.org');
+  });
+
+  it('honours X-Forwarded-Host ONLY when TRUST_PROXY_HEADERS=true (Caddy opt-in)', async () => {
+    process.env.TRUST_PROXY_HEADERS = 'true';
+    const req = makeReq('http://localhost:3000/api/auth/login', {
+      'x-forwarded-host': 'demo.quantika.org',
+      'x-forwarded-proto': 'https',
+      host: 'localhost:3000',
+    });
+    expect(await baseUrl(req)).toBe('https://demo.quantika.org');
+  });
+
+  it('falls back to Host header when no config and no trusted proxy', async () => {
+    const req = makeReq('http://localhost:3000/api/auth/login', { host: 'localhost:3000' });
+    expect(await baseUrl(req)).toBe('http://localhost:3000');
+  });
+});

--- a/__tests__/auth/redirect-url.test.ts
+++ b/__tests__/auth/redirect-url.test.ts
@@ -1,12 +1,28 @@
 import { NextRequest } from 'next/server';
 import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
 
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  // L-1: these legacy cases assume forwarded headers are honoured. After the
+  // hardening that only happens behind the explicit TRUST_PROXY_HEADERS opt-in,
+  // and only when NEXT_PUBLIC_APP_URL is not set. Reset both per test.
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  delete process.env.TRUST_PROXY_HEADERS;
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
 function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest(url, { headers });
 }
 
 describe('getRequestBaseUrl', () => {
-  it('uses X-Forwarded-Host + X-Forwarded-Proto when present (Caddy reverse proxy)', () => {
+  it('uses X-Forwarded-Host + X-Forwarded-Proto when present and TRUST_PROXY_HEADERS=true (Caddy reverse proxy)', () => {
+    process.env.TRUST_PROXY_HEADERS = 'true';
     const req = makeReq('http://localhost:3000/api/auth/login', {
       'x-forwarded-host': 'demo.quantika.org',
       'x-forwarded-proto': 'https',
@@ -36,7 +52,8 @@ describe('getRequestBaseUrl', () => {
     expect(getRequestBaseUrl(req)).toBe('http://127.0.0.1:3000');
   });
 
-  it('respects explicit X-Forwarded-Proto even if Host looks like localhost', () => {
+  it('respects explicit X-Forwarded-Proto even if Host looks like localhost (TRUST_PROXY_HEADERS=true)', () => {
+    process.env.TRUST_PROXY_HEADERS = 'true';
     const req = makeReq('http://localhost:3000/api/auth/login', {
       'x-forwarded-host': 'demo.quantika.org',
       'x-forwarded-proto': 'http',

--- a/__tests__/components/confidence-guard.test.ts
+++ b/__tests__/components/confidence-guard.test.ts
@@ -4,66 +4,103 @@
  * space-only Fragment (leaving dangling whitespace text-nodes that mismatch
  * between SSR and hydration).
  *
- * The fix: every inline ConfIcon call is guarded by VALID_CONF.has(conf)
- * so that numeric scores like 0.97 are treated as absent.
+ * The fix: every inline ConfIcon call is guarded by VALID_CONF.has(conf) inside
+ * components/clickable-field.tsx so that numeric scores like 0.97 are treated as
+ * absent.
+ *
+ * U5 / #679 — HONEST REWRITE. The previous version declared its OWN
+ * `const VALID_CONF = new Set([...])` and a local re-implementation of the guard
+ * expression, then tested THAT. It never imported the SUT — deleting the real
+ * guard (or every SUT file) left all assertions green. This rewrite renders the
+ * REAL ClickableField component via react-dom/server and asserts on the produced
+ * markup, so the actual VALID_CONF guard in clickable-field.tsx is exercised.
+ *
+ * Mutation contract: remove the `VALID_CONF.has(confidence)` check in
+ * clickable-field.tsx (e.g. `const confStr = typeof confidence === 'string' ?
+ * confidence : undefined`) and the "numeric score renders no icon" cases go RED
+ * (a numeric confidence would slip through). Verified in the U5 report.
  */
 
-const VALID_CONF = new Set(['confirmed', 'interpreted', 'uncertain']);
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ClickableField } from '@/components/clickable-field';
 
-describe('VALID_CONF guard — numeric confidence scores (γ-cleanup-4 F1)', () => {
-  it('accepts "confirmed" as valid', () => {
-    expect(VALID_CONF.has('confirmed')).toBe(true);
+// Icon titles map 1:1 to the three valid confidence labels in ConfIcon.
+const ICON_TITLE = {
+  confirmed: 'Confirmed from email',
+  interpreted: 'AI interpreted',
+  uncertain: 'Uncertain — check original',
+} as const;
+
+function render(confidence: unknown): string {
+  return renderToStaticMarkup(
+    createElement(ClickableField, {
+      label: 'Freight',
+      value: 42,
+      // deliberately bypass the prop type to simulate runtime LLM payloads
+      confidence: confidence as never,
+    }),
+  );
+}
+
+// Extract the inner content of the value <span class="font-medium">…</span>.
+// This is where the React #418 dangling-whitespace text-node appears when a
+// non-allowlisted confidence leaks past the guard (e.g. "42 " instead of "42").
+function valueSpanInner(html: string): string {
+  const m = html.match(/<span class="font-medium">([\s\S]*?)<\/span>/);
+  if (!m) throw new Error(`value span not found in: ${html}`);
+  return m[1];
+}
+
+describe('ClickableField VALID_CONF guard — real component render (γ-cleanup-4 F1)', () => {
+  it('renders the ✅ icon for "confirmed"', () => {
+    const html = render('confirmed');
+    expect(html).toContain(`title="${ICON_TITLE.confirmed}"`);
+    expect(html).toContain('✅');
   });
 
-  it('accepts "interpreted" as valid', () => {
-    expect(VALID_CONF.has('interpreted')).toBe(true);
+  it('renders the ⚠️ icon for "interpreted"', () => {
+    const html = render('interpreted');
+    expect(html).toContain(`title="${ICON_TITLE.interpreted}"`);
   });
 
-  it('accepts "uncertain" as valid', () => {
-    expect(VALID_CONF.has('uncertain')).toBe(true);
+  it('renders the ❓ icon for "uncertain"', () => {
+    const html = render('uncertain');
+    expect(html).toContain(`title="${ICON_TITLE.uncertain}"`);
   });
 
-  it('rejects numeric score 0.97 (common LLM parser output)', () => {
-    expect(VALID_CONF.has(String(0.97))).toBe(false);
-    // Simulating runtime: typeof 0.97 !== 'string' so guarded before .has()
-    const conf: unknown = 0.97;
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
-    expect(confStr).toBeUndefined();
+  it('renders NO icon AND NO dangling whitespace for a numeric LLM score 0.97 (React #418)', () => {
+    const html = render(0.97);
+    expect(html).not.toContain('title=');
+    expect(html).not.toMatch(/[✅⚠️❓]/u);
+    // The exact bug signature: the value span must be "42" — NOT "42 " with a
+    // trailing space text-node (which is what the unguarded code produces and
+    // what triggers the SSR/hydration mismatch).
+    expect(valueSpanInner(html)).toBe('42');
   });
 
-  it('rejects numeric score 0 (edge case — falsy but still numeric)', () => {
-    const conf: unknown = 0;
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
-    expect(confStr).toBeUndefined();
+  it('renders NO icon for numeric 0 (falsy but still numeric)', () => {
+    const html = render(0);
+    expect(html).not.toContain('title=');
+    expect(valueSpanInner(html)).toBe('42');
   });
 
-  it('rejects undefined', () => {
-    const conf: unknown = undefined;
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
-    expect(confStr).toBeUndefined();
+  it('renders NO icon for an arbitrary non-allowlisted string ("high")', () => {
+    const html = render('high');
+    expect(html).not.toContain('title=');
+    expect(html).not.toMatch(/[✅⚠️❓]/u);
+    expect(valueSpanInner(html)).toBe('42');
   });
 
-  it('rejects null', () => {
-    const conf: unknown = null;
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf as string) ? conf : undefined;
-    expect(confStr).toBeUndefined();
+  it('renders NO dangling whitespace for undefined / null / empty string', () => {
+    expect(valueSpanInner(render(undefined))).toBe('42');
+    expect(valueSpanInner(render(null))).toBe('42');
+    expect(valueSpanInner(render(''))).toBe('42');
   });
 
-  it('rejects empty string', () => {
-    const conf: unknown = '';
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
-    expect(confStr).toBeUndefined();
-  });
-
-  it('rejects arbitrary string not in the set', () => {
-    const conf: unknown = 'high';
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
-    expect(confStr).toBeUndefined();
-  });
-
-  it('passes through "confirmed" correctly', () => {
-    const conf: unknown = 'confirmed';
-    const confStr = typeof conf === 'string' && VALID_CONF.has(conf) ? conf : undefined;
-    expect(confStr).toBe('confirmed');
+  it('the VALID confidence labels DO append the icon span (asymmetry proves the guard)', () => {
+    // Sanity: a valid label produces "42 <span…>✅</span>" — the space here is
+    // intentional and paired with a real icon node, so it does NOT dangle.
+    expect(valueSpanInner(render('confirmed'))).toMatch(/^42 <span title=/);
   });
 });

--- a/__tests__/fmt-laycan-tz-boundary.test.ts
+++ b/__tests__/fmt-laycan-tz-boundary.test.ts
@@ -1,0 +1,51 @@
+/**
+ * TZ-boundary regression test for fmtLaycan (#676 hydration fix).
+ *
+ * The bug: toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+ * without timeZone: 'UTC' lets the JS runtime apply the local server TZ.
+ * On a VPS set to UTC+3 (or any TZ offset != UTC), timestamps within the
+ * last few hours of a UTC day are shifted into the NEXT calendar day —
+ * causing SSR output to differ from client hydration output, producing a
+ * React hydration mismatch.
+ *
+ * Fix: add timeZone: 'UTC' to the toLocaleDateString options.
+ * The test exercises the midnight boundary: a Unix timestamp that sits
+ * exactly at midnight UTC (day boundary) and verifies the expected UTC day
+ * is rendered, not the day from whatever local TZ the CI/VPS runs in.
+ */
+
+import { fmtLaycan } from '@/lib/utils/fmt-laycan';
+
+/**
+ * Returns a Unix-second timestamp for midnight UTC of a given ISO date.
+ * E.g. '2025-03-01' → Unix seconds for 2025-03-01T00:00:00Z
+ */
+function midnightUtc(isoDate: string): number {
+  return Math.floor(new Date(`${isoDate}T00:00:00Z`).getTime() / 1000);
+}
+
+describe('fmtLaycan — UTC timezone pinning (#676)', () => {
+  it('renders the expected UTC calendar day at midnight UTC (not drifted by server TZ)', () => {
+    // 2025-03-01T00:00:00Z — midnight UTC boundary
+    // Without timeZone:'UTC', on a UTC+3 server this would show Feb 28 (previous day).
+    const ts = midnightUtc('2025-03-01');
+    const result = fmtLaycan(ts, null);
+    expect(result).toBe('Mar 1');
+  });
+
+  it('renders the expected UTC calendar day at 23:59 UTC (last minute of day)', () => {
+    // 2025-03-31T23:59:00Z — one minute before end of March
+    // On UTC+1 this would already be Apr 1.
+    const ts = midnightUtc('2025-04-01') - 60; // 23:59:00Z of Mar 31
+    const result = fmtLaycan(ts, null);
+    expect(result).toBe('Mar 31');
+  });
+
+  it('formats a range with both dates consistently in UTC', () => {
+    const start = midnightUtc('2025-06-01'); // midnight UTC Jun 1
+    const end   = midnightUtc('2025-06-15'); // midnight UTC Jun 15
+    const result = fmtLaycan(start, end);
+    expect(result).toContain('Jun 1');
+    expect(result).toContain('Jun 15');
+  });
+});

--- a/__tests__/lib/ai-provider-bedrock-cache.test.ts
+++ b/__tests__/lib/ai-provider-bedrock-cache.test.ts
@@ -1,0 +1,38 @@
+/**
+ * BUG-2 (MEDIUM) — callBedrockText must NOT attach an Anthropic prompt-caching
+ * breakpoint (cache_control: ephemeral) on tiny system prompts. The breakpoint is
+ * only worthwhile for the large static MATCH prefix (~28k chars); on a short prompt
+ * it is wasted/over-applied (below Bedrock's ~1024-token cacheable minimum).
+ *
+ * The payload's system field is built by the pure helper buildBedrockSystemField,
+ * so we assert its shape directly — no AWS call.
+ */
+import { buildBedrockSystemField, CACHE_MIN_CHARS } from '@/lib/ai-provider';
+
+function hasCacheControl(field: unknown): boolean {
+  return Array.isArray(field) && field.some((b) => b && (b as { cache_control?: unknown }).cache_control);
+}
+
+describe('buildBedrockSystemField — gate cache_control by prefix size (BUG-2)', () => {
+  it('attaches NO cache_control on a short system prompt', () => {
+    const field = buildBedrockSystemField('hi');
+    expect(hasCacheControl(field)).toBe(false);
+  });
+
+  it('sends the short prompt as a plain string (text is preserved)', () => {
+    expect(buildBedrockSystemField('hi')).toBe('hi');
+  });
+
+  it('attaches cache_control on a system prompt at/above CACHE_MIN_CHARS', () => {
+    const big = 'x'.repeat(CACHE_MIN_CHARS);
+    const field = buildBedrockSystemField(big);
+    expect(hasCacheControl(field)).toBe(true);
+    // text is preserved verbatim in the cached block
+    expect((field as Array<{ text: string }>)[0].text).toBe(big);
+  });
+
+  it('CACHE_MIN_CHARS is conservatively above the ~1024-token Bedrock minimum', () => {
+    // ~3-4 chars/token → 4000 chars comfortably exceeds 1024 tokens.
+    expect(CACHE_MIN_CHARS).toBeGreaterThanOrEqual(4000);
+  });
+});

--- a/__tests__/lib/ai-provider-claude-cli.test.ts
+++ b/__tests__/lib/ai-provider-claude-cli.test.ts
@@ -146,4 +146,52 @@ describe('callClaudeCliRaw', () => {
     expect(idx).toBeGreaterThan(-1);
     expect(args[idx + 1]).toBe('0.1');
   });
+
+  // U4 (#675): eval-ergonomics — CLAUDE_CLI_MAX_BUDGET_USD env fallback.
+  // Large parser system prompts blow past the 0.05 default before any output,
+  // producing false error_max_budget_usd on every eval call. The audit's
+  // uncommitted affordance is now permanent. (audit Top-10, "Harness affordance")
+  describe('CLAUDE_CLI_MAX_BUDGET_USD env fallback', () => {
+    const original = process.env.CLAUDE_CLI_MAX_BUDGET_USD;
+    afterEach(() => {
+      if (original === undefined) delete process.env.CLAUDE_CLI_MAX_BUDGET_USD;
+      else process.env.CLAUDE_CLI_MAX_BUDGET_USD = original;
+    });
+
+    it('uses CLAUDE_CLI_MAX_BUDGET_USD when set and no opts override', () => {
+      process.env.CLAUDE_CLI_MAX_BUDGET_USD = '0.30';
+      childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+      callClaudeCliRaw('s', 'u', 'claude-opus-4-7');
+      const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+      const idx = args.indexOf('--max-budget-usd');
+      expect(args[idx + 1]).toBe('0.3');
+    });
+
+    it('opts.maxBudgetUsd overrides the env var', () => {
+      process.env.CLAUDE_CLI_MAX_BUDGET_USD = '0.30';
+      childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+      callClaudeCliRaw('s', 'u', 'claude-opus-4-7', { maxBudgetUsd: 0.12 });
+      const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+      const idx = args.indexOf('--max-budget-usd');
+      expect(args[idx + 1]).toBe('0.12');
+    });
+
+    it('falls back to 0.05 default when env is unset', () => {
+      delete process.env.CLAUDE_CLI_MAX_BUDGET_USD;
+      childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+      callClaudeCliRaw('s', 'u', 'claude-opus-4-7');
+      const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+      const idx = args.indexOf('--max-budget-usd');
+      expect(args[idx + 1]).toBe('0.05');
+    });
+
+    it('falls back to 0.05 default when env is non-numeric garbage', () => {
+      process.env.CLAUDE_CLI_MAX_BUDGET_USD = 'not-a-number';
+      childProcess.spawnSync.mockReturnValue(OK_RESPONSE('ok'));
+      callClaudeCliRaw('s', 'u', 'claude-opus-4-7');
+      const [, args] = childProcess.spawnSync.mock.calls[0] as [string, string[]];
+      const idx = args.indexOf('--max-budget-usd');
+      expect(args[idx + 1]).toBe('0.05');
+    });
+  });
 });

--- a/__tests__/lib/u2-bypass-routing.test.ts
+++ b/__tests__/lib/u2-bypass-routing.test.ts
@@ -1,0 +1,151 @@
+/**
+ * U2 (issue 674): bypass-routing fixes.
+ *
+ * Three call sites previously hard-pinned to OpenAI (lib/openai or raw fetch),
+ * skipping AI_PROVIDER routing AND the ai_audit row:
+ *   - lib/whatsapp/forward-parser.ts
+ *   - lib/economics/route-decision.ts
+ *   - scripts/seed-port-da.ts (defaultLlmCaller)
+ *
+ * These tests prove each now goes through lib/ai-provider:
+ *   (a) honors AI_PROVIDER=gemini (the gemini SDK is invoked, not lib/openai), and
+ *   (b) writes an ai_audit row.
+ *
+ * Providers are MOCKED — no real network.
+ */
+
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+
+// lib/openai must NOT be the path taken when AI_PROVIDER=gemini. We mock it and
+// assert it is NEVER called — a hard-pinned bypass would call it.
+const openaiCallAiJson = jest.fn().mockResolvedValue({ missing_info: [] });
+const openaiCallAiText = jest.fn().mockResolvedValue('openai-text');
+jest.mock('@/lib/openai', () => {
+  const ActualErr = jest.requireActual('@/lib/openai').LLMTimeoutError;
+  return {
+    callAiJson: (...a: unknown[]) => openaiCallAiJson(...a),
+    callAiText: (...a: unknown[]) => openaiCallAiText(...a),
+    LLMTimeoutError: ActualErr,
+  };
+});
+
+const mockGeminiGenerate = jest.fn();
+jest.mock('@google/genai', () => ({
+  GoogleGenAI: jest.fn().mockImplementation(() => ({
+    models: { generateContent: mockGeminiGenerate },
+  })),
+}), { virtual: true });
+
+let testDb: Database.Database;
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: jest.fn(() => testDb) })),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// forward-parser sub-modules (media extractors) — unused for type='text'.
+jest.mock('@/lib/whatsapp/voice-transcribe', () => ({ transcribeAudio: jest.fn() }));
+jest.mock('@/lib/whatsapp/image-ocr', () => ({ extractTextFromImage: jest.fn() }));
+jest.mock('@/lib/whatsapp/pdf-extract', () => ({ extractTextFromPdf: jest.fn() }));
+
+function setGeminiEnv(): void {
+  process.env.AI_PROVIDER = 'gemini';
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = '/dev/null';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+  process.env.AI_MODEL_GEMINI_DEFAULT = 'gemini-2.5-flash';
+}
+
+function clearEnv(): void {
+  for (const k of [
+    'AI_PROVIDER', 'WHATSAPP_FORWARD_PROVIDER', 'ROUTE_DECISION_PROVIDER', 'SEED_PORT_DA_PROVIDER',
+    'GOOGLE_APPLICATION_CREDENTIALS', 'GOOGLE_CLOUD_PROJECT', 'AI_MODEL_GEMINI_DEFAULT',
+  ]) delete process.env[k];
+}
+
+function auditRows() {
+  return testDb.prepare('SELECT scope, provider, ok FROM ai_audit ORDER BY id').all() as Array<{
+    scope: string; provider: string; ok: number;
+  }>;
+}
+
+beforeEach(() => {
+  testDb = new Database(':memory:');
+  runMigrations(testDb, allMigrations);
+  clearEnv();
+  jest.clearAllMocks();
+  const sessionStore = require('@/lib/session-store');
+  (sessionStore.getStore as jest.Mock).mockReturnValue({ getDatabase: jest.fn(() => testDb) });
+  mockGeminiGenerate.mockResolvedValue({ text: '{"missing_info":[]}' });
+});
+
+afterEach(() => testDb.close());
+
+describe('forward-parser routes through ai-provider', () => {
+  it('honors AI_PROVIDER=gemini and writes an ai_audit row (not lib/openai)', async () => {
+    setGeminiEnv();
+    mockGeminiGenerate.mockResolvedValue({
+      text: '{"origin_port":{"value":"Istanbul","confidence":"confirmed"},"missing_info":[]}',
+    });
+    const { parseForwardedMessage } = require('@/lib/whatsapp/forward-parser');
+    const client = { downloadMedia: jest.fn() };
+    await parseForwardedMessage(
+      { id: 'wamid.1', from: '+10000', timestamp: '1', type: 'text', text: { body: 'cargo wheat 50kt istanbul lagos' } },
+      client,
+    );
+
+    expect(mockGeminiGenerate).toHaveBeenCalledTimes(1);
+    expect(openaiCallAiJson).not.toHaveBeenCalled();
+    const rows = auditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].scope).toBe('whatsapp_forward');
+    expect(rows[0].provider).toBe('gemini');
+  });
+});
+
+describe('route-decision routes through ai-provider', () => {
+  it('honors AI_PROVIDER=gemini and writes an ai_audit row (not lib/openai)', async () => {
+    setGeminiEnv();
+    mockGeminiGenerate.mockResolvedValue({ text: 'Suez wins by 2 days.' });
+    const { compareRoutes } = require('@/lib/economics/route-decision');
+    await compareRoutes(
+      'singapore',
+      'rotterdam',
+      { dwt: 80000, ladenSpeed: 14, ballastSpeed: 14, speedKts: 14 } as any,
+      { quantityMt: 70000, type: 'grain' } as any,
+      { bunkerPriceUsdPerMt: 600, euaPriceEur: 70 },
+    );
+
+    expect(mockGeminiGenerate).toHaveBeenCalled();
+    expect(openaiCallAiText).not.toHaveBeenCalled();
+    const rows = auditRows();
+    expect(rows.some((r) => r.scope === 'route_decision' && r.provider === 'gemini')).toBe(true);
+  });
+});
+
+describe('seed-port-da defaultLlmCaller routes through ai-provider', () => {
+  it('honors AI_PROVIDER=gemini and writes an ai_audit row (no raw OpenAI fetch)', async () => {
+    setGeminiEnv();
+    mockGeminiGenerate.mockResolvedValue({
+      text: '{"vessel_dwt_min":65001,"vessel_dwt_max":80000,"port_dues_usd":12000,"pilotage_usd":4000,"tugs_usd":3000,"stevedoring_usd_per_mt":2.5,"confidence":"estimated"}',
+    });
+    // Guard: fetch must not be touched by the new path.
+    const fetchSpy = jest.spyOn(global, 'fetch' as never).mockImplementation((() => {
+      throw new Error('raw fetch must not be called');
+    }) as never);
+
+    const { defaultLlmCaller } = require('../../scripts/seed-port-da');
+    const result = await defaultLlmCaller('gemini-2.5-flash', 'NLRTM', 'Rotterdam', 'panamax', 65001, 80000);
+
+    expect(result.port_dues_usd).toBe(12000);
+    expect(mockGeminiGenerate).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const rows = auditRows();
+    expect(rows.some((r) => r.scope === 'seed_port_da' && r.provider === 'gemini')).toBe(true);
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/__tests__/middleware-rate-limit-trusted-source.test.ts
+++ b/__tests__/middleware-rate-limit-trusted-source.test.ts
@@ -126,4 +126,29 @@ describe('BUG-1 — (d) source unset: fail-closed shared bucket', () => {
     }
     expect((await runMiddleware(loginReq({ 'x-forwarded-for': '9.9.9.200' }))).status).toBe(429);
   });
+
+  it('R2-BUG-1: rotating X-Real-IP must NOT bypass when source is unset (fail-closed)', async () => {
+    // cold-QA round-2 HIGH: the default branch used to trust client-settable
+    // x-real-ip, so rotating it per request defeated the limiter (bare Caddy proxy
+    // passes the client value through). After the fix the default trusts NO client
+    // header → all rotated requests collapse into the one shared bucket.
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      const res = await runMiddleware(loginReq({ 'x-real-ip': `4.4.4.${i}` }));
+      expect(res.status).not.toBe(429);
+    }
+    expect((await runMiddleware(loginReq({ 'x-real-ip': '4.4.4.99' }))).status).toBe(429);
+  });
+});
+
+describe('xrealip mode — explicit opt-in trusts X-Real-IP per value', () => {
+  beforeEach(() => setEnv({ RATE_LIMIT_CLIENT_IP_SOURCE: 'xrealip' }));
+
+  it('buckets per X-Real-IP value (only safe when proxy overwrites it)', async () => {
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      await runMiddleware(loginReq({ 'x-real-ip': '5.5.5.5' }));
+    }
+    // same IP over cap → 429; a distinct IP is its own bucket → still served.
+    expect((await runMiddleware(loginReq({ 'x-real-ip': '5.5.5.5' }))).status).toBe(429);
+    expect((await runMiddleware(loginReq({ 'x-real-ip': '6.6.6.6' }))).status).not.toBe(429);
+  });
 });

--- a/__tests__/middleware-rate-limit-trusted-source.test.ts
+++ b/__tests__/middleware-rate-limit-trusted-source.test.ts
@@ -1,0 +1,129 @@
+/**
+ * BUG-1 (HIGH) — middleware rateLimitKey() must derive the client key from a
+ * TRUSTED source, not the left-most X-Forwarded-For token (which any client can
+ * set freely and rotate per request to defeat loginRateLimiter / adminRateLimiter).
+ *
+ * PROD TOPOLOGY: Cloudflare → Caddy → Next. Cloudflare OVERWRITES CF-Connecting-IP
+ * with the true client IP; Caddy APPENDS to X-Forwarded-For, so the LEFT-most XFF
+ * token is attacker-controlled and the RIGHT-most N tokens are appended by trusted
+ * hops. These probes invoke the REAL middleware handler.
+ */
+
+import { webcrypto } from 'node:crypto';
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_ENV = process.env;
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function setEnv(extra: Record<string, string | undefined>) {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    DEMO_AUTH_ENABLED: 'false', // isolate rate-limit behaviour from the auth guard
+    NODE_ENV: 'test',
+    // start from a clean slate for the IP-source plumbing
+    RATE_LIMIT_CLIENT_IP_SOURCE: undefined,
+    TRUSTED_PROXY_COUNT: undefined,
+    ...extra,
+  };
+}
+
+async function runMiddleware(req: NextRequest) {
+  const { middleware } = await import('../middleware');
+  return middleware(req);
+}
+
+/** POST /api/auth/login carrying the given headers. */
+function loginReq(headers: Record<string, string>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+// loginRateLimiter: 5 / 60s → the 6th request from the same key trips (429).
+const LOGIN_CAP = 5;
+
+describe('BUG-1 — xff-trusted mode: trusted-offset IP, not left-most XFF', () => {
+  beforeEach(() => setEnv({ RATE_LIMIT_CLIENT_IP_SOURCE: 'xff-trusted', TRUSTED_PROXY_COUNT: '1' }));
+
+  it('(a) STILL trips when the attacker rotates the left-most XFF token', async () => {
+    // Simulates prod: attacker sends a fresh "9.9.9.${i}" each request; the single
+    // TRUSTED hop (Caddy) appends a stable IP on the RIGHT. With N=1 the key is the
+    // right-most (trusted) token, which is stable → the throttle accumulates.
+    const TRUSTED = '203.0.113.7';
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      const res = await runMiddleware(loginReq({ 'x-forwarded-for': `9.9.9.${i}, ${TRUSTED}` }));
+      expect(res.status).not.toBe(429);
+    }
+    const blocked = await runMiddleware(loginReq({ 'x-forwarded-for': `9.9.9.99, ${TRUSTED}` }));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+  });
+
+  it('(c) two genuinely distinct trusted IPs are bucketed separately', async () => {
+    const A = '203.0.113.20';
+    const B = '198.51.100.30';
+    // Drive trusted IP A to its cap (rotating left token each time).
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      await runMiddleware(loginReq({ 'x-forwarded-for': `9.9.9.${i}, ${A}` }));
+    }
+    // A is now over the cap → 429.
+    expect((await runMiddleware(loginReq({ 'x-forwarded-for': `9.9.9.77, ${A}` }))).status).toBe(429);
+    // B is a distinct trusted IP, under its own cap → still served.
+    expect((await runMiddleware(loginReq({ 'x-forwarded-for': `8.8.8.1, ${B}` }))).status).not.toBe(429);
+  });
+
+  it('fails closed to a shared bucket when the XFF list is shorter than N', async () => {
+    setEnv({ RATE_LIMIT_CLIENT_IP_SOURCE: 'xff-trusted', TRUSTED_PROXY_COUNT: '2' });
+    // Only one token but N=2 → cannot identify a trusted hop → shared bucket.
+    // Rotating the single token must NOT reset the throttle.
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      await runMiddleware(loginReq({ 'x-forwarded-for': `7.7.7.${i}` }));
+    }
+    expect((await runMiddleware(loginReq({ 'x-forwarded-for': '7.7.7.88' }))).status).toBe(429);
+  });
+});
+
+describe('BUG-1 — cf mode: trust CF-Connecting-IP, ignore client XFF', () => {
+  beforeEach(() => setEnv({ RATE_LIMIT_CLIENT_IP_SOURCE: 'cf' }));
+
+  it('(b) STILL trips with a fixed CF-Connecting-IP while XFF rotates', async () => {
+    // In prod CF OVERWRITES CF-Connecting-IP, so the client cannot rotate it.
+    const CF = '203.0.113.55';
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      const res = await runMiddleware(
+        loginReq({ 'cf-connecting-ip': CF, 'x-forwarded-for': `9.9.9.${i}` }),
+      );
+      expect(res.status).not.toBe(429);
+    }
+    expect(
+      (await runMiddleware(loginReq({ 'cf-connecting-ip': CF, 'x-forwarded-for': '9.9.9.42' }))).status,
+    ).toBe(429);
+  });
+
+  it('fails closed to a shared bucket when CF-Connecting-IP is absent', async () => {
+    // No CF header → never trust the spoofable XFF. Rotating XFF must still trip.
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      await runMiddleware(loginReq({ 'x-forwarded-for': `9.9.9.${i}` }));
+    }
+    expect((await runMiddleware(loginReq({ 'x-forwarded-for': '9.9.9.123' }))).status).toBe(429);
+  });
+});
+
+describe('BUG-1 — (d) source unset: fail-closed shared bucket', () => {
+  beforeEach(() => setEnv({})); // RATE_LIMIT_CLIENT_IP_SOURCE unset
+
+  it('throttles everyone together when no trusted source is configured', async () => {
+    // No trusted source + no x-real-ip → shared bucket. Rotating XFF must not bypass.
+    for (let i = 0; i < LOGIN_CAP; i++) {
+      await runMiddleware(loginReq({ 'x-forwarded-for': `9.9.9.${i}` }));
+    }
+    expect((await runMiddleware(loginReq({ 'x-forwarded-for': '9.9.9.200' }))).status).toBe(429);
+  });
+});

--- a/__tests__/middleware-rate-limit.test.ts
+++ b/__tests__/middleware-rate-limit.test.ts
@@ -22,6 +22,12 @@ beforeEach(() => {
     // Disable the auth guard so we isolate the rate-limit behaviour.
     DEMO_AUTH_ENABLED: 'false',
     NODE_ENV: 'test',
+    // BUG-1: rateLimitKey() now derives the client key from a TRUSTED source.
+    // These tests use an honest single-IP X-Forwarded-For, so trust one appending
+    // hop (Caddy) — with N=1 the trusted-offset is index 0 = that single IP, which
+    // exercises the limiter exactly as before (this is setup, not weakening).
+    RATE_LIMIT_CLIENT_IP_SOURCE: 'xff-trusted',
+    TRUSTED_PROXY_COUNT: '1',
   };
 });
 

--- a/__tests__/middleware-rate-limit.test.ts
+++ b/__tests__/middleware-rate-limit.test.ts
@@ -1,0 +1,114 @@
+/**
+ * U1 / #651 — brute-force throttle tests for middleware.ts.
+ *
+ * M-1: POST /api/auth/login must 429 after N attempts per IP.
+ * L-3: /api/admin/* must 429 after N attempts per IP (limits credential guessing
+ *      against the X-Admin-Token shared secret).
+ *
+ * These invoke the real middleware handler (not string-matching source).
+ */
+
+import { webcrypto } from 'node:crypto';
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    // Disable the auth guard so we isolate the rate-limit behaviour.
+    DEMO_AUTH_ENABLED: 'false',
+    NODE_ENV: 'test',
+  };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+async function runMiddleware(req: NextRequest) {
+  const { middleware } = await import('../middleware');
+  return middleware(req);
+}
+
+function loginReq(ip: string): NextRequest {
+  return new NextRequest('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip, 'content-type': 'application/json' },
+  });
+}
+
+function adminReq(ip: string, path = '/api/admin/knowledge/refresh'): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'x-forwarded-for': ip, 'content-type': 'application/json' },
+  });
+}
+
+describe('M-1 — POST /api/auth/login brute-force throttle', () => {
+  it('429s after the 6th attempt from the same IP within the window', async () => {
+    const ip = '203.0.113.10';
+    // loginRateLimiter is 5 requests / 60s. First 5 pass through.
+    for (let i = 0; i < 5; i++) {
+      const res = await runMiddleware(loginReq(ip));
+      expect(res.status).not.toBe(429);
+    }
+    const blocked = await runMiddleware(loginReq(ip));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+    const body = await blocked.json();
+    expect(body).toEqual({ error: 'Too many requests' });
+  });
+
+  it('counts attempts per-IP (a different IP is not throttled)', async () => {
+    const attacker = '203.0.113.20';
+    for (let i = 0; i < 6; i++) {
+      await runMiddleware(loginReq(attacker));
+    }
+    const attackerBlocked = await runMiddleware(loginReq(attacker));
+    expect(attackerBlocked.status).toBe(429);
+
+    // Fresh IP must still be served.
+    const victim = await runMiddleware(loginReq('198.51.100.99'));
+    expect(victim.status).not.toBe(429);
+  });
+
+  it('does not throttle non-POST requests to the login path', async () => {
+    const ip = '203.0.113.30';
+    for (let i = 0; i < 10; i++) {
+      const res = await runMiddleware(
+        new NextRequest('http://localhost/api/auth/login', {
+          method: 'GET',
+          headers: { 'x-forwarded-for': ip },
+        }),
+      );
+      expect(res.status).not.toBe(429);
+    }
+  });
+});
+
+describe('L-3 — /api/admin/* brute-force throttle', () => {
+  it('429s after the 11th admin attempt from the same IP within the window', async () => {
+    const ip = '203.0.113.40';
+    // adminRateLimiter is 10 requests / 60s.
+    for (let i = 0; i < 10; i++) {
+      const res = await runMiddleware(adminReq(ip));
+      expect(res.status).not.toBe(429);
+    }
+    const blocked = await runMiddleware(adminReq(ip));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+  });
+
+  it('throttle is keyed per-IP for admin routes', async () => {
+    const attacker = '203.0.113.50';
+    for (let i = 0; i < 11; i++) {
+      await runMiddleware(adminReq(attacker));
+    }
+    expect((await runMiddleware(adminReq(attacker))).status).toBe(429);
+    expect((await runMiddleware(adminReq('198.51.100.7'))).status).not.toBe(429);
+  });
+});

--- a/__tests__/regression/RC6-security-blacklist/spec15-CRIT01-sql-injection-tablename.test.ts
+++ b/__tests__/regression/RC6-security-blacklist/spec15-CRIT01-sql-injection-tablename.test.ts
@@ -3,6 +3,22 @@
 // Finding: F-01 — SQL injection via tableName parameter
 // Spec: spec-15-embedandstore-chunks-vectortable-imsbc-vec-ftstable-imsbc-fts
 // DO NOT DELETE — see references/regression_lock_workflow.md
+//
+// U5 / #679 — HONEST REWRITE.
+// The prior version's first case used a bare `.rejects.toThrow()`. That passes
+// on BOTH buggy and fixed code: the malicious name crashes `db.prepare()` with a
+// SQLite syntax error, which satisfies `.toThrow()` even when the allowlist guard
+// is absent. The allowlist guard in pipeline.ts (ALLOWED_VEC_TABLES.includes) is
+// the only thing standing between a user-controlled tableName and raw
+// `INSERT INTO ${tableName}` SQL. The mutation-honest contract below asserts the
+// guard SPECIFICALLY:
+//   (a) the thrown error is the allowlist message, not a SQLite parse error;
+//   (b) the guard fires BEFORE any SQL is prepared/run (db.prepare is never
+//       called and the target table is never mutated);
+//   (c) a plausible, well-formed but non-allowlisted name ("user_data") — which
+//       would NOT crash SQLite's parser — is still rejected. This case is the
+//       true regression sentinel: remove the allowlist and (c) goes RED while a
+//       bare crash-based assertion would stay green.
 
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import Database from "better-sqlite3";
@@ -11,7 +27,8 @@ import { runMigrations } from "@/lib/migrations/runner";
 import { allMigrations } from "@/lib/migrations/index";
 import type { Chunk } from "@/lib/knowledge/embeddings/chunks";
 
-// Mock embedDocuments
+// Mock ONLY the embedding API boundary (network). The SUT — the allowlist guard
+// and the SQL prepare/run path — runs for real against an in-memory SQLite DB.
 let _mockEmbedDocuments: jest.Mock = jest.fn();
 jest.mock("@/lib/knowledge/embeddings/client", () => ({
   embedDocuments: (...args: unknown[]) => _mockEmbedDocuments(...args),
@@ -20,16 +37,16 @@ jest.mock("@/lib/knowledge/embeddings/client", () => ({
 
 import { embedAndStore } from "@/lib/knowledge/embeddings/pipeline";
 
-describe("regression spec15-CRIT01: SQL injection via tableName", () => {
+describe("regression spec15-CRIT01: SQL injection via tableName (allowlist guard)", () => {
   let db: Database.Database;
   const originalEnv = process.env.KNOWLEDGE_RAG_ENABLED;
+  const chunk: Chunk = { content: "Test content", metadata: { source: "imsbc" } };
 
   beforeEach(() => {
     db = new Database(":memory:");
     sqliteVec.load(db);
     runMigrations(db, allMigrations);
     process.env.KNOWLEDGE_RAG_ENABLED = "true";
-
     _mockEmbedDocuments = jest.fn().mockResolvedValue([new Float32Array(768).fill(0.5)]);
   });
 
@@ -38,73 +55,61 @@ describe("regression spec15-CRIT01: SQL injection via tableName", () => {
     process.env.KNOWLEDGE_RAG_ENABLED = originalEnv;
   });
 
-  it("tableName with SQL injection payload must be rejected", async () => {
-    const chunk: Chunk = {
-      content: "Test content",
-      metadata: { source: "imsbc" },
-    };
-
-    // SQL injection attempt: DROP TABLE
-    const maliciousTableName = "imsbc_vec; DROP TABLE imsbc_vec; --";
-
-    // EXPECTED: Should throw error (table name validation)
-    // ACTUAL (buggy code): Executes SQL injection
+  it("rejects a classic ;DROP TABLE payload with the ALLOWLIST error (not a SQLite crash)", async () => {
+    const malicious = "imsbc_vec; DROP TABLE imsbc_vec; --";
     await expect(
-      embedAndStore([chunk], {
-        tableName: maliciousTableName,
-        db,
-      })
-    ).rejects.toThrow();
-    // NOTE: Test currently PASSES on buggy code (SQL injection succeeds)
-    // After fix: should throw Error("Invalid table name")
-  });
-
-  it("tableName with semicolon separator must be rejected", async () => {
-    const chunk: Chunk = {
-      content: "Test content",
-      metadata: { source: "imsbc" },
-    };
-
-    // SQL injection with multiple statements
-    const maliciousTableName = "imsbc_vec; SELECT * FROM sqlite_master";
-
-    await expect(
-      embedAndStore([chunk], {
-        tableName: maliciousTableName,
-        db,
-      })
+      embedAndStore([chunk], { tableName: malicious, db })
     ).rejects.toThrow(/Invalid table name/);
   });
 
-  it("tableName with comment injection must be rejected", async () => {
-    const chunk: Chunk = {
-      content: "Test content",
-      metadata: { source: "imsbc" },
-    };
-
-    // SQL injection with comment
-    const maliciousTableName = "imsbc_vec -- comment";
-
+  it("rejects a plausible non-allowlisted table name (user_data) — the true guard sentinel", async () => {
+    // "user_data" is a valid SQL identifier: it would NOT crash db.prepare().
+    // The ONLY thing that rejects it is the allowlist. Remove the allowlist and
+    // this assertion flips from 'Invalid table name' to a write into user_data.
     await expect(
-      embedAndStore([chunk], {
-        tableName: maliciousTableName,
-        db,
-      })
-    ).rejects.toThrow(/Invalid table name/);
+      embedAndStore([chunk], { tableName: "user_data", db })
+    ).rejects.toThrow(/Invalid table name: user_data/);
   });
 
-  it("valid tableName from allowlist must succeed", async () => {
-    const chunk: Chunk = {
-      content: "Test content",
-      metadata: { source: "imsbc" },
-    };
-
-    // This should work (valid table name)
+  it("fires the guard BEFORE touching the DB — db.prepare is never called", async () => {
+    const prepareSpy = jest.spyOn(db, "prepare");
     await expect(
-      embedAndStore([chunk], {
-        tableName: "imsbc_vec",
-        db,
-      })
+      embedAndStore([chunk], { tableName: "imsbc_vec; DROP TABLE imsbc_vec; --", db })
+    ).rejects.toThrow(/Invalid table name/);
+    expect(prepareSpy).not.toHaveBeenCalled();
+    prepareSpy.mockRestore();
+  });
+
+  it("leaves the real target table intact after a DROP-TABLE injection attempt", async () => {
+    // Pre-existence: migrations created imsbc_vec.
+    const before = db
+      .prepare("SELECT name FROM sqlite_master WHERE name = 'imsbc_vec'")
+      .get();
+    expect(before).toBeTruthy();
+
+    await expect(
+      embedAndStore([chunk], { tableName: "imsbc_vec; DROP TABLE imsbc_vec; --", db })
+    ).rejects.toThrow(/Invalid table name/);
+
+    // The guard threw before any SQL ran — the table must still exist and be empty.
+    const after = db
+      .prepare("SELECT name FROM sqlite_master WHERE name = 'imsbc_vec'")
+      .get();
+    expect(after).toBeTruthy();
+    const rows = db.prepare("SELECT COUNT(*) AS n FROM imsbc_vec").get() as { n: number };
+    expect(rows.n).toBe(0);
+    expect(_mockEmbedDocuments).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty / whitespace-only table name (MED01) with a guard error", async () => {
+    await expect(
+      embedAndStore([chunk], { tableName: "   ", db })
+    ).rejects.toThrow(/tableName is required/);
+  });
+
+  it("accepts an allowlisted vec table (imsbc_vec) without throwing", async () => {
+    await expect(
+      embedAndStore([chunk], { tableName: "imsbc_vec", db })
     ).resolves.not.toThrow();
   });
 });

--- a/__tests__/regression/RC6-security-blacklist/spec15-CRIT02-sql-injection-ftstable.test.ts
+++ b/__tests__/regression/RC6-security-blacklist/spec15-CRIT02-sql-injection-ftstable.test.ts
@@ -38,26 +38,45 @@ describe("regression spec15-CRIT02: SQL injection via ftsTable", () => {
     process.env.KNOWLEDGE_RAG_ENABLED = originalEnv;
   });
 
-  it("ftsTable with SQL injection payload must be rejected", async () => {
-    const chunk: Chunk = {
-      content: "Test content",
-      metadata: { source: "imsbc" },
-    };
-
-    // SQL injection attempt: DROP TABLE via ftsTable
+  // U5 / #679 — HONEST REWRITE of the bare `.rejects.toThrow()` case.
+  // The previous assertion passed on buggy code: the malicious ftsTable crashed
+  // db.prepare with a SQLite syntax error, satisfying `.toThrow()` even with the
+  // allowlist guard removed. We now assert the ALLOWLIST message specifically,
+  // add a plausible non-allowlisted sentinel ("user_fts"), and verify the guard
+  // fires before any FTS SQL is prepared.
+  it("rejects a ;DROP TABLE ftsTable payload with the ALLOWLIST error (not a SQLite crash)", async () => {
+    const chunk: Chunk = { content: "Test content", metadata: { source: "imsbc" } };
     const maliciousFtsTable = "imsbc_fts; DROP TABLE imsbc_fts; --";
-
-    // EXPECTED: Should throw error (table name validation)
-    // ACTUAL (buggy code): Executes SQL injection
     await expect(
-      embedAndStore([chunk], {
-        tableName: "imsbc_vec",
-        ftsTable: maliciousFtsTable,
-        db,
-      })
-    ).rejects.toThrow();
-    // NOTE: Test currently PASSES on buggy code (SQL injection succeeds)
-    // After fix: should throw Error("Invalid ftsTable")
+      embedAndStore([chunk], { tableName: "imsbc_vec", ftsTable: maliciousFtsTable, db })
+    ).rejects.toThrow(/Invalid ftsTable name/);
+  });
+
+  it("rejects a plausible non-allowlisted ftsTable (user_fts) — the true guard sentinel", async () => {
+    // "user_fts" is a valid SQL identifier — it would NOT crash db.prepare(). The
+    // allowlist is the only thing rejecting it. Remove the allowlist and the SUT
+    // would attempt INSERT INTO user_fts instead of throwing.
+    const chunk: Chunk = { content: "Test content", metadata: { source: "imsbc" } };
+    await expect(
+      embedAndStore([chunk], { tableName: "imsbc_vec", ftsTable: "user_fts", db })
+    ).rejects.toThrow(/Invalid ftsTable name: user_fts/);
+  });
+
+  it("fires the ftsTable guard BEFORE preparing any FTS insert — db.prepare never runs", async () => {
+    const chunk: Chunk = { content: "Test content", metadata: { source: "imsbc" } };
+    const prepareSpy = jest.spyOn(db, "prepare");
+    await expect(
+      embedAndStore([chunk], { tableName: "imsbc_vec", ftsTable: "imsbc_fts; DROP TABLE imsbc_fts; --", db })
+    ).rejects.toThrow(/Invalid ftsTable name/);
+    expect(prepareSpy).not.toHaveBeenCalled();
+    prepareSpy.mockRestore();
+  });
+
+  it("rejects an empty / whitespace-only ftsTable with a guard error", async () => {
+    const chunk: Chunk = { content: "Test content", metadata: { source: "imsbc" } };
+    await expect(
+      embedAndStore([chunk], { tableName: "imsbc_vec", ftsTable: "   ", db })
+    ).rejects.toThrow(/ftsTable must be a non-empty string/);
   });
 
   it("ftsTable with UNION injection must be rejected", async () => {

--- a/__tests__/regression/test_forward_parser_edge_cases.test.ts
+++ b/__tests__/regression/test_forward_parser_edge_cases.test.ts
@@ -41,6 +41,13 @@ import { callAiJson } from '@/lib/openai';
 
 const mockCallAiJson = callAiJson as jest.MockedFunction<typeof callAiJson>;
 
+// U2: forward-parser now routes through @/lib/ai-provider (was hard-pinned to
+// @/lib/openai). Pin AI_PROVIDER=openai so the shim delegates to the mocked
+// @/lib/openai layer asserted here (ambient .env sets AI_PROVIDER=gemini).
+beforeEach(() => {
+  process.env.AI_PROVIDER = 'openai';
+});
+
 // Helper: build a minimal WhatsAppIncomingMessage with arbitrary type
 function makeMsg(type: string, extra: Record<string, unknown> = {}): WhatsAppIncomingMessage {
   return {

--- a/__tests__/regression/test_parsers_normalizers_adv.test.ts
+++ b/__tests__/regression/test_parsers_normalizers_adv.test.ts
@@ -60,6 +60,10 @@ describe('ATTACK-4 — forward-parser adversarial edge cases', () => {
     jest.resetAllMocks();
     // Re-setup mockClient.downloadMedia default after reset
     mockClientDownloadMedia.mockResolvedValue({ url: 'http://mock/media', mimeType: 'image/jpeg' });
+    // U2: forward-parser now routes through @/lib/ai-provider (was hard-pinned to
+    // @/lib/openai). Pin AI_PROVIDER=openai so the shim delegates to the mocked
+    // @/lib/openai layer asserted here (ambient .env sets AI_PROVIDER=gemini).
+    process.env.AI_PROVIDER = 'openai';
   });
 
   // ---- BUG CANDIDATE: cargoType always hardcoded to 'BULK' ----

--- a/app/api/admin/cron-heartbeat/route.ts
+++ b/app/api/admin/cron-heartbeat/route.ts
@@ -113,8 +113,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       last_seen_at: lastSeenAt,
     });
   } catch (error) {
+    // L-8: log server-side, do not reflect the raw error string to the client.
+    console.error('[cron-heartbeat] failed to store heartbeat:', error);
     return NextResponse.json(
-      { error: 'Failed to store heartbeat', details: String(error) },
+      { error: 'Failed to store heartbeat' },
       { status: 500 }
     );
   }

--- a/app/api/admin/knowledge/refresh/route.ts
+++ b/app/api/admin/knowledge/refresh/route.ts
@@ -73,8 +73,10 @@ export async function POST(req: NextRequest) {
   try {
     syncLogId = reportSyncStarted(db, slug);
   } catch (error) {
+    // L-8: log server-side, do not reflect the raw error string to the client.
+    console.error('[knowledge/refresh] failed to create sync log entry:', error);
     return NextResponse.json(
-      { error: 'Failed to create sync log entry', details: String(error) },
+      { error: 'Failed to create sync log entry' },
       { status: 500 }
     );
   }
@@ -112,9 +114,10 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // L-8: log the real cause server-side (done above), return generic message.
     return NextResponse.json(
       {
-        error: `Failed to start refresh process: ${err.message}`,
+        error: 'Failed to start refresh process',
         sync_log_id: syncLogId,
         slug,
         status: 'failed',

--- a/app/api/agent/execute/route.ts
+++ b/app/api/agent/execute/route.ts
@@ -69,8 +69,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
     return NextResponse.json(result, { status: 200 });
   } catch (err) {
+    // L-8: log server-side, return a stable generic code (no raw message leak).
+    console.error('[agent/execute] executePlan failed:', err);
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : 'execute_failed' },
+      { error: 'execute_failed' },
       { status: 400 },
     );
   }

--- a/app/api/agent/plan/route.ts
+++ b/app/api/agent/plan/route.ts
@@ -38,8 +38,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const plan = await buildPlan(parsed.data.goal, parsed.data.context ?? {});
     return NextResponse.json(plan, { status: 200 });
   } catch (err) {
+    // L-8: log server-side, return a stable generic code (no raw message leak).
+    console.error('[agent/plan] buildPlan failed:', err);
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : 'plan_failed' },
+      { error: 'plan_failed' },
       { status: 500 },
     );
   }

--- a/app/api/ai/match/__tests__/route.test.ts
+++ b/app/api/ai/match/__tests__/route.test.ts
@@ -300,6 +300,25 @@ describe('POST /api/ai/match — provider migration (γv-06)', () => {
     expect((opts as { timeoutMs?: number }).timeoutMs).toBeGreaterThan(0);
   });
 
+  // U2 (issue 663): the route must thread request.signal so a client disconnect
+  // cancels the in-flight LLM call. Without this, the LLMTimeoutError catch is
+  // dead code on gemini/bedrock.
+  it('threads request.signal into callAiJson opts (client-disconnect cancellation)', async () => {
+    mockGetSession.mockReturnValue(baseSession);
+    mockAnalyzePairs.mockImplementation(async (cargos, vessels, aiScorer) => {
+      await aiScorer({ cargoData: cargos, vesselData: vessels, readinessData: [] });
+      return { matches: [], blockedMatches: [] };
+    });
+    mockCallAiJson.mockResolvedValue({ matches: [] });
+
+    const req = makeRequest('session-1');
+    await POST(req);
+
+    const [, , , opts] = mockCallAiJson.mock.calls[0];
+    expect((opts as { signal?: AbortSignal }).signal).toBeDefined();
+    expect((opts as { signal?: AbortSignal }).signal).toBe(req.signal);
+  });
+
   // ── Provider-specific routing ─────────────────────────────────────────────────
   // These tests verify that MATCH_PROVIDER env drives provider selection through shim
 

--- a/app/api/ai/match/route.ts
+++ b/app/api/ai/match/route.ts
@@ -91,7 +91,10 @@ export async function POST(request: NextRequest) {
       'MATCH',
       matchSystemPrompt,
       promptPayload,
-      { timeoutMs: endpointLlmTimeout(120) },
+      // Thread request.signal so a client disconnect cancels the in-flight LLM
+      // call. Without this the gemini/bedrock branches never see an abort and
+      // the LLMTimeoutError catch below is dead code on those providers.
+      { timeoutMs: endpointLlmTimeout(120), signal: request.signal },
     );
 
     return result.matches || [];

--- a/app/api/analytics/roi/route.ts
+++ b/app/api/analytics/roi/route.ts
@@ -51,7 +51,8 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(summary, { status: 200 });
   } catch (error: any) {
+    // L-8: log server-side, return generic message (no raw error.message leak).
     console.error("GET /api/analytics/roi error:", error);
-    return NextResponse.json({ error: error.message || "Internal server error" }, { status: 500 });
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/app/api/canal/[canal_code]/route.ts
+++ b/app/api/canal/[canal_code]/route.ts
@@ -72,8 +72,10 @@ export async function GET(
       const result = quoteCanal('suez', suezInput);
       return NextResponse.json(result);
     } catch (err) {
+      // L-8: log server-side, return generic message.
+      console.error('[canal] quoteCanal failed:', err);
       return NextResponse.json(
-        { error: (err as Error).message },
+        { error: 'Internal server error' },
         { status: 500 }
       );
     }
@@ -89,8 +91,10 @@ export async function GET(
     const result = quoteCanal(canal_code as CanalCode, input);
     return NextResponse.json(result);
   } catch (err) {
+    // L-8: log server-side, return generic message.
+    console.error('[canal] quoteCanal failed:', err);
     return NextResponse.json(
-      { error: (err as Error).message },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/app/api/charterers/[id]/route.ts
+++ b/app/api/charterers/[id]/route.ts
@@ -51,8 +51,10 @@ export async function GET(
 
     return NextResponse.json(charterer, { status: 200 });
   } catch (error) {
+    // L-8: log the real error server-side, return a generic message to the client.
+    console.error('[charterers/:id] request failed:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -125,8 +127,10 @@ export async function PUT(
 
     return NextResponse.json(updated, { status: 200 });
   } catch (error) {
+    // L-8: log the real error server-side, return a generic message to the client.
+    console.error('[charterers/:id] request failed:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -160,8 +164,10 @@ export async function DELETE(
 
     return new NextResponse(null, { status: 204 });
   } catch (error) {
+    // L-8: log the real error server-side, return a generic message to the client.
+    console.error('[charterers/:id] request failed:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/app/api/charterers/route.ts
+++ b/app/api/charterers/route.ts
@@ -39,8 +39,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json({ charterers }, { status: 200 });
   } catch (error) {
+    // L-8: log the real error server-side, return a generic message to the client.
+    console.error('[charterers] request failed:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }
@@ -115,8 +117,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(charterer, { status: 201 });
   } catch (error) {
+    // L-8: log the real error server-side, return a generic message to the client.
+    console.error('[charterers] request failed:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/app/api/economics/route.ts
+++ b/app/api/economics/route.ts
@@ -54,9 +54,10 @@ export async function POST(request: NextRequest) {
     cache.set(cacheKey, { result, cachedAt: Date.now() });
     return NextResponse.json(result);
   } catch (err) {
-    console.error('[economics] computeEconomics failed:', (err as Error).message);
+    // L-8: log server-side, do not reflect the raw error message to the client.
+    console.error('[economics] computeEconomics failed:', err);
     return NextResponse.json(
-      { error: 'Economics calculation failed', detail: (err as Error).message },
+      { error: 'Economics calculation failed' },
       { status: 500 }
     );
   }

--- a/app/api/health/knowledge/route.ts
+++ b/app/api/health/knowledge/route.ts
@@ -39,11 +39,13 @@ export async function GET(): Promise<NextResponse> {
       { status: httpStatus },
     );
   } catch (error) {
+    // L-8: log server-side, do not reflect the raw error message to the client.
+    console.error('[health/knowledge] health check failed:', error);
     return NextResponse.json(
       {
         status: 'error',
         timestamp: new Date().toISOString(),
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: 'Internal server error',
       },
       { status: 500 },
     );

--- a/app/api/integrations/pipedrive/oauth/route.ts
+++ b/app/api/integrations/pipedrive/oauth/route.ts
@@ -47,11 +47,28 @@ export async function GET(req: NextRequest): Promise<Response> {
     authUrl.searchParams.set('redirect_uri', redirectUri);
     authUrl.searchParams.set('state', csrfState);
 
+    // L-4: harden the CSRF-state cookie.
+    // - Secure: never send the state over plaintext HTTP (skipped in dev so the
+    //   localhost flow still works without TLS).
+    // - Max-Age: bound the cookie's lifetime to the OAuth round-trip (10 min)
+    //   instead of leaving a dangling session cookie.
+    const isProduction = process.env.NODE_ENV === 'production';
+    const stateCookie = [
+      `${STATE_COOKIE}=${csrfState}`,
+      'HttpOnly',
+      'Path=/',
+      'SameSite=Lax',
+      'Max-Age=600',
+      isProduction ? 'Secure' : '',
+    ]
+      .filter(Boolean)
+      .join('; ');
+
     return new Response(null, {
       status: 302,
       headers: {
         location: authUrl.toString(),
-        'set-cookie': `${STATE_COOKIE}=${csrfState}; HttpOnly; Path=/; SameSite=Lax`,
+        'set-cookie': stateCookie,
       },
     });
   }

--- a/app/api/laytime/calculate/route.ts
+++ b/app/api/laytime/calculate/route.ts
@@ -117,9 +117,10 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(response);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
+    // L-8: log server-side, do not reflect the raw error message to the client.
+    console.error('[laytime/calculate] calculation failed:', error);
     return NextResponse.json(
-      { error: 'Failed to calculate laytime', details: message },
+      { error: 'Failed to calculate laytime' },
       { status: 400 }
     );
   }

--- a/app/api/laytime/parse-sof/route.ts
+++ b/app/api/laytime/parse-sof/route.ts
@@ -70,9 +70,10 @@ export async function POST(request: NextRequest) {
     const result = parseSof(typedBody.text);
     return NextResponse.json(result);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
+    // L-8: log server-side, do not reflect the raw error message to the client.
+    console.error('[laytime/parse-sof] parse failed:', error);
     return NextResponse.json(
-      { error: "Failed to parse SOF", details: message },
+      { error: "Failed to parse SOF" },
       { status: 500 }
     );
   }

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -167,9 +167,11 @@ async function resolveDistanceNm(
     );
     return { distanceNm: result.distanceNm };
   } catch (err) {
+    // L-8: log server-side, return a generic message (no raw error leak).
+    console.error('[voyage/tce] distance auto-resolve failed:', err);
     return {
       distanceNm: 0,
-      error: `Cannot auto-resolve distance: ${err instanceof Error ? err.message : String(err)}`,
+      error: 'Cannot auto-resolve distance',
     };
   }
 }

--- a/components/charterers/CharterersTable.tsx
+++ b/components/charterers/CharterersTable.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 
 export interface Charterer {

--- a/components/clickable-field.tsx
+++ b/components/clickable-field.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { SourceQuotePopover } from './source-quote-popover';
 
 interface Props {

--- a/components/dashboard/DashboardKpiStrip.tsx
+++ b/components/dashboard/DashboardKpiStrip.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import { Card } from '@/design-system/primitives';
 import { KpiCard } from '@/components/market/KpiCard';

--- a/components/dashboard/MarketIntelligence.tsx
+++ b/components/dashboard/MarketIntelligence.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { KpiCard } from '@/components/market/KpiCard';
 
 interface MarketIntelligenceProps {

--- a/components/market/FixturesSection.tsx
+++ b/components/market/FixturesSection.tsx
@@ -1,4 +1,3 @@
-'use client';
 import Link from 'next/link';
 
 interface FixtureRow {

--- a/components/market/KnowledgeFeed.tsx
+++ b/components/market/KnowledgeFeed.tsx
@@ -1,4 +1,3 @@
-'use client';
 import Link from 'next/link';
 
 interface KnowledgeRow {

--- a/components/market/RoutesSection.tsx
+++ b/components/market/RoutesSection.tsx
@@ -1,4 +1,3 @@
-'use client';
 import Link from 'next/link';
 
 type DeltaDir = 'up' | 'down' | 'flat';

--- a/lib/__tests__/ai-provider-abort-cache.test.ts
+++ b/lib/__tests__/ai-provider-abort-cache.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for U2 (issue 663 + 674): AI-provider abort/timeout threading + caching.
+ *
+ * Covers the Phase-0 findings:
+ *  - callGeminiText threads abortSignal + timeoutMs (was dropped).
+ *  - callBedrockText threads abortSignal + requestTimeout (both were dropped).
+ *  - Bedrock system block carries cache_control (MATCH_PROMPT prefix caching).
+ *  - A hung gemini/bedrock call rejects with LLMTimeoutError (previously dead
+ *    code on those providers).
+ *  - A caller-supplied signal that is already aborted cancels the call.
+ *
+ * All providers are MOCKED — no real network.
+ */
+
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+
+// ── Mock providers ───────────────────────────────────────────────────────────
+
+jest.mock('@/lib/openai', () => {
+  const ActualErr = jest.requireActual('@/lib/openai').LLMTimeoutError;
+  return {
+    callAiJson: jest.fn().mockResolvedValue({ result: 'openai-json' }),
+    callAiText: jest.fn().mockResolvedValue('openai-text'),
+    LLMTimeoutError: ActualErr,
+  };
+});
+
+const mockGeminiGenerate = jest.fn();
+jest.mock('@google/genai', () => ({
+  GoogleGenAI: jest.fn().mockImplementation(() => ({
+    models: { generateContent: mockGeminiGenerate },
+  })),
+}), { virtual: true });
+
+const mockBedrockSend = jest.fn();
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn().mockImplementation((opts: unknown) => ({
+    __ctorOpts: opts,
+    send: mockBedrockSend,
+  })),
+  InvokeModelCommand: jest.fn().mockImplementation((opts: unknown) => opts),
+}), { virtual: true });
+
+let testDb: Database.Database;
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: jest.fn(() => testDb) })),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function setEnv(vars: Record<string, string | undefined>): void {
+  for (const [k, v] of Object.entries(vars)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+const GEMINI_ENV = {
+  AI_PROVIDER: 'gemini',
+  GOOGLE_APPLICATION_CREDENTIALS: '/dev/null',
+  GOOGLE_CLOUD_PROJECT: 'test-project',
+  AI_MODEL_GEMINI_DEFAULT: 'gemini-2.5-flash',
+};
+
+const BEDROCK_ENV = {
+  AI_PROVIDER: 'bedrock',
+  AWS_REGION: 'us-east-1',
+  AWS_ACCESS_KEY_ID: 'k',
+  AWS_SECRET_ACCESS_KEY: 's',
+  BEDROCK_MODEL_ID: 'anthropic.claude-opus-4-7',
+};
+
+function clearEnv(): void {
+  const keys = [
+    'AI_PROVIDER', 'MATCH_PROVIDER',
+    'GOOGLE_APPLICATION_CREDENTIALS', 'GOOGLE_CLOUD_PROJECT', 'GOOGLE_CLOUD_LOCATION',
+    'AI_MODEL_GEMINI_DEFAULT',
+    'AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'BEDROCK_MODEL_ID',
+  ];
+  for (const k of keys) delete process.env[k];
+}
+
+beforeEach(() => {
+  testDb = new Database(':memory:');
+  runMigrations(testDb, allMigrations);
+  clearEnv();
+  jest.clearAllMocks();
+  const sessionStore = require('@/lib/session-store');
+  (sessionStore.getStore as jest.Mock).mockReturnValue({ getDatabase: jest.fn(() => testDb) });
+  // Sensible default resolutions
+  mockGeminiGenerate.mockResolvedValue({ text: '{"ok":true}' });
+  mockBedrockSend.mockResolvedValue({
+    body: new TextEncoder().encode(JSON.stringify({ content: [{ text: '{"ok":true}' }] })),
+  });
+});
+
+afterEach(() => testDb.close());
+
+// ── Gemini: abortSignal + timeoutMs ─────────────────────────────────────────
+
+describe('callGeminiText threads abortSignal + timeoutMs', () => {
+  it('passes an AbortSignal into the Gemini generateContent config', async () => {
+    setEnv(GEMINI_ENV);
+    const { callAiText } = require('@/lib/ai-provider');
+    await callAiText('classify', 'sys', 'user', { timeoutMs: 5000 });
+
+    expect(mockGeminiGenerate).toHaveBeenCalledTimes(1);
+    const cfg = mockGeminiGenerate.mock.calls[0][0].config;
+    expect(cfg.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(cfg.abortSignal.aborted).toBe(false);
+  });
+
+  it('aborts the Gemini signal when the caller-supplied signal is already aborted', async () => {
+    setEnv(GEMINI_ENV);
+    const { callAiText } = require('@/lib/ai-provider');
+    const ac = new AbortController();
+    ac.abort();
+    await callAiText('classify', 'sys', 'user', { signal: ac.signal });
+
+    const cfg = mockGeminiGenerate.mock.calls[0][0].config;
+    expect(cfg.abortSignal.aborted).toBe(true);
+  });
+
+  it('rejects with LLMTimeoutError when the Gemini call never resolves within timeoutMs', async () => {
+    setEnv(GEMINI_ENV);
+    // Never-resolving generateContent → the internal timeout must fire.
+    mockGeminiGenerate.mockImplementation(() => new Promise(() => {}));
+    const { callAiText } = require('@/lib/ai-provider');
+    const { LLMTimeoutError } = require('@/lib/openai');
+    await expect(callAiText('classify', 'sys', 'user', { timeoutMs: 20 })).rejects.toBeInstanceOf(
+      LLMTimeoutError,
+    );
+  });
+});
+
+// ── Bedrock: abortSignal + requestTimeout + cache_control ────────────────────
+
+describe('callBedrockText threads abortSignal + requestTimeout', () => {
+  it('passes { abortSignal } as the 2nd arg to client.send', async () => {
+    setEnv(BEDROCK_ENV);
+    const { callAiText } = require('@/lib/ai-provider');
+    await callAiText('match', 'sys', 'user', { timeoutMs: 5000 });
+
+    expect(mockBedrockSend).toHaveBeenCalledTimes(1);
+    const sendOpts = mockBedrockSend.mock.calls[0][1];
+    expect(sendOpts).toBeDefined();
+    expect(sendOpts.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('sets requestHandler.requestTimeout from timeoutMs on the Bedrock client', async () => {
+    setEnv(BEDROCK_ENV);
+    const { BedrockRuntimeClient } = require('@aws-sdk/client-bedrock-runtime');
+    const { callAiText } = require('@/lib/ai-provider');
+    await callAiText('match', 'sys', 'user', { timeoutMs: 7777 });
+
+    const ctorOpts = (BedrockRuntimeClient as jest.Mock).mock.calls[0][0];
+    expect(ctorOpts.requestHandler?.requestTimeout).toBe(7777);
+  });
+
+  it('marks the system block with cache_control ephemeral (MATCH prefix caching)', async () => {
+    setEnv(BEDROCK_ENV);
+    const { callAiText } = require('@/lib/ai-provider');
+    await callAiText('match', 'STATIC-MATCH-PREFIX', 'user', {});
+
+    // InvokeModelCommand receives the JSON-stringified payload as body.
+    const cmdArg = mockBedrockSend.mock.calls[0][0];
+    const payload = JSON.parse(cmdArg.body);
+    expect(Array.isArray(payload.system)).toBe(true);
+    expect(payload.system[0].text).toBe('STATIC-MATCH-PREFIX');
+    expect(payload.system[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('rejects with LLMTimeoutError when an aborted caller signal cancels the Bedrock call', async () => {
+    setEnv(BEDROCK_ENV);
+    // Simulate the SDK throwing an AbortError once the signal is aborted.
+    mockBedrockSend.mockImplementation((_cmd: unknown, opts?: { abortSignal?: AbortSignal }) => {
+      if (opts?.abortSignal?.aborted) {
+        const e = new Error('Request aborted');
+        e.name = 'AbortError';
+        return Promise.reject(e);
+      }
+      return Promise.resolve({
+        body: new TextEncoder().encode(JSON.stringify({ content: [{ text: '{}' }] })),
+      });
+    });
+    const ac = new AbortController();
+    ac.abort();
+    const { callAiText } = require('@/lib/ai-provider');
+    const { LLMTimeoutError } = require('@/lib/openai');
+    await expect(callAiText('match', 'sys', 'user', { signal: ac.signal })).rejects.toBeInstanceOf(
+      LLMTimeoutError,
+    );
+  });
+});

--- a/lib/__tests__/ai-provider-abort-cache.test.ts
+++ b/lib/__tests__/ai-provider-abort-cache.test.ts
@@ -166,13 +166,16 @@ describe('callBedrockText threads abortSignal + requestTimeout', () => {
   it('marks the system block with cache_control ephemeral (MATCH prefix caching)', async () => {
     setEnv(BEDROCK_ENV);
     const { callAiText } = require('@/lib/ai-provider');
-    await callAiText('match', 'STATIC-MATCH-PREFIX', 'user', {});
+    // BUG-2: cache_control is gated to a MATCH-sized prefix (>= CACHE_MIN_CHARS=4000).
+    // Short prompts intentionally skip the breakpoint (covered by ai-provider-bedrock-cache.test.ts).
+    const matchPrefix = 'STATIC-MATCH-PREFIX '.repeat(250);
+    await callAiText('match', matchPrefix, 'user', {});
 
     // InvokeModelCommand receives the JSON-stringified payload as body.
     const cmdArg = mockBedrockSend.mock.calls[0][0];
     const payload = JSON.parse(cmdArg.body);
     expect(Array.isArray(payload.system)).toBe(true);
-    expect(payload.system[0].text).toBe('STATIC-MATCH-PREFIX');
+    expect(payload.system[0].text).toBe(matchPrefix);
     expect(payload.system[0].cache_control).toEqual({ type: 'ephemeral' });
   });
 

--- a/lib/__tests__/analytics-import-guard.test.ts
+++ b/lib/__tests__/analytics-import-guard.test.ts
@@ -1,0 +1,36 @@
+/**
+ * BUG-5 (LOW) — analytics.track() / initAnalytics() use `await import('posthog-js')`.
+ * Four callers fire these un-awaited, so a failed dynamic import (network/bundle
+ * error) floats an UNHANDLED PROMISE REJECTION. The functions must swallow load/init
+ * failures internally so they always resolve, never reject into an un-awaited caller.
+ *
+ * Here `import('posthog-js')` is mocked to FAIL. track()/initAnalytics() must still
+ * resolve (undefined) without throwing — proving an un-awaited caller can't float a
+ * rejection. We keep the deferred-bundle win (still a dynamic import, no static one).
+ */
+jest.mock('posthog-js', () => {
+  throw new Error('simulated posthog-js load failure');
+});
+
+describe('analytics — dynamic import failure must not reject (BUG-5)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, NEXT_PUBLIC_POSTHOG_KEY: 'test-key' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('track() resolves (no unhandled rejection) when posthog-js fails to load', async () => {
+    const { track } = await import('../analytics');
+    await expect(track('evt', { a: 1 })).resolves.toBeUndefined();
+  });
+
+  it('initAnalytics() resolves when posthog-js fails to load', async () => {
+    const { initAnalytics } = await import('../analytics');
+    await expect(initAnalytics()).resolves.toBeUndefined();
+  });
+});

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -22,6 +22,7 @@ describe('analytics', () => {
       const { track } = await import('../analytics')
       const { default: posthog } = await import('posthog-js')
       track('test_event')
+      await Promise.resolve()
       expect(posthog.capture).not.toHaveBeenCalled()
     })
 
@@ -32,6 +33,7 @@ describe('analytics', () => {
       const { track } = await import('../analytics')
       const { default: posthog } = await import('posthog-js')
       track('test_event')
+      await Promise.resolve()
       expect(posthog.capture).not.toHaveBeenCalled()
       windowSpy.mockRestore()
     })
@@ -40,7 +42,7 @@ describe('analytics', () => {
       process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key'
       const { track } = await import('../analytics')
       const { default: posthog } = await import('posthog-js')
-      track('test_event', { foo: 'bar' })
+      await track('test_event', { foo: 'bar' })
       expect(posthog.capture).toHaveBeenCalledWith('test_event', { foo: 'bar' })
     })
 
@@ -48,7 +50,7 @@ describe('analytics', () => {
       process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key'
       const { track } = await import('../analytics')
       const { default: posthog } = await import('posthog-js')
-      track('test_event')
+      await track('test_event')
       expect(posthog.capture).toHaveBeenCalledWith('test_event', undefined)
     })
   })
@@ -77,7 +79,7 @@ describe('analytics', () => {
       process.env.NEXT_PUBLIC_POSTHOG_KEY = 'test-key'
       const { initAnalytics } = await import('../analytics')
       const { default: posthog } = await import('posthog-js')
-      initAnalytics()
+      await initAnalytics()
       expect(posthog.init).toHaveBeenCalledWith('test-key', expect.objectContaining({
         api_host: 'https://app.posthog.com',
       }))

--- a/lib/__tests__/laytime-dd-money-sign.test.ts
+++ b/lib/__tests__/laytime-dd-money-sign.test.ts
@@ -1,0 +1,117 @@
+/**
+ * U5 / #679 — Laytime → Demurrage/Despatch MONEY-SIGN integration guard.
+ *
+ * Audit finding (COVERAGE_GAP, high): "calculator.ts portHolidays +
+ * weatherDelayHours directly subtract from used laytime and swing
+ * demurrage/despatch money. A sign error or off-by-one in charterparty D/D money
+ * calc would be invisible."
+ *
+ * The existing lib/__tests__/laytime-calculator.test.ts proves portHolidays and
+ * weatherDelayHours move usedLaytimeHours (and are mutation-honest about it). The
+ * gap that remained: no test runs the FULL pipeline calculateLaytime ->
+ * calculateDemurrageDespatch and asserts that those exclusions FLIP the money
+ * SIGN (charterer-pays demurrage vs. owner-pays despatch) and produce the correct
+ * dollar figure. A sign error in the deduction would silently invert who owes
+ * whom thousands of USD.
+ *
+ * Both SUTs are the REAL functions — nothing is mocked. Mutation contract is
+ * documented per-assertion; verified in the U5 report.
+ */
+
+import { calculateLaytime } from '../laytime/calculator';
+import { calculateDemurrageDespatch } from '../laytime/dd-calculator';
+import type { LaytimeInput } from '../types';
+
+const DEMURRAGE_RATE = 8000; // USD/day
+const DESPATCH_RATE = 4000; // USD/day (half demurrage, the dd-calculator default)
+
+describe('laytime → D/D money sign: portHolidays flips demurrage → despatch', () => {
+  // Window: 6 full SHEX days (May 11 Mon … May 16 Sat), 5 days allowed.
+  // Without holidays → 6 days used vs 5 allowed → 24h demurrage (charterer PAYS).
+  // Add 2 port holidays inside the window → 4 days counted vs 5 allowed →
+  //   despatch (owner is PAID). The sign MUST flip.
+  const base: LaytimeInput = {
+    allowedLaytimeDays: 5,
+    mode: 'SHEX',
+    commencedAt: '2026-05-11T00:00:00Z', // Monday
+    completedAt: '2026-05-17T00:00:00Z', // Sunday (excluded by SHEX) → 6 counted days Mon–Sat
+  };
+
+  it('NO holidays → demurrage, charterer pays a positive netAmount', () => {
+    const laytime = calculateLaytime(base);
+    expect(laytime.demurrageOrDespatch).toBe('demurrage');
+    const money = calculateDemurrageDespatch({
+      laytimeResult: laytime,
+      demurrageRateUsdPerDay: DEMURRAGE_RATE,
+      despatchRateUsdPerDay: DESPATCH_RATE,
+    });
+    expect(money.status).toBe('demurrage');
+    // netHours ≈ +24 → 1 day demurrage → +$8000 owed by charterer.
+    expect(money.netAmount).toBeCloseTo(DEMURRAGE_RATE, 0);
+    expect(money.netAmount).toBeGreaterThan(0);
+    expect(money.despatchAmount).toBe(0);
+  });
+
+  it('TWO port holidays inside the window → despatch, owner is paid (negative netAmount)', () => {
+    const withHolidays: LaytimeInput = {
+      ...base,
+      portHolidays: ['2026-05-13', '2026-05-14'], // Wed + Thu inside the window
+    };
+    const laytime = calculateLaytime(withHolidays);
+    // 6 counted days minus 2 holidays = 4 days used vs 5 allowed.
+    expect(laytime.usedLaytimeHours).toBeCloseTo(4 * 24, 1);
+    expect(laytime.demurrageOrDespatch).toBe('despatch');
+
+    const money = calculateDemurrageDespatch({
+      laytimeResult: laytime,
+      demurrageRateUsdPerDay: DEMURRAGE_RATE,
+      despatchRateUsdPerDay: DESPATCH_RATE,
+    });
+    expect(money.status).toBe('despatch');
+    // netHours ≈ -24 → 1 day despatch at $4000 → netAmount = -$4000 (owner earns).
+    expect(money.netAmount).toBeCloseTo(-DESPATCH_RATE, 0);
+    expect(money.netAmount).toBeLessThan(0);
+    expect(money.demurrageAmount).toBe(0);
+  });
+});
+
+describe('laytime → D/D money sign: weatherDelayHours flips demurrage → despatch dollars', () => {
+  // 6 SHINC days used vs 5 allowed → 24h demurrage = $8000 owed by charterer.
+  // 36h weather delay deducted → 4.5 days used vs 5 allowed → 12h DESPATCH.
+  // A SIGN error (ADDING weather delay instead of subtracting) would push to 60h
+  // demurrage → +$20000 the WRONG WAY. This asserts the dollar sign + magnitude.
+  const base: LaytimeInput = {
+    allowedLaytimeDays: 5,
+    mode: 'SHINC',
+    commencedAt: '2026-05-12T00:00:00Z',
+    completedAt: '2026-05-18T00:00:00Z', // 6 days
+  };
+
+  it('without weather delay → 24h demurrage = $8000 (charterer pays)', () => {
+    const laytime = calculateLaytime(base);
+    const money = calculateDemurrageDespatch({
+      laytimeResult: laytime,
+      demurrageRateUsdPerDay: DEMURRAGE_RATE,
+    });
+    expect(money.status).toBe('demurrage');
+    expect(money.demurrageAmount).toBeCloseTo(DEMURRAGE_RATE, 0); // 1 day × $8000
+    expect(money.netAmount).toBeGreaterThan(0);
+  });
+
+  it('36h weather delay flips to despatch — owner earns $2000 (proves SUBTRACTION, not addition)', () => {
+    const laytime = calculateLaytime({ ...base, weatherDelayHours: 36 });
+    expect(laytime.usedLaytimeHours).toBeCloseTo(4.5 * 24, 1); // 6 days − 36h = 4.5 days
+    expect(laytime.demurrageOrDespatch).toBe('despatch');
+    const money = calculateDemurrageDespatch({
+      laytimeResult: laytime,
+      demurrageRateUsdPerDay: DEMURRAGE_RATE,
+      despatchRateUsdPerDay: DESPATCH_RATE,
+    });
+    expect(money.status).toBe('despatch');
+    // 12h despatch at $4000/day = $2000 earned by owner → negative netAmount.
+    expect(money.despatchAmount).toBeCloseTo((12 / 24) * DESPATCH_RATE, 0); // $2000
+    expect(money.netAmount).toBeCloseTo(-((12 / 24) * DESPATCH_RATE), 0);
+    expect(money.netAmount).toBeLessThan(0);
+    expect(money.demurrageAmount).toBe(0);
+  });
+});

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -13,6 +13,53 @@ import { logger } from '@/lib/logger';
 import { getStore } from '@/lib/session-store';
 import * as openaiLib from '@/lib/openai';
 
+const DEFAULT_TIMEOUT_MS = 85_000;
+
+/**
+ * Compose an internal timeout AbortController with an optional caller-supplied
+ * signal. Mirrors lib/openai.ts `buildAbortController` so gemini/bedrock get the
+ * same abort+timeout semantics the openai branch already has.
+ *
+ * Returns the controller (its `.signal` is what providers must thread through),
+ * the resolved timeoutMs, and a `cleanup()` that clears the timer + detaches the
+ * external listener. Whichever of {internal timeout, external signal} fires
+ * first aborts the controller.
+ */
+function buildAbortController(opts: AiOpts | undefined): {
+  controller: AbortController;
+  cleanup: () => void;
+  timeoutMs: number;
+} {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  if (typeof (timeoutId as NodeJS.Timeout).unref === 'function') {
+    (timeoutId as NodeJS.Timeout).unref();
+  }
+
+  const externalSignal = opts?.signal;
+  let externalListener: (() => void) | undefined;
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalListener = () => controller.abort();
+      externalSignal.addEventListener('abort', externalListener);
+    }
+  }
+
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    if (externalSignal && externalListener) {
+      externalSignal.removeEventListener('abort', externalListener);
+    }
+  };
+
+  return { controller, cleanup, timeoutMs };
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type Provider = 'openai' | 'gemini' | 'bedrock' | 'claude-cli';
@@ -507,6 +554,7 @@ async function callGeminiText(
             topP?: number;
             topK?: number;
             seed?: number;
+            abortSignal?: AbortSignal;
           };
         }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
       };
@@ -532,6 +580,7 @@ async function callGeminiText(
     topP?: number;
     topK?: number;
     seed?: number;
+    abortSignal?: AbortSignal;
   } = { systemInstruction: system };
 
   if (opts?.thinkingBudget !== undefined) {
@@ -548,7 +597,14 @@ async function callGeminiText(
 
   Object.assign(config, buildGeminiSamplingFields(opts ?? {}));
 
-  const timeoutMs = opts?.timeoutMs ?? 85_000;
+  // Thread abortSignal + timeoutMs: compose the caller's signal with an internal
+  // timeout controller. The composed signal is passed to the SDK so a
+  // client-disconnect (caller signal) OR the timeout actually CANCELS the
+  // in-flight Vertex request instead of leaking it. The Promise.race below still
+  // surfaces a typed LLMTimeoutError to the caller on timeout.
+  const { controller, cleanup, timeoutMs } = buildAbortController(opts);
+  config.abortSignal = controller.signal;
+
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutHandle = setTimeout(
@@ -567,8 +623,17 @@ async function callGeminiText(
       timeoutPromise,
     ]);
     return { text: response.text ?? '', usage: extractGeminiUsage(response.usageMetadata) };
+  } catch (err) {
+    // If the composed signal aborted (caller disconnect OR timeout), surface a
+    // typed LLMTimeoutError so route-level `instanceof LLMTimeoutError` handling
+    // (504 response) is reachable on the gemini path — previously dead code.
+    if (controller.signal.aborted && !(err instanceof openaiLib.LLMTimeoutError)) {
+      throw new openaiLib.LLMTimeoutError(`Gemini aborted after ${timeoutMs}ms`);
+    }
+    throw err;
   } finally {
     clearTimeout(timeoutHandle);
+    cleanup();
   }
 }
 
@@ -634,11 +699,22 @@ async function callBedrockText(
 ): Promise<{ text: string; usage?: Usage }> {
   assertBedrockEnv();
   const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
-    BedrockRuntimeClient: new (opts: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } }) => {
-      send: (cmd: unknown) => Promise<{ body: Uint8Array }>;
+    BedrockRuntimeClient: new (opts: {
+      region: string;
+      credentials: { accessKeyId: string; secretAccessKey: string };
+      requestHandler?: { requestTimeout?: number };
+    }) => {
+      send: (cmd: unknown, options?: { abortSignal?: AbortSignal }) => Promise<{ body: Uint8Array }>;
     };
     InvokeModelCommand: new (opts: { modelId: string; contentType: string; accept: string; body: string }) => unknown;
   };
+
+  // Thread abortSignal + timeoutMs: compose caller signal with internal timeout.
+  // - requestHandler.requestTimeout caps the socket-level wait at timeoutMs.
+  // - client.send(cmd, { abortSignal }) cancels the in-flight request when the
+  //   composed signal fires (caller disconnect OR timeout) — previously BOTH
+  //   were dropped, so MATCH_PROVIDER=bedrock calls could hang up to maxDuration.
+  const { controller, cleanup, timeoutMs } = buildAbortController(opts);
 
   const client = new BedrockRuntimeClient({
     region: process.env.AWS_REGION!,
@@ -646,12 +722,17 @@ async function callBedrockText(
       accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
     },
+    requestHandler: { requestTimeout: timeoutMs },
   });
 
   const payload = {
     anthropic_version: 'bedrock-2023-05-31',
     ...buildBedrockSamplingFields(opts ?? {}),
-    system,
+    // cache_control on the system block: Anthropic prompt caching bills the
+    // large static prefix (e.g. MATCH_PROMPT ~6956 tok) at the cheaper cache-read
+    // rate on warm hits. `system` accepts a content-block array; the ephemeral
+    // breakpoint marks everything up to here as cacheable.
+    system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
     messages: [{ role: 'user', content: user }],
   };
 
@@ -662,10 +743,21 @@ async function callBedrockText(
     body: JSON.stringify(payload),
   });
 
-  const response = await client.send(cmd);
-  const decoded = new TextDecoder().decode(response.body);
-  const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
-  return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
+  try {
+    const response = await client.send(cmd, { abortSignal: controller.signal });
+    const decoded = new TextDecoder().decode(response.body);
+    const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
+    return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
+  } catch (err) {
+    // Surface a typed LLMTimeoutError on abort/timeout so route-level
+    // `instanceof LLMTimeoutError` (504) is reachable on the bedrock path.
+    if (controller.signal.aborted && !(err instanceof openaiLib.LLMTimeoutError)) {
+      throw new openaiLib.LLMTimeoutError(`Bedrock aborted after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    cleanup();
+  }
 }
 
 async function callBedrockAudio(

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -356,7 +356,12 @@ export function callClaudeCliRaw(
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { spawnSync } = require('child_process') as typeof import('child_process');
 
-  const budget = opts?.maxBudgetUsd ?? 0.05;
+  // Eval-ergonomics: large parser/vessel system prompts (~32-35 KB) plus the
+  // baked-in Claude-Code context can exceed the 0.05 default before any output,
+  // turning every call into a false error_max_budget_usd. Allow an env override
+  // for eval runs (CLAUDE_CLI_MAX_BUDGET_USD). Explicit opts still win; absent
+  // both, the historical 0.05 default is preserved.
+  const budget = opts?.maxBudgetUsd ?? (Number(process.env.CLAUDE_CLI_MAX_BUDGET_USD) || 0.05);
   const args = ['--print', '--model', model, '--output-format', 'json', '--max-budget-usd', String(budget)];
   if (system) {
     args.push('--system-prompt', system);

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -136,6 +136,32 @@ export function buildBedrockSamplingFields(opts: AiOpts): Record<string, unknown
 }
 
 /**
+ * Minimum system-prompt length (chars) before we attach an Anthropic prompt-caching
+ * breakpoint. Bedrock requires a minimum cacheable prefix (~1024 tokens for Claude);
+ * a cache_control marker below that can't form a cache block and is wasted. We gate
+ * on characters as a cheap proxy: at ~3-4 chars/token, 4000 chars is conservatively
+ * above ~1024 tokens, so only a genuinely large static prefix (e.g. MATCH_PROMPT
+ * ~28k chars) carries the breakpoint; short calls (e.g. "hi") do not.
+ */
+export const CACHE_MIN_CHARS = 4000;
+
+type BedrockSystemField =
+  | string
+  | Array<{ type: 'text'; text: string; cache_control: { type: 'ephemeral' } }>;
+
+/**
+ * Builds the Bedrock `system` field, attaching a cache_control ephemeral breakpoint
+ * ONLY when the prefix is large enough to be worth caching (>= CACHE_MIN_CHARS).
+ * Below the threshold it returns a plain string with no breakpoint.
+ */
+export function buildBedrockSystemField(system: string): BedrockSystemField {
+  if (system.length >= CACHE_MIN_CHARS) {
+    return [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }];
+  }
+  return system;
+}
+
+/**
  * Returns Gemini httpOptions with retryOptions when maxRetries is set.
  * Gemini SDK retryOptions.attempts includes the initial call, so attempts = maxRetries + 1.
  * Returns undefined when maxRetries is not specified (SDK uses its default of 5 attempts).
@@ -736,8 +762,9 @@ async function callBedrockText(
     // cache_control on the system block: Anthropic prompt caching bills the
     // large static prefix (e.g. MATCH_PROMPT ~6956 tok) at the cheaper cache-read
     // rate on warm hits. `system` accepts a content-block array; the ephemeral
-    // breakpoint marks everything up to here as cacheable.
-    system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
+    // breakpoint marks everything up to here as cacheable. Gated by prefix size so
+    // short prompts don't carry a wasted breakpoint (see buildBedrockSystemField).
+    system: buildBedrockSystemField(system),
     messages: [{ role: 'user', content: user }],
   };
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -5,14 +5,27 @@ let initialized = false
 export async function initAnalytics() {
   if (typeof window === 'undefined' || !POSTHOG_KEY || initialized) return
   initialized = true
-  const posthog = (await import('posthog-js')).default
-  posthog.init(POSTHOG_KEY, {
-    api_host: 'https://app.posthog.com',
-  })
+  // posthog is best-effort, lazily imported to keep it out of the main bundle.
+  // Several callers fire this un-awaited, so a failed dynamic import/init must be
+  // swallowed here — otherwise it floats an unhandled promise rejection.
+  try {
+    const posthog = (await import('posthog-js')).default
+    posthog.init(POSTHOG_KEY, {
+      api_host: 'https://app.posthog.com',
+    })
+  } catch (err) {
+    console.debug('[analytics] initAnalytics failed (ignored):', err)
+  }
 }
 
 export async function track(event: string, properties?: Record<string, unknown>) {
   if (!POSTHOG_KEY || typeof window === 'undefined') return
-  const posthog = (await import('posthog-js')).default
-  posthog.capture(event, properties)
+  // Same contract as initAnalytics: callers fire-and-forget, so a load/capture
+  // failure is swallowed rather than rejected into an un-awaited caller.
+  try {
+    const posthog = (await import('posthog-js')).default
+    posthog.capture(event, properties)
+  } catch (err) {
+    console.debug('[analytics] track failed (ignored):', err)
+  }
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,18 +1,18 @@
-import posthog from 'posthog-js'
-
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY
 
 let initialized = false
 
-export function initAnalytics() {
+export async function initAnalytics() {
   if (typeof window === 'undefined' || !POSTHOG_KEY || initialized) return
   initialized = true
+  const posthog = (await import('posthog-js')).default
   posthog.init(POSTHOG_KEY, {
     api_host: 'https://app.posthog.com',
   })
 }
 
-export function track(event: string, properties?: Record<string, unknown>) {
+export async function track(event: string, properties?: Record<string, unknown>) {
   if (!POSTHOG_KEY || typeof window === 'undefined') return
+  const posthog = (await import('posthog-js')).default
   posthog.capture(event, properties)
 }

--- a/lib/auth/admin.ts
+++ b/lib/auth/admin.ts
@@ -22,6 +22,27 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+
+/**
+ * Constant-time comparison of two strings (L-3). Encodes to UTF-8 bytes and
+ * compares with crypto.timingSafeEqual. timingSafeEqual throws on unequal
+ * lengths, so we compare both a length-equality flag and a fixed-length digest
+ * to avoid leaking the secret length through early-return timing.
+ */
+function timingSafeStrEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  // Compare against a fixed-length representation so length mismatch does not
+  // short-circuit. We hash neither — just pad to equal length deterministically.
+  const len = Math.max(aBuf.length, bBuf.length);
+  const aPad = Buffer.alloc(len);
+  const bPad = Buffer.alloc(len);
+  aBuf.copy(aPad);
+  bBuf.copy(bPad);
+  const equalBytes = timingSafeEqual(aPad, bPad);
+  return equalBytes && aBuf.length === bBuf.length;
+}
 
 export function requireAdmin(req: NextRequest): NextResponse | null {
   const expected = process.env.ADMIN_TOKEN;
@@ -34,7 +55,7 @@ export function requireAdmin(req: NextRequest): NextResponse | null {
   }
 
   const provided = req.headers.get('X-Admin-Token');
-  if (!provided || provided !== expected) {
+  if (!provided || !timingSafeStrEqual(provided, expected)) {
     return NextResponse.json(
       { error: 'Unauthorized: invalid or missing X-Admin-Token header' },
       { status: 401 },

--- a/lib/auth/admin.ts
+++ b/lib/auth/admin.ts
@@ -22,26 +22,22 @@
 
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-import { timingSafeEqual } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 
 /**
- * Constant-time comparison of two strings (L-3). Encodes to UTF-8 bytes and
- * compares with crypto.timingSafeEqual. timingSafeEqual throws on unequal
- * lengths, so we compare both a length-equality flag and a fixed-length digest
- * to avoid leaking the secret length through early-return timing.
+ * Constant-time comparison of two strings (L-3). Both sides are hashed to a
+ * fixed-width sha256 digest first, then compared with crypto.timingSafeEqual.
+ * Hashing collapses inputs of any length to equal-width (32-byte) digests, so the
+ * comparison is constant-time REGARDLESS of input length — the previous pad-to-
+ * max(len) approach leaked the secret length through length-dependent work, a
+ * timing oracle. Equal digest widths also mean timingSafeEqual never throws.
+ * sha256 of distinct strings differs with overwhelming probability, so digest
+ * equality is equivalent to string equality for this auth check.
  */
 function timingSafeStrEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, 'utf8');
-  const bBuf = Buffer.from(b, 'utf8');
-  // Compare against a fixed-length representation so length mismatch does not
-  // short-circuit. We hash neither — just pad to equal length deterministically.
-  const len = Math.max(aBuf.length, bBuf.length);
-  const aPad = Buffer.alloc(len);
-  const bPad = Buffer.alloc(len);
-  aBuf.copy(aPad);
-  bBuf.copy(bPad);
-  const equalBytes = timingSafeEqual(aPad, bPad);
-  return equalBytes && aBuf.length === bBuf.length;
+  const da = createHash('sha256').update(a, 'utf8').digest();
+  const db = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(da, db);
 }
 
 export function requireAdmin(req: NextRequest): NextResponse | null {

--- a/lib/auth/redirect-url.ts
+++ b/lib/auth/redirect-url.ts
@@ -1,12 +1,34 @@
 import { NextRequest } from 'next/server';
 
 /**
- * Build the external base URL behind a reverse proxy (e.g. Caddy → localhost:3000).
- * Prefers X-Forwarded-{Proto,Host} → Host header → request.url as last resort.
+ * Build the external base URL used for server-issued redirects.
+ *
+ * L-1 hardening: the client-controlled `X-Forwarded-Host` header must NOT be
+ * trusted by default — an attacker could set it to an arbitrary domain and turn
+ * a login redirect into an open redirect / host-header poisoning vector.
+ *
+ * Resolution order:
+ *   1. NEXT_PUBLIC_APP_URL          — canonical server config (always preferred).
+ *   2. X-Forwarded-{Host,Proto}     — only when TRUST_PROXY_HEADERS=true
+ *                                     (explicit opt-in for the Caddy deployment,
+ *                                      which strips/overwrites these headers).
+ *   3. Host header                  — the value Next.js itself parsed.
+ *   4. request.url                  — last resort.
  */
 export function getRequestBaseUrl(request: NextRequest): string {
-  const fwdHost = request.headers.get('x-forwarded-host');
-  const fwdProto = request.headers.get('x-forwarded-proto');
+  // 1. Trusted server-side configuration wins outright.
+  const configured = process.env.NEXT_PUBLIC_APP_URL;
+  if (configured) {
+    return configured.replace(/\/+$/, '');
+  }
+
+  const trustProxy = process.env.TRUST_PROXY_HEADERS === 'true';
+
+  // 2. Forwarded headers are only consulted behind a trusted proxy.
+  const fwdHost = trustProxy ? request.headers.get('x-forwarded-host') : null;
+  const fwdProto = trustProxy ? request.headers.get('x-forwarded-proto') : null;
+
+  // 3. Otherwise rely on the Host header Next.js parsed for this request.
   const host = fwdHost ?? request.headers.get('host');
 
   if (host) {
@@ -14,6 +36,7 @@ export function getRequestBaseUrl(request: NextRequest): string {
     return `${proto}://${host}`;
   }
 
+  // 4. Last resort.
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
 }

--- a/lib/economics/__tests__/compute-economics-real-math.test.ts
+++ b/lib/economics/__tests__/compute-economics-real-math.test.ts
@@ -1,0 +1,134 @@
+/**
+ * U5 / #679 — REAL computeEconomics money math (replaces the fully-mocked
+ * lib/economics/__tests__/index.test.ts behavior for the cost-summation path).
+ *
+ * Audit finding (high): "computeEconomics integration test mocks all four
+ * sub-modules — verifies mock return values, not aggregation logic. A bug in the
+ * cost-summation loop inside computeEconomics would not be caught."
+ *
+ * Honest approach: mock ONLY the two NETWORK I/O boundaries (fetchBunkerPrices,
+ * fetchEuaPrice) — those do real fetch() and cannot run in unit tests. The pure
+ * calculators (calculateEuEts, calculateWarRiskPremium, optimizeSplitBunker) and
+ * the REAL computeEconomics summation all execute for real. Expected dollar
+ * figures are DERIVED by invoking the real calculators in the test, so the
+ * assertions track the production formulas instead of frozen magic numbers.
+ *
+ * Mutation contract: change the `bunkerCost + etsUsd + warRisk.premiumUsd`
+ * summation in lib/economics/index.ts (drop a term, flip a sign, swap EUR→USD
+ * factor) and the totalUsd assertion goes RED. Verified in the U5 report.
+ */
+
+import type { BunkerPrice } from '../bunker';
+
+// ── Mock ONLY the network boundary ──
+const FETCHED_AT = '2026-05-20T00:00:00.000Z';
+const BUNKER_MAP = new Map<string, BunkerPrice>([
+  ['Rotterdam', { port: 'Rotterdam', vlsfo: 500, mgo: 720, fetched_at: FETCHED_AT }],
+  ['Singapore', { port: 'Singapore', vlsfo: 450, mgo: 690, fetched_at: FETCHED_AT }],
+]);
+const EUA_PRICE = 80;
+
+jest.mock('../bunker', () => {
+  const actual = jest.requireActual('../bunker');
+  return {
+    ...actual,
+    fetchBunkerPrices: jest.fn().mockResolvedValue(
+      new Map([
+        ['Rotterdam', { port: 'Rotterdam', vlsfo: 500, mgo: 720, fetched_at: '2026-05-20T00:00:00.000Z' }],
+        ['Singapore', { port: 'Singapore', vlsfo: 450, mgo: 690, fetched_at: '2026-05-20T00:00:00.000Z' }],
+      ])
+    ),
+  };
+});
+
+jest.mock('../ets', () => {
+  const actual = jest.requireActual('../ets');
+  return {
+    ...actual,
+    // Keep REAL calculateEuEts; mock only the network fetch.
+    fetchEuaPrice: jest.fn().mockResolvedValue({ price: 80, fetched_at: '2026-05-20T00:00:00.000Z' }),
+  };
+});
+
+// war-risk and split-bunker are pure — NOT mocked, they run for real.
+
+import { computeEconomics, type EconomicsInput } from '../index';
+import { calculateEuEts } from '../ets';
+import { calculateWarRiskPremium } from '../war-risk';
+import { optimizeSplitBunker } from '../split-bunker';
+
+const INPUT: EconomicsInput = {
+  route: { fromPort: 'Rotterdam', toPort: 'Singapore', viaCanal: 'Suez' },
+  vesselValueUsd: 15_000_000,
+  daysInHra: 2,
+  distanceNm: 11_000,
+  euLegPercent: 0.5,
+  vlsfoBurnMt: 400,
+  consumptionMtPerDay: 30,
+};
+
+const ESTIMATED_DAYS = 20; // hardcoded in computeEconomics + split-bunker
+
+describe('computeEconomics — REAL cost summation (only network mocked)', () => {
+  it('totalUsd equals the real bunker + ETS(USD) + hull-war-premium composition', async () => {
+    const result = await computeEconomics(INPUT);
+
+    // Derive expected pieces from the REAL calculators the production code uses.
+    const ets = calculateEuEts({
+      distanceNm: INPUT.distanceNm,
+      euLegPercent: INPUT.euLegPercent,
+      vlsfoBurnMt: INPUT.vlsfoBurnMt,
+      euaPrice: EUA_PRICE,
+    });
+    const expectedEtsUsd = Math.round(ets.amountEur * 1.08);
+
+    const warRisk = calculateWarRiskPremium({
+      route: { fromPort: INPUT.route.fromPort, toPort: INPUT.route.toPort, viaCanal: INPUT.route.viaCanal },
+      vesselValueUsd: INPUT.vesselValueUsd,
+      daysInHra: INPUT.daysInHra,
+    });
+
+    const split = optimizeSplitBunker({
+      route: { fromPort: INPUT.route.fromPort, toPort: INPUT.route.toPort, intermediatePorts: [] },
+      bunkerPrices: BUNKER_MAP,
+      consumptionMtPerDay: INPUT.consumptionMtPerDay,
+    });
+    const bunkerPort = split.bunkerPlan[0]?.port ?? INPUT.route.fromPort;
+    const cheapest = BUNKER_MAP.get(bunkerPort)!;
+    const expectedBunkerCost = Math.round(cheapest.vlsfo * INPUT.consumptionMtPerDay * ESTIMATED_DAYS);
+
+    const expectedTotal = expectedBunkerCost + expectedEtsUsd + warRisk.premiumUsd;
+
+    // Real sub-modules really ran:
+    expect(result.breakdown.bunkerPort).toBe('Singapore'); // cheaper than Rotterdam
+    expect(result.breakdown.bunkerCost).toBe(expectedBunkerCost);
+    expect(result.breakdown.euEtsAmount).toBe(ets.amountEur);
+    expect(result.breakdown.warRiskPremium).toBe(warRisk.premiumUsd);
+
+    // The aggregation under test:
+    expect(result.totalUsd).toBe(expectedTotal);
+  });
+
+  it('produces concrete, non-zero figures (sanity on the real fixture)', async () => {
+    const result = await computeEconomics(INPUT);
+    // Singapore @ 450 USD/MT × 30 MT/day × 20 days = 270_000.
+    expect(result.breakdown.bunkerCost).toBe(270_000);
+    // Suez routing → Red Sea HRA dominant (0.075%): 15M × 0.00075 = 11_250 hull.
+    expect(result.breakdown.warRiskPremium).toBe(11_250);
+    expect(result.breakdown.warRiskZones).toContain('Red Sea / Bab al-Mandeb HRA');
+    // ETS: 400 × 3.114 × 0.5 × 80 = 49_824 EUR.
+    expect(result.breakdown.euEtsAmount).toBe(49_824);
+    expect(result.totalUsd).toBeGreaterThan(0);
+  });
+
+  it('drops the war-risk premium to 0 for a route with no HRA exposure (real branch)', async () => {
+    const safe = await computeEconomics({
+      ...INPUT,
+      route: { fromPort: 'Rotterdam', toPort: 'New York' }, // no canal, no HRA ports
+    });
+    expect(safe.breakdown.warRiskPremium).toBe(0);
+    expect(safe.breakdown.warRiskZones).toEqual([]);
+    // total still includes bunker + ETS.
+    expect(safe.totalUsd).toBeGreaterThan(0);
+  });
+});

--- a/lib/economics/route-decision.ts
+++ b/lib/economics/route-decision.ts
@@ -14,7 +14,7 @@
  */
 
 import { calculateTCE, type VoyageInput, type TCEBreakdown } from './voyage-calculator';
-import { callAiText } from '@/lib/openai';
+import { callAiText } from '@/lib/ai-provider';
 
 // βf3-06: LLM reason timeout — cap the AI explain call so cold-start ≤5s.
 // The LLM path is non-critical (fallback template is always available).
@@ -267,10 +267,13 @@ async function llmReason(
     // outer Promise.race resolves with `fallback` while the LLM keeps streaming
     // for ~80s, consuming CLI proxy quota and a connection slot. Defense-in-depth:
     // we still keep the outer race in case callAiText hangs in some other way.
+    // Route through the unified ai-provider shim (scope ROUTE_DECISION) so the
+    // call honors AI_PROVIDER / ROUTE_DECISION_PROVIDER and writes an ai_audit
+    // row, instead of hard-pinning to OpenAI via lib/openai.
     const aiPromise = callAiText(
-      prompt,
+      'route_decision',
       systemPrompt,
-      undefined,
+      prompt,
       { timeoutMs: LLM_REASON_TIMEOUT_MS },
     ).then(text => {
       const trimmed = (text ?? '').trim();

--- a/lib/prompts/__tests__/parser-robustness-u4.test.ts
+++ b/lib/prompts/__tests__/parser-robustness-u4.test.ts
@@ -1,0 +1,71 @@
+/**
+ * U4 (#675) — Parser robustness prompt-design guards.
+ *
+ * Source: docs/audits/2026-05-28-parser-adversarial-audit.md (Top-10 #1, #2).
+ *
+ * These tests assert the *content* of the exported prompt constants that the
+ * route handlers feed verbatim to the LLM. They are NOT source-text grep over a
+ * handler file — they import the actual constant the production route consumes
+ * (app/api/ai/parse-recap/route.ts imports FIXTURE_RECAP_PARSER_PROMPT; the
+ * progonq + parse-cargo paths import CARGO_INQUIRY_PARSER_PROMPT). A prompt is a
+ * pure data artifact; its wording IS the unit under test for a prompt-design fix.
+ *
+ * Scope separation (per U4 caveat): these guard PROMPT DESIGN only. They do NOT
+ * assert model behavior — prod Gemini is additionally shielded by responseSchema
+ * (parse-recap/route.ts:59). The gap these close is the OpenAI/Bedrock fallback
+ * path where responseSchema is ignored (U2 capability matrix), so the prompt
+ * wording is the only defense against prose/markdown/CoT leakage and silent
+ * conflict resolution.
+ */
+
+import { FIXTURE_RECAP_PARSER_PROMPT } from '@/lib/prompts/parse-recap';
+import { CARGO_INQUIRY_PARSER_PROMPT } from '@/lib/prompts/parse-cargo';
+
+describe('U4 parse-recap prompt — strict JSON-only output rule (audit Top-10 #2)', () => {
+  const p = FIXTURE_RECAP_PARSER_PROMPT.toLowerCase();
+
+  it('forbids prose / acknowledgement preamble', () => {
+    // Must instruct the model to emit ONLY JSON — no "I've received…" preamble.
+    expect(p).toContain('only a single json object');
+  });
+
+  it('forbids markdown headings and bold (the ## Recap / **Fixture leak)', () => {
+    expect(p).toMatch(/never[^.]*\bmarkdown\b/);
+    // Explicitly names the heading + bold artifacts the audit observed.
+    expect(p).toContain('heading');
+  });
+
+  it('the JSON-only rule is reinforced as the final instruction', () => {
+    // A trailing "Output: JSON object with all fields above." alone is NOT
+    // sufficient (that text predates this fix). The strict rule must be present
+    // and explicitly negative ("never prose").
+    expect(p).toContain('never prose');
+  });
+});
+
+describe('U4 parse-cargo prompt — universal conflict / hedge rule (audit Top-10 #1, cargo-adv-05)', () => {
+  const p = CARGO_INQUIRY_PARSER_PROMPT;
+  const lower = p.toLowerCase();
+
+  it('has a dedicated conflicting-values rule', () => {
+    // Pre-fix grep for conflict|two values|operative|both candidates returned ZERO.
+    expect(lower).toMatch(/conflict/);
+  });
+
+  it('instructs uncertain confidence (not confirmed) on two unresolved values', () => {
+    expect(lower).toContain('uncertain');
+    // The rule must tie the conflict to a confidence downgrade, not a silent pick.
+    expect(lower).toMatch(/(?:do not|must not|never) silently pick/);
+  });
+
+  it('requires recording both candidates in missing_info', () => {
+    expect(lower).toMatch(/both (candidate|value)/);
+    expect(lower).toContain('missing_info');
+  });
+
+  it('carves out the resolved-conflict case (operative value)', () => {
+    // recap-adv-03/08 prove the model should stay confident when the email
+    // explicitly states which value is operative — the rule must NOT over-hedge.
+    expect(lower).toContain('operative');
+  });
+});

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -267,6 +267,29 @@ Allowed extractions:
 If none of the above apply: laycan = null. Do NOT guess "Spot" from
 contextual hints ("asap", "urgent", "vessel ready", absence of any window).
 
+=== CONFLICTING VALUES RULE (universal — applies to EVERY field) ===
+
+When the email gives TWO OR MORE different values for the SAME field (e.g. two
+tonnages for one cargo stem, two laycans, two load rates) and the email does NOT
+explicitly state which one is operative/final, you MUST NOT silently pick one and
+mark it 'confirmed'. Instead:
+  1. Set that field's confidence = 'uncertain' (never 'confirmed').
+  2. Put the field value to the FIRST stated candidate (do not fabricate a midpoint).
+  3. Record BOTH candidates in missing_info as a human-readable note, e.g.
+     "Conflicting tonnage: cargo line states 'abt 30,000 mts' but recap states
+     '25,000 mt 10% moloo' — quantity to be confirmed".
+  ✗ weight_mt = {value: 25000, confidence: 'confirmed', ...} when the email also says
+     "abt 30,000 mts" for the same stem → WRONG (silent pick + false confidence)
+  ✓ weight_mt = {value: 30000, confidence: 'uncertain', source_text: "abt 30,000 mts..."}
+     AND missing_info contains a note naming BOTH candidate tonnages.
+
+RESOLVED-CONFLICT CARVE-OUT: This rule fires ONLY for UNRESOLVED conflicts. If the
+email explicitly states which value is operative ("the agreed quantity is 25,000 mt
+— ignore the earlier figure", "this is the operative number", "pls work to these
+dates", "amend your records to X"), then USE the operative value with
+confidence='confirmed' and do NOT add a missing_info conflict note. Do not over-hedge
+a conflict the sender already resolved.
+
 === missing_info RULES ===
 
 missing_info MUST be a plain string array (string[]). Each element is a human-readable English sentence describing ONE specific missing piece of information.

--- a/lib/prompts/parse-recap.ts
+++ b/lib/prompts/parse-recap.ts
@@ -228,4 +228,12 @@ Extract fields:
   ✓ additional_terms = [...each substantive clause as a separate string element...]
 - unknown_terms: array of { term, context }
 
+OUTPUT FORMAT — STRICT (read last, obey absolutely):
+Respond with ONLY a single JSON object containing the fields above — never prose,
+acknowledgements ("I've received…", "Here is…"), explanations, chain-of-thought,
+markdown code fences, markdown headings (no "## Recap", "# Fixture"), bold/**bold**,
+or any preamble before or after the JSON. The FIRST character of your response MUST
+be "{" and the LAST character MUST be "}". If there is nothing to extract, still
+return the JSON object with every field set to null — do NOT explain why in prose.
+
 Output: JSON object with all fields above.`;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -55,3 +55,12 @@ export class RateLimiter {
 
 export const aiRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 20 });
 export const parserEmailRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 20 });
+
+// M-1: brute-force protection on POST /api/auth/login. Stricter than the AI
+// limiter — a real user logs in a handful of times per minute, an attacker
+// hammers it. 5 attempts / 60s per IP.
+export const loginRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 5 });
+
+// L-3: throttle credential-guessing against /api/admin/* shared-secret endpoints.
+// Admin tooling is low-frequency; cap at 10 attempts / 60s per IP.
+export const adminRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 10 });

--- a/lib/utils/fmt-laycan.ts
+++ b/lib/utils/fmt-laycan.ts
@@ -1,7 +1,7 @@
 export function fmtLaycan(start: number | null, end: number | null): string {
   if (!start && !end) return '—';
   const fmt = (ts: number) =>
-    new Date(ts * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    new Date(ts * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
   if (start && end) return `${fmt(start)}–${fmt(end)}`;
   if (start) return fmt(start);
   return fmt(end!);

--- a/lib/whatsapp/__tests__/forward-parser.test.ts
+++ b/lib/whatsapp/__tests__/forward-parser.test.ts
@@ -56,6 +56,11 @@ describe('parseForwardedMessage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     client = new MockWhatsAppClient();
+    // U2: forward-parser now routes through @/lib/ai-provider (was hard-pinned to
+    // @/lib/openai). Pin AI_PROVIDER=openai so the shim delegates to the mocked
+    // openai layer asserted below (otherwise the ambient .env AI_PROVIDER=gemini
+    // would route past these mocks).
+    process.env.AI_PROVIDER = 'openai';
     // Default: AI returns a parsed cargo
     mockCallAiJson.mockResolvedValue(MOCK_PARSED_CARGO);
   });

--- a/lib/whatsapp/forward-parser.ts
+++ b/lib/whatsapp/forward-parser.ts
@@ -1,7 +1,8 @@
 import type { WhatsAppClient } from './client';
 import type { WhatsAppIncomingMessage } from './types';
 import type { ParsedCargo, ParsedVessel, ConfidenceLevel } from '@/lib/types';
-import { callAiJson, LLMTimeoutError } from '@/lib/openai';
+import { callAiJson } from '@/lib/ai-provider';
+import { LLMTimeoutError } from '@/lib/openai';
 
 /**
  * wave-γ-1 hardening: cap LLM call for inbound WhatsApp parse at 30s. The
@@ -162,13 +163,14 @@ export async function parseForwardedMessage(
 
   let rawOrNull: RawParseResponse | null;
   try {
+    // Route through the unified ai-provider shim (scope WHATSAPP_FORWARD) so the
+    // call honors AI_PROVIDER / WHATSAPP_FORWARD_PROVIDER and writes an ai_audit
+    // row, instead of hard-pinning to OpenAI via lib/openai.
     rawOrNull = await callAiJson<RawParseResponse>(
-      rawText,
+      'whatsapp_forward',
       FORWARD_PARSE_SYSTEM_PROMPT,
-      undefined,
-      {},
-      16000,
-      { timeoutMs: FORWARD_PARSE_TIMEOUT_MS },
+      rawText,
+      { timeoutMs: FORWARD_PARSE_TIMEOUT_MS, maxTokens: 16000 },
     );
   } catch (err) {
     if (err instanceof LLMTimeoutError) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -81,10 +81,11 @@ const SHARED_BUCKET = '__shared__';
  *                    everything to its LEFT is attacker-controlled and ignored.
  *                    If the list is shorter than N (or N is misconfigured) →
  *                    fail-closed.
- *  - unset / 'none' / anything else → no trusted source configured. We honour
- *                    x-real-ip ONLY as an explicit secondary, under the documented
- *                    assumption that the front proxy sets it from a trusted value;
- *                    otherwise → fail-closed. We NEVER fall back to raw XFF.
+ *  - 'xrealip'     → X-Real-IP, ONLY when the front proxy OVERWRITES it from a
+ *                    trusted value (a bare reverse_proxy does NOT). Explicit opt-in.
+ *  - unset / 'none' / anything else → NO trusted source. We trust NO client-settable
+ *                    header here (x-real-ip and the left-most X-Forwarded-For are both
+ *                    spoofable behind a bare proxy) → fail-closed to SHARED_BUCKET.
  *
  * In every misconfigured/missing/short case we return SHARED_BUCKET rather than an
  * attacker-chosen value — a missing config must never grant unlimited attempts.
@@ -107,9 +108,18 @@ function rateLimitKey(request: NextRequest): string {
     return tokens[tokens.length - n] || SHARED_BUCKET;
   }
 
-  // No trusted source configured. x-real-ip is the only documented secondary;
-  // never the spoofable left-most X-Forwarded-For token.
-  return request.headers.get('x-real-ip')?.trim() || SHARED_BUCKET;
+  if (source === 'xrealip') {
+    // Explicit opt-in: ONLY safe when the front proxy OVERWRITES X-Real-IP from a
+    // trusted value. A bare `reverse_proxy` (e.g. the demo Caddyfile) does NOT, so
+    // this must never be the default.
+    return request.headers.get('x-real-ip')?.trim() || SHARED_BUCKET;
+  }
+
+  // No trusted source configured → fail-closed. We must NOT trust any
+  // client-settable header here: both x-real-ip and the left-most X-Forwarded-For
+  // pass through a bare proxy unchanged, so honouring either reopens the
+  // rotate-header bypass (cold-QA R2-BUG-1).
+  return SHARED_BUCKET;
 }
 
 function tooManyRequests(retryAfterMs: number): NextResponse {

--- a/middleware.ts
+++ b/middleware.ts
@@ -57,15 +57,59 @@ function isCsrfPath(pathname: string): boolean {
   return CSRF_PATHS.some(p => pathname.startsWith(p));
 }
 
+// Fail-closed bucket: a SINGLE shared key so that, when no trusted client IP can
+// be derived, everyone is throttled together rather than each attacker getting
+// their own fresh bucket. Over-throttling is acceptable; a bypass is not.
+const SHARED_BUCKET = '__shared__';
+
 /**
- * Best-effort client key for rate limiting. Behind a reverse proxy the real
- * client IP arrives in x-forwarded-for (left-most entry); fall back to
- * x-real-ip, then a constant bucket so a missing header can't bypass the limit.
+ * Client key for the brute-force throttles (M-1 / L-3), derived from a TRUSTED
+ * source so an attacker cannot rotate it per request to defeat the limiter.
+ *
+ * The left-most X-Forwarded-For entry is CLIENT-CONTROLLED (Caddy only appends,
+ * never rewrites) and must never be used as the key again. The trust model is
+ * selected by RATE_LIMIT_CLIENT_IP_SOURCE and is FAIL-CLOSED:
+ *
+ *  - 'cf'          → CF-Connecting-IP. Safe in prod because Cloudflare OVERWRITES
+ *                    any client-supplied value with the true client IP. If the
+ *                    header is absent (request didn't transit CF) → fail-closed.
+ *  - 'xff-trusted' → the IP observed by the OUTERMOST trusted hop. Reads
+ *                    TRUSTED_PROXY_COUNT (N = number of trusted appending hops,
+ *                    e.g. Caddy = 1) and takes the X-Forwarded-For token at index
+ *                    (len - N): the last N tokens were appended by trusted hops,
+ *                    so tokens[len - N] is the first trusted-appended value and
+ *                    everything to its LEFT is attacker-controlled and ignored.
+ *                    If the list is shorter than N (or N is misconfigured) →
+ *                    fail-closed.
+ *  - unset / 'none' / anything else → no trusted source configured. We honour
+ *                    x-real-ip ONLY as an explicit secondary, under the documented
+ *                    assumption that the front proxy sets it from a trusted value;
+ *                    otherwise → fail-closed. We NEVER fall back to raw XFF.
+ *
+ * In every misconfigured/missing/short case we return SHARED_BUCKET rather than an
+ * attacker-chosen value — a missing config must never grant unlimited attempts.
  */
 function rateLimitKey(request: NextRequest): string {
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) return forwarded.split(',')[0].trim();
-  return request.headers.get('x-real-ip')?.trim() ?? 'anonymous';
+  const source = process.env.RATE_LIMIT_CLIENT_IP_SOURCE;
+
+  if (source === 'cf') {
+    const cf = request.headers.get('cf-connecting-ip')?.trim();
+    return cf || SHARED_BUCKET; // absent CF header → fail-closed
+  }
+
+  if (source === 'xff-trusted') {
+    const n = Number.parseInt(process.env.TRUSTED_PROXY_COUNT ?? '', 10);
+    if (!Number.isInteger(n) || n < 1) return SHARED_BUCKET; // misconfigured → fail-closed
+    const forwarded = request.headers.get('x-forwarded-for');
+    if (!forwarded) return SHARED_BUCKET;
+    const tokens = forwarded.split(',').map((t) => t.trim()).filter(Boolean);
+    if (tokens.length < n) return SHARED_BUCKET; // list shorter than N trusted hops → fail-closed
+    return tokens[tokens.length - n] || SHARED_BUCKET;
+  }
+
+  // No trusted source configured. x-real-ip is the only documented secondary;
+  // never the spoofable left-most X-Forwarded-For token.
+  return request.headers.get('x-real-ip')?.trim() || SHARED_BUCKET;
 }
 
 function tooManyRequests(retryAfterMs: number): NextResponse {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkCsrfRequest } from '@/lib/csrf';
-import { aiRateLimiter } from '@/lib/rate-limit';
+import { aiRateLimiter, loginRateLimiter, adminRateLimiter } from '@/lib/rate-limit';
 import { getAuthConfig } from '@/lib/auth/config';
 import { verifyAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
 import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
@@ -57,8 +57,41 @@ function isCsrfPath(pathname: string): boolean {
   return CSRF_PATHS.some(p => pathname.startsWith(p));
 }
 
+/**
+ * Best-effort client key for rate limiting. Behind a reverse proxy the real
+ * client IP arrives in x-forwarded-for (left-most entry); fall back to
+ * x-real-ip, then a constant bucket so a missing header can't bypass the limit.
+ */
+function rateLimitKey(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0].trim();
+  return request.headers.get('x-real-ip')?.trim() ?? 'anonymous';
+}
+
+function tooManyRequests(retryAfterMs: number): NextResponse {
+  const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+  return NextResponse.json(
+    { error: 'Too many requests' },
+    { status: 429, headers: { 'Retry-After': String(retryAfterSec) } },
+  );
+}
+
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
+
+  // ── Brute-force throttles (M-1 / L-3) ─────────────────────────────────────
+  // Applied before the auth guard because /api/auth/login is in AUTH_BYPASS_PATHS
+  // and /api/admin/* endpoints carry their own shared-secret auth — neither path
+  // would otherwise be rate-limited by the /api/ai/* block below.
+  if (request.method === 'POST' && pathname === '/api/auth/login') {
+    const { allowed, retryAfterMs } = loginRateLimiter.check(rateLimitKey(request));
+    if (!allowed) return tooManyRequests(retryAfterMs);
+  }
+
+  if (pathname.startsWith('/api/admin/')) {
+    const { allowed, retryAfterMs } = adminRateLimiter.check(rateLimitKey(request));
+    if (!allowed) return tooManyRequests(retryAfterMs);
+  }
 
   // ── Auth guard ────────────────────────────────────────────────────────────
   const authConfig = getAuthConfig();

--- a/scripts/seed-port-da.ts
+++ b/scripts/seed-port-da.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import { getDb } from '../lib/db';
 import { runMigrations } from '../lib/migrations/runner';
 import { allMigrations } from '../lib/migrations/index';
+import { callAiJson } from '../lib/ai-provider';
 
 // --------------------------------------------------------------------------
 // Types
@@ -98,24 +99,16 @@ Required JSON shape:
 }
 Use realistic estimates. Respond with JSON only.`;
 
-  const apiKey = process.env['OPENAI_API_KEY'] ?? '';
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({
-      model,
-      messages: [{ role: 'user', content: prompt }],
-      temperature: 0,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`LLM API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data = await response.json() as { choices: Array<{ message: { content: string } }> };
-  const raw = data.choices[0]?.message?.content ?? '{}';
-  return JSON.parse(raw) as LlmGapBracket;
+  // Route through the unified ai-provider shim (scope SEED_PORT_DA) instead of a
+  // raw OpenAI fetch: this honors AI_PROVIDER / SEED_PORT_DA_PROVIDER, applies a
+  // bounded timeout, runs extractJson before JSON.parse, and writes an ai_audit
+  // row. `model` is passed through so per-bracket model overrides still apply.
+  return callAiJson<LlmGapBracket>(
+    'seed_port_da',
+    'You are a port cost estimator. Respond with JSON only (no markdown).',
+    prompt,
+    { model, temperature: 0, timeoutMs: 30_000 },
+  );
 };
 
 // --------------------------------------------------------------------------

--- a/tests/economics/route-decision.test.ts
+++ b/tests/economics/route-decision.test.ts
@@ -58,6 +58,10 @@ const MARKET = { bunkerPriceUsdPerMt: 620, euaPriceEur: 75 };
 describe('compareRoutes — β-06', () => {
   beforeEach(() => {
     mockedCallAiText.mockReset();
+    // U2: route-decision now routes through @/lib/ai-provider. Pin
+    // AI_PROVIDER=openai so the shim delegates to the mocked @/lib/openai layer
+    // asserted below (ambient .env sets AI_PROVIDER=gemini).
+    process.env.AI_PROVIDER = 'openai';
   });
 
   it('returns side-by-side TCE for Suez and Cape with a recommendation', async () => {

--- a/tests/regression/RC6-security-blacklist/gamma-18-F10-missing-auth-check.test.ts
+++ b/tests/regression/RC6-security-blacklist/gamma-18-F10-missing-auth-check.test.ts
@@ -4,6 +4,17 @@
 // Fix: Added requireSession() check -> returns 401 for unauthenticated requests
 // Spec: spec/gamma-18-roi-guarantee-workflow
 // DO NOT DELETE — see references/regression_lock_workflow.md
+//
+// ⚠️ U5 / #679 — SUPERSEDED. This file is DISHONEST AND DEAD:
+//   (a) it lives under tests/regression/, which jest.config.mjs ignores, so it
+//       has NEVER run; and
+//   (b) it jest.mock()s @/lib/session, so `requireSession` here is a re-implemented
+//       MOCK — deleting the real auth call from the route would not turn it red.
+// The honest, mutation-verified replacement lives at
+//   __tests__/api/analytics/roi-auth.test.ts
+// which exercises the REAL requireSession against a REAL in-memory session store.
+// Kept (not deleted) only to honour the regression_lock_workflow "DO NOT DELETE"
+// convention; treat roi-auth.test.ts as authoritative.
 
 import Database from "better-sqlite3";
 import { NextRequest } from "next/server";

--- a/tests/regression/test_forward_parser_edge_cases.test.ts
+++ b/tests/regression/test_forward_parser_edge_cases.test.ts
@@ -41,6 +41,13 @@ import { callAiJson } from '@/lib/openai';
 
 const mockCallAiJson = callAiJson as jest.MockedFunction<typeof callAiJson>;
 
+// U2: forward-parser now routes through @/lib/ai-provider (was hard-pinned to
+// @/lib/openai). Pin AI_PROVIDER=openai so the shim delegates to the mocked
+// @/lib/openai layer asserted here (ambient .env sets AI_PROVIDER=gemini).
+beforeEach(() => {
+  process.env.AI_PROVIDER = 'openai';
+});
+
 // Helper: build a minimal WhatsAppIncomingMessage with arbitrary type
 function makeMsg(type: string, extra: Record<string, unknown> = {}): WhatsAppIncomingMessage {
   return {

--- a/tests/regression/test_parsers_normalizers_adv.test.ts
+++ b/tests/regression/test_parsers_normalizers_adv.test.ts
@@ -60,6 +60,10 @@ describe('ATTACK-4 — forward-parser adversarial edge cases', () => {
     jest.resetAllMocks();
     // Re-setup mockClient.downloadMedia default after reset
     mockClientDownloadMedia.mockResolvedValue({ url: 'http://mock/media', mimeType: 'image/jpeg' });
+    // U2: forward-parser now routes through @/lib/ai-provider (was hard-pinned to
+    // @/lib/openai). Pin AI_PROVIDER=openai so the shim delegates to the mocked
+    // @/lib/openai layer asserted here (ambient .env sets AI_PROVIDER=gemini).
+    process.env.AI_PROVIDER = 'openai';
   });
 
   // ---- BUG CANDIDATE: cargoType always hardcoded to 'BULK' ----


### PR DESCRIPTION
## DW remediation wave — 6 audit reports → verified fixes

Превращает 6 read-only аудитов (28 мая) в проверенные код-фиксы за одну структурированную Dynamic-Workflows волну на dev-VPS. **#659 (dead-code) намеренно НЕ включён** — снос вынесен на ручной ревью.

Запуск: `brainstorming → writing-plans → DW (Phase-0 verify → Phase-1 ∥ fixes → Phase-2 tests) → integration verify`. Каждая находка сверена с HEAD перед фиксом (guardrail), каждый guard mutation-honest (revert → RED).

### Что сделано

| Unit | Issue | Δ | Суть |
|---|---|---|---|
| U1 | #651 security | 25 файлов | rate-limit `POST /api/auth/login` (M-1) + `/api/admin/*` (L-3); `timingSafeEqual` в requireAdmin; `X-Forwarded-Host` за opt-in `TRUST_PROXY_HEADERS` (L-1); OAuth state-cookie `Secure`+`Max-Age` (L-4); generic 5xx вместо raw `error.message` на 14 routes (L-8) |
| U2 | #663 + #674 | 16 | abort+timeout прокинуты в gemini+bedrock ветки `ai-provider.ts`; `request.signal` в match-route → `LLMTimeoutError` теперь живой код; `cache_control` на статический MATCH-префикс (Bedrock); 3 shim-bypass (`forward-parser`, `route-decision`, `seed-port-da`) маршрутизированы через shim + `ai_audit` |
| U3 | #676 rsc | 10 | posthog → `dynamic import` (−55 KB-gz с 7+ routes); 7×лишний `'use client'` снят; `fmt-laycan` пин `timeZone:'UTC'` (SSR off-by-one) |
| U4 | #675 parser | 5 | parse-recap prompt: JSON-only / never-prose (закрывает JSON-leak на fallback без `responseSchema`); parse-cargo universal conflict/hedge rule (cargo-adv-05); eval budget-cap env |
| U5 | #679 tests | 7 | честные guard'ы: SQLi allowlist (был зелёным и на баге), ROI auth (мокал сам себя), laytime D/D money-sign, реальный `computeEconomics`, VALID_CONF render. requireAdmin **не задублирован** — уже покрыт U1 |

### Verification (integration-ветка)

- ✅ Merge 5 юнитов — **0 конфликтов** (62 файла, +1873/−198)
- ✅ `tsc --noEmit` clean · `next build` ✓ (72 страницы)
- ✅ **79 тестов зелёные** (48 Phase-1 + 31 Phase-2), независимый прогон
- ✅ mutation-honest по всем guard'ам (revert→RED→restore→GREEN)

### ⚠️ Найдено, НЕ пофикшено (по правилу «репортить, не фиксить»)

1. **Реальный prod-баг (laytime D/D classification):** `calculator.ts` использует EPSILON-tolerance (±0.01h) для метки demurrage/despatch, а `dd-calculator.ts` — strict `>0/<0/===0`. На «впритык» рейсе метки расходятся (`balanced` vs `despatch`) + ms-truncation residual в day-loop. Low-dollar на грани, но инвертирует who-owes-whom. → отдельная fix-волна.
2. **Системная находка (test infra):** `jest.config.mjs` игнорирует весь `/tests/regression/` → часть «critical regression locks» (включая старый ROI auth lock) **никогда не запускалась**. → follow-up: перенести в `__tests__/` или убрать ignore.

### Caveat

U4 (parser) проверен только jest-юнитами — на VPS нет cloud-creds. Реальный prod-eval Gemini 2.5 — отдельный шаг через progonb.

Refs: #651 #663 #674 #675 #676 #679 · #659 — отдельно (ручной ревью).

🤖 Generated via Dynamic Workflows (Opus 4.8) on dev-VPS

---
### Update — CI green
CI поймал 1 регрессию: `lib/__tests__/analytics.test.ts` звал `track()/initAnalytics()` без `await` после того как U3 сделал их async (dynamic posthog import). Тест обновлён под новый контракт (`await` на 3 вызова; негативные кейсы не тронуты). Ветка обновлена на свежий main (0 конфликтов). На HEAD `8a19759`: **CI ✓ (Test+Build) · TypeCheck+Audit ✓ · pre-merge-guard ✓** — полный suite 7852 теста зелёный.

---
### Update — cold-QA round (FAIL → fixed)
Независимый cold-start `/test-skill` дал **FAIL (1 HIGH, 2 MED, 2 LOW)**. Fix-раунд (Opus, TDD + mutation-honest), коммит `d0f6c5c`:

| # | Sev | Фикс |
|---|---|---|
| BUG-1 | **HIGH** | rate-limit больше не на left-most `X-Forwarded-For` (обходился ротацией заголовка → M-1/L-3 не работали). Новый `rateLimitKey`: env `RATE_LIMIT_CLIENT_IP_SOURCE` (`cf`=CF-Connecting-IP / `xff-trusted`+`TRUSTED_PROXY_COUNT`), **fail-closed** на общий bucket при любой ошибке конфига |
| BUG-2 | MED | Bedrock `cache_control` теперь под gate `system.length≥4000` (был безусловно на каждом вызове) |
| BUG-4 | LOW | `timingSafeStrEqual` → SHA-256 обеих сторон → constant-width compare (убран length-oracle) |
| BUG-5 | LOW | `track()/initAnalytics()` обёрнуты в try/catch (async import не уронит unhandled rejection) |
| BUG-3 | MED | **deferred** (pre-existing): `Host`-trust в redirect-url при незаданном `NEXT_PUBLIC_APP_URL`; код не трогаем (риск demo-redirect), вынесено в prod-config follow-up |

**⚠️ PROD-CONFIG (обязательно перед эффективным rate-limit):** задать на проде `RATE_LIMIT_CLIENT_IP_SOURCE=cf` (demo за Cloudflare). Без неё лимитер fail-closed уходит в общий bucket — безопасно, но не пер-IP. Плюс follow-up BUG-3: подтвердить `NEXT_PUBLIC_APP_URL=https://demo.quantika.org` в prod-env.

Gate: повторный cold-QA после этого фикса до снятия блокировки merge.

**Followup `96f6100`:** CI поймал взаимодействие BUG-2 fix со старым U2-тестом: `ai-provider-abort-cache.test.ts` ассертил `cache_control` на коротком system-промпте, но новый gate (`≥4000` симв.) его там больше не ставит. Тест обновлён под реальный сценарий — MATCH-размерный префикс (короткий случай покрыт `ai-provider-bedrock-cache.test.ts`). 11/11 bedrock-cache тестов зелёные в `--ci`. Изменён только тест-файл — прод-код фикса (`d0f6c5c`) не тронут.

---
### Update — cold-QA round 2 (FAIL → fixed), `8ae40b1`
Повторный cold-QA подтвердил Round-1 фиксы, но нашёл **конвергентный HIGH (R2-BUG-1):** дефолтная ветка `rateLimitKey` доверяла client-settable `X-Real-IP` (та же дыра, что BUG-1, перемещённая с XFF). Caddyfile demo — голый `reverse_proxy`, не перезаписывает X-Real-IP → проба: ротация X-Real-IP = 0/50 throttled.

**Фикс:** дефолт теперь **полностью fail-closed** — НИ одному client-заголовку не доверяем без явного `RATE_LIMIT_CLIENT_IP_SOURCE`. `x-real-ip` доступен только под явным opt-in режимом `xrealip` (для прокси, который его перезаписывает). Env задокументирован в `.env.local.example`. Тест R2-BUG-1: ротация X-Real-IP в дефолте → throttles (TDD: на старом коде RED, после фикса GREEN). 13/13 middleware-тестов зелёные, tsc clean.

MEDIUM/LOW от round-2 (parse-recap consumer extractJson, Host-redirect при unset NEXT_PUBLIC_APP_URL) — pre-existing, не блокируют, в follow-up.
