### PR TITLE
feat(matching): wire match.economics — TCE $/day + JWC war-risk (L2 #5+#6)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-l2-economics-wiring.md
+++ b/docs/superpowers/plans/2026-05-30-l2-economics-wiring.md
@@ -1,0 +1,277 @@
+# L2 Economics Wiring — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate `Match.economics` (TCE $/day + JWC war-risk) in the matching pipeline by wiring the already-working TCE engine + war-risk into `analyzePairs`.
+
+**Architecture:** A new pure helper `buildMatchEconomics()` in `lib/matching/tce-calculator.ts` reuses the existing `estimateFreightRate` + `computeEstimatedTce` (so the per-day TCE is byte-identical to the value `compute-matches.ts` already persists to the `tce_usd_per_day` DB column) and adds `calculateWarRiskPremium` for the JWC line item, returning an `EconomicsResult`. `analyzePairs` calls it for each main (good/possible) match after the realism partition, attaching the result to `match.economics`. Scoring, ranking, bucketing untouched — economics is display-only.
+
+**Tech Stack:** TypeScript, Jest, better-sqlite3 (test infra only — helper is DB-free).
+
+---
+
+## Scope
+
+- **IN (#5):** wire `match.economics` (TCE $/day) for good/possible matches in `analyzePairs`.
+- **IN (#6):** JWC war-risk premium surfaced inside that `EconomicsResult` (`breakdown.warRiskPremium / warRiskZones / warRiskBreakdown`).
+- **OUT (#7):** freight-rate source — reuse `estimateFreightRate` as-is.
+- **OUT (#8):** score / ranking / bucket partition — NOT touched. Economics computed AFTER partition; never read by sort/filter.
+- **OUT:** UI (wave B), DB schema (no economics column — out of scope), `lib/types.ts` non-additive edits.
+
+## Key design decisions (assumptions documented — founder not at terminal)
+
+1. **Per-day consistency:** `buildMatchEconomics` computes distance the same way `compute-matches.ts` does — `getPortDistance(loadPort, dischargePort)` (the laden/revenue voyage), NOT `readiness.distanceNm` (the ballast leg). Same inputs + same `computeEstimatedTce` ⇒ `economics.tceUsdPerDay === tce_usd_per_day` DB column. This is the "reuse, don't duplicate" the brief mandates.
+2. **War-risk is a separate line item, not folded into per-day.** `computeEstimatedTce` blanks the route ports, so its internal war-risk is already 0 and the persisted per-day excludes war-risk. We keep `tceUsdPerDay` identical to the DB column and surface the real-port JWC premium separately in `breakdown` (matches how the live economics breakdown treats war risk). Vessel value for the premium = `DEFAULT_VESSEL_VALUE_USD` (22M), same valuation `computeEstimatedTce` uses.
+3. **Insufficient data ⇒ `economics` stays `undefined`.** No distance (ports unresolved) ⇒ `buildMatchEconomics` returns `null` ⇒ field left unset. Never throws, never fabricates.
+4. **`tceUsdPerDay` is an additive optional field** on `EconomicsResult` (`lib/types.ts`). `EconomicsResult` had no per-day field; additive-only per parallel-wave constraint.
+5. **Only main (good/possible) matches** get economics. `lowConfidenceMatches` / `insufficientData` buckets are left as-is.
+
+## File Structure
+
+- `lib/types.ts` — Modify: add additive `tceUsdPerDay?: number` to `EconomicsResult`.
+- `lib/matching/tce-calculator.ts` — Modify: additive `breakdown` on `TceEstimate`; add `buildMatchEconomics()`.
+- `lib/matching/pair-analyzer.ts` — Modify: import helper + `getPortDistance`; attach economics to main matches after partition.
+- `lib/matching/__tests__/tce-calculator.test.ts` — Modify: unit tests for `buildMatchEconomics`.
+- `lib/__tests__/matching/economics-wiring.test.ts` — Create: integration test on `analyzePairs`.
+
+---
+
+### Task 1: Additive `tceUsdPerDay` on `EconomicsResult`
+
+**Files:**
+- Modify: `lib/types.ts:62-70`
+
+- [ ] **Step 1: Add field**
+
+```typescript
+export interface EconomicsResult {
+  breakdown: EconomicsBreakdown;
+  totalUsd: number;                    // sum of all costs in USD-equivalent
+  calculatedAt: string;                // ISO 8601
+  dataFreshness: {
+    bunker: string;                    // ISO 8601 of bunker price scrape
+    eua: string;                       // ISO 8601 of EUA price scrape
+  };
+  /** Headline Time-Charter-Equivalent ($/day). Additive (spec L2 #5) — present
+   *  when economics is computed in the matching pipeline; absent for the legacy
+   *  /api/economics shape. */
+  tceUsdPerDay?: number;
+}
+```
+
+- [ ] **Step 2: Typecheck** — `npx tsc --noEmit` → no new errors (additive optional).
+
+---
+
+### Task 2: `buildMatchEconomics` helper (unit-tested)
+
+**Files:**
+- Modify: `lib/matching/tce-calculator.ts`
+- Test: `lib/matching/__tests__/tce-calculator.test.ts`
+
+- [ ] **Step 1: Write failing unit tests** (append to tce-calculator.test.ts)
+
+```typescript
+import { buildMatchEconomics } from '@/lib/matching/tce-calculator';
+
+describe('buildMatchEconomics', () => {
+  const CALC_AT = '2026-05-30T00:00:00.000Z';
+  const base = {
+    cargoType: 'GRAIN', distanceNm: 3000, vesselDwt: 50000, quantityMt: 45000,
+    speedKts: 12, consumptionMt: 25, loadPort: 'Rotterdam', dischargePort: 'Hamburg',
+    calculatedAt: CALC_AT,
+  };
+
+  it('returns null when distance is not positive', () => {
+    expect(buildMatchEconomics({ ...base, distanceNm: 0 })).toBeNull();
+  });
+
+  it('populates a finite tceUsdPerDay equal to computeEstimatedTce', () => {
+    const econ = buildMatchEconomics(base)!;
+    expect(econ).not.toBeNull();
+    expect(Number.isFinite(econ.tceUsdPerDay!)).toBe(true);
+    const freight = estimateFreightRate(base.cargoType, base.distanceNm, base.vesselDwt);
+    const tce = computeEstimatedTce(freight, base.distanceNm, base.vesselDwt, base.quantityMt, base.speedKts, base.consumptionMt);
+    expect(econ.tceUsdPerDay).toBe(tce.tce_usd_per_day);
+    expect(econ.calculatedAt).toBe(CALC_AT);
+  });
+
+  it('no war-risk for a non-HRA route → empty zones, zero premium', () => {
+    const econ = buildMatchEconomics(base)!;
+    expect(econ.breakdown.warRiskZones).toEqual([]);
+    expect(econ.breakdown.warRiskPremium).toBe(0);
+  });
+
+  it('surfaces JWC war-risk when load port is in a high-risk area', () => {
+    const econ = buildMatchEconomics({ ...base, loadPort: 'Lagos', dischargePort: 'Hamburg' })!;
+    expect(econ.breakdown.warRiskZones.length).toBeGreaterThan(0);
+    expect(econ.breakdown.warRiskPremium).toBeGreaterThan(0);
+    expect(econ.breakdown.warRiskBreakdown!.totalPremiumUsd).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `npx jest lib/matching/__tests__/tce-calculator.test.ts -t buildMatchEconomics` → FAIL ("buildMatchEconomics is not a function").
+
+- [ ] **Step 3: Implement** — in `lib/matching/tce-calculator.ts`:
+
+```typescript
+// top imports
+import { calculateTCE, type TCEBreakdown } from '@/lib/economics/voyage-calculator';
+import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
+import type { EconomicsResult } from '@/lib/types';
+
+// extend TceEstimate additively
+export interface TceEstimate {
+  tce_usd_per_day: number;
+  freight_rate_usd_per_mt: number;
+  freight_rate_source: 'estimated' | 'manual';
+  /** Full deterministic breakdown from the voyage calculator (additive, spec L2 #5). */
+  breakdown: TCEBreakdown;
+}
+
+// in computeEstimatedTce return, add:
+//   breakdown: result.breakdown,
+
+export interface MatchEconomicsInput {
+  cargoType: string | null;
+  distanceNm: number;
+  vesselDwt: number;
+  quantityMt: number;
+  speedKts: number;
+  consumptionMt: number;
+  loadPort: string | null;
+  dischargePort: string | null;
+  /** ISO 8601 timestamp; passed in so the result is deterministic/testable. */
+  calculatedAt: string;
+  /** Vessel value for the war-risk hull premium. Defaults to DEFAULT_VESSEL_VALUE_USD. */
+  vesselValueUsd?: number;
+}
+
+/**
+ * Build the EconomicsResult attached to a Match (spec L2 #5 + #6).
+ *
+ * Reuses estimateFreightRate + computeEstimatedTce so tceUsdPerDay is identical
+ * to the tce_usd_per_day value compute-matches.ts persists to the DB. JWC war-risk
+ * (#6) is computed separately with the REAL load/discharge ports and surfaced as a
+ * breakdown line item (the per-day figure excludes it, mirroring the DB column).
+ *
+ * Returns null when distance is unavailable → caller leaves match.economics undefined.
+ */
+export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult | null {
+  if (!(input.distanceNm > 0)) return null;
+
+  const freight = estimateFreightRate(input.cargoType, input.distanceNm, input.vesselDwt);
+  const tce = computeEstimatedTce(
+    freight, input.distanceNm, input.vesselDwt, input.quantityMt, input.speedKts, input.consumptionMt,
+  );
+
+  const war = calculateWarRiskPremium({
+    route: { fromPort: input.loadPort ?? '', toPort: input.dischargePort ?? '' },
+    vesselValueUsd: input.vesselValueUsd ?? DEFAULT_VESSEL_VALUE_USD,
+  });
+
+  return {
+    breakdown: {
+      bunkerCost: tce.breakdown.bunker_usd,
+      bunkerPort: input.loadPort ?? '',
+      euEtsAmount: tce.breakdown.ets_eur,
+      euEtsApplicable: tce.breakdown.applicable.ets,
+      warRiskPremium: war.premiumUsd,
+      warRiskZones: war.zones,
+      warRiskTotal: war.breakdown?.totalPremiumUsd,
+      warRiskBreakdown: war.breakdown,
+    },
+    totalUsd: tce.breakdown.total_costs_usd + war.premiumUsd,
+    calculatedAt: input.calculatedAt,
+    dataFreshness: { bunker: 'estimated', eua: 'estimated' },
+    tceUsdPerDay: tce.tce_usd_per_day,
+  };
+}
+```
+
+- [ ] **Step 4: Run, verify pass** — `npx jest lib/matching/__tests__/tce-calculator.test.ts` → PASS (all, incl. pre-existing).
+
+- [ ] **Step 5: Commit** — `feat(economics): buildMatchEconomics helper — TCE + JWC war-risk → EconomicsResult`
+
+---
+
+### Task 3: Wire into `analyzePairs`
+
+**Files:**
+- Modify: `lib/matching/pair-analyzer.ts`
+- Test: `lib/__tests__/matching/economics-wiring.test.ts` (create)
+
+- [ ] **Step 1: Write failing integration test** (`lib/__tests__/matching/economics-wiring.test.ts`)
+
+Mirrors the mock setup in `lib/__tests__/matching/pair-analyzer.test.ts` (readiness `ideal`, hard filters pass, scoring identity) and additionally mocks `getPortDistance`. Asserts a good/possible main match has `economics.tceUsdPerDay` as a finite number, and that with no resolvable distance the field is `undefined`.
+
+```typescript
+// (full test body written during execution — mirrors pair-analyzer.test.ts mocks,
+//  adds jest.mock('@/lib/sailing/port-distances', () => ({ getPortDistance: jest.fn() }))
+//  case A: getPortDistance → { nm: 3000 } ⇒ result.matches[0].economics.tceUsdPerDay finite
+//  case B: getPortDistance → null         ⇒ result.matches[0].economics undefined )
+```
+
+- [ ] **Step 2: Run, verify fail** — economics is undefined before wiring.
+
+- [ ] **Step 3: Implement** — in `pair-analyzer.ts`:
+  - Add imports: `getPortDistance` from `@/lib/sailing/port-distances`; `buildMatchEconomics`, `parseLeadingNumber` from `@/lib/matching/tce-calculator`.
+  - After the realism partition builds `mainMatches`, before `return`, attach economics:
+
+```typescript
+  // ── Economics enrichment (spec L2 #5 + #6) ─────────────────────────────────
+  // Display-only: computed AFTER the partition so it can never affect score,
+  // ranking, or bucketing. Mirrors compute-matches.ts distance logic so the
+  // per-day TCE equals the persisted tce_usd_per_day column.
+  const economicsCalcAt = new Date().toISOString();
+  for (const m of mainMatches) {
+    const cargo = cargos.find((c) => c.emailId === m.cargoEmailId && c.itemIndex === m.cargoItemIndex);
+    const vessel = vessels.find((v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex);
+    if (!cargo || !vessel) continue;
+
+    const loadPort = cfValue(cargo.originPort);
+    const dischargePort = cfValue(cargo.destinationPort);
+    const distanceResult = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+    if (!distanceResult || !(distanceResult.nm > 0)) continue;
+
+    const cargoType =
+      typeof cargo.cargoType === 'object' && cargo.cargoType !== null && 'value' in cargo.cargoType
+        ? (cargo.cargoType as unknown as { value: string }).value
+        : (cargo.cargoType as string | null);
+
+    const econ = buildMatchEconomics({
+      cargoType,
+      distanceNm: distanceResult.nm,
+      vesselDwt: cfValue(vessel.dwtSummer) ?? 0,
+      quantityMt: cfValue(cargo.weightMt) ?? 0,
+      speedKts: parseLeadingNumber(vessel.speedLaden),
+      consumptionMt: parseLeadingNumber(vessel.consumption),
+      loadPort,
+      dischargePort,
+      calculatedAt: economicsCalcAt,
+    });
+    if (econ) m.economics = econ;
+  }
+
+  return { matches: mainMatches, lowConfidenceMatches, insufficientData, blockedMatches };
+```
+
+- [ ] **Step 4: Run, verify pass** — new integration test PASS; existing `pair-analyzer.test.ts` still PASS (null ports ⇒ distance null ⇒ economics undefined, no assertions broken).
+
+- [ ] **Step 5: Commit** — `feat(matching): attach match.economics (TCE + war-risk) to main matches`
+
+---
+
+### Task 4: Regression + acceptance verification
+
+- [ ] `npx jest lib/matching lib/__tests__/matching tests/economics` → green.
+- [ ] `npx tsx scripts/research/match-realism-funnel.ts` → output unchanged vs `main` (funnel reimplements filters/readiness, never calls analyzePairs — structurally unaffected; confirm anyway).
+- [ ] `NODE_OPTIONS='--max-old-space-size=8192' npx jest` full suite (single run). Known foreign flake `scripts/progonq/score-classify` is not our regression.
+- [ ] requesting-code-review → verification-before-completion → finishing-a-development-branch (draft PR to main, do NOT merge).
+
+## Self-Review
+
+- **Spec coverage:** #5 → Task 2+3. #6 → Task 2 (war-risk in breakdown) + integration. #7/#8 untouched (helper reuses estimateFreightRate; economics attached post-partition). ✅
+- **Placeholders:** Task 3 test body is described not pasted — written in full at execution (mock-heavy, mirrors existing file). All production code shown in full. ✅
+- **Type consistency:** `buildMatchEconomics` / `MatchEconomicsInput` / `EconomicsResult.tceUsdPerDay` / `TceEstimate.breakdown` consistent across tasks. ✅

--- a/lib/__tests__/matching/economics-wiring.test.ts
+++ b/lib/__tests__/matching/economics-wiring.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Integration tests — economics wiring in analyzePairs (spec L2 #5 + #6).
+ *
+ * The matching engine internals are mocked the same way as pair-analyzer.test.ts
+ * (readiness `ideal`, hard filters pass, scoring identity) so the test stays
+ * deterministic and LLM-free. getPortDistance is mocked because the economics
+ * loop derives the laden-voyage distance from it (mirroring compute-matches.ts).
+ *
+ * Asserts:
+ *   - a good/possible main match gets `economics` populated with a finite TCE $/day
+ *   - JWC war-risk (#6) flows end-to-end into economics.breakdown for an HRA port
+ *   - no resolvable distance → `economics` stays undefined (no crash, no fabrication)
+ */
+
+import { analyzePairs, type AiScorer, type RawMatch } from '@/lib/matching/pair-analyzer';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+
+jest.mock('@/lib/sailing/readiness-gap', () => ({
+  calculateReadinessGap: jest.fn().mockReturnValue({
+    verdict: 'ideal',
+    gapDays: 5,
+    sailingDays: 3,
+    explanation: 'ok',
+    distanceNm: 500,
+    arrivalDate: null,
+    openDate: null,
+    laycanStart: null,
+    laycanEnd: null,
+    speedKn: null,
+  }),
+  detectSpot: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/lib/sailing/match-filters', () => ({
+  runHardFilters: jest.fn().mockReturnValue({
+    pass: true,
+    failures: [],
+    checks: {
+      draft: { pass: true },
+      crane: { pass: true },
+      volume: { pass: true },
+      cargoVessel: { pass: true },
+    },
+  }),
+}));
+
+jest.mock('@/lib/sailing/match-scoring', () => ({
+  applyReadinessScoring: jest.fn().mockImplementation((m) => m),
+  computeScoreBreakdown: jest.fn().mockReturnValue({
+    components: [],
+    basePhysical: 60,
+    readinessAdjustment: 0,
+    sanctionsAdjustment: 0,
+    finalScore: 60, // → 'possible' → main match bucket
+  }),
+  deriveMatchLevel: jest.fn().mockImplementation((score: number) =>
+    score > 70 ? 'good' : score > 40 ? 'possible' : 'weak',
+  ),
+}));
+
+jest.mock('@/lib/sailing/date-parsing', () => ({
+  parseLaycan: jest.fn().mockReturnValue(null),
+  parseVesselOpenDate: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@/lib/sailing/date-sanity', () => ({
+  validateDates: jest.fn().mockReturnValue({ valid: true, issues: [] }),
+}));
+
+jest.mock('@/lib/validation/sanctions', () => ({
+  checkSanctions: jest.fn().mockReturnValue({ risk: 'NONE', blocking: false }),
+}));
+
+jest.mock('@/lib/matching/reason-enricher', () => ({
+  enrichReasons: jest.fn().mockImplementation((reasons: string[], issues: string[]) => ({ reasons, issues })),
+}));
+
+jest.mock('@/lib/sailing/port-distances', () => ({
+  getPortDistance: jest.fn().mockReturnValue({ nm: 3000, exact: true }),
+}));
+
+import { getPortDistance } from '@/lib/sailing/port-distances';
+
+function makeCargo(overrides: Partial<ParsedCargo> = {}): ParsedCargo {
+  return {
+    emailId: 'cargo-1',
+    itemIndex: 0,
+    originPort: { value: 'Rotterdam', confidence: 'confirmed' } as unknown as ParsedCargo['originPort'],
+    originCountry: null,
+    destinationPort: { value: 'Hamburg', confidence: 'confirmed' } as unknown as ParsedCargo['destinationPort'],
+    destinationCountry: null,
+    cargoDescription: null,
+    weightMt: { value: 45000, confidence: 'confirmed' } as unknown as ParsedCargo['weightMt'],
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BULK',
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    ...overrides,
+  };
+}
+
+function makeVessel(overrides: Partial<ParsedVessel> = {}): ParsedVessel {
+  return {
+    emailId: 'vessel-1',
+    itemIndex: 0,
+    vesselName: null,
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: { value: 50000, confidence: 'confirmed' } as unknown as ParsedVessel['dwtSummer'],
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: '12 knots',
+    speedBallast: null,
+    consumption: '25 mt/day',
+    deckCapacity: null,
+    specialFeatures: [],
+    ...overrides,
+  };
+}
+
+function rawMatchFor(cargo: ParsedCargo, vessel: ParsedVessel, score = 75): RawMatch {
+  return {
+    cargo_email_id: cargo.emailId,
+    cargo_item_index: cargo.itemIndex,
+    vessel_email_id: vessel.emailId,
+    vessel_item_index: vessel.itemIndex,
+    score,
+    match_level: 'good',
+    match_reasons: ['DWT fits'],
+    issues: [],
+  };
+}
+
+describe('analyzePairs — economics wiring (spec L2 #5 + #6)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getPortDistance as jest.Mock).mockReturnValue({ nm: 3000, exact: true });
+  });
+
+  it('populates economics with a finite TCE $/day on a good/possible main match (#5)', async () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    const aiScorer: AiScorer = jest.fn().mockResolvedValue([rawMatchFor(cargo, vessel)]);
+
+    const result = await analyzePairs([cargo], [vessel], aiScorer);
+
+    expect(result.matches).toHaveLength(1);
+    const econ = result.matches[0].economics;
+    expect(econ).toBeDefined();
+    expect(Number.isFinite(econ!.tceUsdPerDay!)).toBe(true);
+    expect(econ!.breakdown).toBeDefined();
+    expect(typeof econ!.totalUsd).toBe('number');
+  });
+
+  it('surfaces JWC war-risk in economics when the load port is in an HRA (#6)', async () => {
+    const cargo = makeCargo({
+      originPort: { value: 'Lagos', confidence: 'confirmed' } as unknown as ParsedCargo['originPort'],
+    });
+    const vessel = makeVessel();
+    (getPortDistance as jest.Mock).mockReturnValue({ nm: 4200, exact: true });
+    const aiScorer: AiScorer = jest.fn().mockResolvedValue([rawMatchFor(cargo, vessel)]);
+
+    const result = await analyzePairs([cargo], [vessel], aiScorer);
+
+    const econ = result.matches[0].economics;
+    expect(econ).toBeDefined();
+    expect(econ!.breakdown.warRiskZones.length).toBeGreaterThan(0);
+    expect(econ!.breakdown.warRiskPremium).toBeGreaterThan(0);
+  });
+
+  it('leaves economics undefined when distance is unresolvable (no crash)', async () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    (getPortDistance as jest.Mock).mockReturnValue(null);
+    const aiScorer: AiScorer = jest.fn().mockResolvedValue([rawMatchFor(cargo, vessel)]);
+
+    const result = await analyzePairs([cargo], [vessel], aiScorer);
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].economics).toBeUndefined();
+  });
+});

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -27,6 +27,7 @@ import {
   estimateFreightRate,
   computeEstimatedTce,
   parseLeadingNumber,
+  buildMatchEconomics,
 } from '@/lib/matching/tce-calculator';
 
 describe('parseLeadingNumber', () => {
@@ -50,13 +51,31 @@ describe('parseLeadingNumber', () => {
     expect(parseLeadingNumber(undefined)).toBe(0);
   });
 
-  it('returns a raw number unchanged (LLM-parsed fields can be numbers, not strings)', () => {
+  // Real/demo parsed data stores speed/consumption as ConfidenceField objects
+  // ({ value, confidence, source_text }) or raw numbers, despite the string typing.
+  // parseLeadingNumber must tolerate both rather than crash on `.match` (L2 wiring).
+  // (raw-number tolerance also guards the frozen-demo dashboard crash, #684.)
+  it('returns a finite number unchanged', () => {
+    expect(parseLeadingNumber(13)).toBe(13);
     expect(parseLeadingNumber(12.5)).toBe(12.5);
     expect(parseLeadingNumber(0)).toBe(0);
   });
 
-  it('returns 0 for a non-finite number', () => {
+  it('returns 0 for non-finite numbers', () => {
     expect(parseLeadingNumber(NaN)).toBe(0);
+    expect(parseLeadingNumber(Infinity)).toBe(0);
+  });
+
+  it('unwraps a ConfidenceField object with a numeric value', () => {
+    expect(parseLeadingNumber({ value: 13, confidence: 'confirmed', source_text: '13 knts' })).toBe(13);
+  });
+
+  it('unwraps a ConfidenceField object with a string value', () => {
+    expect(parseLeadingNumber({ value: '12.5 knots', confidence: 'estimated' })).toBe(12.5);
+  });
+
+  it('returns 0 for an object without a value field', () => {
+    expect(parseLeadingNumber({ confidence: 'estimated' })).toBe(0);
   });
 });
 
@@ -152,5 +171,53 @@ describe('computeEstimatedTce', () => {
     const tce_low = computeEstimatedTce(low, 3000, 50000, 45000).tce_usd_per_day;
     const tce_high = computeEstimatedTce(high, 3000, 50000, 45000).tce_usd_per_day;
     expect(tce_high).toBeGreaterThan(tce_low);
+  });
+});
+
+describe('buildMatchEconomics', () => {
+  const CALC_AT = '2026-05-30T00:00:00.000Z';
+  const base = {
+    cargoType: 'GRAIN',
+    distanceNm: 3000,
+    vesselDwt: 50000,
+    quantityMt: 45000,
+    speedKts: 12,
+    consumptionMt: 25,
+    loadPort: 'Rotterdam',
+    dischargePort: 'Hamburg',
+    calculatedAt: CALC_AT,
+  };
+
+  it('returns null when distance is not positive', () => {
+    expect(buildMatchEconomics({ ...base, distanceNm: 0 })).toBeNull();
+    expect(buildMatchEconomics({ ...base, distanceNm: -5 })).toBeNull();
+  });
+
+  it('populates a finite tceUsdPerDay identical to computeEstimatedTce', () => {
+    const econ = buildMatchEconomics(base);
+    expect(econ).not.toBeNull();
+    expect(Number.isFinite(econ!.tceUsdPerDay!)).toBe(true);
+
+    const freight = estimateFreightRate(base.cargoType, base.distanceNm, base.vesselDwt);
+    const tce = computeEstimatedTce(
+      freight, base.distanceNm, base.vesselDwt, base.quantityMt, base.speedKts, base.consumptionMt,
+    );
+    // Per-day TCE must match the value compute-matches.ts persists to the DB column.
+    expect(econ!.tceUsdPerDay).toBe(tce.tce_usd_per_day);
+    expect(econ!.calculatedAt).toBe(CALC_AT);
+  });
+
+  it('non-HRA route → empty war-risk zones, zero premium', () => {
+    const econ = buildMatchEconomics(base);
+    expect(econ!.breakdown.warRiskZones).toEqual([]);
+    expect(econ!.breakdown.warRiskPremium).toBe(0);
+    expect(econ!.breakdown.warRiskBreakdown).toBeUndefined();
+  });
+
+  it('surfaces JWC war-risk when load port is in a high-risk area (#6)', () => {
+    const econ = buildMatchEconomics({ ...base, loadPort: 'Lagos', dischargePort: 'Hamburg' });
+    expect(econ!.breakdown.warRiskZones.length).toBeGreaterThan(0);
+    expect(econ!.breakdown.warRiskPremium).toBeGreaterThan(0);
+    expect(econ!.breakdown.warRiskBreakdown!.totalPremiumUsd).toBeGreaterThan(0);
   });
 });

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -17,6 +17,8 @@ import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { validateDates } from '@/lib/sailing/date-sanity';
 import { checkSanctions } from '@/lib/validation/sanctions';
 import { enrichReasons } from '@/lib/matching/reason-enricher';
+import { buildMatchEconomics, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { getPortDistance } from '@/lib/sailing/port-distances';
 import { formatNumber } from '@/lib/utils';
 import { LLMTimeoutError } from '@/lib/openai';
 import { now } from '@/lib/clock';
@@ -611,6 +613,48 @@ export async function analyzePairs(
     } else {
       mainMatches.push(m);
     }
+  }
+
+  // ── Economics enrichment (spec L2 #5 + #6) ─────────────────────────────────
+  // Display-only: computed AFTER the realism partition so it can never affect
+  // score, ranking, or bucketing. Only good/possible main matches get economics.
+  // Distance is the laden voyage (load → discharge) via getPortDistance — the same
+  // source compute-matches.ts uses to persist tce_usd_per_day, so the per-day
+  // figure here equals the persisted column. JWC war-risk (#6) is folded in by
+  // buildMatchEconomics. No data → economics stays undefined (never throws).
+  const economicsCalcAt = new Date().toISOString();
+  for (const m of mainMatches) {
+    const cargo = cargos.find(
+      (c) => c.emailId === m.cargoEmailId && c.itemIndex === m.cargoItemIndex,
+    );
+    const vessel = vessels.find(
+      (v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex,
+    );
+    if (!cargo || !vessel) continue;
+
+    const loadPort = cfValue(cargo.originPort);
+    const dischargePort = cfValue(cargo.destinationPort);
+    const distanceResult =
+      loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+    if (!distanceResult || !(distanceResult.nm > 0)) continue;
+
+    const cargoType =
+      typeof cargo.cargoType === 'object' && cargo.cargoType !== null && 'value' in cargo.cargoType
+        ? (cargo.cargoType as unknown as { value: string }).value
+        : (cargo.cargoType as string | null);
+
+    const econ = buildMatchEconomics({
+      cargoType,
+      distanceNm: distanceResult.nm,
+      vesselDwt: cfValue(vessel.dwtSummer) ?? 0,
+      quantityMt: cfValue(cargo.weightMt) ?? 0,
+      speedKts: parseLeadingNumber(vessel.speedLaden),
+      consumptionMt: parseLeadingNumber(vessel.consumption),
+      loadPort,
+      dischargePort,
+      calculatedAt: economicsCalcAt,
+    });
+    if (econ) m.economics = econ;
   }
 
   return { matches: mainMatches, lowConfidenceMatches, insufficientData, blockedMatches };

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -1,4 +1,6 @@
-import { calculateTCE } from '@/lib/economics/voyage-calculator';
+import { calculateTCE, type TCEBreakdown } from '@/lib/economics/voyage-calculator';
+import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
+import type { EconomicsResult } from '@/lib/types';
 
 // Ballpark base freight rates (USD/mt) per cargo class
 const BASE_RATES: Record<string, number> = {
@@ -36,14 +38,23 @@ export interface TceEstimate {
   tce_usd_per_day: number;
   freight_rate_usd_per_mt: number;
   freight_rate_source: 'estimated' | 'manual';
+  /** Full deterministic voyage breakdown (additive, spec L2 #5). */
+  breakdown: TCEBreakdown;
 }
 
-// Parse a leading number from values like "12.5 knots", "25 mt/day", or a raw
-// number (LLM-parsed fields can arrive as numbers, not strings).
-export function parseLeadingNumber(s: string | number | null | undefined): number {
+// Parse a leading number from strings like "12.5 knots", "25 mt/day", a raw
+// number (LLM-parsed fields can arrive as numbers, not strings), or a
+// ConfidenceField object ({ value, confidence, source_text }). Real/demo parsed
+// data stores speed/consumption as any of these despite the string typing, so
+// tolerate all rather than throw on `.match`.
+export function parseLeadingNumber(s: unknown): number {
   if (s == null) return 0;
   if (typeof s === 'number') return Number.isFinite(s) ? s : 0;
-  const m = String(s).match(/(\d+(?:\.\d+)?)/);
+  if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
+    return parseLeadingNumber((s as { value: unknown }).value);
+  }
+  if (typeof s !== 'string') return 0;
+  const m = s.match(/(\d+(?:\.\d+)?)/);
   return m ? Number(m[1]) : 0;
 }
 
@@ -118,5 +129,69 @@ export function computeEstimatedTce(
     tce_usd_per_day: result.daily_tce_usd,
     freight_rate_usd_per_mt: freightRate.rate,
     freight_rate_source: freightRate.source,
+    breakdown: result.breakdown,
+  };
+}
+
+export interface MatchEconomicsInput {
+  cargoType: string | null;
+  distanceNm: number;
+  vesselDwt: number;
+  quantityMt: number;
+  speedKts: number;
+  consumptionMt: number;
+  loadPort: string | null;
+  dischargePort: string | null;
+  /** ISO 8601 timestamp; passed in so the result is deterministic/testable. */
+  calculatedAt: string;
+  /** Vessel value for the war-risk hull premium. Defaults to DEFAULT_VESSEL_VALUE_USD. */
+  vesselValueUsd?: number;
+}
+
+/**
+ * Build the EconomicsResult attached to a Match (spec L2 #5 + #6).
+ *
+ * Reuses estimateFreightRate + computeEstimatedTce so `tceUsdPerDay` is identical
+ * to the `tce_usd_per_day` value compute-matches.ts persists to the DB column.
+ * JWC war-risk (#6) is computed separately with the REAL load/discharge ports and
+ * surfaced as a breakdown line item — the per-day figure excludes it (the TCE
+ * engine blanks the route ports), mirroring the persisted column and the live
+ * economics breakdown, where war risk is a separate cost line.
+ *
+ * Returns null when distance is unavailable → caller leaves match.economics undefined.
+ */
+export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult | null {
+  if (!(input.distanceNm > 0)) return null;
+
+  const freight = estimateFreightRate(input.cargoType, input.distanceNm, input.vesselDwt);
+  const tce = computeEstimatedTce(
+    freight,
+    input.distanceNm,
+    input.vesselDwt,
+    input.quantityMt,
+    input.speedKts,
+    input.consumptionMt,
+  );
+
+  const war = calculateWarRiskPremium({
+    route: { fromPort: input.loadPort ?? '', toPort: input.dischargePort ?? '' },
+    vesselValueUsd: input.vesselValueUsd ?? DEFAULT_VESSEL_VALUE_USD,
+  });
+
+  return {
+    breakdown: {
+      bunkerCost: tce.breakdown.bunker_usd,
+      bunkerPort: input.loadPort ?? '',
+      euEtsAmount: tce.breakdown.ets_eur,
+      euEtsApplicable: tce.breakdown.applicable.ets,
+      warRiskPremium: war.premiumUsd,
+      warRiskZones: war.zones,
+      warRiskTotal: war.breakdown?.totalPremiumUsd,
+      warRiskBreakdown: war.breakdown,
+    },
+    totalUsd: tce.breakdown.total_costs_usd + war.premiumUsd,
+    calculatedAt: input.calculatedAt,
+    dataFreshness: { bunker: 'estimated', eua: 'estimated' },
+    tceUsdPerDay: tce.tce_usd_per_day,
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,12 @@ export interface EconomicsResult {
    * Headline Time-Charter-Equivalent ($/day). Additive (spec L2 #5): present when
    * economics is computed in the matching pipeline (buildMatchEconomics); absent
    * for the legacy /api/economics shape.
+   *
+   * NOTE: pre-war-risk. Mirrors the persisted `tce_usd_per_day` column, which the
+   * TCE engine computes with blanked route ports → the JWC premium is NOT folded
+   * into this daily figure. The premium is surfaced separately in
+   * `breakdown.warRiskPremium` / `warRiskBreakdown`. Don't read this alone as a
+   * war-risk-inclusive daily P&L on HRA routes.
    */
   tceUsdPerDay?: number;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,6 +67,12 @@ export interface EconomicsResult {
     bunker: string;                    // ISO 8601 of bunker price scrape
     eua: string;                       // ISO 8601 of EUA price scrape
   };
+  /**
+   * Headline Time-Charter-Equivalent ($/day). Additive (spec L2 #5): present when
+   * economics is computed in the matching pipeline (buildMatchEconomics); absent
+   * for the legacy /api/economics shape.
+   */
+  tceUsdPerDay?: number;
 }
 
 // ── FuelEU Maritime (Spec γ-11) ──


### PR DESCRIPTION
## Summary

Wave **L2-wiring**: populate `Match.economics` in the matching pipeline. The TCE engine (`lib/economics/voyage-calculator.ts`) and war-risk (`lib/economics/war-risk.ts`) already worked, but `match.economics` was always empty. This **wires the ready pieces** — it is wiring, not new engine work.

- **#5** — `analyzePairs` now attaches an `EconomicsResult` (TCE $/day) to each good/possible **main** match via a new pure helper `buildMatchEconomics`.
- **#6** — JWC war-risk premium is surfaced inside that `EconomicsResult` (`breakdown.warRiskPremium / warRiskZones / warRiskBreakdown`).

### Out of scope (deliberately untouched)
- **#7** freight-rate source — reuses `estimateFreightRate` as-is (real benchmark = separate design session).
- **#8** score/ranking — economics is **display-only**, computed *after* the realism partition; never read back into sort/filter/bucketing.
- UI (wave B), bucket partitioning (core), `lib/types.ts` changed **additive-only** (parallel waves A/B).

## Stacking note
Branches off the wave-core/bucket base `bad9639` (PR #694), **not yet on `main`**. Until #694 merges, this PR's diff shows the full stack; the **L2-specific changes are the 3 commits** `5ffd026..bd5268f`. Draft — **do not merge** (per handover).

## Key design decisions (founder not at terminal — documented assumptions)
1. **Per-day consistency:** distance via `getPortDistance(load, discharge)` (laden voyage), mirroring `compute-matches.ts` → `economics.tceUsdPerDay` equals the persisted `tce_usd_per_day` column (same `estimateFreightRate`+`computeEstimatedTce` chain).
2. **War-risk is a separate line item**, not folded into per-day (the TCE engine blanks route ports, so the persisted per-day already excludes it). `tceUsdPerDay` is documented **pre-war-risk**; the real-port JWC premium lives in `breakdown`.
3. **Insufficient data → `economics` undefined** (no resolvable distance → helper returns `null`). Never throws, never fabricates.
4. **`parseLeadingNumber` hardened** to tolerate `ConfidenceField {value,confidence}` objects + raw numbers — demo/real parsed data stores speed/consumption that way; the same latent crash existed at `compute-matches.ts:72`.

## Test Plan / Verification
- [x] `npx jest lib/matching lib/__tests__/matching` — green (189 tests incl. new unit + integration).
- [x] Full suite: **7169 passed**, 1 failed = `scripts/progonq/score-classify` (known foreign flake, pre-cleared in handover — unrelated to matching/economics).
- [x] `npx tsc --noEmit` — clean.
- [x] Acceptance on real demo (79×51): 178 main matches (all good/possible), **142 carry economics + finite TCE $/day** (36 lack resolvable port distance → `undefined`), 5 carry JWC war-risk zones, conservation total == 4029 (count/partition unchanged), 0 economics leak into low-confidence/insufficient buckets.
- [x] `scripts/research/match-realism-funnel.ts` runs identically (it reimplements filters/readiness, never calls `analyzePairs`).
- [x] Independent code review: **Ready to merge — Yes**, only Minor findings (duplication/clarity); Minor #3 applied, #1/#2 (cross-file refactors) noted as follow-ups to stay surgical.

## Follow-ups (non-blocking)
- Map-based cargo/vessel lookup in `analyzePairs` (perf, session-sized today).
- Extract shared `cargoTypeValue()` helper to dedupe the 3 TCE-input sites (drift guard on the consistency invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
