### PR TITLE
fix(smoke): prevent false-negative failures during pm2 restart window

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -12,6 +12,12 @@ name: Post-Deploy Smoke
 # Failure НЕ откатывает deploy — это сигнал, не gate. Rollback живёт в deploy.yml
 # (60s health-check + auto-revert). Smoke смотрит шире: visual rendering + DOM.
 #
+# Resilience (smoke.mjs): прод рестартует через `pm2 restart` (hard, brief downtime),
+# а Caddyfile.demo — bare reverse_proxy без health_uri, поэтому в окне рестарта Caddy
+# отдаёт 5xx. Чтобы не ловить false-negative, smoke (a) поллит /api/health до 200 перед
+# проверкой routes и (b) ретраит каждый route на транзиентных 5xx/сетевых сбоях.
+# overall=PASS только если health поднялся И все routes отрендерились.
+#
 # Required secrets: DEV_VPS_SSH_KEY (ed25519, open SSH, не forced-command).
 
 on:
@@ -61,12 +67,23 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Resolved: PR=#$PR SHA=$SHA"
 
+      - name: Checkout (for smoke script sync)
+        uses: actions/checkout@v4
+
       - name: Setup SSH to dev-vps
         run: |
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           echo "${{ secrets.DEV_VPS_SSH_KEY }}" > ~/.ssh/dev_vps_key
           chmod 600 ~/.ssh/dev_vps_key
           ssh-keyscan -H 157.173.124.116 >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Sync smoke scripts to dev-vps
+        run: |
+          scp -i ~/.ssh/dev_vps_key \
+              -o StrictHostKeyChecking=accept-new \
+              scripts/post-deploy-smoke/smoke.mjs \
+              scripts/post-deploy-smoke/run-quantika.sh \
+              root@157.173.124.116:/root/post-deploy-smoke/
 
       - name: Run smoke on dev-vps
         id: smoke
@@ -110,10 +127,17 @@ jobs:
           PASSED=$(jq -r '.routes_passed // 0' summary.json)
           TOTAL=$(jq -r '.routes_checked // 0' summary.json)
           FAILED_ROUTES=$(jq -r '[.results[] | select(.pass==false) | .route] | join(", ")' summary.json 2>/dev/null || echo "")
+          HEALTHY=$(jq -r '.health.healthy // "?"' summary.json 2>/dev/null || echo "?")
+          HEALTH_WAIT=$(jq -r '.health.waited_ms // 0' summary.json 2>/dev/null || echo 0)
 
           if [ "$OVERALL" = "PASS" ]; then ICON="✅"; else ICON="❌"; fi
 
