### PR TITLE
fix(matches): normalize empty vessel_name/cargo_ref to null (UI fallback engages)

### DIFF
--- a/lib/matching/__tests__/matches-repository-vessel-name.test.ts
+++ b/lib/matching/__tests__/matches-repository-vessel-name.test.ts
@@ -12,7 +12,16 @@ import migration034 from '@/lib/migrations/034-matches-unique-constraint';
 import migration035 from '@/lib/migrations/035-matches-tce-distance';
 import migration036 from '@/lib/migrations/036-matches-freight-rate';
 import migration041 from '@/lib/migrations/041-matches-vessel-name';
-import { createMatch, getMatch } from '@/lib/matching/matches-repository';
+import { createMatch, getMatch, listMatches } from '@/lib/matching/matches-repository';
+import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
+import { computeAndPersistMatches } from '@/lib/matching/compute-matches';
+import { resolveSyntheticCargo, resolveSyntheticVessel } from '@/lib/sample-data/synthetic-economics';
+import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+
+jest.mock('@/lib/matching/pair-analyzer', () => ({
+  analyzePairs: jest.fn(),
+}));
+import { analyzePairs } from '@/lib/matching/pair-analyzer';
 
 function freshDb(): Database.Database {
   const db = new Database(':memory:');
@@ -89,5 +98,66 @@ describe('createMatch — vessel_name / cargo_ref columns', () => {
     const fetched = getMatch(db, match.id);
     expect(fetched!.vessel_name).toBe('PANTHERA J');
     expect(fetched!.cargo_ref).toBe('Iron ore, 50 000 mt');
+  });
+});
+
+/**
+ * Producer write-through — empty-string normalization.
+ *
+ * cfValue() returns the raw field value, so a ConfidenceField parsed as
+ * { value: '' } yields "" (NOT null). The UI fallback `vessel_name ?? vessel_id`
+ * uses ?? (null/undefined only), so a stored "" would render as a BLANK cell
+ * instead of falling back to vessel_id. The producers must therefore normalize
+ * "" -> null at write time (|| null, not ?? null).
+ *
+ * PI2 behavioral: drives the real persist/compute producers (where the
+ * normalization lives — createMatch faithfully stores whatever it is given)
+ * and reads back via listMatches.
+ */
+describe('producer write-through — empty-string vesselName/cargoDescription → null', () => {
+  // Links to the synthetic demo cargo/vessel (same emailIds + itemIndex 0).
+  const DEMO_MATCH: Match = {
+    cargoEmailId: 'demo-cargo-economics',
+    cargoItemIndex: 0,
+    vesselEmailId: 'demo-vessel-economics',
+    vesselItemIndex: 0,
+    score: 88,
+    matchLevel: 'good',
+    matchReasons: ['DWT fit'],
+    issues: [],
+  };
+
+  // The exact shape cfValue() collapses to "" — a parsed-but-empty ConfidenceField.
+  const EMPTY_CF = { value: '', confidence: 'uncertain' as const };
+  const emptyNameVessel = (): ParsedVessel => ({ ...resolveSyntheticVessel(new Date()), vesselName: EMPTY_CF });
+  const emptyDescCargo = (): ParsedCargo => ({ ...resolveSyntheticCargo(new Date()), cargoDescription: EMPTY_CF });
+
+  it('persistSessionMatches: empty cfValue("") stored as null (UI ?? fallback engages)', () => {
+    const db = freshDb();
+    persistSessionMatches(db, 'session-empty-cf', [DEMO_MATCH], [emptyDescCargo()], [emptyNameVessel()]);
+
+    const [match] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+    expect(match).toBeDefined();
+    // Guard against a false-green: prove the vessel/cargo were actually linked
+    // (otherwise the `vessel ? ... : null` branch yields null regardless of the fix).
+    expect(match.vessel_dwt).toBe(58000);
+    expect(match.load_port).toBe('CNSHA');
+    // The fix under test: "" is normalized to null so the UI fallback engages.
+    expect(match.vessel_name).toBeNull();
+    expect(match.cargo_ref).toBeNull();
+  });
+
+  it('computeAndPersistMatches: empty cfValue("") stored as null', async () => {
+    const db = freshDb();
+    (analyzePairs as jest.Mock).mockResolvedValueOnce({ matches: [DEMO_MATCH], blockedMatches: [] });
+
+    await computeAndPersistMatches([emptyDescCargo()], [emptyNameVessel()], 'session-empty-compute', db);
+
+    const [match] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+    expect(match).toBeDefined();
+    expect(match.vessel_dwt).toBe(58000);
+    expect(match.load_port).toBe('CNSHA');
+    expect(match.vessel_name).toBeNull();
+    expect(match.cargo_ref).toBeNull();
   });
 });

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -94,8 +94,8 @@ export async function computeAndPersistMatches(
       distance_nm: distanceResult ? distanceResult.nm : null,
       freight_rate_usd_per_mt,
       freight_rate_source,
-      vessel_name: vessel ? (cfValue(vessel.vesselName) ?? null) : null,
-      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) ?? null) : null,
+      vessel_name: vessel ? (cfValue(vessel.vesselName) || null) : null,
+      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) || null) : null,
     });
   }
 

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -65,8 +65,8 @@ export function persistSessionMatches(
       distance_nm: distanceResult ? distanceResult.nm : null,
       freight_rate_usd_per_mt,
       freight_rate_source,
-      vessel_name: vessel ? (cfValue(vessel.vesselName) ?? null) : null,
-      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) ?? null) : null,
+      vessel_name: vessel ? (cfValue(vessel.vesselName) || null) : null,
+      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) || null) : null,
     });
   }
 }


