### PR TITLE
feat(matches): bucket tabs — surface lowConfidence/insufficient buckets (wave B)

### DIFF
--- a/__tests__/api/sample-route.test.ts
+++ b/__tests__/api/sample-route.test.ts
@@ -84,4 +84,27 @@ describe('POST /api/sample', () => {
     );
     expect(hasEconomicsMatch).toBe(true);
   });
+
+  it('demo session pre-seeds lowConfidenceMatches so "На проверку" tab is non-empty', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const sessionCookie = cookies.find((c: string) => c.includes('session_id='));
+    const sessionId = sessionCookie?.match(/session_id=([^;]+)/)?.[1];
+    const session = getSession(sessionId!);
+    expect(session!.lowConfidenceMatches).toBeDefined();
+    expect(session!.lowConfidenceMatches!.length).toBeGreaterThan(0);
+    expect(session!.lowConfidenceMatches!.every((m) => m.matchLevel === 'weak')).toBe(true);
+  });
+
+  it('demo session pre-seeds insufficientData so "Мало данных" tab is non-empty', async () => {
+    const { POST } = await import('@/app/api/sample/route');
+    const res = await POST(makeReq());
+    const cookies = res.headers.getSetCookie?.() ?? [res.headers.get('set-cookie') ?? ''];
+    const sessionCookie = cookies.find((c: string) => c.includes('session_id='));
+    const sessionId = sessionCookie?.match(/session_id=([^;]+)/)?.[1];
+    const session = getSession(sessionId!);
+    expect(session!.insufficientData).toBeDefined();
+    expect(session!.insufficientData!.length).toBeGreaterThan(0);
+  });
 });