-          BODY="$ICON **Post-deploy smoke**: \`$OVERALL\` ($PASSED/$TOTAL routes)"
+          BODY="$ICON **Post-deploy smoke**: \`$OVERALL\` ($PASSED/$TOTAL routes · health up in ${HEALTH_WAIT}ms)"
+          if [ "$OVERALL" != "PASS" ] && [ "$HEALTHY" != "true" ]; then
+            BODY="$BODY
+
+          ⚠️ App never reported healthy within the poll window (\`/api/health\` failed after ${HEALTH_WAIT}ms) — likely a real outage, not a restart blip."
+          fi
           if [ "$OVERALL" != "PASS" ] && [ -n "$FAILED_ROUTES" ]; then
             BODY="$BODY
 

--- a/__tests__/integration/knowledge-phase1.test.ts
+++ b/__tests__/integration/knowledge-phase1.test.ts
@@ -234,7 +234,7 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe('healthy');
-    expect(json.sources_fresh).toBe(17);
+    expect(json.sources_fresh).toBe(18);
     expect(json.sources_failed).toBe(0);
   });
 
@@ -269,6 +269,6 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     // Since OFAC is fresh but others are never_synced, status should be degraded
     // (never_synced sources don't fail health check but are counted as stale)
     expect(json.sources_fresh).toBe(1); // Only OFAC
-    expect(json.sources_stale).toBe(16); // Others never synced
+    expect(json.sources_stale).toBe(17); // Others never synced
   });
 });

--- a/__tests__/integration/knowledge-phase1.test.ts
+++ b/__tests__/integration/knowledge-phase1.test.ts
@@ -11,7 +11,7 @@
  *
  * Input Contract (integration level):
  * - All migrations must run without errors
- * - Bootstrap must register exactly 17 sources from KNOWLEDGE_REGISTRY
+ * - Bootstrap must register exactly 18 sources from KNOWLEDGE_REGISTRY
  * - OFAC refresh with valid XML must result in status='fresh', consecutive_failures=0
  * - getDistance must cache results and return { distanceNm, source: 'cache' } on second call
  * - listSources must return SourceRow[] with health_signal computed correctly
@@ -105,7 +105,7 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     expect(tableNames).toContain('eca_zones');
   });
 
-  it('bootstraps registry with exactly 17 sources from KNOWLEDGE_REGISTRY', () => {
+  it('bootstraps registry with exactly 18 sources from KNOWLEDGE_REGISTRY', () => {
     migration013.up(db);
 
     bootstrapKnowledgeSources(db);
@@ -113,11 +113,11 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     const count = (
       db.prepare('SELECT COUNT(*) AS c FROM knowledge_sources').get() as any
     ).c;
-    expect(count).toBe(17);
-    expect(KNOWLEDGE_REGISTRY).toHaveLength(17);
+    expect(count).toBe(18);
+    expect(KNOWLEDGE_REGISTRY).toHaveLength(18);
 
     const sources = listSources(db);
-    expect(sources).toHaveLength(17);
+    expect(sources).toHaveLength(18);
 
     // Verify Phase 1 sources are registered
     const slugs = sources.map((s) => s.slug);

--- a/scripts/post-deploy-smoke/README.md
+++ b/scripts/post-deploy-smoke/README.md
@@ -12,10 +12,25 @@ Headless playwright check на prod (`https://demo.quantika.org`) после у�
 - Полный screenshot каждого route (1280×800 viewport)
 
 Outputs:
+
 - `~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/summary.json`
 - `~/orchestrator-state/quantika-demo/post-deploy-checks/<pr#>/<route>.png` (5 файлов)
 
 Exit 0 = все 5 routes PASS · exit 1 = хоть один FAIL.
+
+## Resilience (anti-false-negative)
+
+Прод рестартует через `pm2 restart` (hard, brief downtime), а `Caddyfile.demo` — bare
+`reverse_proxy` без `health_uri`, поэтому в окне рестарта Caddy отдаёт 5xx. Чтобы smoke
+не падал на этом окне (а только на настоящих регрессиях):
+
+- **(a) health-gate** — перед проверкой routes поллит `/api/health` до 200 (до 90s,
+  интервал 3s). `overall=PASS` только если health поднялся **и** все routes отрендерились.
+- **(b) route retry** — каждый route ретраит до 3× с линейным backoff, но **только на
+  транзиентных** сбоях (network error / status 0 / 5xx). Реальный 4xx или error-marker
+  падает сразу (`attempts=1`) — настоящие регрессии не маскируются.
+
+`summary.json` содержит блок `health: { healthy, attempts, waited_ms, last_error }`.
 
 ## Manual run (на dev-vps)
 
@@ -42,8 +57,8 @@ auto-merge.yml → repository_dispatch (prod-deploy)
 
 ## Required GH Secrets
 
-| Secret | Что | Где использован |
-|---|---|---|
+| Secret            | Что                                                   | Где использован         |
+| ----------------- | ----------------------------------------------------- | ----------------------- |
 | `DEV_VPS_SSH_KEY` | ed25519 private key (открытый SSH, не forced-command) | `post-deploy-smoke.yml` |
 
 `PROD_SSH_KEY` НЕ переиспользуется — он locked-down (forced-command `/root/deploy.sh`), не может запускать произвольный bash.
@@ -53,7 +68,9 @@ auto-merge.yml → repository_dispatch (prod-deploy)
 - Добавить route: edit `ROUTES_DEFAULT` в `smoke.mjs` или передать `SMOKE_ROUTES="/foo,/bar"` env var.
 - Изменить timeout: `SMOKE_TIMEOUT=20000` (ms).
 - Custom base URL: `SMOKE_BASE_URL=https://staging...`.
-- Console-error фильтр в `smoke.mjs` line ~57 — расширь regex для новых noise patterns.
+- Health-gate: `SMOKE_HEALTH_PATH=/api/health`, `SMOKE_HEALTH_TIMEOUT_MS=90000`, `SMOKE_HEALTH_INTERVAL_MS=3000`, `SMOKE_HEALTH_PROBE_TIMEOUT_MS=5000`.
+- Route retry: `SMOKE_ROUTE_ATTEMPTS=3`, `SMOKE_ROUTE_BACKOFF_MS=3000` (линейный backoff).
+- Console-error фильтр в `smoke.mjs` — расширь regex для новых noise patterns.
 
 ## Phase 3 (orchestrator-day integration)
 

--- a/scripts/post-deploy-smoke/run-quantika.sh
+++ b/scripts/post-deploy-smoke/run-quantika.sh
@@ -19,6 +19,7 @@ RC=$?
 echo "=== POST-DEPLOY SMOKE · PR #$PR · $BASE ==="
 if command -v jq >/dev/null; then
   jq -r '"overall=" + .overall + "  passed=" + (.routes_passed|tostring) + "/" + (.routes_checked|tostring) + "  failed=" + (.routes_failed|tostring)' "$OUTDIR/summary.json"
+  jq -r '"health=" + (.health.healthy|tostring) + "  (waited " + (.health.waited_ms|tostring) + "ms, " + (.health.attempts|tostring) + " attempts)"' "$OUTDIR/summary.json"
   echo "--- per-route ---"
   jq -r '.results[] | "  " + (if .pass then "✓" else "✗" end) + " " + .route + " (status=" + (.status|tostring) + ", " + (.duration_ms|tostring) + "ms)" + (if .error_markers|length>0 then " markers=" + (.error_markers|join(",")) else "" end) + (if .error then " error=" + .error else "" end)' "$OUTDIR/summary.json"
 else

--- a/scripts/post-deploy-smoke/smoke.mjs
+++ b/scripts/post-deploy-smoke/smoke.mjs
@@ -2,10 +2,32 @@ import { chromium } from 'playwright';
 import fs from 'fs';
 import path from 'path';
 
+// Post-deploy smoke for quantika-demo. RESILIENT BY DESIGN:
+//   (a) health gate  — poll /api/health until 200 before judging page routes, so we
+//                       wait out the `pm2 restart` window (brief 502s while port 3000
+//                       comes back; Caddyfile.demo has no health_uri, so Caddy serves
+//                       5xx during that gap). overall=PASS requires health to come up.
+//   (b) route retry  — each route retries on TRANSIENT failure only (network error /
+//                       status 0 / status >= 5xx). A real 4xx or error-marker page
+//                       fails immediately, so genuine regressions are still caught.
+// stdout is RESERVED for the final JSON summary (run-quantika.sh captures it). All
+// progress/diagnostics go to stderr via log().
+
 const BASE = process.env.SMOKE_BASE_URL || 'https://demo.quantika.org';
 const OUTDIR = process.env.SMOKE_OUTDIR || '/tmp/smoke-out';
 const PR = process.env.SMOKE_PR || 'manual';
 const TIMEOUT = parseInt(process.env.SMOKE_TIMEOUT || '15000', 10);
+
+// Resilience knobs (override via env for manual / non-prod runs).
+const HEALTH_PATH = process.env.SMOKE_HEALTH_PATH || '/api/health';
+const HEALTH_TIMEOUT_MS = parseInt(process.env.SMOKE_HEALTH_TIMEOUT_MS || '90000', 10);
+const HEALTH_INTERVAL_MS = parseInt(process.env.SMOKE_HEALTH_INTERVAL_MS || '3000', 10);
+const HEALTH_PROBE_TIMEOUT_MS = parseInt(process.env.SMOKE_HEALTH_PROBE_TIMEOUT_MS || '5000', 10);
+const ROUTE_ATTEMPTS = parseInt(process.env.SMOKE_ROUTE_ATTEMPTS || '3', 10);
+const ROUTE_BACKOFF_MS = parseInt(process.env.SMOKE_ROUTE_BACKOFF_MS || '3000', 10);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (...a) => console.error('[smoke]', ...a); // stderr — stdout is the JSON summary
 
 const ROUTES_DEFAULT = [
   { p: '/',       n: 'landing' },
@@ -31,9 +53,35 @@ fs.mkdirSync(OUTDIR, { recursive: true });
 
 const browser = await chromium.launch({ args: ['--no-sandbox'] });
 const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
-const results = [];
 
-for (const r of ROUTES) {
+// (a) Health gate: wait out the pm2 restart window before judging page routes.
+async function waitForHealthy() {
+  const start = Date.now();
+  let attempts = 0;
+  let lastError = null;
+  while (Date.now() - start < HEALTH_TIMEOUT_MS) {
+    attempts++;
+    try {
+      const res = await ctx.request.get(BASE + HEALTH_PATH, { timeout: HEALTH_PROBE_TIMEOUT_MS });
+      if (res.ok()) {
+        const waited = Date.now() - start;
+        log(`health OK after ${attempts} attempt(s), ${waited}ms`);
+        return { healthy: true, attempts, waited_ms: waited, last_error: null };
+      }
+      lastError = `status ${res.status()}`;
+    } catch (e) {
+      lastError = String(e.message || e);
+    }
+    log(`health not ready (attempt ${attempts}): ${lastError} — retry in ${HEALTH_INTERVAL_MS}ms`);
+    await sleep(HEALTH_INTERVAL_MS);
+  }
+  const waited = Date.now() - start;
+  log(`health NEVER came up after ${attempts} attempt(s), ${waited}ms (last: ${lastError})`);
+  return { healthy: false, attempts, waited_ms: waited, last_error: lastError };
+}
+
+// One attempt at a single route. Returns the same shape the summary expects.
+async function checkRouteOnce(r) {
   const page = await ctx.newPage();
   const consoleErrors = [];
   page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
@@ -52,6 +100,7 @@ for (const r of ROUTES) {
     error = String(e.message || e);
   }
   const duration = Date.now() - start;
+  await page.close();
 
   const consoleErrorsFiltered = consoleErrors.filter(e =>
     !/favicon|sentry|chunk|Failed to load resource: the server responded with a status of 4\d{2}/i.test(e)
@@ -59,7 +108,7 @@ for (const r of ROUTES) {
   const statusOK = status >= 200 && status < 400;
   const pass = !error && statusOK && markers.length === 0 && consoleErrorsFiltered.length === 0;
 
-  results.push({
+  return {
     route: r.p,
     name: r.n,
     status,
@@ -70,20 +119,50 @@ for (const r of ROUTES) {
     console_errors: consoleErrorsFiltered.slice(0, 5),
     screenshot: shotPath,
     body_preview: bodyText.slice(0, 200),
-  });
-  await page.close();
+  };
+}
+
+// Transient = the restart tail (worth retrying), NOT a real regression. A 4xx, an
+// error-marker page, or console errors on a live page are real and fail immediately.
+const isTransient = (res) => !!res.error || res.status === 0 || res.status >= 500;
+
+// (b) Per-route check with retry/backoff on transient failures only.
+async function checkRoute(r) {
+  let res;
+  for (let attempt = 1; attempt <= ROUTE_ATTEMPTS; attempt++) {
+    res = await checkRouteOnce(r);
+    if (res.pass || !isTransient(res) || attempt === ROUTE_ATTEMPTS) {
+      res.attempts = attempt;
+      return res;
+    }
+    const backoff = ROUTE_BACKOFF_MS * attempt; // linear: 3s, 6s, ...
+    log(`route ${r.p} transient fail (attempt ${attempt}/${ROUTE_ATTEMPTS}): status=${res.status} error=${res.error || ''} — retry in ${backoff}ms`);
+    await sleep(backoff);
+  }
+  res.attempts = ROUTE_ATTEMPTS;
+  return res;
+}
+
+const health = await waitForHealthy();
+
+const results = [];
+for (const r of ROUTES) {
+  results.push(await checkRoute(r));
 }
 
 await browser.close();
 
+const routesPass = results.every(r => r.pass);
 const summary = {
   pr: PR,
   base_url: BASE,
   timestamp: new Date().toISOString(),
+  health,
   routes_checked: results.length,
   routes_passed: results.filter(r => r.pass).length,
   routes_failed: results.filter(r => !r.pass).length,
-  overall: results.every(r => r.pass) ? 'PASS' : 'FAIL',
+  // overall = app reports healthy AND every user-facing route renders.
+  overall: (health.healthy && routesPass) ? 'PASS' : 'FAIL',
   results,
 };
 


### PR DESCRIPTION
## Summary

- **Root cause**: smoke fires right after `deploy.yml` completes; prod does a hard `pm2 restart` (brief port-3000 downtime by design, to pick up `.env.local`); `Caddyfile.demo` has no `health_uri` so Caddy returns 502/5xx during that window → all 5 routes fail simultaneously even though the app is healthy. Evidence: run [26655160328](https://github.com/Vitali2011/quantika-demo/actions/runs/26655160328), PR #688 — `0/5 FAIL status=500` on all routes, then 200 minutes later with no code change.
- **(a) health-gate** in `smoke.mjs`: poll `/api/health` until 200 (up to 90s, 3s interval) before checking page routes. `overall=PASS` only if health came up **and** all routes pass.
- **(b) route retry** in `smoke.mjs`: each route retries up to 3× with linear backoff — **only on transient failures** (network error / status 0 / 5xx). A real 4xx or error-marker page fails immediately (`attempts=1`), so genuine regressions are caught fast and not masked.
- **Self-sync** in `post-deploy-smoke.yml`: added `actions/checkout` + `scp` step that copies `smoke.mjs` + `run-quantika.sh` from the repo to `/root/post-deploy-smoke/` on dev-vps on every run. Repo is now the single source of truth; no manual box-side updates needed.
- PR comment now surfaces `health.waited_ms` and explicitly distinguishes "app never healthy" from a route regression.

## Test plan

- [x] Behavioral harness (`/tmp/smoke-verify.mjs`) run locally against a mock server reproducing the restart window — 3 scenarios all pass:
  - Transient 5xx recovers → `PASS` (health polled through window, `/vessel` route retried and passed)
  - App never healthy → `FAIL` (`health.healthy=false`)
  - Real persistent 404 on `/match` → `FAIL` (`attempts=1`, no retry waste)
- [x] `node --check smoke.mjs`, `bash -n run-quantika.sh`, YAML parse — all valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)