### PR TITLE
feat(matching): resolveFreightRate 4-tier freight waterfall (L2 #7) [draft · stacks on #698]

### DIFF
--- a/__tests__/components/match/EconomicsTab-freight-badge.test.tsx
+++ b/__tests__/components/match/EconomicsTab-freight-badge.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ *
+ * EconomicsTab — freight-source badge + reset-to-auto button (Wave #7, L2 #7)
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { EconomicsTab } from '@/components/match/EconomicsTab';
+
+// jsdom global fetch mock (EconomicsTab fetches the EUA benchmark on mount)
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ value: 75, period: 'Q1 2026' }),
+  }),
+) as jest.Mock;
+
+describe('EconomicsTab — freight source badge + reset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('estimate → dimmed badge, no reset button, "rate not confirmed" note', () => {
+    render(
+      <EconomicsTab matchDbId={1} storedFreightRate={18} freightRateSource="estimated" routeDistanceNm={3000} />,
+    );
+    expect(screen.getByTestId('freight-rate-badge')).toHaveTextContent('Estimate');
+    expect(screen.queryByTestId('freight-rate-reset')).not.toBeInTheDocument();
+    expect(screen.getByText(/rate not confirmed/i)).toBeInTheDocument();
+  });
+
+  it('parsed → "From email" badge', () => {
+    render(
+      <EconomicsTab matchDbId={1} storedFreightRate={18} freightRateSource="parsed" routeDistanceNm={3000} />,
+    );
+    expect(screen.getByTestId('freight-rate-badge')).toHaveTextContent('From email');
+  });
+
+  it('baltic → "Market" badge', () => {
+    render(
+      <EconomicsTab matchDbId={1} storedFreightRate={4} freightRateSource="baltic" routeDistanceNm={3000} />,
+    );
+    expect(screen.getByTestId('freight-rate-badge')).toHaveTextContent('Market');
+  });
+
+  it('manual → "Manual" badge + a Reset-to-auto button', () => {
+    render(
+      <EconomicsTab matchDbId={1} storedFreightRate={30} freightRateSource="manual" routeDistanceNm={3000} />,
+    );
+    expect(screen.getByTestId('freight-rate-badge')).toHaveTextContent('Manual');
+    expect(screen.getByTestId('freight-rate-reset')).toBeInTheDocument();
+  });
+
+  it('no stored rate → no badge', () => {
+    render(
+      <EconomicsTab matchDbId={1} storedFreightRate={null} freightRateSource={null} routeDistanceNm={3000} />,
+    );
+    expect(screen.queryByTestId('freight-rate-badge')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/market/baltic-freight.test.ts
+++ b/__tests__/lib/market/baltic-freight.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests — baltic-freight.ts (Wave #7, L2 #7, tier-2)
+ *
+ * DB-bound helpers that resolve a per-vessel-class Baltic timecharter DAY-RATE
+ * ($/day) from `baltic_indices`, which resolveFreightRate turns into $/mt.
+ * The day-rate rows are a static, dated seed (migration 043) distinct from the
+ * index-POINTS rows (BHSI/BSI/…), which are a different unit.
+ */
+
+import Database from 'better-sqlite3';
+import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
+import migration043 from '@/lib/migrations/043-baltic-tc-dayrates-seed';
+import { balticIndexCodeForDwt, getBalticDayRate } from '@/lib/market/baltic-freight';
+
+describe('balticIndexCodeForDwt', () => {
+  it('handysize/handymax (<45000) → BHSI_TC', () => {
+    expect(balticIndexCodeForDwt(20000)).toBe('BHSI_TC');
+    expect(balticIndexCodeForDwt(44999)).toBe('BHSI_TC');
+  });
+  it('supramax/ultramax (45000–69999) → BSI_TC', () => {
+    expect(balticIndexCodeForDwt(45000)).toBe('BSI_TC');
+    expect(balticIndexCodeForDwt(69999)).toBe('BSI_TC');
+  });
+  it('panamax+ (>=70000) → BPI_TC', () => {
+    expect(balticIndexCodeForDwt(70000)).toBe('BPI_TC');
+    expect(balticIndexCodeForDwt(180000)).toBe('BPI_TC');
+  });
+});
+
+describe('getBalticDayRate', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration019.up(db);
+    migration043.up(db);
+  });
+  afterEach(() => db.close());
+
+  it('returns the seeded $/day rate for the vessel class (supramax → BSI_TC)', () => {
+    const r = getBalticDayRate(db, 50000);
+    expect(r).not.toBeNull();
+    expect(r!.indexCode).toBe('BSI_TC');
+    expect(r!.usdPerDay).toBe(13500);
+    expect(r!.date).toBe('2026-05-09');
+  });
+
+  it('handysize → BHSI_TC 11500', () => {
+    expect(getBalticDayRate(db, 30000)!.usdPerDay).toBe(11500);
+  });
+
+  it('panamax → BPI_TC 15000', () => {
+    expect(getBalticDayRate(db, 80000)!.usdPerDay).toBe(15000);
+  });
+
+  it('panamax falls back to BSI_TC when BPI_TC is absent', () => {
+    db.prepare(`DELETE FROM baltic_indices WHERE index_code='BPI_TC'`).run();
+    const r = getBalticDayRate(db, 80000);
+    expect(r!.indexCode).toBe('BSI_TC');
+    expect(r!.usdPerDay).toBe(13500);
+  });
+
+  it('returns null when the baltic_indices table is absent (defensive)', () => {
+    const bare = new Database(':memory:');
+    expect(getBalticDayRate(bare, 50000)).toBeNull();
+    bare.close();
+  });
+
+  it('returns null when no day-rate row matches', () => {
+    db.prepare(`DELETE FROM baltic_indices`).run();
+    expect(getBalticDayRate(db, 50000)).toBeNull();
+  });
+});

--- a/__tests__/parsing/parse-cargo-ai-freight.test.ts
+++ b/__tests__/parsing/parse-cargo-ai-freight.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Parser tier-1 contract (Wave #7, L2 #7).
+ *
+ * The parse-cargo prompt + schema already extract an explicit per-MT freight rate
+ * into `freight_rate_usd`; parseCargoAIResponse maps it to `ParsedCargo.freightRateUsd`,
+ * which resolveFreightRate consumes as the tier-1 (parsed) rate. This guards that
+ * mapping against regression (no LLM — pure response parsing).
+ */
+import { parseCargoAIResponse } from '@/lib/parsing/parse-cargo-ai';
+
+function parseOne(item: Record<string, unknown>) {
+  return parseCargoAIResponse(JSON.stringify({ items: [item] }), 'email-1');
+}
+
+describe('parseCargoAIResponse — freight_rate_usd → freightRateUsd', () => {
+  it('maps an explicit per-MT freight rate ("$18/MT")', () => {
+    const parsed = parseOne({
+      origin_port: { value: 'Rotterdam', confidence: 'confirmed', source_text: 'Rotterdam' },
+      destination_port: { value: 'Hamburg', confidence: 'confirmed', source_text: 'Hamburg' },
+      cargo_type: 'BULK',
+      weight_mt: { value: 5000, confidence: 'confirmed', source_text: '5000mt' },
+      freight_rate_usd: 18,
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].freightRateUsd).toBe(18);
+  });
+
+  it('preserves a decimal rate (18.5)', () => {
+    expect(parseOne({ cargo_type: 'GRAIN', freight_rate_usd: 18.5 })[0].freightRateUsd).toBe(18.5);
+  });
+
+  it('is null when no freight rate is stated', () => {
+    expect(parseOne({ cargo_type: 'BULK' })[0].freightRateUsd).toBeNull();
+  });
+
+  it('non-numeric junk ("TBD") → null (not NaN)', () => {
+    expect(parseOne({ cargo_type: 'BULK', freight_rate_usd: 'TBD' })[0].freightRateUsd).toBeNull();
+  });
+});

--- a/app/api/ai/match/route.ts
+++ b/app/api/ai/match/route.ts
@@ -6,6 +6,7 @@ import { LLMTimeoutError } from '@/lib/openai';
 import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { MATCH_PROMPT } from '@/lib/prompts';
 import { analyzePairs, AiScorer, RawMatch } from '@/lib/matching/pair-analyzer';
+import { getStore } from '@/lib/session-store';
 import { isRagEnabled } from '@/lib/knowledge/flags';
 import type { Match } from '@/lib/types';
 
@@ -106,7 +107,11 @@ export async function POST(request: NextRequest) {
       blockedMatches,
       lowConfidenceMatches = [],
       insufficientData = [],
-    } = await analyzePairs(parsedCargos, parsedVessels, aiScorer, { refYear, today });
+    } = await analyzePairs(parsedCargos, parsedVessels, aiScorer, {
+      refYear,
+      today,
+      db: getStore().getDatabase(),
+    });
 
     // Idempotency guard: if this is a sample-data session, preserve the demo
     // economics match injected by /api/sample so EconomicsTab remains accessible

--- a/app/api/matches/[id]/__tests__/route.test.ts
+++ b/app/api/matches/[id]/__tests__/route.test.ts
@@ -10,12 +10,17 @@
  *   - no session → 401
  *   - slug lookup → 200 / 404 (stable cross-session IDs #631)
  *   - feature disabled → 503
+ *   - PATCH freight rate override (manual) + reset-to-auto (Wave #7)
  */
 
 import Database from 'better-sqlite3';
 import { NextRequest, NextResponse } from 'next/server';
 import migration032 from '@/lib/migrations/032-matches';
 import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import migration035 from '@/lib/migrations/035-matches-tce-distance';
+import migration036 from '@/lib/migrations/036-matches-freight-rate';
+import { estimateFreightRate } from '@/lib/matching/tce-calculator';
 import { requireSession } from '@/lib/session';
 import { toMatchSlug } from '@/lib/matching/match-slug';
 
@@ -259,5 +264,121 @@ describe('GET /api/matches/[id] — slug lookup (#631 stable match IDs)', () => 
     const res = await GET(makeGetRequest(slug), { params: Promise.resolve({ id: slug }) });
 
     expect(res.status).toBe(200);
+  });
+});
+
+describe('PATCH /api/matches/[id] — freight rate override + reset (Wave #7)', () => {
+  let db: Database.Database;
+
+  function freshDbFreight(): Database.Database {
+    const d = new Database(':memory:');
+    migration032.up(d);
+    migration033.up(d);
+    migration034.up(d);
+    migration035.up(d);
+    migration036.up(d);
+    return d;
+  }
+
+  function seedFreightMatch(
+    database: Database.Database,
+    userId: string,
+    opts: {
+      cargo_type?: string;
+      vessel_dwt?: number;
+      distance_nm?: number;
+      rate?: number;
+      source?: string;
+    } = {},
+  ): number {
+    const res = database
+      .prepare(
+        `INSERT INTO matches
+           (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+            cargo_type, load_port, discharge_port, vessel_dwt, distance_nm, tce_usd_per_day,
+            freight_rate_usd_per_mt, freight_rate_source)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        'cargo-1',
+        'vessel-1',
+        80,
+        '{}',
+        'shortlist',
+        userId,
+        Date.now(),
+        Date.now(),
+        opts.cargo_type ?? 'GRAIN',
+        'NLRTM',
+        'DEHAM',
+        opts.vessel_dwt ?? 50000,
+        opts.distance_nm ?? 3000,
+        10000,
+        opts.rate ?? 99,
+        opts.source ?? 'manual',
+      );
+    return res.lastInsertRowid as number;
+  }
+
+  async function patch(id: number, body: unknown) {
+    const { PATCH } = await import('@/app/api/matches/[id]/route');
+    const req = new NextRequest(`http://localhost/api/matches/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return PATCH(req, { params: Promise.resolve({ id: String(id) }) });
+  }
+
+  beforeEach(() => {
+    db = freshDbFreight();
+    testDb = db;
+    process.env.MATCHES_ENABLED = 'true';
+    mockRequireSession.mockReturnValue(SESSION_A);
+  });
+
+  afterEach(() => {
+    db.close();
+    delete process.env.MATCHES_ENABLED;
+  });
+
+  it('manual override sets source=manual and the supplied rate', async () => {
+    const id = seedFreightMatch(db, 'user-a', { source: 'estimated', rate: 14 });
+    const res = await patch(id, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.freight_rate_source).toBe('manual');
+    expect(body.freight_rate_usd_per_mt).toBe(25);
+    expect(Number.isFinite(body.tce_usd_per_day)).toBe(true);
+  });
+
+  it('rejects a non-positive manual rate with 400', async () => {
+    const id = seedFreightMatch(db, 'user-a', {});
+    expect((await patch(id, { freight_rate_usd_per_mt: 0 })).status).toBe(400);
+    expect((await patch(id, { freight_rate_usd_per_mt: -3 })).status).toBe(400);
+  });
+
+  it('reset_freight_rate clears a sticky manual override → estimate tier', async () => {
+    const id = seedFreightMatch(db, 'user-a', {
+      source: 'manual',
+      rate: 99,
+      cargo_type: 'GRAIN',
+      vessel_dwt: 50000,
+      distance_nm: 3000,
+    });
+    const res = await patch(id, { reset_freight_rate: true });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.freight_rate_source).toBe('estimated');
+    const est = estimateFreightRate('GRAIN', 3000, 50000);
+    expect(body.freight_rate_usd_per_mt).toBe(est.rate);
+    expect(body.freight_rate_usd_per_mt).not.toBe(99);
+    expect(Number.isFinite(body.tce_usd_per_day)).toBe(true);
+  });
+
+  it('reset on a match owned by another session → 404', async () => {
+    const id = seedFreightMatch(db, 'user-b', {});
+    mockRequireSession.mockReturnValueOnce(SESSION_A);
+    expect((await patch(id, { reset_freight_rate: true })).status).toBe(404);
   });
 });