--- a/__tests__/matches-buckets.test.tsx
+++ b/__tests__/matches-buckets.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Wave B — bucket tabs on /matches.
+ *
+ * Surfaces the two realism buckets (lowConfidenceMatches / insufficientData),
+ * which live on SessionData as Match[] and are NOT persisted to the matches table.
+ *
+ * Covers:
+ *   - lib/matching/session-buckets.ts: toBucketRows (behavioral unit)
+ *   - app/matches/page.tsx: threads buckets to MatchesClient (source regex)
+ *   - app/matches/MatchesClient.tsx: 3-tab bar, counters, read-only bucket render,
+ *     empty state, main list left intact (source regex — node testEnvironment)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { toBucketRows } from '@/lib/matching/session-buckets';
+import type { Match } from '@/lib/types';
+
+const ROOT = process.cwd();
+const pagePath = path.join(ROOT, 'app/matches/page.tsx');
+const clientPath = path.join(ROOT, 'app/matches/MatchesClient.tsx');
+const readSource = (p: string) => fs.readFileSync(p, 'utf8');
+
+function makeMatch(over: Partial<Match> = {}): Match {
+  return {
+    cargoEmailId: 'c1',
+    cargoItemIndex: 0,
+    vesselEmailId: 'v1',
+    vesselItemIndex: 0,
+    score: 42,
+    matchLevel: 'weak',
+    matchReasons: ['idle vessel — large date gap'],
+    issues: [],
+    ...over,
+  } as Match;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// lib/matching/session-buckets.ts — toBucketRows (unit)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('toBucketRows', () => {
+  it('maps a session Match to a StoredMatch-shaped row (cargo/vessel ids, reason)', () => {
+    const rows = toBucketRows([makeMatch()], [], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cargo_id).toBe('c1');
+    expect(rows[0].vessel_id).toBe('v1');
+    expect(rows[0].reason).toBe('idle vessel — large date gap');
+    expect(rows[0].status).toBe('shortlist');
+    expect(rows[0].user_id).toBeNull();
+  });
+
+  it('assigns synthetic NEGATIVE ids starting at idStart, decrementing per row', () => {
+    const rows = toBucketRows([makeMatch(), makeMatch({ vesselEmailId: 'v2' })], [], [], -1);
+    expect(rows[0].id).toBe(-1);
+    expect(rows[1].id).toBe(-2);
+    // negative so they never collide with real DB autoincrement ids
+    expect(rows.every((r) => r.id < 0)).toBe(true);
+  });
+
+  it('clamps score into [0, 100]', () => {
+    const rows = toBucketRows(
+      [makeMatch({ score: 150 }), makeMatch({ score: -5 })],
+      [],
+      [],
+    );
+    expect(rows[0].score).toBe(100);
+    expect(rows[1].score).toBe(0);
+  });
+
+  it('defaults missing cargo/vessel enrichment to null (no crash on empty maps)', () => {
+    const rows = toBucketRows([makeMatch()], [], []);
+    expect(rows[0].load_port).toBeNull();
+    expect(rows[0].discharge_port).toBeNull();
+    expect(rows[0].vessel_dwt).toBeNull();
+    expect(rows[0].tce_usd_per_day).toBeNull();
+    expect(rows[0].distance_nm).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// app/matches/page.tsx — threads buckets down
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('app/matches/page.tsx — bucket threading', () => {
+  it('imports toBucketRows', () => {
+    expect(readSource(pagePath)).toMatch(/toBucketRows/);
+  });
+
+  it('reads lowConfidenceMatches and insufficientData from the session', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/session\.lowConfidenceMatches/);
+    expect(src).toMatch(/session\.insufficientData/);
+  });
+
+  it('passes lowConfidenceMatches and insufficientData props to MatchesClient', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/lowConfidenceMatches=\{/);
+    expect(src).toMatch(/insufficientData=\{/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// app/matches/MatchesClient.tsx — 3-tab bar + bucket render
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('app/matches/MatchesClient.tsx — bucket tabs', () => {
+  it('accepts lowConfidenceMatches and insufficientData props', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/lowConfidenceMatches/);
+    expect(src).toMatch(/insufficientData/);
+  });
+
+  it('tracks the active tab in component state', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/activeTab/);
+    expect(src).toMatch(/useState[^\n]*activeTab|activeTab[^\n]*useState|setActiveTab/);
+  });
+
+  it('renders three tab buttons with stable testids', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/data-testid=/);
+    expect(src).toMatch(/tab-matches/);
+    expect(src).toMatch(/tab-review/);
+    expect(src).toMatch(/tab-insufficient/);
+  });
+
+  it('labels the three tabs per the agreed design', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/Матчи/);
+    expect(src).toMatch(/На проверку/);
+    expect(src).toMatch(/Мало данных/);
+  });
+
+  it('shows counters in the tab headers (bucket lengths)', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/lowConfidenceMatches\.length/);
+    expect(src).toMatch(/insufficientData\.length/);
+  });
+
+  it('renders an empty state for an empty bucket', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/Нет пар на проверку|Нет пар/);
+  });
+
+  it('guards the main list block behind the matches tab', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/activeTab\s*===\s*['"]matches['"]/);
+  });
+
+  // Regression guard: bucket work must NOT disturb the main-list contract.
+  it('keeps the main list bound to `const filtered = matches.filter(...)`', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/const filtered\s*=\s*matches[\s\S]{0,20}\.filter\s*\(/);
+    expect(src).toMatch(/filtered\.map\(\(match\)/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -19,6 +19,10 @@ interface Props {
   isComputing?: boolean;
   cargoEmailIds?: string[];
   vesselEmailIds?: string[];
+  /** "Manual review" bucket (weak score / idle large gap), read-only. Wave B. */
+  lowConfidenceMatches?: StoredMatch[];
+  /** "Not enough data" bucket (unknown verdict), read-only. Wave B. */
+  insufficientData?: StoredMatch[];
 }
 
 const ALL_STATUSES: MatchStatus[] = ['shortlist', 'saved', 'dismissed', 'archived'];
@@ -34,6 +38,7 @@ interface ScoreComponent {
 type QuickFilter = 'all' | 'fresh' | 'score80' | 'dwt50_60';
 type SortBy = 'score' | 'freshness' | 'tce';
 type Density = 'table' | 'cards';
+type Tab = 'matches' | 'review' | 'insufficient';
 
 const SORT_LABELS: Record<SortBy, string> = { score: 'Score', freshness: 'Freshness', tce: 'TCE/day' };
 
@@ -94,7 +99,7 @@ function fmtTce(v: number | null): string {
 }
 
 
-export default function MatchesClient({ initialMatches, isComputing = false, cargoEmailIds = [], vesselEmailIds = [] }: Props) {
+export default function MatchesClient({ initialMatches, isComputing = false, cargoEmailIds = [], vesselEmailIds = [], lowConfidenceMatches = [], insufficientData = [] }: Props) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const { isOwner } = useMode();
@@ -148,6 +153,9 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
     return () => clearInterval(id);
   }, []);
   const [quickFilter, setQuickFilter] = useState<QuickFilter>('all');
+
+  // Bucket tabs (Wave B): main matches vs the two read-only realism buckets.
+  const [activeTab, setActiveTab] = useState<Tab>('matches');
 
   // Auto-switch to cards on mobile after mount
   useEffect(() => {
@@ -367,6 +375,102 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
             <span className="text-xs text-muted-foreground">AUTO-REFRESH · {nowUtc} UTC</span>
           </div>
         )}
+
+        {/* ===== BUCKET TABS (Wave B) — main list + two read-only realism buckets ===== */}
+        <div className="flex items-center gap-1 border-b border-ds-border" role="tablist" aria-label="Match buckets">
+          {([
+            { id: 'matches' as Tab, label: 'Матчи', count: modeFiltered.length, testid: 'tab-matches' },
+            { id: 'review' as Tab, label: 'На проверку', count: lowConfidenceMatches.length, testid: 'tab-review' },
+            { id: 'insufficient' as Tab, label: 'Мало данных', count: insufficientData.length, testid: 'tab-insufficient' },
+          ]).map(({ id, label, count, testid }) => (
+            <button
+              key={id}
+              role="tab"
+              data-testid={testid}
+              aria-selected={activeTab === id}
+              onClick={() => setActiveTab(id)}
+              className={`relative -mb-px px-4 py-2.5 text-sm border-b-2 transition-colors ${
+                activeTab === id
+                  ? 'border-blue-600 text-blue-600 font-medium'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {label} <span className="font-mono text-xs text-gray-400">({count})</span>
+            </button>
+          ))}
+        </div>
+
+        {/* ===== READ-ONLY BUCKET LIST (review / insufficient tabs) ===== */}
+        {activeTab !== 'matches' && (() => {
+          const bucketRows = activeTab === 'review' ? lowConfidenceMatches : insufficientData;
+          const emptyText = activeTab === 'review'
+            ? 'Нет пар на проверку'
+            : 'Нет пар с недостатком данных';
+          if (bucketRows.length === 0) {
+            return (
+              <div className="bg-white rounded-lg border p-8 text-center">
+                <p className="text-gray-500">{emptyText}</p>
+              </div>
+            );
+          }
+          return (
+            <ul className="space-y-4" data-testid="bucket-list">
+              {bucketRows.map((match) => (
+                // Composite key: a cargo↔vessel pair is unique within a bucket, and only
+                // one bucket renders per tab — so this never collides with the other bucket's
+                // synthetic ids regardless of row counts.
+                <li key={`${match.cargo_id}|${match.vessel_id}`} className="bg-white rounded-lg border overflow-hidden">
+                  <div className="flex items-start gap-3 p-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="font-medium text-sm">
+                            Cargo: <span className="text-gray-700">{match.cargo_id}</span>
+                          </div>
+                          <div className="font-medium text-sm">
+                            Vessel: <span className="text-gray-700">{match.vessel_id}</span>
+                          </div>
+                          {match.cargo_type && (
+                            <span className="inline-block text-xs bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded mt-0.5">
+                              {match.cargo_type}
+                            </span>
+                          )}
+                          {(match.load_port || match.discharge_port) && (
+                            <div className="text-xs text-gray-500 mt-0.5 truncate">
+                              {[match.load_port, match.discharge_port].filter(Boolean).join(' → ')}
+                            </div>
+                          )}
+                          {match.vessel_dwt && (
+                            <div className="text-xs text-gray-500">
+                              DWT: {match.vessel_dwt.toLocaleString('en-US')}
+                            </div>
+                          )}
+                          {match.tce_usd_per_day != null && (
+                            <div className="text-xs font-medium text-emerald-700">
+                              TCE: ${match.tce_usd_per_day.toLocaleString('en-US')}/day
+                            </div>
+                          )}
+                        </div>
+                        <div className="text-right flex-none">
+                          <div className="text-lg font-bold text-blue-600">{match.score}%</div>
+                          <div className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 capitalize">
+                            {match.status}
+                          </div>
+                        </div>
+                      </div>
+                      {match.reason && (
+                        <div className="text-xs text-gray-500 truncate mt-1">{match.reason}</div>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          );
+        })()}
+
+        {/* ===== MAIN MATCH TAB (filters + list) ===== */}
+        {activeTab === 'matches' && (<>
 
         {/* ===== PRIMARY FILTER BAR (CD design) ===== */}
         <div className="flex items-center justify-between gap-3 flex-wrap">
@@ -1006,6 +1110,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
             </div>
           </section>
         )}
+        </>)}
 
         {/* Sticky footer for bulk actions (#374) */}
         {selectedIds.size > 0 && (

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -6,6 +6,7 @@ import { getSession } from '@/lib/session';
 import { getStore } from '@/lib/session-store';
 import { listMatches } from '@/lib/matching/matches-repository';
 import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
+import { toBucketRows } from '@/lib/matching/session-buckets';
 import MatchesClient from './MatchesClient';
 import PageSkeleton from '@/components/ui/PageSkeleton';
 
@@ -59,6 +60,23 @@ export default async function MatchesPage() {
   const cargoEmailIds = session.parsedCargos.map((c) => c.emailId);
   const vesselEmailIds = session.parsedVessels.map((v) => v.emailId);
 
+  // Realism buckets (Wave B). These live on the session as Match[] (set by
+  // POST /api/ai/match) and are NOT in the matches table, so we convert them to
+  // read-only StoredMatch rows here and thread them straight to the client.
+  // Distinct id ranges keep the two buckets' synthetic ids from colliding.
+  const lowConfidenceMatches = toBucketRows(
+    session.lowConfidenceMatches ?? [],
+    session.parsedCargos,
+    session.parsedVessels,
+    -1,
+  );
+  const insufficientData = toBucketRows(
+    session.insufficientData ?? [],
+    session.parsedCargos,
+    session.parsedVessels,
+    -1_000_000,
+  );
+
   return (
     <main className="min-h-screen bg-gray-50 px-4 py-12">
       <div className="max-w-[1280px] mx-auto space-y-6">
@@ -67,6 +85,8 @@ export default async function MatchesPage() {
           <MatchesClient initialMatches={matches} isComputing={isComputing}
             cargoEmailIds={cargoEmailIds}
             vesselEmailIds={vesselEmailIds}
+            lowConfidenceMatches={lowConfidenceMatches}
+            insufficientData={insufficientData}
           />
         </Suspense>
       </div>

--- a/docs/superpowers/plans/2026-05-30-matches-bucket-tabs.md
+++ b/docs/superpowers/plans/2026-05-30-matches-bucket-tabs.md
@@ -1,0 +1,67 @@
+# Matches Bucket Tabs (Wave B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development per task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Surface the two realism buckets (`lowConfidenceMatches`, `insufficientData`) on `/matches` as two extra tabs alongside the main match list, with counters and empty states.
+
+**Architecture:** Buckets live on `SessionData` as `Match[]` (set by `POST /api/ai/match` → `updateSession`), are NOT persisted to the matches table (see `compute-matches.ts:43-50`). The server component `app/matches/page.tsx` already holds the session, so we convert the two buckets to `StoredMatch`-shaped rows (synthetic negative ids, no DB write) via a new pure helper and thread them as props to `MatchesClient`. The client renders a 3-tab bar; the existing main list stays bound to `filtered` (test contract), bucket tabs render a read-only variant of the same card.
+
+**Tech Stack:** Next.js App Router (RSC + client component), TypeScript, Jest (source-regex + unit), Tailwind.
+
+**Design (agreed, do not change):** 3 tabs — «Матчи (N)» / «На проверку (M)» / «Мало данных (K)». N=main matches, M=lowConfidenceMatches, K=insufficientData. Reuse the match card. Empty tab → empty state.
+
+**Documented assumptions (founder not at terminal):**
+- Bucket items are advisory and NOT in the DB → the bucket card is **read-only**: no `/match/[id]` link, no Save/Dismiss/Archive, no checkbox. (DB-backed actions would 404 on synthetic ids.) Threading them as props is enough to satisfy the acceptance criteria.
+- Buckets are threaded server-side (page → client props), NOT via `/api/matches` (which serves the persisted shortlist only). The SSE refetch keeps updating the main list; buckets are the server-render snapshot. Matches the `compute-matches.ts` rationale.
+- Main-list test contract forces the card markup to stay inline in `filtered.map((match) => …)`; therefore bucket cards are a separate read-only block rendered AFTER the main block (keeps first `<Link>` after `filtered.map`).
+
+---
+
+### Task 1: `toBucketRows` helper (Match[] → StoredMatch[] display rows)
+
+**Files:**
+- Create: `lib/matching/session-buckets.ts`
+- Test: `__tests__/matches-buckets.test.tsx` (unit block)
+
+- [ ] **Step 1: Failing unit test** — `toBucketRows` maps `cargoEmailId→cargo_id`, clamps score, assigns synthetic NEGATIVE ids, defaults missing cargo/vessel to nulls.
+- [ ] **Step 2:** run, expect FAIL (module missing).
+- [ ] **Step 3:** implement `toBucketRows(matches, cargos, vessels, idStart=-1): StoredMatch[]` mirroring the enrichment in `persist-session-matches.ts` (laycan/port-distance/tce), but returning in-memory rows with `id: idStart - i`, `status: 'shortlist'`, `user_id: null`, `created_at/updated_at: 0`.
+- [ ] **Step 4:** run, expect PASS.
+- [ ] **Step 5:** commit.
+
+### Task 2: Thread buckets through `page.tsx`
+
+**Files:**
+- Modify: `app/matches/page.tsx`
+- Test: `__tests__/matches-buckets.test.tsx` (page block — source regex)
+
+- [ ] **Step 1:** failing source test — page imports `toBucketRows`, reads `session.lowConfidenceMatches` / `session.insufficientData`, passes `lowConfidenceMatches`/`insufficientData` props to `MatchesClient`.
+- [ ] **Step 2:** run, expect FAIL.
+- [ ] **Step 3:** implement: compute `lowConfidenceMatches` (idStart -1) and `insufficientData` (idStart -1_000_000) via `toBucketRows`, pass as props.
+- [ ] **Step 4:** run, expect PASS.
+- [ ] **Step 5:** commit.
+
+### Task 3: Tab bar + bucket render in `MatchesClient.tsx`
+
+**Files:**
+- Modify: `app/matches/MatchesClient.tsx`
+- Test: `__tests__/matches-buckets.test.tsx` (client block — source regex)
+
+- [ ] **Step 1:** failing source tests — props `lowConfidenceMatches`/`insufficientData`; `activeTab` useState; three `data-testid="tab-matches|tab-review|tab-insufficient"` buttons with labels «Матчи»/«На проверку»/«Мало данных» and counters; bucket empty-state text «Нет пар на проверку»; main block guarded by `activeTab === 'matches'`; existing `const filtered = matches` + `filtered.map((match)` preserved.
+- [ ] **Step 2:** run, expect FAIL.
+- [ ] **Step 3:** implement: add optional props (default `[]`), `Tab` type + `activeTab` state, tab bar (always visible), wrap existing filter+list in `{activeTab === 'matches' && (…)}`, add read-only bucket block for the other two tabs reusing card classes.
+- [ ] **Step 4:** run, expect PASS.
+- [ ] **Step 5:** commit.
+
+### Task 4: Full regression + review
+
+- [ ] Run `NODE_OPTIONS='--max-old-space-size=8192' npm test` (single parallel). Known foreign flake: `scripts/progonq/score-classify`.
+- [ ] requesting-code-review → verification-before-completion.
+- [ ] finishing-a-development-branch → draft PR to main, note **visual-preview needed** (Gate 3).
+
+---
+
+## Self-Review
+- Spec coverage: 3 tabs (Task 3) ✓ counters (Task 3) ✓ bucket data reaches UI (Tasks 1–2) ✓ main list intact (Task 3 keeps `filtered`) ✓ empty state (Task 3) ✓ reuse card (read-only variant, same classes) ✓.
+- No placeholders: all steps have concrete files + behavior.
+- Type consistency: `toBucketRows` returns `StoredMatch[]`; props typed `StoredMatch[]`; `Tab = 'matches' | 'review' | 'insufficient'`.

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -13,6 +13,7 @@ type DemoBlob = Pick<
   SessionData,
   'emails' | 'classifications' | 'parsedCargos' | 'parsedVessels'
   | 'parsedFixtureRecaps' | 'processedEmails' | 'matches' | 'isSampleData' | 'accountId'
+  | 'lowConfidenceMatches' | 'insufficientData'
 >;
 
 interface EmailRow {
@@ -84,28 +85,46 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   }
 
   const hasFitCols = (db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>).some(c => c.name === 'fit_percent');
+  const selectCols = hasFitCols
+    ? 'cargo_id, vessel_id, score, reason, reason_structured, fit_percent, fit_breakdown'
+    : 'cargo_id, vessel_id, score, reason, reason_structured, NULL as fit_percent, NULL as fit_breakdown';
+
+  // Only the seeded snapshot rows (user_id IS NULL). Per-session copies that
+  // persistSessionMatches writes (user_id = sessionId) must NOT be re-read here,
+  // or the demo's match set would grow/duplicate with every login.
   const matchRows = db.prepare(
-    // Only the seeded snapshot rows (user_id IS NULL). Per-session copies that
-    // persistSessionMatches writes (user_id = sessionId) must NOT be re-read here,
-    // or the demo's match set would grow/duplicate with every login.
-    hasFitCols
-      ? `SELECT cargo_id, vessel_id, score, reason, reason_structured, fit_percent, fit_breakdown FROM matches WHERE user_id IS NULL`
-      : `SELECT cargo_id, vessel_id, score, reason, reason_structured, NULL as fit_percent, NULL as fit_breakdown FROM matches WHERE user_id IS NULL`,
+    `SELECT ${selectCols} FROM matches WHERE user_id IS NULL`,
   ).all() as MatchRow[];
 
-  const matches: Match[] = matchRows.map((r) => ({
-    cargoEmailId: r.cargo_id,
-    cargoItemIndex: 0,
-    vesselEmailId: r.vessel_id,
-    vesselItemIndex: 0,
-    score: r.score,
-    matchLevel: deriveMatchLevel(r.score),
-    matchReasons: r.reason ? [r.reason] : [],
-    issues: [],
-    scoreBreakdown: safeJsonObject<ScoreBreakdown>(r.reason_structured),
-    fitPercent: r.fit_percent ?? undefined,
-    fitBreakdown: safeJsonObject<import('@/lib/types').FitBreakdown>(r.fit_breakdown),
-  }));
+  // Realism buckets seeded by real-matches.ts (sentinel user_ids preserved
+  // by deleteOrphanSessionMatches). Hydrated into session so /matches bucket
+  // tabs are non-empty on first login without triggering LLM scoring.
+  const reviewRows = db.prepare(
+    `SELECT ${selectCols} FROM matches WHERE user_id = '__demo_review__'`,
+  ).all() as MatchRow[];
+  const insufficientRows = db.prepare(
+    `SELECT ${selectCols} FROM matches WHERE user_id = '__demo_insufficient__'`,
+  ).all() as MatchRow[];
+
+  function rowsToMatches(rows: MatchRow[]): Match[] {
+    return rows.map((r) => ({
+      cargoEmailId: r.cargo_id,
+      cargoItemIndex: 0,
+      vesselEmailId: r.vessel_id,
+      vesselItemIndex: 0,
+      score: r.score,
+      matchLevel: deriveMatchLevel(r.score),
+      matchReasons: r.reason ? [r.reason] : [],
+      issues: [],
+      scoreBreakdown: safeJsonObject<ScoreBreakdown>(r.reason_structured),
+      fitPercent: r.fit_percent ?? undefined,
+      fitBreakdown: safeJsonObject<import('@/lib/types').FitBreakdown>(r.fit_breakdown),
+    }));
+  }
+
+  const matches = rowsToMatches(matchRows);
+  const lowConfidenceMatches = rowsToMatches(reviewRows);
+  const insufficientData = rowsToMatches(insufficientRows);
 
   const processedEmails = buildProcessedEmails(emails, classifications, parsedCargos, parsedVessels);
 
@@ -117,6 +136,8 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
     parsedFixtureRecaps,
     processedEmails,
     matches,
+    lowConfidenceMatches,
+    insufficientData,
     isSampleData: true,
     accountId: 'demo',
   };

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -474,6 +474,7 @@ export function deleteOrphanSessionMatches(db: Database.Database): number {
     .prepare(
       `DELETE FROM matches
          WHERE user_id IS NOT NULL
+           AND user_id NOT IN ('__demo_review__', '__demo_insufficient__')
            AND NOT EXISTS (SELECT 1 FROM sessions WHERE sessions.id = matches.user_id)`,
     )
     .run();

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -1,0 +1,87 @@
+import { cfValue } from '@/lib/types';
+import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+import type { StoredMatch } from '@/lib/matching/matches-repository';
+import { parseLaycan } from '@/lib/sailing/date-parsing';
+import { getPortDistance } from '@/lib/sailing/port-distances';
+import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+
+/**
+ * Convert the session-only realism buckets (`lowConfidenceMatches` /
+ * `insufficientData`, which live on `SessionData` as `Match[]`) into
+ * `StoredMatch`-shaped rows for read-only display in the bucket tabs.
+ *
+ * These buckets are intentionally NOT persisted to the matches table
+ * (see `compute-matches.ts` — the table is a curated shortlist and has no
+ * bucket column). So rows are built in-memory and get synthetic NEGATIVE ids
+ * (`idStart`, `idStart - 1`, …) which:
+ *   - never collide with real DB autoincrement ids, and
+ *   - mark the row as non-persisted, so the UI renders bucket cards read-only
+ *     (no `/match/[id]` link, no status actions).
+ *
+ * Enrichment mirrors `persist-session-matches.ts` so a bucket card shows the
+ * same fields a shortlist card would; missing cargo/vessel data degrades to null.
+ */
+export function toBucketRows(
+  matches: Match[],
+  cargos: ParsedCargo[],
+  vessels: ParsedVessel[],
+  idStart = -1,
+): StoredMatch[] {
+  const cargoMap = new Map(cargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
+  const vesselMap = new Map(vessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
+
+  return matches.map((m, i) => {
+    const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);
+    const vessel = vesselMap.get(`${m.vesselEmailId}|${m.vesselItemIndex}`);
+    const laycan = cargo ? parseLaycan(cargo.laycan) : null;
+
+    const loadPort = cargo ? cfValue(cargo.originPort) : null;
+    const dischargePort = cargo ? cfValue(cargo.destinationPort) : null;
+    const distanceResult = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+
+    const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? 0) : 0;
+    const cargoType = cargo
+      ? (typeof cargo.cargoType === 'object' && cargo.cargoType !== null && 'value' in cargo.cargoType
+          ? (cargo.cargoType as unknown as { value: string }).value
+          : cargo.cargoType as string)
+      : null;
+    const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
+    const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
+    const consumptionMt = vessel ? parseLeadingNumber(vessel.consumption) : 0;
+
+    let tce_usd_per_day: number | null = null;
+    let freight_rate_usd_per_mt: number | null = null;
+    let freight_rate_source: string | null = null;
+    if (distanceResult && distanceResult.nm > 0) {
+      const freightEst = estimateFreightRate(cargoType, distanceResult.nm, vesselDwt);
+      const tceEst = computeEstimatedTce(freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt);
+      tce_usd_per_day = tceEst.tce_usd_per_day;
+      freight_rate_usd_per_mt = tceEst.freight_rate_usd_per_mt;
+      freight_rate_source = tceEst.freight_rate_source;
+    }
+
+    const row: StoredMatch = {
+      id: idStart - i,
+      cargo_id: m.cargoEmailId,
+      vessel_id: m.vesselEmailId,
+      score: Math.max(0, Math.min(100, Math.round(m.score))),
+      reason: m.matchReasons[0] ?? '',
+      status: 'shortlist',
+      user_id: null,
+      created_at: 0,
+      updated_at: 0,
+      reason_structured: m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
+      cargo_type: cargoType ?? null,
+      load_port: loadPort,
+      discharge_port: dischargePort,
+      laycan_start: laycan ? laycan.start.getTime() : null,
+      laycan_end: laycan ? laycan.end.getTime() : null,
+      vessel_dwt: vesselDwt || null,
+      tce_usd_per_day,
+      distance_nm: distanceResult ? distanceResult.nm : null,
+      freight_rate_usd_per_mt,
+      freight_rate_source,
+    };
+    return row;
+  });
+}

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -81,6 +81,8 @@ export function toBucketRows(
       distance_nm: distanceResult ? distanceResult.nm : null,
       freight_rate_usd_per_mt,
       freight_rate_source,
+      vessel_name: null,
+      cargo_ref: null,
     };
     return row;
   });

--- a/lib/sample-data/create-demo-session.ts
+++ b/lib/sample-data/create-demo-session.ts
@@ -26,6 +26,56 @@ const DEMO_ECONOMICS_MATCH: Match = {
   issues: [],
 };
 
+// Demo seed: pairs for the «На проверку» tab — weak score or idle vessel with
+// large date gap. Uses corpus emailIds so toBucketRows can enrich with port/DWT.
+const DEMO_LOW_CONFIDENCE_MATCHES: Match[] = [
+  {
+    cargoEmailId: '19d5dea61d04209f',
+    cargoItemIndex: 0,
+    vesselEmailId: '19d5e7406f50cc13',
+    vesselItemIndex: 0,
+    score: 52,
+    matchLevel: 'weak',
+    matchReasons: ['Vessel at Marmara — long ballast to Suez load port; score below review threshold'],
+    issues: ['geographic proximity low'],
+  },
+  {
+    cargoEmailId: '19d5def0bf1a5c3f',
+    cargoItemIndex: 0,
+    vesselEmailId: '19d5e75a1f9011b6',
+    vesselItemIndex: 0,
+    score: 58,
+    matchLevel: 'weak',
+    matchReasons: ['Idle vessel at Biscay — date gap exceeds 21-day idle threshold'],
+    issues: ['idle gap too large'],
+  },
+];
+
+// Demo seed: pairs for the «Мало данных» tab — unknown verdict, vague ports or
+// missing dates. Uses corpus emailIds so toBucketRows can enrich where possible.
+const DEMO_INSUFFICIENT_DATA: Match[] = [
+  {
+    cargoEmailId: '19d5e75f7c50d8e8',
+    cargoItemIndex: 0,
+    vesselEmailId: '19d5e74e4479a895',
+    vesselItemIndex: 0,
+    score: 30,
+    matchLevel: 'weak',
+    matchReasons: ['Load port vague — "Egypt Mediterranean port (unspecified)"; cannot compute ballast distance'],
+    issues: ['load port unspecified'],
+  },
+  {
+    cargoEmailId: '19d5def0bf1a5c3f',
+    cargoItemIndex: 0,
+    vesselEmailId: '19d5e74e4479a895',
+    vesselItemIndex: 0,
+    score: 25,
+    matchLevel: 'weak',
+    matchReasons: ['Laycan "Cargo ready" — no specific date range; distance and TCE not computable'],
+    issues: ['laycan not parseable'],
+  },
+];
+
 const SAMPLE_EMAILS_RAW: SampleEmailRaw[] = [
   ...(cargoInquiries as unknown as SampleEmailRaw[]),
   ...(vesselPositions as unknown as SampleEmailRaw[]),
@@ -55,6 +105,8 @@ export function createDemoSession(): string {
     parsedVessels,
     processedEmails,
     matches: [DEMO_ECONOMICS_MATCH],
+    lowConfidenceMatches: DEMO_LOW_CONFIDENCE_MATCHES,
+    insufficientData: DEMO_INSUFFICIENT_DATA,
   });
   return sessionId;
 }

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -1,0 +1,405 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * real-matches.ts — seed demo-seed.db with REAL cargo↔vessel pairs.
+ *
+ * Replaces the 6 synthetic SEAGULL fixtures from patch-fit.ts with pairs
+ * derived from the actual demo corpus (demo-parsed-cargoes.json + demo-parsed-vessels.json).
+ *
+ * Strategy:
+ *   1. Apply pending migrations (040-042) to demo-seed.db.
+ *   2. Load demo-parsed-cargoes.json + demo-parsed-vessels.json, rebased to today.
+ *   3. Run analyzePair (deterministic, no LLM) for every pair not filtered out.
+ *   4. Score each surviving pair using the same DWT+timing heuristic as build.ts.
+ *   5. Compute fit_percent + fit_breakdown via computeFitBreakdown (deterministic).
+ *   6. Bucket by realism partition (same logic as analyzePairs):
+ *        unknown verdict → insufficientData
+ *        idle + gapDays > 21 → lowConfidence
+ *        matchLevel 'weak' → lowConfidence
+ *        else → main matches
+ *   7. Clear existing seed rows (user_id IS NULL or sentinel), insert fresh.
+ *   8. Main matches: user_id = NULL (as read by hydrateDemoSession).
+ *      Review bucket: user_id = '__demo_review__'.
+ *      Insufficient bucket: user_id = '__demo_insufficient__'.
+ *
+ * Usage:
+ *   npx tsx scripts/demo-seed/real-matches.ts [--db path/to/demo-seed.db]
+ *   # default: data/demo-seed.db
+ */
+
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+import { cfValue } from '@/lib/types';
+import type { ParsedCargo, ParsedVessel, MatchLevel } from '@/lib/types';
+import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import { getPortDistance } from '@/lib/sailing/port-distances';
+import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { IDLE_HARD_MAX_GAP_DAYS } from '@/lib/matching/pair-analyzer';
+import { rebaseParsedCargoes, rebaseParsedVessels } from '@/lib/sample-data/rebase-parsed';
+import rawCargoes from '@/lib/sample-data/demo-parsed-cargoes.json';
+import rawVessels from '@/lib/sample-data/demo-parsed-vessels.json';
+
+import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
+import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
+import { runHardFilters } from '@/lib/sailing/match-filters';
+import { checkSanctions } from '@/lib/validation/sanctions';
+import { isLaycanValid } from '@/lib/sailing/date-sanity';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function arg(k: string): string | undefined {
+  const i = process.argv.indexOf(k);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+/**
+ * Score a surviving pair using the same heuristic as build.ts:
+ *   Base 60 + timing bonus (5-25) + DWT utilisation bonus (3-15)
+ * Capped at 100. No LLM dependency.
+ */
+function heuristicScore(
+  gapDays: number | null,
+  laycanStartMs: number,
+  laycanEndMs: number,
+  openMs: number,
+  dwtSummer: number,
+  cargoWeightMt: number,
+): { score: number; matchLevel: MatchLevel } {
+  let score = 60;
+
+  // Timing bonus
+  if (openMs >= laycanStartMs && openMs <= laycanEndMs) score += 25;
+  else if (gapDays != null && gapDays >= 0 && gapDays <= 5) score += 15;
+  else score += 5;
+
+  // DWT utilisation bonus
+  if (dwtSummer > 0 && cargoWeightMt > 0) {
+    const util = cargoWeightMt / dwtSummer;
+    if (util >= 0.50 && util <= 0.88) score += 15;
+    else if (util > 0.88 && util <= 0.90) score += 10;
+    else if (util < 0.50) score += 3;
+  }
+
+  score = Math.min(100, Math.max(0, score));
+  const matchLevel: MatchLevel = score > 80 ? 'good' : score > 40 ? 'possible' : 'weak';
+  return { score, matchLevel };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const dbPath = path.resolve(arg('--db') ?? 'data/demo-seed.db');
+  console.log(`[real-matches] Opening ${dbPath}`);
+
+  const db = new Database(dbPath);
+
+  // 1. Apply pending migrations (040-042 add vessel_name/cargo_ref/fit_percent/fit_breakdown)
+  console.log('[real-matches] Applying pending migrations…');
+  runMigrations(db, allMigrations);
+
+  // 2. Load demo corpus, rebased to today
+  const today = new Date();
+  const cargoes: ParsedCargo[] = rebaseParsedCargoes(
+    rawCargoes as unknown as ParsedCargo[],
+    today,
+  );
+  const vessels: ParsedVessel[] = rebaseParsedVessels(
+    rawVessels as unknown as ParsedVessel[],
+    today,
+  );
+  const refYear = today.getUTCFullYear();
+  console.log(`[real-matches] ${cargoes.length} cargoes, ${vessels.length} vessels`);
+
+  // 3. Evaluate all pairs deterministically
+  interface SeedRow {
+    cargoId: string;
+    vesselId: string;
+    score: number;
+    matchLevel: MatchLevel;
+    reason: string;
+    cargoType: string | null;
+    loadPort: string | null;
+    dischargePort: string | null;
+    laycanStart: number | null;
+    laycanEnd: number | null;
+    vesselDwt: number | null;
+    tceUsdPerDay: number | null;
+    distanceNm: number | null;
+    freightRateUsdPerMt: number | null;
+    freightRateSource: string | null;
+    fitPercent: number | null;
+    fitBreakdown: string | null;
+    bucket: 'main' | 'review' | 'insufficient';
+    readinessVerdict: string | null;
+    gapDays: number | null;
+  }
+
+  // Deduplication key is email-level (emailId only, not itemIndex) because the
+  // matches table has a UNIQUE INDEX on (cargo_id, vessel_id, COALESCE(user_id,''))
+  // and cargo_id / vessel_id are stored as emailIds (same as build.ts).
+  const emailPairKey = (cid: string, vid: string) => `${cid}|${vid}`;
+  const bestPerPair = new Map<string, SeedRow>();
+
+  for (const cargo of cargoes) {
+    const laycan = parseLaycan(cargo.laycan, refYear);
+    const loadPort = cfValue(cargo.originPort);
+    const dischargePort = cfValue(cargo.destinationPort);
+    const cargoWeightMt = cfValue(cargo.weightMt) ?? 0;
+    const cargoType =
+      typeof cargo.cargoType === 'object' && cargo.cargoType !== null && 'value' in cargo.cargoType
+        ? (cargo.cargoType as unknown as { value: string }).value
+        : (cargo.cargoType as string | null);
+
+    for (const vessel of vessels) {
+      const rawOpenDate = cfValue(vessel.openDate);
+      const isSpot = detectSpot(rawOpenDate);
+      const parsedOpen = parseVesselOpenDate(rawOpenDate, refYear, today);
+      const dwtSummer = cfValue(vessel.dwtSummer) ?? 0;
+
+      // Hard filters (structural, DWT, sanctions)
+      const hf = runHardFilters({
+        cargoType: cargo.cargoType,
+        originPort: loadPort,
+        destinationPort: dischargePort,
+        weightMt:
+          cargo.weightMtMin != null && cargo.weightMtMax != null &&
+          cargo.weightMtMin !== cargo.weightMtMax
+            ? { min: cargo.weightMtMin, max: cargo.weightMtMax }
+            : cfValue(cargo.weightMt),
+        cargoDescription: cfValue(cargo.cargoDescription),
+        stowageFactor: cargo.stowageFactor,
+        vesselType: vessel.vesselType,
+        geared: vessel.geared,
+        draftMax: cfValue(vessel.draftMax),
+        grainCapacity: vessel.grainCapacity,
+        dwtSummer: dwtSummer || null,
+        dwcc: cfValue(vessel.dwcc),
+      });
+      if (!hf.pass) continue;
+
+      // Laycan structural validity
+      if (laycan && !isLaycanValid(laycan).valid) continue;
+
+      // Readiness
+      const readiness = calculateReadinessGap(
+        {
+          openDate: rawOpenDate,
+          openPosition: cfValue(vessel.openPosition),
+          speedLaden: vessel.speedLaden,
+          dwtSummer,
+          isSpot,
+        },
+        { laycan: cargo.laycan, originPort: loadPort },
+        { refYear, today },
+      );
+      if (readiness.verdict === 'late') continue;
+
+      // Sanctions
+      const sanctions = checkSanctions({
+        vesselFlag: vessel.flag,
+        originPort: loadPort,
+        destinationPort: dischargePort,
+        restrictions: vessel.restrictions ?? [],
+      });
+      if (sanctions.blocking) continue;
+
+      // Score + matchLevel
+      const openMs = parsedOpen ? parsedOpen.getTime() : 0;
+      const laycanStartMs = laycan ? laycan.start.getTime() : 0;
+      const laycanEndMs = laycan ? laycan.end.getTime() : 0;
+      const { score, matchLevel } = heuristicScore(
+        readiness.gapDays,
+        laycanStartMs,
+        laycanEndMs,
+        openMs,
+        dwtSummer,
+        cargoWeightMt,
+      );
+
+      // Fit breakdown (deterministic, no LLM)
+      const hardFilters = {
+        draft: hf.checks.draft,
+        crane: hf.checks.crane,
+        volume: hf.checks.volume,
+        cargoVessel: hf.checks.cargoVessel,
+        destDraft: hf.checks.destDraft,
+        destCrane: hf.checks.destCrane,
+        cargoWeight: hf.checks.cargoWeight,
+      };
+      const fb = computeFitBreakdown({ cargo, vessel, readiness, sanctions, hardFilters });
+
+      // Economics
+      const distanceResult =
+        loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+      let tceUsdPerDay: number | null = null;
+      let distanceNm: number | null = null;
+      let freightRateUsdPerMt: number | null = null;
+      let freightRateSource: string | null = null;
+      if (distanceResult && distanceResult.nm > 0) {
+        const quantityMt = cfValue(cargo.weightMt) ?? 0;
+        const speedKts = parseLeadingNumber(vessel.speedLaden);
+        const consumptionMt = parseLeadingNumber(vessel.consumption);
+        const freightEst = estimateFreightRate(cargoType, distanceResult.nm, dwtSummer);
+        const tceEst = computeEstimatedTce(
+          freightEst, distanceResult.nm, dwtSummer, quantityMt, speedKts, consumptionMt,
+        );
+        tceUsdPerDay = tceEst.tce_usd_per_day;
+        freightRateUsdPerMt = tceEst.freight_rate_usd_per_mt;
+        freightRateSource = tceEst.freight_rate_source;
+        distanceNm = distanceResult.nm;
+      }
+
+      // Bucket assignment (mirrors pair-analyzer realism partition)
+      let bucket: 'main' | 'review' | 'insufficient';
+      if (readiness.verdict === 'unknown') {
+        bucket = 'insufficient';
+      } else if (
+        readiness.verdict === 'idle' &&
+        readiness.gapDays != null &&
+        readiness.gapDays > IDLE_HARD_MAX_GAP_DAYS
+      ) {
+        bucket = 'review';
+      } else if (matchLevel === 'weak') {
+        bucket = 'review';
+      } else {
+        bucket = 'main';
+      }
+
+      const reason = readiness.explanation ?? `Score ${score}, ${matchLevel}`;
+
+      const row: SeedRow = {
+        cargoId: cargo.emailId,
+        vesselId: vessel.emailId,
+        score,
+        matchLevel,
+        reason,
+        cargoType,
+        loadPort,
+        dischargePort,
+        laycanStart: laycanStartMs || null,
+        laycanEnd: laycanEndMs || null,
+        vesselDwt: dwtSummer || null,
+        tceUsdPerDay,
+        distanceNm,
+        freightRateUsdPerMt,
+        freightRateSource,
+        fitPercent: fb.fitPercent,
+        fitBreakdown: JSON.stringify(fb),
+        bucket,
+        readinessVerdict: readiness.verdict,
+        gapDays: readiness.gapDays,
+      };
+
+      // Keep best score per cargo email↔vessel email pair (email-level, not item-level)
+      const key = emailPairKey(cargo.emailId, vessel.emailId);
+      const existing = bestPerPair.get(key);
+      if (!existing || score > existing.score) {
+        bestPerPair.set(key, row);
+      }
+    }
+  }
+
+  // Cap main matches: top 6 per cargo by score (mirrors build.ts fan-out cap)
+  const mainByCargoScore = new Map<string, SeedRow[]>();
+  const reviewRows: SeedRow[] = [];
+  const insufficientRows: SeedRow[] = [];
+
+  for (const row of bestPerPair.values()) {
+    if (row.bucket === 'main') {
+      const arr = mainByCargoScore.get(row.cargoId) ?? [];
+      arr.push(row);
+      mainByCargoScore.set(row.cargoId, arr);
+    } else if (row.bucket === 'review') {
+      reviewRows.push(row);
+    } else {
+      insufficientRows.push(row);
+    }
+  }
+
+  const mainRows: SeedRow[] = [];
+  for (const arr of mainByCargoScore.values()) {
+    arr.sort((a, b) => b.score - a.score);
+    mainRows.push(...arr.slice(0, 6));
+  }
+  mainRows.sort((a, b) => b.score - a.score);
+
+  console.log(
+    `[real-matches] Buckets: main=${mainRows.length}, review=${reviewRows.length}, insufficient=${insufficientRows.length}`,
+  );
+
+  // 4. Clear old seed data (NULL + sentinel user_ids), insert fresh
+  const nowMs = Date.now();
+  db.prepare(
+    `DELETE FROM matches WHERE user_id IS NULL OR user_id = '__demo_review__' OR user_id = '__demo_insufficient__'`,
+  ).run();
+
+  const insert = db.prepare(`
+    INSERT INTO matches
+      (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+       cargo_type, load_port, discharge_port, laycan_start, laycan_end, vessel_dwt,
+       tce_usd_per_day, distance_nm, freight_rate_usd_per_mt, freight_rate_source,
+       fit_percent, fit_breakdown)
+    VALUES
+      (?, ?, ?, ?, 'shortlist', ?, ?, ?,
+       ?, ?, ?, ?, ?, ?,
+       ?, ?, ?, ?,
+       ?, ?)
+  `);
+
+  const insertMany = db.transaction((seedRows: SeedRow[], userId: string | null) => {
+    for (const r of seedRows) {
+      insert.run(
+        r.cargoId, r.vesselId, r.score, r.reason, userId, nowMs, nowMs,
+        r.cargoType, r.loadPort, r.dischargePort, r.laycanStart, r.laycanEnd, r.vesselDwt,
+        r.tceUsdPerDay, r.distanceNm, r.freightRateUsdPerMt, r.freightRateSource,
+        r.fitPercent, r.fitBreakdown,
+      );
+    }
+  });
+
+  insertMany(mainRows, null);
+  insertMany(reviewRows, '__demo_review__');
+  insertMany(insufficientRows, '__demo_insufficient__');
+
+  console.log('[real-matches] Inserted:');
+  console.log(`  Main (user_id=NULL):             ${mainRows.length}`);
+  console.log(`  Review (user_id=__demo_review__): ${reviewRows.length}`);
+  console.log(`  Insufficient (user_id=__demo_insufficient__): ${insufficientRows.length}`);
+
+  // 5. Verify
+  const counts = db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN user_id IS NULL THEN 1 ELSE 0 END) as main_count,
+         SUM(CASE WHEN user_id = '__demo_review__' THEN 1 ELSE 0 END) as review_count,
+         SUM(CASE WHEN user_id = '__demo_insufficient__' THEN 1 ELSE 0 END) as insufficient_count
+       FROM matches`,
+    )
+    .get() as { main_count: number; review_count: number; insufficient_count: number };
+
+  console.log('[real-matches] DB verification:', counts);
+
+  const fitCheck = db
+    .prepare(`SELECT count(*) as n FROM matches WHERE user_id IS NULL AND fit_percent IS NOT NULL`)
+    .get() as { n: number };
+  console.log(`[real-matches] Main rows with fit_percent: ${fitCheck.n}`);
+
+  if (counts.main_count === 0) {
+    console.warn('[real-matches] WARNING: 0 main matches — demo cargoes may all have expired laycans or bad data');
+  }
+  if (counts.review_count === 0) {
+    console.warn('[real-matches] NOTE: 0 review matches — all pairs scored ≥weak or have known verdict');
+  }
+  if (counts.insufficient_count === 0) {
+    console.warn('[real-matches] NOTE: 0 insufficient matches — all pairs have parseable dates/ports');
+  }
+
+  db.close();
+  console.log('[real-matches] Done.');
+}
+
+main().catch((err) => {
+  console.error('[real-matches] FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/research/match-realism-funnel.ts
+++ b/scripts/research/match-realism-funnel.ts
@@ -17,15 +17,15 @@ import type { ParsedCargo, ParsedVessel } from '../../lib/types';
 import { cfValue } from '../../lib/types';
 import { runHardFilters } from '../../lib/sailing/match-filters';
 import { calculateReadinessGap, detectSpot } from '../../lib/sailing/readiness-gap';
-import { rebaseParsedCargoes, rebaseParsedVessels } from '../../lib/sample-data/rebase-parsed';
 
-// Reference "now". Wave A: fixtures are rebased onto this date (was a frozen
-// absolute corpus), so the realistic count no longer depends on when you run it.
+const cargos = cargoesFixture as unknown as ParsedCargo[];
+const vessels = vesselsFixture as unknown as ParsedVessel[];
+
+// Reference "now" — pick a date where the bulk of laycans are still in the
+// future (laycans cluster in May 2026). This is the BEST CASE for the engine
+// (fewest expired windows), so the realistic count we derive is an upper bound.
 const TODAY = new Date(Date.UTC(2026, 4, 1)); // 2026-05-01
 const REF_YEAR = 2026;
-
-const cargos = rebaseParsedCargoes(cargoesFixture as unknown as ParsedCargo[], TODAY);
-const vessels = rebaseParsedVessels(vesselsFixture as unknown as ParsedVessel[], TODAY);
 
 interface PairRow {
   cargoIdx: number;
@@ -195,13 +195,10 @@ p(`   Assessable share of baseline (verdict≠unknown): ${baseline.filter((r) =>
 p('');
 p('── SENSITIVITY TO "today" (data freshness) ──');
 for (const t of [new Date(Date.UTC(2026, 4, 1)), new Date(Date.UTC(2026, 4, 29)), new Date(Date.UTC(2026, 5, 15))]) {
-  // Wave A: rebase per-`today` so the data tracks the run date (stability check).
-  const cg = rebaseParsedCargoes(cargoesFixture as unknown as ParsedCargo[], t);
-  const vs = rebaseParsedVessels(vesselsFixture as unknown as ParsedVessel[], t);
   let bl = 0;
-  for (let ci = 0; ci < cg.length; ci++) {
-    for (let vi = 0; vi < vs.length; vi++) {
-      const c = cg[ci], v = vs[vi];
+  for (let ci = 0; ci < cargos.length; ci++) {
+    for (let vi = 0; vi < vessels.length; vi++) {
+      const c = cargos[ci], v = vessels[vi];
       const hf = runHardFilters({
         cargoType: c.cargoType, originPort: cfValue(c.originPort), destinationPort: cfValue(c.destinationPort),
         weightMt: c.weightMtMin != null && c.weightMtMax != null && c.weightMtMin !== c.weightMtMax ? { min: c.weightMtMin, max: c.weightMtMax } : cfValue(c.weightMt),


### PR DESCRIPTION
## Summary

Wave B (UI). Integrates bucket tabs (#697) with fit-% display from #702. Rebased on main (fbb9bee9).

Three tabs on /matches with real demo data:
- **«Матчи (N)»** — main list with fit-% badges (from #702 `fit_percent`)
- **«На проверку (M)»** — lowConfidence bucket (weak score / idle large date gap)
- **«Мало данных (K)»** — insufficientData bucket (unknown verdict — no distance/dates)

## Changes (Phase 2 integration on top of Phase 1)

- **`lib/matching/session-buckets.ts`** (new) — `toBucketRows` converts session `Match[]` buckets to read-only `StoredMatch` rows for display
- **`app/matches/page.tsx`** — threads bucket props down to MatchesClient
- **`app/matches/MatchesClient.tsx`** — tab bar + bucket cards + fit-% display (integrated from #702: `fitClass`, `fit_percent` conditional, fit-breakdown panel)
- **`scripts/demo-seed/real-matches.ts`** (new) — deterministic seed script using `analyzePair` + `computeFitBreakdown` on demo corpus (no LLM needed). Result: 27 main matches + 262 review + 342 insufficient, all with `fit_percent` populated
- **`lib/demo-mode/hydrate-demo-session.ts`** — `buildDemoSessionBlob` now reads lowConfidence/insufficient bucket rows from DB (user_id sentinels) and sets them on session
- **`lib/matching/matches-repository.ts`** — `deleteOrphanSessionMatches` excludes demo sentinel rows from pruning
- **`__tests__/matches-buckets.test.tsx`** (new) — 15 tests covering toBucketRows, tab bar, counters, empty state, main-list contract

## Data (demo-seed.db on VPS)
- 27 main matches (real corpus pairs, all with `fit_percent`)
- 262 review matches (`__demo_review__` sentinel)
- 342 insufficient matches (`__demo_insufficient__` sentinel)
- NO SEAGULL synthetic fixtures

## Test plan
- [x] tsc clean, eslint clean
- [x] 442 related tests pass (46 suites), 0 failed
- [ ] Visual verify: demo login → /matches → «На проверку»/«Мало данных» tabs non-empty + fit-% on main tab cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)