### PR TITLE
fix(auth): fail-closed getRequestBaseUrl — don't trust client Host for redirects (BUG-3)

### DIFF
--- a/__tests__/auth/redirect-url.test.ts
+++ b/__tests__/auth/redirect-url.test.ts
@@ -31,11 +31,33 @@ describe('getRequestBaseUrl', () => {
     expect(getRequestBaseUrl(req)).toBe('https://demo.quantika.org');
   });
 
-  it('falls back to Host header with https when X-Forwarded-* missing (public host)', () => {
+  it('does NOT honor an untrusted public Host header (fail-closed → safe default)', () => {
     const req = makeReq('http://localhost:3000/api/auth/login', {
-      host: 'demo.quantika.org',
+      host: 'tenant.example.com',
     });
-    expect(getRequestBaseUrl(req)).toBe('https://demo.quantika.org');
+    const result = getRequestBaseUrl(req);
+    expect(result).toBe('https://demo.quantika.org');
+    expect(result).not.toContain('tenant.example.com');
+  });
+
+  it('does not turn a spoofed Host into an open redirect (BUG-3)', () => {
+    const req = makeReq('http://localhost:3000/dashboard', { host: 'evil.example' });
+    const result = getRequestBaseUrl(req);
+    expect(result).toBe('https://demo.quantika.org');
+    expect(result).not.toContain('evil.example');
+  });
+
+  it('fail-closed invariant: never echoes an untrusted non-local Host', () => {
+    const hostiles = [
+      'evil.example', 'attacker.com', 'demo.quantika.org.evil.net',
+      'localhost.evil.com', '127.0.0.1.evil.com', 'evil.com:8080', 'xn--80ak6aa92e.com',
+    ];
+    for (const h of hostiles) {
+      const req = makeReq('http://localhost:3000/dashboard', { host: h });
+      const result = getRequestBaseUrl(req);
+      expect(result).toBe('https://demo.quantika.org');
+      expect(result).not.toContain(h);
+    }
   });
 
   it('falls back to Host with http for localhost (dev)', () => {

--- a/lib/auth/redirect-url.ts
+++ b/lib/auth/redirect-url.ts
@@ -3,18 +3,29 @@ import { NextRequest } from 'next/server';
 /**
  * Build the external base URL used for server-issued redirects.
  *
- * L-1 hardening: the client-controlled `X-Forwarded-Host` header must NOT be
- * trusted by default — an attacker could set it to an arbitrary domain and turn
- * a login redirect into an open redirect / host-header poisoning vector.
+ * Fail-closed (BUG-3): a non-local Host header that arrives without trusted
+ * configuration (NEXT_PUBLIC_APP_URL) or a trusted proxy (TRUST_PROXY_HEADERS)
+ * is client-controlled and MUST NOT be echoed into a redirect base — doing so
+ * enables open-redirect / host-header poisoning.
  *
  * Resolution order:
  *   1. NEXT_PUBLIC_APP_URL          — canonical server config (always preferred).
  *   2. X-Forwarded-{Host,Proto}     — only when TRUST_PROXY_HEADERS=true
- *                                     (explicit opt-in for the Caddy deployment,
- *                                      which strips/overwrites these headers).
- *   3. Host header                  — the value Next.js itself parsed.
- *   4. request.url                  — last resort.
+ *                                     (explicit opt-in for the Caddy deployment).
+ *   3. Host header                  — honoured ONLY if it came from a trusted
+ *                                     proxy (fwdHost set) OR is genuine localhost /
+ *                                     127.0.0.1. Exact match only — localhost.evil.com
+ *                                     and 127.0.0.1.evil.com are NOT local.
+ *   4. Untrusted non-local Host     — safe default https://demo.quantika.org
+ *   5. request.url                  — last resort when Host header absent.
  */
+
+function isLocalHost(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === 'localhost' || h.startsWith('localhost:')
+    || h === '127.0.0.1' || h.startsWith('127.0.0.1:');
+}
+
 export function getRequestBaseUrl(request: NextRequest): string {
   // 1. Trusted server-side configuration wins outright.
   const configured = process.env.NEXT_PUBLIC_APP_URL;
@@ -23,20 +34,26 @@ export function getRequestBaseUrl(request: NextRequest): string {
   }
 
   const trustProxy = process.env.TRUST_PROXY_HEADERS === 'true';
-
-  // 2. Forwarded headers are only consulted behind a trusted proxy.
+  // 2. Forwarded headers only behind an explicitly trusted proxy.
   const fwdHost = trustProxy ? request.headers.get('x-forwarded-host') : null;
   const fwdProto = trustProxy ? request.headers.get('x-forwarded-proto') : null;
-
-  // 3. Otherwise rely on the Host header Next.js parsed for this request.
   const host = fwdHost ?? request.headers.get('host');
 
   if (host) {
-    const proto = fwdProto ?? (host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https');
-    return `${proto}://${host}`;
+    const local = isLocalHost(host);
+    // BUG-3 fail-closed: a non-local Host header is client-controlled. Echoing it
+    // into a redirect base without trusted config (NEXT_PUBLIC_APP_URL) or a trusted
+    // proxy (TRUST_PROXY_HEADERS=true → fwdHost set) is an open-redirect /
+    // host-header-poisoning vector.
+    if (fwdHost || local) {
+      const proto = fwdProto ?? (local ? 'http' : 'https');
+      return `${proto}://${host}`;
+    }
+    // Untrusted, non-local Host → safe default (mirrors lib/csrf.ts fallback).
+    return 'https://demo.quantika.org';
   }
 
-  // 4. Last resort.
+  // 3. Last resort.
   const url = new URL(request.url);
   return `${url.protocol}//${url.host}`;
 }


### PR DESCRIPTION
## What & why
Cold-QA on PR #686 flagged **BUG-3** (MEDIUM, pre-existing): `getRequestBaseUrl` echoed a client-controlled `Host` header into the server-side redirect base (`/login`, `/dashboard`) when **neither** `NEXT_PUBLIC_APP_URL` **nor** `TRUST_PROXY_HEADERS=true` was set — an open-redirect / host-header-poisoning vector. #686 merged before this follow-up landed, so this applies the fix on top of `main`.

## Fix (`lib/auth/redirect-url.ts`)
- Non-local `Host` with no trusted config/proxy → return safe default `https://demo.quantika.org` (mirrors `lib/csrf.ts`) instead of echoing the attacker host.
- Tighten localhost detection to **exact** match → `localhost.evil.com` / `127.0.0.1.evil.com` are NOT treated as local.
- Unchanged for prod (`NEXT_PUBLIC_APP_URL` wins), dev (`localhost`), trusted-proxy (`TRUST_PROXY_HEADERS=true`). Consumers (`middleware`, `login`, `logout`) only do first-party redirects → unaffected.

## Risk / exploitability
Prod was **not** externally exploitable (Cloudflare 403s spoofed `Host`; Caddy overwrites `X-Forwarded-Host`) — verified live. This removes the latent app-layer fail-open so the code no longer depends on the env var being present.

## Tests (8/8 green)
- Spoofed-Host regression (`evil.example` → safe default, no leak).
- Fail-closed invariant over 7 hostile hosts (incl. `localhost.evil.com`, punycode, ports).
- Flipped the old "honor public Host" test to assert fail-closed (security-contract intent change).
- Independent adversarial QI (security-auditor, 11-class boundary): **PASS, 0 CRITICAL / 0 HIGH**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)