--- a/app/api/matches/[id]/route.ts
+++ b/app/api/matches/[id]/route.ts
@@ -9,7 +9,8 @@ import {
 } from '@/lib/matching/matches-repository';
 import { fromMatchSlug } from '@/lib/matching/match-slug';
 import type { MatchStatus } from '@/lib/matching/matches-repository';
-import { estimateFreightRate, computeEstimatedTce } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce } from '@/lib/matching/tce-calculator';
+import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 
 export const dynamic = 'force-dynamic';
 
@@ -87,7 +88,7 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { status, freight_rate_usd_per_mt } = body;
+    const { status, freight_rate_usd_per_mt, reset_freight_rate } = body;
 
     const db = getStore().getDatabase();
     const existing = getMatch(db, id);
@@ -97,6 +98,33 @@ export async function PATCH(
         { error: `Match not found: ${id}` },
         { status: 404 }
       );
+    }
+
+    // Reset-to-auto path (Wave #7): clear a sticky manual override and recompute the
+    // automatic rate from the stored match fields. Without the original email/quantity
+    // context the waterfall resolves to the estimate tier; parsed/baltic re-apply on
+    // the next full recompute.
+    if (reset_freight_rate === true) {
+      const resolved = resolveFreightRate({
+        cargoType: existing.cargo_type,
+        vesselDwt: existing.vessel_dwt ?? 0,
+        quantityMt: 0,
+        distanceNm: existing.distance_nm ?? 0,
+      });
+      const tceEst = computeEstimatedTce(
+        { rate: resolved.value, source: resolved.source, confidence: resolved.confidence },
+        existing.distance_nm ?? 0,
+        existing.vessel_dwt ?? 0,
+        0,
+      );
+      const updated = updateMatchFreightRate(
+        db,
+        id,
+        resolved.value,
+        tceEst.tce_usd_per_day,
+        resolved.source,
+      );
+      return NextResponse.json(updated, { status: 200 });
     }
 
     // Freight rate override path

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -13,6 +13,7 @@ import { filterMatchesByMode } from '@/lib/matching/mode-filter';
 import { useToast } from '@/components/ui/toast';
 import { abbrPort } from '@/lib/utils/abbr-port';
 import { fmtLaycan, isLaycanExpired } from '@/lib/utils/fmt-laycan';
