### PR TITLE
feat(matches): show real vessel names not emailId hashes

### DIFF
--- a/__tests__/matches-table-layout.test.tsx
+++ b/__tests__/matches-table-layout.test.tsx
@@ -38,7 +38,7 @@ describe('MatchesClient.tsx — VESSEL column wraps long names (#636 pattern)', 
 
   it('table view vessel cells use break-words class', () => {
     const tableSection = src.slice(src.indexOf('TABLE VIEW'));
-    expect(tableSection).toMatch(/break-words[^>]*>\{match\.vessel_id\}|className="[^"]*break-words[^"]*"[^>]*>\{match\.vessel_id\}/);
+    expect(tableSection).toMatch(/break-words[^>]*>\{match\.vessel_name \?\? match\.vessel_id\}|className="[^"]*break-words[^"]*"[^>]*>\{match\.vessel_name \?\? match\.vessel_id\}/);
   });
 
   it('outer wrapper does not use overflow-x-hidden (which clips scrollable table)', () => {

--- a/__tests__/mode-aware-content.test.ts
+++ b/__tests__/mode-aware-content.test.ts
@@ -40,6 +40,8 @@ function makeMatch(id: number, cargoId: string, vesselId: string): StoredMatch {
     user_id: 'session-1',
     created_at: 1000000,
     updated_at: 1000000,
+    vessel_name: null,
+    cargo_ref: null,
   };
 }
 

--- a/__tests__/ui/matches-vessel-wrap.test.tsx
+++ b/__tests__/ui/matches-vessel-wrap.test.tsx
@@ -78,6 +78,8 @@ const longVesselMatch: StoredMatch = {
   distance_nm: null,
   freight_rate_usd_per_mt: null,
   freight_rate_source: null,
+  vessel_name: null,
+  cargo_ref: null,
 };
 
 describe('MatchesClient — long vessel name wraps (#662)', () => {

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -134,7 +134,7 @@ export default async function MatchDetailPage({ params }: Props) {
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2 mb-1">
                 <h1 className="text-lg sm:text-2xl font-semibold text-white truncate">
-                  MV {storedMatch.vessel_id}
+                  {storedMatch.vessel_name ?? storedMatch.vessel_id}
                 </h1>
                 {badgeCfg && (
                   <Badge className="bg-ds-accent-soft text-ds-accent-soft-fg border-0 text-xs">
@@ -170,7 +170,7 @@ export default async function MatchDetailPage({ params }: Props) {
                 <dl className="space-y-1 text-sm">
                   <div className="flex justify-between gap-2">
                     <dt className="text-ds-text-muted">Name</dt>
-                    <dd className="font-medium text-ds-text truncate">{storedMatch.vessel_id}</dd>
+                    <dd className="font-medium text-ds-text truncate">{storedMatch.vessel_name ?? storedMatch.vessel_id}</dd>
                   </div>
                   {storedMatch.vessel_dwt && (
                     <div className="flex justify-between gap-2">

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -618,10 +618,10 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                         <div className="flex items-start justify-between gap-2">
                           <div className="min-w-0">
                             <div className="font-medium text-sm">
-                              Cargo: <span className="text-gray-700">{match.cargo_id}</span>
+                              Cargo: <span className="text-gray-700">{match.cargo_ref ?? match.cargo_id}</span>
                             </div>
                             <div className="font-medium text-sm">
-                              Vessel: <span className="text-gray-700">{match.vessel_id}</span>
+                              Vessel: <span className="text-gray-700">{match.vessel_name ?? match.vessel_id}</span>
                             </div>
                             {match.cargo_type && (
                               <span className="inline-block text-xs bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded mt-0.5">
@@ -856,9 +856,9 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                           <td className="py-[13px] px-3 align-middle">
                             <div className="flex items-center gap-[10px]">
                               <span className="w-7 h-7 rounded-[7px] bg-ds-accent text-ds-accent-fg flex-shrink-0 inline-flex items-center justify-center font-mono text-[11.5px] font-medium">
-                                {vesselInitials(match.vessel_id)}
+                                {vesselInitials(match.vessel_name ?? match.vessel_id)}
                               </span>
-                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_id}</span>
+                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_name ?? match.vessel_id}</span>
                             </div>
                           </td>
                         )}
@@ -891,9 +891,9 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                           <td className="py-[13px] px-3 align-middle">
                             <div className="flex items-center gap-[10px]">
                               <span className="w-7 h-7 rounded-[7px] bg-ds-accent text-ds-accent-fg flex-shrink-0 inline-flex items-center justify-center font-mono text-[11.5px] font-medium">
-                                {vesselInitials(match.vessel_id)}
+                                {vesselInitials(match.vessel_name ?? match.vessel_id)}
                               </span>
-                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_id}</span>
+                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_name ?? match.vessel_id}</span>
                             </div>
                           </td>
                         ) : (

--- a/lib/matching/__tests__/matches-csv.test.ts
+++ b/lib/matching/__tests__/matches-csv.test.ts
@@ -23,6 +23,8 @@ function makeMatch(overrides: Partial<StoredMatch> = {}): StoredMatch {
     distance_nm: null,
     freight_rate_usd_per_mt: null,
     freight_rate_source: null,
+    vessel_name: null,
+    cargo_ref: null,
     ...overrides,
   };
 }

--- a/lib/matching/__tests__/matches-repository-vessel-name.test.ts
+++ b/lib/matching/__tests__/matches-repository-vessel-name.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests — createMatch vessel_name / cargo_ref write-through.
+ *
+ * Uses migration 041 DB so vessel_name and cargo_ref columns exist.
+ * PI2 behavioral: round-trips through createMatch and reads back via getMatch.
+ */
+
+import Database from 'better-sqlite3';
+import migration032 from '@/lib/migrations/032-matches';
+import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import migration035 from '@/lib/migrations/035-matches-tce-distance';
+import migration036 from '@/lib/migrations/036-matches-freight-rate';
+import migration041 from '@/lib/migrations/041-matches-vessel-name';
+import { createMatch, getMatch } from '@/lib/matching/matches-repository';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  migration033.up(db);
+  migration034.up(db);
+  migration035.up(db);
+  migration036.up(db);
+  migration041.up(db);
+  return db;
+}
+
+describe('createMatch — vessel_name / cargo_ref columns', () => {
+  it('persists vessel_name when provided', () => {
+    const db = freshDb();
+    const match = createMatch(db, {
+      cargo_id: 'cargo-1',
+      vessel_id: 'vessel-1',
+      score: 80,
+      reason: 'good fit',
+      vessel_name: 'MV BARABULKA',
+    });
+    const fetched = getMatch(db, match.id);
+    expect(fetched!.vessel_name).toBe('MV BARABULKA');
+  });
+
+  it('persists cargo_ref when provided', () => {
+    const db = freshDb();
+    const match = createMatch(db, {
+      cargo_id: 'cargo-1',
+      vessel_id: 'vessel-1',
+      score: 80,
+      reason: 'good fit',
+      cargo_ref: 'Cement in sling bags, 10 000 mt',
+    });
+    const fetched = getMatch(db, match.id);
+    expect(fetched!.cargo_ref).toBe('Cement in sling bags, 10 000 mt');
+  });
+
+  it('vessel_name is null when not provided', () => {
+    const db = freshDb();
+    const match = createMatch(db, {
+      cargo_id: 'cargo-2',
+      vessel_id: 'vessel-2',
+      score: 60,
+      reason: 'ok fit',
+    });
+    const fetched = getMatch(db, match.id);
+    expect(fetched!.vessel_name).toBeNull();
+  });
+
+  it('cargo_ref is null when not provided', () => {
+    const db = freshDb();
+    const match = createMatch(db, {
+      cargo_id: 'cargo-2',
+      vessel_id: 'vessel-2',
+      score: 60,
+      reason: 'ok fit',
+    });
+    const fetched = getMatch(db, match.id);
+    expect(fetched!.cargo_ref).toBeNull();
+  });
+
+  it('persists both vessel_name and cargo_ref together', () => {
+    const db = freshDb();
+    const match = createMatch(db, {
+      cargo_id: 'cargo-3',
+      vessel_id: 'vessel-3',
+      score: 90,
+      reason: 'excellent',
+      vessel_name: 'PANTHERA J',
+      cargo_ref: 'Iron ore, 50 000 mt',
+    });
+    const fetched = getMatch(db, match.id);
+    expect(fetched!.vessel_name).toBe('PANTHERA J');
+    expect(fetched!.cargo_ref).toBe('Iron ore, 50 000 mt');
+  });
+});

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -94,6 +94,8 @@ export async function computeAndPersistMatches(
       distance_nm: distanceResult ? distanceResult.nm : null,
       freight_rate_usd_per_mt,
       freight_rate_source,
+      vessel_name: vessel ? (cfValue(vessel.vesselName) ?? null) : null,
+      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) ?? null) : null,
     });
   }
 

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -23,6 +23,8 @@ export interface StoredMatch {
   distance_nm: number | null;
   freight_rate_usd_per_mt: number | null;
   freight_rate_source: string | null;
+  vessel_name: string | null;
+  cargo_ref: string | null;
 }
 
 export interface CreateMatchInput {
@@ -43,6 +45,8 @@ export interface CreateMatchInput {
   distance_nm?: number | null;
   freight_rate_usd_per_mt?: number | null;
   freight_rate_source?: string | null;
+  vessel_name?: string | null;
+  cargo_ref?: string | null;
 }
 
 export interface ListMatchesOptions {
@@ -83,6 +87,11 @@ function hasFreightRateColumns(db: Database.Database): boolean {
   return cols.some((c) => c.name === 'freight_rate_usd_per_mt');
 }
 
+function hasVesselNameColumns(db: Database.Database): boolean {
+  const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+  return cols.some((c) => c.name === 'vessel_name');
+}
+
 export function createMatch(db: Database.Database, input: CreateMatchInput): StoredMatch {
   const now = Date.now();
   const status: MatchStatus = input.status ?? 'shortlist';
@@ -90,7 +99,53 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
 
   let result: { lastInsertRowid: number | bigint; changes: number };
 
-  if (hasFreightRateColumns(db)) {
+  if (hasVesselNameColumns(db)) {
+    const reason_structured = input.reason_structured ?? null;
+    const cargo_type = input.cargo_type ?? null;
+    const load_port = input.load_port ?? null;
+    const discharge_port = input.discharge_port ?? null;
+    const laycan_start = input.laycan_start ?? null;
+    const laycan_end = input.laycan_end ?? null;
+    const vessel_dwt = input.vessel_dwt ?? null;
+    const tce_usd_per_day = input.tce_usd_per_day ?? null;
+    const distance_nm = input.distance_nm ?? null;
+    const freight_rate_usd_per_mt = input.freight_rate_usd_per_mt ?? null;
+    const freight_rate_source = input.freight_rate_source ?? null;
+    const vessel_name = input.vessel_name ?? null;
+    const cargo_ref = input.cargo_ref ?? null;
+
+    const stmt = db.prepare(
+      `INSERT OR IGNORE INTO matches
+         (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+          reason_structured, cargo_type, load_port, discharge_port,
+          laycan_start, laycan_end, vessel_dwt, tce_usd_per_day, distance_nm,
+          freight_rate_usd_per_mt, freight_rate_source, vessel_name, cargo_ref)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    result = stmt.run(
+      input.cargo_id,
+      input.vessel_id,
+      input.score,
+      input.reason,
+      status,
+      user_id,
+      now,
+      now,
+      reason_structured,
+      cargo_type,
+      load_port,
+      discharge_port,
+      laycan_start,
+      laycan_end,
+      vessel_dwt,
+      tce_usd_per_day,
+      distance_nm,
+      freight_rate_usd_per_mt,
+      freight_rate_source,
+      vessel_name,
+      cargo_ref,
+    );
+  } else if (hasFreightRateColumns(db)) {
     const reason_structured = input.reason_structured ?? null;
     const cargo_type = input.cargo_type ?? null;
     const load_port = input.load_port ?? null;

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -65,6 +65,8 @@ export function persistSessionMatches(
       distance_nm: distanceResult ? distanceResult.nm : null,
       freight_rate_usd_per_mt,
       freight_rate_source,
+      vessel_name: vessel ? (cfValue(vessel.vesselName) ?? null) : null,
+      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) ?? null) : null,
     });
   }
 }

--- a/lib/migrations/041-matches-vessel-name.ts
+++ b/lib/migrations/041-matches-vessel-name.ts
@@ -1,0 +1,21 @@
+import type { Migration } from './types';
+
+const migration041: Migration = {
+  version: 41,
+  name: 'matches-vessel-name',
+  up(db) {
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    if (!names.has('vessel_name')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN vessel_name TEXT`);
+    }
+    if (!names.has('cargo_ref')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN cargo_ref TEXT`);
+    }
+  },
+  down(db) {
+    void db;
+  },
+};
+
+export default migration041;

--- a/lib/migrations/__tests__/041-matches-vessel-name.test.ts
+++ b/lib/migrations/__tests__/041-matches-vessel-name.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests — migration 041 (vessel_name + cargo_ref columns).
+ *
+ * Covers:
+ *   - up() adds vessel_name column to matches
+ *   - up() adds cargo_ref column to matches
+ *   - Both columns accept NULL
+ *   - Both columns accept non-null text values
+ *   - up() is idempotent (re-run after already applied does not throw)
+ *   - Migration metadata (version, name)
+ */
+
+import Database from 'better-sqlite3';
+import migration032 from '../032-matches';
+import migration033 from '../033-matches-score-breakdown';
+import migration034 from '../034-matches-unique-constraint';
+import migration035 from '../035-matches-tce-distance';
+import migration036 from '../036-matches-freight-rate';
+import migration041 from '../041-matches-vessel-name';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration032.up(db);
+  migration033.up(db);
+  migration034.up(db);
+  migration035.up(db);
+  migration036.up(db);
+  migration041.up(db);
+  return db;
+}
+
+function insertRow(
+  db: Database.Database,
+  extra: Record<string, unknown> = {},
+): void {
+  const base = {
+    cargo_id: 'cargo-1',
+    vessel_id: 'vessel-1',
+    score: 75,
+    reason: 'test',
+    status: 'shortlist',
+    user_id: 'user-1',
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+  const merged = { ...base, ...extra };
+  const cols = Object.keys(merged).join(', ');
+  const placeholders = Object.keys(merged).map(() => '?').join(', ');
+  db.prepare(`INSERT INTO matches (${cols}) VALUES (${placeholders})`).run(
+    ...Object.values(merged),
+  );
+}
+
+describe('migration 041 — vessel_name + cargo_ref columns', () => {
+  it('adds vessel_name column', () => {
+    const db = freshDb();
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'vessel_name')).toBe(true);
+  });
+
+  it('adds cargo_ref column', () => {
+    const db = freshDb();
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'cargo_ref')).toBe(true);
+  });
+
+  it('accepts NULL vessel_name', () => {
+    const db = freshDb();
+    insertRow(db, { vessel_name: null });
+    const row = db.prepare('SELECT vessel_name FROM matches LIMIT 1').get() as { vessel_name: string | null };
+    expect(row.vessel_name).toBeNull();
+  });
+
+  it('accepts NULL cargo_ref', () => {
+    const db = freshDb();
+    insertRow(db, { cargo_ref: null });
+    const row = db.prepare('SELECT cargo_ref FROM matches LIMIT 1').get() as { cargo_ref: string | null };
+    expect(row.cargo_ref).toBeNull();
+  });
+
+  it('stores vessel_name text', () => {
+    const db = freshDb();
+    insertRow(db, { vessel_name: 'MV BARABULKA' });
+    const row = db.prepare('SELECT vessel_name FROM matches LIMIT 1').get() as { vessel_name: string | null };
+    expect(row.vessel_name).toBe('MV BARABULKA');
+  });
+
+  it('stores cargo_ref text', () => {
+    const db = freshDb();
+    insertRow(db, { cargo_ref: 'Cement in sling bags' });
+    const row = db.prepare('SELECT cargo_ref FROM matches LIMIT 1').get() as { cargo_ref: string | null };
+    expect(row.cargo_ref).toBe('Cement in sling bags');
+  });
+
+  it('is idempotent — re-running up() does not throw', () => {
+    const db = new Database(':memory:');
+    migration032.up(db);
+    migration033.up(db);
+    migration034.up(db);
+    migration035.up(db);
+    migration036.up(db);
+    migration041.up(db);
+    expect(() => migration041.up(db)).not.toThrow();
+  });
+
+  it('has version=41', () => {
+    expect(migration041.version).toBe(41);
+  });
+
+  it('has name="matches-vessel-name"', () => {
+    expect(migration041.name).toBe('matches-vessel-name');
+  });
+});

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -38,6 +38,7 @@ import migration037 from './037-add-user-preferred-mode';
 import migration038 from './038-jobs-progress';
 import migration039 from './039-demo-seed-meta';
 import migration040 from './040-counter-offers';
+import migration041 from './041-matches-vessel-name';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041];


### PR DESCRIPTION
Demo /matches showed Gmail emailId hashes (e.g. 19e097b0d6404a40) in the VESSEL column instead of real ship names. Root cause: matches denormalized only vessel_id=emailId; the real name (already present in session.parsedVessels from demo-parsed-vessels.json — MV BARABULKA, PANTHERA J, …) was never carried into the matches table, and the UI rendered the id directly. Display gap, NOT anonymization.

## Changes
- Migration 041: idempotent ADD COLUMN vessel_name TEXT + cargo_ref TEXT on matches (registered in index.ts)
- matches-repository: vessel_name/cargo_ref in StoredMatch + CreateMatchInput; new hasVesselNameColumns INSERT branch
- persist-session-matches + compute-matches: write cfValue(vessel.vesselName) / cfValue(cargo.cargoDescription)
- UI: MatchesClient (cards+table) + match/[id] use vessel_name ?? vessel_id, cargo_ref ?? cargo_id

## QA
Cold-start /test-skill: PASS — 0 CRITICAL, 0 HIGH. 1 MEDIUM (empty-string cfValue bypass — follow-up, does not affect demo fixtures). 1 pre-existing flaky perf test (compare-routes-perf timing, unrelated). 2231+ tests green, typecheck clean.

## Deploy note
Existing seeded matches rows have vessel_name=NULL (INSERT OR IGNORE skips them). New sessions get names automatically; for the frozen demo a backfill/re-seed of visible matches rows is needed post-deploy.

Out of scope: anonymization (scripts/demo-seed), Cargo/Vessels/Email screens (already readable), port abbreviations.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>