### PR DESCRIPTION
## What & why

Follow-up polish to #687 (matches `vessel_name` denormalization, migration 041), found by cold QA.

`cfValue()` returns the raw `ConfidenceField` value, so a field parsed as `{ value: '' }` yields `""` — **not** `null`. The two denormalized write-sites used `cfValue(...) ?? null`, and `??` only catches `null`/`undefined`. So an empty-string name/description was persisted into `matches.vessel_name` / `matches.cargo_ref`.

The UI fallback then renders it via `vessel_name ?? vessel_id` (also `??`), which likewise passes `""` through — so the cell shows up **blank** instead of falling back to the `vessel_id` (the emailId).

## The fix (surgical — 4 lines)

`?? null` → `|| null` at both producer write-sites, so `""` normalizes to `null` and the UI fallback engages:

```diff
-      vessel_name: vessel ? (cfValue(vessel.vesselName) ?? null) : null,
-      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) ?? null) : null,
+      vessel_name: vessel ? (cfValue(vessel.vesselName) || null) : null,
+      cargo_ref: cargo ? (cfValue(cargo.cargoDescription) || null) : null,
```

- `lib/matching/persist-session-matches.ts`
- `lib/matching/compute-matches.ts`

**Safe** because both fields are `ConfidenceField<string>` — there is no falsy-but-valid value to clobber (no `0`/`false`, unlike a numeric field).

## Scope boundaries (intentionally untouched)

- **`cfValue` helper (`lib/types.ts`)** — many consumers; changing it risks regressions. Out of scope.
- **UI components** — `??` is correct once the stored value is `null`; no change needed.
- **`pair-analyzer.ts` `vessel_name: cfValue(...)`** — that builds the **LLM matching payload**, a different consumer (the model reads it, no UI fallback). Left alone.
- **`createMatch` / migration 041** — the repository faithfully stores what it's given; normalization belongs at the producer (single source of truth).

## Tests

Adds two producer write-through cases to `lib/matching/__tests__/matches-repository-vessel-name.test.ts` (PI2-behavioral: drives the real `persistSessionMatches` + `computeAndPersistMatches`, reads back via `listMatches`):

- empty `cfValue("")` → stored `vessel_name` / `cargo_ref` is `null`
- guarded against false-green by also asserting `vessel_dwt` / `load_port` are populated (proves the match row was actually linked, so the `vessel ? … : null` branch really executed)

Verified RED→GREEN (both fail with `Received: ""` before the fix, pass after).

## Verification

- Target test: **7/7** green (2 new + 5 existing)
- `lib/matching` suite: **170/170** green · API producer tests: **16/16** green
- `tsc --noEmit`: clean · ESLint on changed files: clean · pre-commit hook (eslint + tsc): passed
- Full suite: 7774 passed. The only failing suite — `scripts/__tests__/data-integrity-check.test.ts` — **fails identically on a clean `main` checkout** (a `tsx` subprocess producing empty stdout, unrelated to this change). Not introduced by this PR.

## Impact

Low-priority polish: current demo fixtures only contain real names or `null`, so this does not change the live demo. It hardens against any future parse that yields an empty `ConfidenceField`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