+import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 
 interface Props {
   initialMatches: StoredMatch[];
@@ -186,7 +187,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   const [dwt_max, setDwtMax] = useState(() => searchParams.get('dwt_max') ?? '');
 
   // Apply Filters handler
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- pre-existing async useCallback, refactor in R5
+   
   const handleApplyFilters = useCallback(async () => {
     const params = new URLSearchParams();
     for (const ct of cargoTypes) params.append('cargo_type', ct);
@@ -209,7 +210,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   }, [cargoTypes, route, laycan_from, laycan_to, score_min, dwt_min, dwt_max, filterStatus, router]);
 
   // Clear Filters handler
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- pre-existing async useCallback, refactor in R5
+   
   const handleClearFilters = useCallback(async () => {
     setCargoTypes([]);
     setRoute('');
@@ -759,14 +760,15 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                                 Distance: {match.distance_nm.toLocaleString('en-US')} nm
                               </div>
                             )}
-                            {match.tce_usd_per_day != null && (
-                              <div className="text-xs font-medium text-emerald-700 flex items-center gap-1">
-                                TCE: ${match.tce_usd_per_day.toLocaleString('en-US')}/day
-                                {match.freight_rate_source === 'estimated' && (
-                                  <span className="text-xs bg-amber-100 text-amber-700 px-1 rounded" title="Estimated freight rate">est</span>
-                                )}
-                              </div>
-                            )}
+                            {match.tce_usd_per_day != null && (() => {
+                              const badge = freightBadge(match.freight_rate_source);
+                              return (
+                                <div className={`text-xs font-medium flex items-center gap-1 ${badge.dimmed ? 'text-gray-400' : 'text-emerald-700'}`}>
+                                  TCE: ${match.tce_usd_per_day.toLocaleString('en-US')}/day
+                                  <span className={`text-xs px-1 rounded ${FREIGHT_BADGE_CLASSES[badge.tone]}`} title={badge.title}>{badge.label}</span>
+                                </div>
+                              );
+                            })()}
                           </div>
                           <div className="text-right flex-none">
                             {match.fit_percent != null ? (

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -5,6 +5,7 @@ import type { ParsedVessel, ParsedCargo } from '@/lib/types';
 import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
 import { calculateFuelEu } from '@/lib/economics/fueleu';
 import { estimateVoyageDays } from '@/lib/economics/voyage-days';
+import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 
 interface EconomicsTabProps {
   commissionPercent?: number | null;
@@ -58,6 +59,9 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const [overrideTce, setOverrideTce] = useState<number | null>(null);
   const [overrideSaving, setOverrideSaving] = useState(false);
   const [overrideError, setOverrideError] = useState<string | null>(null);
+  const [currentRate, setCurrentRate] = useState<number | null>(storedFreightRate ?? null);
+  const [currentSource, setCurrentSource] = useState<string | null>(freightRateSource ?? null);
+  const [resetting, setResetting] = useState(false);
   const [bunkerPort, setBunkerPort] = useState<BunkerPort>('SGSIN');
   const [bunkerGrade, setBunkerGrade] = useState<BunkerGrade>('VLSFO');
   const [displayCurrency, setDisplayCurrency] = useState<DisplayCurrency>('USD');
@@ -103,6 +107,8 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
       } else {
         const updated = await res.json();
         setOverrideTce(updated.tce_usd_per_day ?? null);
+        setCurrentRate(updated.freight_rate_usd_per_mt ?? rate);
+        setCurrentSource(updated.freight_rate_source ?? 'manual');
       }
     } catch {
       setOverrideError('Network error');
@@ -110,6 +116,36 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
       setOverrideSaving(false);
     }
   }, [matchDbId, overrideRate]);
+
+  // Reset a sticky manual override back to the automatic (waterfall) rate (Wave #7).
+  const handleReset = useCallback(async () => {
+    if (!matchDbId) return;
+    setResetting(true);
+    setOverrideError(null);
+    try {
+      const res = await fetch(`/api/matches/${matchDbId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reset_freight_rate: true }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setOverrideError((data as { error?: string }).error ?? `Error ${res.status}`);
+      } else {
+        const updated = await res.json();
+        setCurrentRate(updated.freight_rate_usd_per_mt ?? null);
+        setCurrentSource(updated.freight_rate_source ?? 'estimated');
+        setOverrideTce(updated.tce_usd_per_day ?? null);
+        setOverrideRate(
+          updated.freight_rate_usd_per_mt != null ? String(updated.freight_rate_usd_per_mt) : '',
+        );
+      }
+    } catch {
+      setOverrideError('Network error');
+    } finally {
+      setResetting(false);
+    }
+  }, [matchDbId]);
 
   const compareInputs = useMemo(() => {
     const origin = cargo?.originPort?.value ?? '';
@@ -185,13 +221,39 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
       {matchDbId != null && (
         <div data-testid="freight-rate-override" className="rounded border border-blue-200 bg-blue-50 p-3 space-y-2">
           <h3 className="text-xs font-semibold text-blue-900">Freight Rate Override</h3>
-          {storedFreightRate != null && (
-            <p className="text-xs text-gray-600">
-              Current: <span className="font-medium">${storedFreightRate}/mt</span>
-              {freightRateSource === 'estimated' && (
-                <span className="ml-1 text-amber-700 bg-amber-100 px-1 rounded">est</span>
-              )}
-            </p>
+          {currentRate != null && (() => {
+            const badge = freightBadge(currentSource);
+            return (
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-gray-600">
+                  Current:{' '}
+                  <span className={`font-medium ${badge.dimmed ? 'text-gray-400' : ''}`}>
+                    ${currentRate}/mt
+                  </span>
+                  <span
+                    data-testid="freight-rate-badge"
+                    className={`ml-1 px-1 rounded ${FREIGHT_BADGE_CLASSES[badge.tone]}`}
+                    title={badge.title}
+                  >
+                    {badge.label}
+                  </span>
+                </p>
+                {currentSource === 'manual' && (
+                  <button
+                    type="button"
+                    data-testid="freight-rate-reset"
+                    onClick={handleReset}
+                    disabled={resetting}
+                    className="text-xs text-blue-600 hover:underline disabled:opacity-50 flex-none"
+                  >
+                    {resetting ? '…' : 'Reset to auto'}
+                  </button>
+                )}
+              </div>
+            );
+          })()}
+          {currentSource === 'estimated' && (
+            <p className="text-xs text-amber-700">≈ estimate — rate not confirmed</p>
           )}
           {overrideTce != null && (
             <p data-testid="override-tce-result" className="text-xs font-medium text-emerald-700">

--- a/docs/plans/freight-rate-waterfall.md
+++ b/docs/plans/freight-rate-waterfall.md
@@ -1,0 +1,175 @@
+# Plan: Freight-rate waterfall (`resolveFreightRate`) — Wave #7 / L2 #7
+
+Branch: `fix/freight-rate-waterfall` (off L2-economics-wiring). Source design: `~/.handover/freight-brief.md` (founder-agreed, do not redo).
+
+## Goal
+
+One function `resolveFreightRate(input) → { value, source, confidence }` — a 4-tier priority
+waterfall feeding the freight rate into TCE display. **TCE formula, match count, and ranking
+must not change** — the rate only affects what TCE is _shown_, not which pairs match.
+
+Tiers (highest priority first):
+| # | source | trigger | confidence | badge |
+|---|--------|---------|-----------|-------|
+| 0 | `manual` | broker override present (sticky) | 1.0 | ✎ вручную |
+| 1 | `parsed` | `cargo.freightRateUsd` present ($/mt from email) | 0.9 | ✓ из письма |
+| 2 | `baltic` | per-class $/day index available + distance + tonnes | 0.5 | ~ рынок (Baltic <date>) |
+| 3 | `estimated`| always (fallback) — existing `estimateFreightRate` | 0.3–0.6 | ≈ оценка (dimmed, "ставка не подтверждена") |
+
+## Reality-check findings (from code probe 2026-05-30)
+
+1. **tier-3 exists, keep verbatim**: `estimateFreightRate(cargoType, distanceNm, dwt)` →
+   `{rate, source:'estimated', confidence}` at `lib/matching/tce-calculator.ts:79`. NOT a wrapper —
+   `resolveFreightRate` selects among tiers and calls this one for tier 3.
+2. **TCE untouched**: `computeEstimatedTce(freightEst, …)` already passes `freightEst.source` through to
+   `TceEstimate.freight_rate_source`. Feeding it `source:'parsed'|'baltic'|'manual'` needs only a TYPE
+   widening of `FreightRateEstimate.source` — no formula change.
+3. **tier-1 parser already done**: `freight_rate_usd` (per-MT) fully extracted —
+   `lib/prompts/parse-cargo.ts:387-395` + `lib/schemas/parse-cargo.ts:61` + `lib/parsing/parse-cargo-ai.ts:116`
+   → `ParsedCargo.freightRateUsd` (`lib/types.ts:192`). **Do NOT touch the prompt** (regression risk).
+   Work = consume `cargo.freightRateUsd` + add a fixture proving extraction.
+4. **manual already sticky**: persistence is `INSERT OR IGNORE` (createMatch) + idempotency guard
+   (compute-matches skips if matches exist). No code path UPDATEs an existing row's rate except the
+   explicit PATCH. So "sticky" = (a) don't add an overwrite path, (b) add a UI reset path.
+5. **Baltic unit mismatch** (DOCUMENTED ASSUMPTION): brief formula needs per-class **$/day**; seeds are
+   index **points** (BHSI=650, BSI=1100, BCI=1600, BDI=1450; only TOEPFER_TMI=12683 is real $/day).
+   BHSI is typed `unit:'index'` for KPI display — must not repurpose. → add a _separate_ static, dated
+   per-class TC-average $/day seed; existing points rows untouched.
+6. **call-sites** of the rate today: `compute-matches.ts:80`, `persist-session-matches.ts:43`,
+   `pair-analyzer.ts:642` (buildMatchEconomics), `app/api/matches/[id]/route.ts:100` (manual PATCH).
+7. **UI chain**: `app/match/[id]/page.tsx:240-241` → `components/match/MatchTabs.tsx` →
+   `components/match/EconomicsTab.tsx` (override box + `est` badge only, lines 184-228, 191-193).
+   `app/matches/MatchesClient.tsx:594` also shows `estimated` badge.
+
+## Decisions / assumptions (founder absent → documented, proceeding)
+
+- **A1 Baltic $/day seed**: new migration `039-baltic-tc-dayrates-seed` (021–038 already exist; next free
+  version is 39) inserts per-class TC-average $/day rows into `baltic_indices` with distinct codes
+  `BHSI_TC`, `BSI_TC`, `BPI_TC`, `source='static-seed'`, `price_date='2026-05-09'` (same date as existing
+  seed), realistic magnitudes anchored to TOEPFER_TMI≈12,683: handysize `BHSI_TC≈11500`,
+  supramax `BSI_TC≈13500`, panamax `BPI_TC≈15000`. Live feed = L4, out of scope.
+  Register in `lib/migrations/index.ts` (`import migration039` + append to `allMigrations`).
+  `getBalticDayRate` wraps the lookup in try/catch → missing `baltic_indices` table returns null
+  (protects existing tests whose in-memory DB never ran migration 019/039).
+- **A2 class mapping** (by DWT, brief's intent): `dwt<45000→BHSI_TC` (handysize/handymax),
+  `45000≤dwt<70000→BSI_TC` (supramax/ultramax), `dwt≥70000→BPI_TC` (panamax+). Panamax→BPI_TC
+  (we seed it; brief's "BPI if present else BSI" fallback kept if row missing).
+- **A3 tier-2 fires only when** baltic day-rate row found AND `distanceNm>0` AND `quantityMt>0` AND
+  `estimateVoyageDays>0`; else fall through to tier 3. Guards against the $0.x/mt nonsense.
+- **A4 reset-to-auto**: PATCH accepts `{ reset_freight_rate: true }` → recompute the AUTO rate from the
+  stored match row (cargo_type, distance_nm, vessel_dwt) via `resolveFreightRate` with no manual/parsed and
+  no quantity → resolves to **estimate** (tier 3), restoring the original persisted value; sets
+  `freight_rate_source` back to the resolved source. (parsed/baltic need the original email/quantity which
+  the match row doesn't store — re-applied on the next full recompute; documented in the route + UI copy.)
+- **A5 lumpsum**: out of scope — parser extracts per-MT only today; lumpsum normalization would need a
+  prompt change (regression risk) + reliable quantity. Deferred; noted in PR.
+- **A6 confidence ladder**: manual 1.0 / parsed 0.9 / baltic 0.5 / estimate unchanged 0.3–0.6.
+
+## Architecture
+
+`resolveFreightRate` stays **pure** (no DB) for testability; the caller resolves the baltic day-rate.
+
+```
+// lib/matching/freight-resolver.ts (NEW)
+export type FreightRateSource = 'manual' | 'parsed' | 'baltic' | 'estimated';
+export interface ResolveFreightInput {
+  cargoType: string | null;
+  parsedFreightRateUsdPerMt?: number | null;   // tier 1 — cargo.freightRateUsd
+  vesselDwt: number;
+  quantityMt: number;
+  distanceNm: number;
+  speedKts?: number;
+  manualRateUsdPerMt?: number | null;           // tier 0
+  balticDayRate?: { usdPerDay: number; date: string; indexCode: string } | null; // tier 2 (caller-resolved)
+}
+export interface ResolvedFreightRate {
+  value: number; source: FreightRateSource; confidence: number; balticDate?: string;
+}
+export function resolveFreightRate(i: ResolveFreightInput): ResolvedFreightRate
+```
+
+```
+// lib/market/baltic-freight.ts (NEW) — DB-bound tier-2 helpers
+export function balticIndexCodeForDwt(dwt: number): 'BHSI_TC'|'BSI_TC'|'BPI_TC'
+export function getBalticDayRate(db, dwt): { usdPerDay; date; indexCode } | null  // getLatestBalticIndex + fallback BPI_TC→BSI_TC
+```
+
+Tier-2 math inside `resolveFreightRate`:
+`value = round2( balticDayRate.usdPerDay * estimateVoyageDays(distanceNm, speedKts) / quantityMt )`
+(import `estimateVoyageDays` from `lib/economics/voyage-days.ts`). Guard A3.
+
+Type widening (additive): `FreightRateEstimate.source` and `TceEstimate.freight_rate_source` in
+`tce-calculator.ts` → include `'parsed'|'baltic'`. `updateMatchFreightRate` source param → `FreightRateSource`.
+
+## Steps (TDD — test first each step; `lib/types.ts` additive only)
+
+### S1 — freight-resolver core (pure)
+
+- TEST `lib/matching/__tests__/freight-resolver.test.ts`: priority (manual beats all; parsed beats
+  baltic/estimate; baltic beats estimate; estimate fallback); confidence per tier; tier-2 math on
+  2–3 routes gives sane $/mt (e.g. BSI_TC 13500 × 12d / 45000t ≈ $3.6/mt — sane); tier-2 guards
+  (no baltic / qty 0 / dist 0 → estimate); manual 0/negative ignored → next tier.
+- IMPL `lib/matching/freight-resolver.ts`.
+
+### S2 — baltic day-rate seed + helper
+
+- TEST `__tests__/lib/market/baltic-freight.test.ts`: `balticIndexCodeForDwt` boundaries (44999→BHSI_TC,
+  45000→BSI_TC, 70000→BPI_TC); `getBalticDayRate` returns seeded row; BPI_TC missing → BSI_TC fallback.
+- IMPL migration `lib/migrations/021-baltic-tc-dayrates-seed.ts` (+ register in migration index) +
+  `lib/market/baltic-freight.ts`. Verify migration list wiring (find the registry).
+
+### S3 — widen TCE source types (additive, no formula change)
+
+- TEST: extend `tce-calculator.test.ts` — `computeEstimatedTce` passes through `source:'baltic'|'parsed'`.
+- IMPL: widen `FreightRateEstimate.source`, `TceEstimate.freight_rate_source` unions.
+
+### S4 — wire matching pipeline to resolveFreightRate
+
+- TEST `compute-matches` + `persist-session-matches` + `pair-analyzer`/buildMatchEconomics: when
+  `cargo.freightRateUsd` set → source `parsed`; when baltic available + no parsed → `baltic`; else `estimated`.
+  **Assert match COUNT + ranking unchanged** (snapshot existing match-count tests stay green).
+- IMPL: replace `estimateFreightRate→computeEstimatedTce` blocks in `compute-matches.ts:79-85`,
+  `persist-session-matches.ts:42-48`, and `buildMatchEconomics` (`tce-calculator.ts:162`) with
+  `resolveFreightRate(...)` → feed `{rate:value, source}` into `computeEstimatedTce`. `buildMatchEconomics`
+  gains optional `parsedFreightRateUsdPerMt` + `balticDayRate` inputs; pair-analyzer passes
+  `cargo.freightRateUsd` + `getBalticDayRate(db, dwt)`. (pair-analyzer has no db today → thread db in OR
+  resolve baltic in compute-matches and pass through; pick least-invasive in impl.)
+
+### S5 — reset path in PATCH route
+
+- TEST `app/api/matches/[id]/__tests__/route.test.ts`: `{reset_freight_rate:true}` → recomputes auto
+  (source `estimated`), clears manual; manual override still works; bad input 400; 404 other-session.
+- IMPL: add reset branch in `app/api/matches/[id]/route.ts` PATCH using `resolveFreightRate` from stored row.
+
+### S6 — UI: 4-source badges + sticky + reset button
+
+- TEST `__tests__/components/match/EconomicsTab-freight-badge.test.tsx`: renders correct badge per
+  source (manual/parsed/baltic/estimated); estimate dimmed + "ставка не подтверждена"; baltic shows date;
+  reset button visible only when source==='manual'; clicking reset PATCHes `{reset_freight_rate:true}`.
+- IMPL: `EconomicsTab.tsx` badge map + reset button; `MatchesClient.tsx:594` badge map (all 4).
+  TCE always shown (already is) with source badge. Mark PR `needs visual-preview`.
+
+### S7 — tier-1 parser fixture (NO prompt change)
+
+- TEST: add a parse-cargo fixture/case asserting `freight_rate_usd` ("$18/mt", "usd 22 pmt") →
+  `freightRateUsd` populated. (parser logic already supports it — fixture guards the contract.)
+
+## Verification (verification-before-completion)
+
+- `NODE_OPTIONS='--max-old-space-size=8192' npm test` (ONE run; known-foreign flake
+  `progonq/score-classify` is NOT our regression). Capture pass/fail counts.
+- `npx tsc --noEmit` clean. eslint clean (fresh-worktree: commit with `--no-verify` after manual
+  eslint+tsc per project memory).
+- Manual sanity in a test: baltic $/mt on 2–3 routes is plausible ($1–$15/mt range).
+- Confirm match count/ranking tests unchanged (no edits to their expectations — PI3).
+
+## Process gates (founder-mandated)
+
+TDD (this plan) → **/test-skill** (risk-override: parser touched, adversarial QA) →
+requesting-code-review → verification-before-completion → finishing-a-development-branch
+(draft PR to main, do NOT merge, mark `needs visual-preview`).
+
+## Out of scope (hard)
+
+Live Baltic feed; TCE/scoring formula; match count/ranking; bucket partitioning; lumpsum parsing;
+prompt rewrite. `lib/types.ts` additive only.

--- a/lib/market/baltic-freight.ts
+++ b/lib/market/baltic-freight.ts
@@ -1,0 +1,50 @@
+import type Database from 'better-sqlite3';
+import { getLatestBalticIndex } from '@/lib/market/baltic-repository';
+
+/**
+ * Per-vessel-class Baltic timecharter day-rate codes ($/day) — see migration 039.
+ * Distinct from the index-POINTS codes (BHSI/BSI/…) which are a different unit.
+ */
+export type BalticTcCode = 'BHSI_TC' | 'BSI_TC' | 'BPI_TC';
+
+export interface BalticDayRate {
+  usdPerDay: number;
+  date: string;
+  indexCode: string;
+}
+
+/**
+ * Map a vessel DWT to its Baltic class day-rate code (brief's class mapping):
+ *   < 45,000          → BHSI_TC (handysize / handymax)
+ *   45,000 – 69,999   → BSI_TC  (supramax / ultramax)
+ *   ≥ 70,000          → BPI_TC  (panamax+)
+ */
+export function balticIndexCodeForDwt(dwt: number): BalticTcCode {
+  if (dwt < 45000) return 'BHSI_TC';
+  if (dwt < 70000) return 'BSI_TC';
+  return 'BPI_TC';
+}
+
+/**
+ * Resolve the latest per-class Baltic timecharter day-rate for a vessel DWT.
+ * Panamax falls back to BSI_TC when BPI_TC is unavailable (brief). Returns null
+ * when no positive day-rate row exists — or, defensively, when the baltic_indices
+ * table is absent (so callers whose DB never ran migration 019/039 just skip tier-2
+ * rather than throw).
+ */
+export function getBalticDayRate(db: Database.Database, dwt: number): BalticDayRate | null {
+  const primary = balticIndexCodeForDwt(dwt);
+  const codes: BalticTcCode[] = primary === 'BPI_TC' ? ['BPI_TC', 'BSI_TC'] : [primary];
+  try {
+    for (const code of codes) {
+      const row = getLatestBalticIndex(db, code);
+      if (row && Number.isFinite(row.value) && row.value > 0) {
+        return { usdPerDay: row.value, date: row.price_date, indexCode: row.index_code };
+      }
+    }
+    return null;
+  } catch {
+    // baltic_indices table missing (e.g. a minimal test DB) — skip tier-2 cleanly.
+    return null;
+  }
+}

--- a/lib/matching/__tests__/freight-badge.test.ts
+++ b/lib/matching/__tests__/freight-badge.test.ts
@@ -1,0 +1,48 @@
+import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
+
+describe('freightBadge', () => {
+  it('manual → pen icon, not dimmed', () => {
+    const b = freightBadge('manual');
+    expect(b.tone).toBe('manual');
+    expect(b.dimmed).toBe(false);
+    expect(b.label).toContain('✎');
+  });
+
+  it('parsed → check icon', () => {
+    const b = freightBadge('parsed');
+    expect(b.tone).toBe('parsed');
+    expect(b.dimmed).toBe(false);
+    expect(b.label).toContain('✓');
+  });
+
+  it('baltic includes the index date when provided', () => {
+    const b = freightBadge('baltic', '2026-05-09');
+    expect(b.tone).toBe('baltic');
+    expect(b.label).toContain('2026-05-09');
+    expect(b.label).toContain('Baltic');
+  });
+
+  it('baltic without a date still labels Baltic', () => {
+    expect(freightBadge('baltic').label).toContain('Baltic');
+  });
+
+  it('estimated → dimmed + "not confirmed" title', () => {
+    const b = freightBadge('estimated');
+    expect(b.tone).toBe('estimate');
+    expect(b.dimmed).toBe(true);
+    expect(b.title.toLowerCase()).toContain('not confirmed');
+    expect(b.label).toContain('≈');
+  });
+
+  it('unknown / null source falls back to the estimate badge', () => {
+    expect(freightBadge(null).tone).toBe('estimate');
+    expect(freightBadge(undefined).tone).toBe('estimate');
+    expect(freightBadge('something-else').tone).toBe('estimate');
+  });
+
+  it('every tone has a non-empty class', () => {
+    (['manual', 'parsed', 'baltic', 'estimate'] as const).forEach((t) => {
+      expect(FREIGHT_BADGE_CLASSES[t]).toBeTruthy();
+    });
+  });
+});

--- a/lib/matching/__tests__/freight-resolver.test.ts
+++ b/lib/matching/__tests__/freight-resolver.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests — freight-resolver.ts (Wave #7, L2 #7)
+ *
+ * resolveFreightRate is a PURE 4-tier priority waterfall:
+ *   0 manual  (sticky broker override)        → confidence 1.0   → 'manual'
+ *   1 parsed  (cargo.freightRateUsd, $/mt)     → confidence 0.9   → 'parsed'
+ *   2 baltic  (per-class $/day × days ÷ tonnes)→ confidence 0.5   → 'baltic'
+ *   3 estimate(existing estimateFreightRate)   → confidence 0.3-0.6 'estimated'
+ *
+ * Priority: a higher tier always wins when its input is valid. Invalid/absent
+ * input at a tier falls through to the next. estimate is the always-present floor.
+ */
+
+import { resolveFreightRate, type ResolveFreightInput } from '@/lib/matching/freight-resolver';
+import { estimateFreightRate } from '@/lib/matching/tce-calculator';
+import { estimateVoyageDays } from '@/lib/economics/voyage-days';
+
+const base: ResolveFreightInput = {
+  cargoType: 'GRAIN',
+  vesselDwt: 50000,
+  quantityMt: 45000,
+  distanceNm: 3000,
+  speedKts: 12,
+};
+
+const balticInput = { usdPerDay: 13500, date: '2026-05-09', indexCode: 'BSI_TC' };
+
+describe('resolveFreightRate — tier priority', () => {
+  it('tier 0: manual beats every other tier', () => {
+    const r = resolveFreightRate({
+      ...base,
+      manualRateUsdPerMt: 31,
+      parsedFreightRateUsdPerMt: 18,
+      balticDayRate: balticInput,
+    });
+    expect(r.source).toBe('manual');
+    expect(r.value).toBe(31);
+    expect(r.confidence).toBe(1.0);
+  });
+
+  it('tier 1: parsed beats baltic + estimate (no manual)', () => {
+    const r = resolveFreightRate({
+      ...base,
+      parsedFreightRateUsdPerMt: 18,
+      balticDayRate: balticInput,
+    });
+    expect(r.source).toBe('parsed');
+    expect(r.value).toBe(18);
+    expect(r.confidence).toBe(0.9);
+  });
+
+  it('tier 2: baltic beats estimate (no manual/parsed)', () => {
+    const r = resolveFreightRate({ ...base, balticDayRate: balticInput });
+    expect(r.source).toBe('baltic');
+    expect(r.balticDate).toBe('2026-05-09');
+    expect(r.confidence).toBe(0.5);
+  });
+
+  it('tier 3: estimate is the fallback floor', () => {
+    const r = resolveFreightRate(base);
+    expect(r.source).toBe('estimated');
+    const est = estimateFreightRate(base.cargoType, base.distanceNm, base.vesselDwt);
+    expect(r.value).toBe(est.rate);
+    expect(r.confidence).toBe(est.confidence);
+  });
+});
+
+describe('resolveFreightRate — invalid input falls through', () => {
+  it('manual <= 0 or null is ignored → next tier', () => {
+    expect(resolveFreightRate({ ...base, manualRateUsdPerMt: 0, parsedFreightRateUsdPerMt: 18 }).source).toBe('parsed');
+    expect(resolveFreightRate({ ...base, manualRateUsdPerMt: -5, parsedFreightRateUsdPerMt: 18 }).source).toBe('parsed');
+    expect(resolveFreightRate({ ...base, manualRateUsdPerMt: null, parsedFreightRateUsdPerMt: 18 }).source).toBe('parsed');
+  });
+
+  it('parsed <= 0 or null is ignored → next tier', () => {
+    expect(resolveFreightRate({ ...base, parsedFreightRateUsdPerMt: 0, balticDayRate: balticInput }).source).toBe('baltic');
+    expect(resolveFreightRate({ ...base, parsedFreightRateUsdPerMt: null, balticDayRate: balticInput }).source).toBe('baltic');
+  });
+
+  it('baltic guards (missing rate / zero qty / zero distance / zero voyage) → estimate', () => {
+    expect(resolveFreightRate({ ...base, balticDayRate: null }).source).toBe('estimated');
+    expect(resolveFreightRate({ ...base, quantityMt: 0, balticDayRate: balticInput }).source).toBe('estimated');
+    expect(resolveFreightRate({ ...base, distanceNm: 0, balticDayRate: balticInput }).source).toBe('estimated');
+    expect(resolveFreightRate({ ...base, balticDayRate: { usdPerDay: 0, date: '2026-05-09', indexCode: 'BSI_TC' } }).source).toBe('estimated');
+  });
+});
+
+describe('resolveFreightRate — tier-2 math gives sane $/mt', () => {
+  it('matches (usdPerDay × voyageDays ÷ tonnes), rounded to 2dp', () => {
+    const r = resolveFreightRate({ ...base, balticDayRate: balticInput });
+    const days = estimateVoyageDays(base.distanceNm, base.speedKts);
+    const expected = Math.round((balticInput.usdPerDay * days) / base.quantityMt * 100) / 100;
+    expect(r.value).toBe(expected);
+  });
+
+  it('is plausible ($0.5–$20/mt) on three representative routes', () => {
+    const routes = [
+      { distanceNm: 3000, quantityMt: 45000, balticDayRate: { usdPerDay: 13500, date: 'd', indexCode: 'BSI_TC' } },
+      { distanceNm: 6000, quantityMt: 30000, balticDayRate: { usdPerDay: 11500, date: 'd', indexCode: 'BHSI_TC' } },
+      { distanceNm: 9000, quantityMt: 70000, balticDayRate: { usdPerDay: 15000, date: 'd', indexCode: 'BPI_TC' } },
+    ];
+    for (const route of routes) {
+      const r = resolveFreightRate({ ...base, ...route });
+      expect(r.source).toBe('baltic');
+      expect(r.value).toBeGreaterThan(0.5);
+      expect(r.value).toBeLessThan(20);
+    }
+  });
+});

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -150,6 +150,16 @@ describe('computeEstimatedTce', () => {
     expect(result.freight_rate_usd_per_mt).toBe(30);
   });
 
+  it('passes through waterfall sources (parsed / baltic) unchanged (Wave #7)', () => {
+    const parsed = computeEstimatedTce({ rate: 18, source: 'parsed', confidence: 0.9 }, 3000, 50000, 45000);
+    expect(parsed.freight_rate_source).toBe('parsed');
+    expect(parsed.freight_rate_usd_per_mt).toBe(18);
+
+    const baltic = computeEstimatedTce({ rate: 3.6, source: 'baltic', confidence: 0.5 }, 3000, 50000, 45000);
+    expect(baltic.freight_rate_source).toBe('baltic');
+    expect(baltic.freight_rate_usd_per_mt).toBe(3.6);
+  });
+
   it('zero distance uses 10-day fallback and still returns finite TCE', () => {
     const est = estimateFreightRate('BULK', 0, 50000);
     const result = computeEstimatedTce(est, 0, 50000, 45000);

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -8,7 +8,9 @@ import { MATCH_PROMPT } from '@/lib/prompts';
 import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { resolveFreightRate } from '@/lib/matching/freight-resolver';
+import { getBalticDayRate } from '@/lib/market/baltic-freight';
 
 /**
  * Compute matches for a session and persist them to the DB.
@@ -48,7 +50,10 @@ export async function computeAndPersistMatches(
   // path computes the same partition and persists all buckets to the session
   // (see app/api/ai/match/route.ts + its route tests). So this path shows the
   // shortlist; the full bucketed list is served live.
-  const { matches } = await analyzePairs(cargos, vessels, aiScorer);
+  // Pass db so the economics-enrichment loop in analyzePairs can resolve the same
+  // Baltic tier-2 rate the persisted tce_usd_per_day column uses → match.economics
+  // stays consistent with the DB column on the auto-precompute path (code-review #2).
+  const { matches } = await analyzePairs(cargos, vessels, aiScorer, { db });
 
   const cargoMap = new Map(cargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselMap = new Map(vessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
@@ -77,8 +82,19 @@ export async function computeAndPersistMatches(
     let freight_rate_source: string | null = null;
 
     if (distanceResult && distanceResult.nm > 0) {
-      const freightEst = estimateFreightRate(cargoType, distanceResult.nm, vesselDwt);
-      const tceEst = computeEstimatedTce(freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt);
+      const resolved = resolveFreightRate({
+        cargoType,
+        parsedFreightRateUsdPerMt: cargo?.freightRateUsd ?? null,
+        vesselDwt,
+        quantityMt,
+        distanceNm: distanceResult.nm,
+        speedKts,
+        balticDayRate: getBalticDayRate(db, vesselDwt),
+      });
+      const tceEst = computeEstimatedTce(
+        { rate: resolved.value, source: resolved.source, confidence: resolved.confidence },
+        distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt,
+      );
       tce_usd_per_day = tceEst.tce_usd_per_day;
       freight_rate_usd_per_mt = tceEst.freight_rate_usd_per_mt;
       freight_rate_source = tceEst.freight_rate_source;

--- a/lib/matching/freight-badge.ts
+++ b/lib/matching/freight-badge.ts
@@ -1,0 +1,56 @@
+import type { FreightRateSource } from '@/lib/matching/tce-calculator';
+
+/**
+ * UI badge metadata for a resolved freight-rate source (Wave #7, L2 #7).
+ * Shared by EconomicsTab and the matches list so the badge stays consistent.
+ * Pure (no React) → unit-testable.
+ */
+export type FreightBadgeTone = 'manual' | 'parsed' | 'baltic' | 'estimate';
+
+export interface FreightBadge {
+  label: string;
+  title: string;
+  tone: FreightBadgeTone;
+  /** estimate tier → the TCE number should be visually muted ("rate not confirmed"). */
+  dimmed: boolean;
+}
+
+/**
+ * Map a persisted `freight_rate_source` (free-text string) to its badge. Unknown
+ * or null sources fall back to the estimate badge — the honest default when the
+ * provenance is unclear.
+ */
+export function freightBadge(
+  source: FreightRateSource | string | null | undefined,
+  balticDate?: string | null,
+): FreightBadge {
+  switch (source) {
+    case 'manual':
+      return { label: '✎ Manual', title: 'Broker-entered rate (kept until reset)', tone: 'manual', dimmed: false };
+    case 'parsed':
+      return { label: '✓ From email', title: 'Freight rate parsed from the email', tone: 'parsed', dimmed: false };
+    case 'baltic':
+      return {
+        label: balticDate ? `~ Market (Baltic ${balticDate})` : '~ Market (Baltic)',
+        title: 'Derived from the Baltic timecharter index',
+        tone: 'baltic',
+        dimmed: false,
+      };
+    case 'estimated':
+    default:
+      return {
+        label: '≈ Estimate',
+        title: 'Heuristic estimate — rate not confirmed',
+        tone: 'estimate',
+        dimmed: true,
+      };
+  }
+}
+
+/** Tailwind classes per tone (chip background + text). */
+export const FREIGHT_BADGE_CLASSES: Record<FreightBadgeTone, string> = {
+  manual: 'bg-blue-100 text-blue-700',
+  parsed: 'bg-emerald-100 text-emerald-700',
+  baltic: 'bg-sky-100 text-sky-700',
+  estimate: 'bg-amber-100 text-amber-700',
+};

--- a/lib/matching/freight-resolver.ts
+++ b/lib/matching/freight-resolver.ts
@@ -1,0 +1,73 @@
+import { estimateFreightRate, type FreightRateSource } from '@/lib/matching/tce-calculator';
+import { estimateVoyageDays } from '@/lib/economics/voyage-days';
+
+export type { FreightRateSource };
+
+export interface ResolveFreightInput {
+  /** Cargo class for the tier-3 estimate (e.g. 'GRAIN'); null → median fallback. */
+  cargoType: string | null;
+  /** Tier 1 — rate parsed from the email ($/mt). `cargo.freightRateUsd`. */
+  parsedFreightRateUsdPerMt?: number | null;
+  vesselDwt: number;
+  quantityMt: number;
+  distanceNm: number;
+  /** Vessel laden speed (kn). Defaults to 12 inside estimateVoyageDays when absent. */
+  speedKts?: number;
+  /** Tier 0 — sticky broker override ($/mt). Wins over all other tiers when > 0. */
+  manualRateUsdPerMt?: number | null;
+  /**
+   * Tier 2 — per-vessel-class Baltic timecharter day-rate ($/day), resolved by the
+   * caller from `baltic_indices` (keeps this function pure / DB-free). null → skip tier.
+   */
+  balticDayRate?: { usdPerDay: number; date: string; indexCode: string } | null;
+}
+
+export interface ResolvedFreightRate {
+  value: number;
+  source: FreightRateSource;
+  confidence: number;
+  /** Baltic index date, present only when source === 'baltic'. */
+  balticDate?: string;
+}
+
+const PARSED_CONFIDENCE = 0.9;
+const BALTIC_CONFIDENCE = 0.5;
+
+const isPositive = (n: number | null | undefined): n is number =>
+  n != null && Number.isFinite(n) && n > 0;
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Resolve the freight rate via a 4-tier priority waterfall. Pure & deterministic —
+ * the highest tier with valid input wins; estimate (tier 3) is the always-present
+ * floor. Does NOT touch the TCE formula: callers feed `{value, source}` into the
+ * existing computeEstimatedTce.
+ */
+export function resolveFreightRate(input: ResolveFreightInput): ResolvedFreightRate {
+  // Tier 0 — manual (sticky broker override)
+  if (isPositive(input.manualRateUsdPerMt)) {
+    return { value: round2(input.manualRateUsdPerMt), source: 'manual', confidence: 1.0 };
+  }
+
+  // Tier 1 — parsed from email ($/mt)
+  if (isPositive(input.parsedFreightRateUsdPerMt)) {
+    return { value: round2(input.parsedFreightRateUsdPerMt), source: 'parsed', confidence: PARSED_CONFIDENCE };
+  }
+
+  // Tier 2 — Baltic market: $/mt = ($/day × voyage days) ÷ tonnes
+  const baltic = input.balticDayRate;
+  if (baltic && isPositive(baltic.usdPerDay) && input.distanceNm > 0 && input.quantityMt > 0) {
+    const days = estimateVoyageDays(input.distanceNm, input.speedKts);
+    if (days > 0) {
+      const value = round2((baltic.usdPerDay * days) / input.quantityMt);
+      if (value > 0) {
+        return { value, source: 'baltic', confidence: BALTIC_CONFIDENCE, balticDate: baltic.date };
+      }
+    }
+  }
+
+  // Tier 3 — estimate (existing engine, unchanged)
+  const est = estimateFreightRate(input.cargoType, input.distanceNm, input.vesselDwt);
+  return { value: est.rate, source: 'estimated', confidence: est.confidence };
+}

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3';
+import type { FreightRateSource } from '@/lib/matching/tce-calculator';
 
 export type MatchStatus = 'shortlist' | 'saved' | 'dismissed' | 'archived';
 
@@ -486,7 +487,7 @@ export function updateMatchFreightRate(
   id: number,
   freight_rate_usd_per_mt: number,
   tce_usd_per_day: number,
-  source: 'manual' | 'estimated' = 'manual',
+  source: FreightRateSource = 'manual',
 ): StoredMatch {
   const existing = getMatch(db, id);
   if (!existing) throw new Error(`Match not found: ${id}`);

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -19,6 +19,9 @@ import { validateDates, isLaycanValid } from '@/lib/sailing/date-sanity';
 import { checkSanctions } from '@/lib/validation/sanctions';
 import { enrichReasons } from '@/lib/matching/reason-enricher';
 import { buildMatchEconomics, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { resolveFreightRate } from '@/lib/matching/freight-resolver';
+import { getBalticDayRate } from '@/lib/market/baltic-freight';
+import type Database from 'better-sqlite3';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { formatNumber } from '@/lib/utils';
 import { LLMTimeoutError } from '@/lib/openai';
@@ -210,7 +213,7 @@ export async function analyzePairs(
   cargos: ParsedCargo[],
   vessels: ParsedVessel[],
   aiScorer: AiScorer,
-  options?: { refYear?: number; today?: Date },
+  options?: { refYear?: number; today?: Date; db?: Database.Database },
 ): Promise<AnalyzePairsResult> {
   if (cargos.length === 0 || vessels.length === 0) {
     return { matches: [], lowConfidenceMatches: [], insufficientData: [], blockedMatches: [] };
@@ -219,6 +222,7 @@ export async function analyzePairs(
   const today = options?.today ?? now();
   const currentYear = today.getUTCFullYear();
   const refYear = options?.refYear ?? currentYear;
+  const db = options?.db;
 
   // O(n²) pair analysis loop
   const analyses: PairAnalysis[] = [];
@@ -698,16 +702,33 @@ export async function analyzePairs(
         ? (cargo.cargoType as unknown as { value: string }).value
         : (cargo.cargoType as string | null);
 
+    const ecoDwt = cfValue(vessel.dwtSummer) ?? 0;
+    const ecoQty = cfValue(cargo.weightMt) ?? 0;
+    const ecoSpeed = parseLeadingNumber(vessel.speedLaden);
+    const resolvedFreight = resolveFreightRate({
+      cargoType,
+      parsedFreightRateUsdPerMt: cargo.freightRateUsd ?? null,
+      vesselDwt: ecoDwt,
+      quantityMt: ecoQty,
+      distanceNm: distanceResult.nm,
+      speedKts: ecoSpeed,
+      balticDayRate: db ? getBalticDayRate(db, ecoDwt) : null,
+    });
     const econ = buildMatchEconomics({
       cargoType,
       distanceNm: distanceResult.nm,
-      vesselDwt: cfValue(vessel.dwtSummer) ?? 0,
-      quantityMt: cfValue(cargo.weightMt) ?? 0,
-      speedKts: parseLeadingNumber(vessel.speedLaden),
+      vesselDwt: ecoDwt,
+      quantityMt: ecoQty,
+      speedKts: ecoSpeed,
       consumptionMt: parseLeadingNumber(vessel.consumption),
       loadPort,
       dischargePort,
       calculatedAt: economicsCalcAt,
+      resolvedFreight: {
+        rate: resolvedFreight.value,
+        source: resolvedFreight.source,
+        confidence: resolvedFreight.confidence,
+      },
     });
     if (econ) m.economics = econ;
   }

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -4,7 +4,9 @@ import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
 import { createMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { resolveFreightRate } from '@/lib/matching/freight-resolver';
+import { getBalticDayRate } from '@/lib/market/baltic-freight';
 
 export function persistSessionMatches(
   db: Database.Database,
@@ -40,8 +42,19 @@ export function persistSessionMatches(
     let freight_rate_source: string | null = null;
 
     if (distanceResult && distanceResult.nm > 0) {
-      const freightEst = estimateFreightRate(cargoTypeStr, distanceResult.nm, vesselDwt);
-      const tceEst = computeEstimatedTce(freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt);
+      const resolved = resolveFreightRate({
+        cargoType: cargoTypeStr,
+        parsedFreightRateUsdPerMt: cargo?.freightRateUsd ?? null,
+        vesselDwt,
+        quantityMt,
+        distanceNm: distanceResult.nm,
+        speedKts,
+        balticDayRate: getBalticDayRate(db, vesselDwt),
+      });
+      const tceEst = computeEstimatedTce(
+        { rate: resolved.value, source: resolved.source, confidence: resolved.confidence },
+        distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt,
+      );
       tce_usd_per_day = tceEst.tce_usd_per_day;
       freight_rate_usd_per_mt = tceEst.freight_rate_usd_per_mt;
       freight_rate_source = tceEst.freight_rate_source;

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -28,16 +28,24 @@ const DEFAULT_SPEED_KTS = 12;
 const DEFAULT_CONSUMPTION_MT_PER_DAY = 25;
 const DEFAULT_VESSEL_VALUE_USD = 22_000_000;
 
+/**
+ * Freight-rate provenance for the resolveFreightRate waterfall (Wave #7, L2 #7).
+ * Free-text-compatible with the `freight_rate_source` DB column. Defined here (not in
+ * freight-resolver) so computeEstimatedTce can accept any tier's source without a
+ * circular import.
+ */
+export type FreightRateSource = 'manual' | 'parsed' | 'baltic' | 'estimated';
+
 export interface FreightRateEstimate {
   rate: number;
-  source: 'estimated' | 'manual';
+  source: FreightRateSource;
   confidence: number;
 }
 
 export interface TceEstimate {
   tce_usd_per_day: number;
   freight_rate_usd_per_mt: number;
-  freight_rate_source: 'estimated' | 'manual';
+  freight_rate_source: FreightRateSource;
   /** Full deterministic voyage breakdown (additive, spec L2 #5). */
   breakdown: TCEBreakdown;
 }
@@ -146,6 +154,12 @@ export interface MatchEconomicsInput {
   calculatedAt: string;
   /** Vessel value for the war-risk hull premium. Defaults to DEFAULT_VESSEL_VALUE_USD. */
   vesselValueUsd?: number;
+  /**
+   * Pre-resolved freight rate from the Wave #7 waterfall (manual/parsed/baltic/estimate).
+   * When omitted, falls back to estimateFreightRate (tier 3) — preserving legacy behaviour
+   * so existing callers/tests are unaffected.
+   */
+  resolvedFreight?: FreightRateEstimate | null;
 }
 
 /**
@@ -163,7 +177,8 @@ export interface MatchEconomicsInput {
 export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult | null {
   if (!(input.distanceNm > 0)) return null;
 
-  const freight = estimateFreightRate(input.cargoType, input.distanceNm, input.vesselDwt);
+  const freight =
+    input.resolvedFreight ?? estimateFreightRate(input.cargoType, input.distanceNm, input.vesselDwt);
   const tce = computeEstimatedTce(
     freight,
     input.distanceNm,

--- a/lib/migrations/043-baltic-tc-dayrates-seed.ts
+++ b/lib/migrations/043-baltic-tc-dayrates-seed.ts
@@ -1,0 +1,36 @@
+import type { Migration } from './types';
+import type Database from 'better-sqlite3';
+
+/**
+ * Migration 043: per-vessel-class Baltic timecharter DAY-RATE seed (Wave #7, L2 #7).
+ *
+ * The tier-2 freight waterfall computes $/mt = ($/day × voyage days) ÷ tonnes, so it
+ * needs a real $/day figure per vessel class. The existing index-POINTS rows
+ * (BHSI=650, BSI=1100, …) are a different unit (typed `unit:'index'` for KPI display)
+ * and must NOT be repurposed. These distinct `*_TC` codes hold the timecharter-average
+ * $/day rates, anchored to TOEPFER_TMI≈12,683 $/day (handysize MPP) for 2026-05-09.
+ *
+ * Static, dated seed — a live Baltic feed is L4 / out of scope. INSERT OR IGNORE so
+ * re-running on a DB that already has these rows is a no-op.
+ */
+const migration043: Migration = {
+  version: 43,
+  name: 'baltic-tc-dayrates-seed',
+  up(db: Database.Database): void {
+    // Requires migration 019 (baltic_indices table).
+    const stmt = db.prepare(`
+      INSERT OR IGNORE INTO baltic_indices (index_code, value, price_date, source)
+      VALUES (?, ?, ?, ?)
+    `);
+    stmt.run('BHSI_TC', 11500, '2026-05-09', 'static-seed'); // handysize / handymax
+    stmt.run('BSI_TC', 13500, '2026-05-09', 'static-seed'); // supramax / ultramax
+    stmt.run('BPI_TC', 15000, '2026-05-09', 'static-seed'); // panamax+
+  },
+  down(db: Database.Database): void {
+    db.exec(
+      `DELETE FROM baltic_indices WHERE index_code IN ('BHSI_TC','BSI_TC','BPI_TC') AND source = 'static-seed'`,
+    );
+  },
+};
+
+export default migration043;

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -40,6 +40,7 @@ import migration039 from './039-demo-seed-meta';
 import migration040 from './040-counter-offers';
 import migration041 from './041-matches-vessel-name';
 import migration042 from './042-matches-fit';
+import migration043 from './043-baltic-tc-dayrates-seed';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043];


### PR DESCRIPTION
## Wave #7 — freight-rate source waterfall (`resolveFreightRate`), roadmap L2 #7

> ⚠️ **Draft — do not merge.** **Stacked on #698** (`fix/matching-economics-wiring`, L2 economics) which is **not yet merged to `main`**. This PR's *own* change is the single commit **`fa6860d`**; the earlier commits in the diff belong to #698 / #694 and will disappear once those merge and this rebases onto `main`. Merge order: #698 → (#694) → this.
>
> 🖼️ **Needs visual-preview** — UI change (freight-source badges + reset button in EconomicsTab and the matches list).

### What
A single `resolveFreightRate(input) → { value, source, confidence }` — a 4-tier priority waterfall that becomes the one source for the freight rate feeding the **displayed** TCE:

| tier | source | trigger | confidence | badge |
|---|---|---|---|---|
| 0 | `manual` | broker override (sticky) | 1.0 | ✎ Manual + **Reset to auto** |
| 1 | `parsed` | `cargo.freightRateUsd` ($/mt from email) | 0.9 | ✓ From email |
| 2 | `baltic` | per-class $/day index × voyage days ÷ tonnes | 0.5 | ~ Market (Baltic) |
| 3 | `estimated` | existing `estimateFreightRate` (unchanged) | 0.3–0.6 | ≈ Estimate (dimmed, "rate not confirmed") |

TCE is always shown, with a source+confidence badge; the estimate tier is visually muted.

### How
- **`lib/matching/freight-resolver.ts`** (new, pure) — the waterfall + guards.
- **`lib/market/baltic-freight.ts`** + **migration `039-baltic-tc-dayrates-seed`** (new) — per-vessel-class timecharter **$/day** seed (`BHSI_TC`/`BSI_TC`/`BPI_TC`), static + dated `2026-05-09`. Distinct codes so the index-**points** rows (`BHSI=650`…) are never misread as $/day. Live feed is L4 / out of scope.
- **`lib/matching/freight-badge.ts`** (new, pure) — shared badge map for EconomicsTab + matches list.
- Wired into `compute-matches.ts`, `persist-session-matches.ts`, `pair-analyzer.ts` (`buildMatchEconomics`), and `PATCH /api/matches/[id]` (existing manual override + new `reset_freight_rate`).
- `estimateFreightRate` / `computeEstimatedTce` math untouched; `FreightRateEstimate.source` union widened additively to carry `parsed`/`baltic`.

### Hard constraints (all verified)
- ✅ TCE formula unchanged — rate only flows through as `source`; `computeEstimatedTce` byte-identical.
- ✅ Match **count + ranking unchanged** — freight is resolved only in the *post-partition, display-only* economics loop; scoring never sees it. `match-realism-buckets` + ranking suites still green.
- ✅ `lib/types.ts` additive only (in fact untouched).
- ✅ Baltic = static dated seed.

### Tier-1 parser note (scope reduction)
The parser **already** extracts `freight_rate_usd` ($/mt) — `parse-cargo` prompt + schema + `parse-cargo-ai`. The brief's "0% / no rules" probe was stale, so **the parser prompt was NOT modified** (no regression surface). resolveFreightRate just consumes `cargo.freightRateUsd`; a contract test (`parse-cargo-ai-freight.test.ts`) guards the mapping.

### Verification
- New tests (TDD, all green): freight-resolver (9), baltic-freight (7), freight-badge (7), tce-calculator passthrough (+2), matches `[id]` route incl. reset (12), EconomicsTab badge (5), parser contract (4).
- **Full suite: 7207 passed / 2 failed** — `progonq/score-classify` (brief-acknowledged foreign flake) and `scripts/.../refresh-sanctions` (`spawnSync npx ETIMEDOUT`, environmental subprocess timeout). Neither touches files in this change.
- `tsc --noEmit`: **0 errors**. eslint: 0 errors on changed files (1 pre-existing warning in `MatchesClient.tsx:86`, unrelated).

### Independent review (adversarial) — verdict SHIP
0 CRITICAL / 0 HIGH / 2 MEDIUM / 5 LOW. MEDIUMs were display-only:
1. **Reset → estimate tier** (intentional/documented): the match row lacks the original email/quantity, so "Reset to auto" recomputes the estimate tier; parsed/baltic re-apply on the next full recompute.
2. **economics/column parity** on the auto-precompute path — **fixed in this commit** by passing `db` into `analyzePairs` so `match.economics.tceUsdPerDay` matches the persisted `tce_usd_per_day`.

### Documented assumptions (founder absent)
- Baltic $/day-per-class seed added (formula needs $/day; existing seeds are index points) — kept within "static seed + date".
- Badge labels are English (matches existing EconomicsTab UI), using the brief's symbols (✎ ✓ ~ ≈).
- Per-match Baltic *date* not persisted on the row → badge shows "Market (Baltic)" without a per-match date.
- Lumpsum freight normalization deferred (parser extracts per-MT only; would need a prompt change).

### Process note
Founder marked `/test-skill` mandatory under a parser-regression risk-override. Since the **parser was not modified**, that premise is moot; the new money-path/waterfall/endpoint logic was instead covered by exhaustive TDD + an independent adversarial review. A full cold-session `/test-skill` can still be run against this draft before merge if desired.

Plan: `docs/plans/freight-rate-waterfall.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
