### PR TITLE
feat(matching): ballast + size as hard criteria (Wave C, levers 3+4)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-matching-ballast-size-cap.md
+++ b/docs/superpowers/plans/2026-05-30-matching-ballast-size-cap.md
@@ -1,0 +1,76 @@
+# Matching Ballast + Size Realism Cap (Wave C, levers 3+4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ballast distance (lever 3) and cargo/vessel size proportion (lever 4) HARD criteria — a `good` match with an uneconomic ballast leg for its vessel class, or with low utilisation (deadfreight), is capped to `possible` — EXCEPT legitimate part-cargo loads, which stay.
+
+**Architecture:** A pure `applyBallastSizeCap(input)` function in `lib/sailing/match-scoring.ts` (peer of the existing `applyOverloadGuard`), called from `lib/matching/pair-analyzer.ts` in a loop AFTER scores are final and BEFORE the realism partition. The cap only ever lowers a `good` tier to `possible` (score → 69); missing data never triggers a cap; part-cargo is exempt from the size guard. Class-aware ballast thresholds reuse `classifyVesselByDwt`.
+
+**Tech Stack:** TypeScript, Jest (ts-jest), Next.js lib code. Acceptance harness via `tsx`.
+
+---
+
+## Reality-check (confirmed by reading the code)
+
+- `classifyVesselByDwt(dwt)` exists in `lib/sailing/readiness-gap.ts:89` → `VesselClassName` (`handysize|supramax|panamax|capesize`).
+- `readiness.distanceNm` is computed and available per pair in `pair-analyzer.ts` via `analysisMap`.
+- `deriveMatchLevel(score)` (`match-scoring.ts:154`): `>=70 good`, `>=40 possible`, else `weak`.
+- `applyOverloadGuard` (`match-scoring.ts:170`) is the existing precedent for a pure tier-capping guard.
+- util formula precedent: funnel script `vesselCapacity = dwcc ?? dwt*0.9`, `util = cargoWeightMax / capacity`. We use `dwcc ?? dwt` (raw) for the cap.
+- **DISCREPANCY (documented assumption):** the brief's acceptance harness `scripts/research/top-matches-broker-view.ts` and `docs/research/match-realism-2026-05/ROADMAP-to-100.md` do NOT exist in this worktree (fresh main). Only `scripts/research/match-realism-funnel.ts` + `README.md` exist. → We CREATE a `top-matches-broker-view.ts` harness that runs the real engine (`analyzePairs` with a no-op aiScorer = sweep path) and ranks main matches by score, printing util%, ballast nm, verdict, matchLevel. This reproduces the broker-view concept and serves as the before/after acceptance benchmark.
+- **Mock caveat:** `lib/__tests__/matching/pair-analyzer.test.ts:34` manually mocks `@/lib/sailing/match-scoring` with a factory listing only 3 exports. The new `applyBallastSizeCap` import would resolve to `undefined`. → add a passthrough mock entry (new-dependency wiring, not an expectation change).
+
+## Thresholds (documented assumptions; sensitivity shown in tests)
+
+- `BALLAST_GOOD_MAX_NM`: handysize 1500, supramax 2000, panamax 2500, capesize 4000 (nm). handysize 1500 is the research "worth-calling" ballast cap from the funnel; monotonic with class because small geared/near-sea tonnage is region-bound.
+- `PROPORTION_GOOD_MIN_UTIL = 0.5` (util `< 0.5` cuts; exactly `0.5` stays). From research ("full cargo = 85–98% DWT; <50% = deadfreight").
+- part-cargo detection: `/\bpart[\s-]?cargo\b|\bpart[\s-]?load\b|\bpart[\s-]?lot\b/i`. Bare "parcel" intentionally NOT matched (would over-exempt full small lots and let false-goods survive).
+
+---
+
+### Task 1: `applyBallastSizeCap` + helpers in match-scoring.ts (TDD)
+
+**Files:**
+- Modify: `lib/sailing/match-scoring.ts`
+- Test: `lib/sailing/__tests__/match-scoring.test.ts`
+
+- [ ] **Step 1: Write failing tests** (new `describe('applyBallastSizeCap — ballast + size realism cap', ...)`): handysize 1580nm good→possible; handysize 580nm stays good; handysize 205nm/99%util stays; util 34% (2500/7300) not-part-cargo good→possible; util 5% part-cargo stays good; util 75% stays; util exactly 0.5 stays, 0.49 caps; capesize 3000nm stays, handysize 3000nm caps; already-possible (score 60) no-op; missing distance → ballast no-op; missing capacity → size no-op; idempotent (no duplicate BALLAST:/SIZE: issue); `isPartCargo` matches "part cargo"/"part-cargo", rejects "full cargo".
+- [ ] **Step 2: Run, verify fail** — `npx jest lib/sailing/__tests__/match-scoring.test.ts -t "applyBallastSizeCap"` → FAIL (not a function).
+- [ ] **Step 3: Implement** `BALLAST_GOOD_MAX_NM`, `PROPORTION_GOOD_MIN_UTIL`, `isPartCargo`, `applyBallastSizeCap` + `import { classifyVesselByDwt }` + `VesselClassName` type.
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit.**
+
+### Task 2: Wire cap into pair-analyzer (TDD)
+
+**Files:**
+- Modify: `lib/matching/pair-analyzer.ts` (import + cap loop after the final score-sync loop, before dedupe)
+- Modify: `lib/__tests__/matching/pair-analyzer.test.ts:34` (add `applyBallastSizeCap` passthrough to mock factory)
+- Test: `lib/__tests__/matching/pair-analyzer.test.ts` (new test: a high-score far-ballast pair lands in `matches` as `possible`, not `good`)
+
+- [ ] **Step 1: Add passthrough to mock factory** — `applyBallastSizeCap: jest.fn().mockImplementation((input) => input.match)`.
+- [ ] **Step 2: Write failing integration test** (un-mocked-cap variant — use `jest.requireActual` for the cap, or assert via the broker harness in Task 3). Minimal: assert existing suite still green after wiring.
+- [ ] **Step 3: Implement cap loop** in `analyzePairs`.
+- [ ] **Step 4: Run** `npx jest lib/__tests__/matching/pair-analyzer.test.ts lib/__tests__/matching/match-realism-buckets.test.ts` → PASS.
+- [ ] **Step 5: Commit.**
+
+### Task 3: broker-view acceptance harness
+
+**Files:**
+- Create: `scripts/research/top-matches-broker-view.ts`
+
+- [ ] **Step 1: Implement** — load demo fixtures (rebased), run `analyzePairs(cargos, vessels, async () => [])`, rank `result.matches` by score desc, print top 20 rows `[rank, score, level, util%, ballastNm, verdict, cargoType, desc]`, plus counts of good/possible and how many `good` were capped (issue contains `BALLAST:`/`SIZE:`).
+- [ ] **Step 2: Run** `npx tsx scripts/research/top-matches-broker-view.ts` → verify false-goods (far-ballast / low-util non-part-cargo) are `possible` not `good`; legit high-util short-ballast stay `good`; part-cargo low-util stays.
+- [ ] **Step 3: Commit.**
+
+### Task 4: /test-skill + full suite + review + PR
+
+- [ ] Run `/test-skill` (risk-override — touches scoring/matching).
+- [ ] `NODE_OPTIONS='--max-old-space-size=8192' npm test` (one run). Known foreign flake: progonq/score-classify + compare-routes-perf env — not our regression.
+- [ ] requesting-code-review + verification-before-completion.
+- [ ] finishing-a-development-branch → draft PR to main, do NOT merge.
+
+## Self-Review
+
+- Spec coverage: lever 3 (ballast, class-aware) ✓ Task 1/2; lever 4 (util + part-cargo exempt) ✓ Task 1/2; acceptance harness ✓ Task 3; "show with note" ✓ (issue text, stays in main as possible); part-cargo MUST NOT cut ✓ (isPartCargo exemption + test).
+- Placeholder scan: none (all code shown in implementation steps below).
+- Type consistency: `applyBallastSizeCap` signature identical across function, mock, and call site; `BallastSizeCapInput` fields match call site.

--- a/lib/__tests__/matching/match-realism-buckets.test.ts
+++ b/lib/__tests__/matching/match-realism-buckets.test.ts
@@ -271,25 +271,9 @@ describe('analyzePairs — demo realism (79×51), levers 1+2+5', () => {
     expect(offenders).toHaveLength(0);
   });
 
-  it('legit part-cargo low-util pairs are NOT demoted out of good (exemption holds)', async () => {
-    // Synthetic part-cargo: 5% util, short ballast, ideal timing → stays good.
-    const partCargo = makeCargo({
-      emailId: 'pc-1',
-      cargoDescription: { value: 'Mobile machinery, part cargo', confidence: 'confirmed' },
-      weightMt: { value: 400, confidence: 'confirmed' },
-      cargoType: 'BREAK_BULK',
-    });
-    const bigVessel = makeVessel({
-      emailId: 'pv-1',
-      vesselType: 'general cargo',
-      dwtSummer: { value: 8000, confidence: 'confirmed' },
-    });
-    const result = await analyzePairs([partCargo], [bigVessel], offline, { refYear: 2026, today: TODAY });
-    // It must survive in the main list (not bucketed) and keep a non-weak tier;
-    // crucially it carries NO SIZE: cap flag despite ~5% utilisation.
-    const all = [...result.matches, ...result.lowConfidenceMatches];
-    const pc = all.find((m) => m.cargoEmailId === 'pc-1');
-    expect(pc).toBeDefined();
-    expect((pc!.issues ?? []).some((i) => i.startsWith('SIZE:'))).toBe(false);
-  });
+  // NB: the part-cargo size exemption is unit-tested directly in
+  // lib/sailing/__tests__/match-scoring.test.ts (a score-81 'good' part-cargo at
+  // 5% util stays good). A full-engine integration test is omitted on purpose —
+  // the offline sweep cannot reliably produce a 'good'-tier synthetic part-cargo
+  // pair, so the cap would early-return and the assertion would be a tautology.
 });

--- a/lib/__tests__/matching/match-realism-buckets.test.ts
+++ b/lib/__tests__/matching/match-realism-buckets.test.ts
@@ -241,7 +241,9 @@ describe('analyzePairs — demo realism (79×51), levers 1+2+5', () => {
       const vessel = vessels.find(
         (v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex,
       );
-      const cls = classifyVesselByDwt(vessel ? cfValue(vessel.dwtSummer) : null);
+      const dwt = vessel ? cfValue(vessel.dwtSummer) : null;
+      if (dwt == null) return false; // unknown DWT → ballast guard skipped (conservative)
+      const cls = classifyVesselByDwt(dwt);
       return dist > BALLAST_GOOD_MAX_NM[cls];
     });
     expect(offenders).toHaveLength(0);

--- a/lib/__tests__/matching/match-realism-buckets.test.ts
+++ b/lib/__tests__/matching/match-realism-buckets.test.ts
@@ -23,6 +23,13 @@ import {
   type AiScorer,
 } from '@/lib/matching/pair-analyzer';
 import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+import { cfValue } from '@/lib/types';
+import { classifyVesselByDwt } from '@/lib/sailing/readiness-gap';
+import {
+  BALLAST_GOOD_MAX_NM,
+  PROPORTION_GOOD_MIN_UTIL,
+  isPartCargo,
+} from '@/lib/sailing/match-scoring';
 
 const offline: AiScorer = jest.fn().mockResolvedValue([]);
 
@@ -217,5 +224,70 @@ describe('analyzePairs — demo realism (79×51), levers 1+2+5', () => {
       result.insufficientData.length +
       result.blockedMatches.length;
     expect(total).toBe(cargos.length * vessels.length);
+  });
+
+  // ── Wave C — ballast + size hard cap (levers 3 + 4) ────────────────────────
+  // After the cap, a 'good' main match must respect its vessel-class ballast
+  // radius (lever 3) and, unless it is a part-cargo, the minimum utilisation
+  // (lever 4). A pair that violates either is demoted to 'possible' (it still
+  // shows, flagged), so it can no longer be 'good'.
+
+  it('lever 3: every main "good" match is within its vessel-class ballast radius', async () => {
+    const result = await analyzePairs(cargos, vessels, offline, { refYear: 2026, today: DEMO_TODAY });
+    const offenders = result.matches.filter((m) => {
+      if (m.matchLevel !== 'good') return false;
+      const dist = m.readiness?.distanceNm;
+      if (dist == null) return false;
+      const vessel = vessels.find(
+        (v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex,
+      );
+      const cls = classifyVesselByDwt(vessel ? cfValue(vessel.dwtSummer) : null);
+      return dist > BALLAST_GOOD_MAX_NM[cls];
+    });
+    expect(offenders).toHaveLength(0);
+  });
+
+  it('lever 4: every main "good" non-part-cargo match meets the minimum utilisation', async () => {
+    const result = await analyzePairs(cargos, vessels, offline, { refYear: 2026, today: DEMO_TODAY });
+    const offenders = result.matches.filter((m) => {
+      if (m.matchLevel !== 'good') return false;
+      const cargo = cargos.find(
+        (c) => c.emailId === m.cargoEmailId && c.itemIndex === m.cargoItemIndex,
+      );
+      const vessel = vessels.find(
+        (v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex,
+      );
+      if (!cargo || !vessel) return false;
+      if (isPartCargo(cfValue(cargo.cargoDescription))) return false;
+      const dwcc = cfValue(vessel.dwcc);
+      const dwt = cfValue(vessel.dwtSummer);
+      const cap = dwcc != null && dwcc > 0 ? dwcc : dwt != null && dwt > 0 ? dwt : null;
+      const wt = cargo.weightMtMax ?? cfValue(cargo.weightMt);
+      if (cap == null || wt == null || wt <= 0) return false;
+      return wt / cap < PROPORTION_GOOD_MIN_UTIL;
+    });
+    expect(offenders).toHaveLength(0);
+  });
+
+  it('legit part-cargo low-util pairs are NOT demoted out of good (exemption holds)', async () => {
+    // Synthetic part-cargo: 5% util, short ballast, ideal timing → stays good.
+    const partCargo = makeCargo({
+      emailId: 'pc-1',
+      cargoDescription: { value: 'Mobile machinery, part cargo', confidence: 'confirmed' },
+      weightMt: { value: 400, confidence: 'confirmed' },
+      cargoType: 'BREAK_BULK',
+    });
+    const bigVessel = makeVessel({
+      emailId: 'pv-1',
+      vesselType: 'general cargo',
+      dwtSummer: { value: 8000, confidence: 'confirmed' },
+    });
+    const result = await analyzePairs([partCargo], [bigVessel], offline, { refYear: 2026, today: TODAY });
+    // It must survive in the main list (not bucketed) and keep a non-weak tier;
+    // crucially it carries NO SIZE: cap flag despite ~5% utilisation.
+    const all = [...result.matches, ...result.lowConfidenceMatches];
+    const pc = all.find((m) => m.cargoEmailId === 'pc-1');
+    expect(pc).toBeDefined();
+    expect((pc!.issues ?? []).some((i) => i.startsWith('SIZE:'))).toBe(false);
   });
 });

--- a/lib/__tests__/matching/pair-analyzer.test.ts
+++ b/lib/__tests__/matching/pair-analyzer.test.ts
@@ -43,6 +43,10 @@ jest.mock('@/lib/sailing/match-scoring', () => ({
   deriveMatchLevel: jest.fn().mockImplementation((score: number) =>
     score > 70 ? 'good' : score > 40 ? 'possible' : 'weak',
   ),
+  // Wave C: cap is exercised by its own unit tests + match-realism-buckets
+  // (real engine). Here it is a passthrough so the bucket/sort contracts under
+  // test are unaffected by the cap.
+  applyBallastSizeCap: jest.fn().mockImplementation((input) => input.match),
 }));
 
 jest.mock('@/lib/sailing/date-parsing', () => ({

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -11,7 +11,7 @@ import type {
 import { cfValue, isRange } from '@/lib/types';
 import { computeMatchConfidence } from '@/lib/confidence';
 import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
-import { applyReadinessScoring, computeScoreBreakdown, deriveMatchLevel } from '@/lib/sailing/match-scoring';
+import { applyReadinessScoring, computeScoreBreakdown, deriveMatchLevel, applyBallastSizeCap } from '@/lib/sailing/match-scoring';
 import { runHardFilters } from '@/lib/sailing/match-filters';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { validateDates } from '@/lib/sailing/date-sanity';
@@ -548,6 +548,35 @@ export async function analyzePairs(
       );
       allMatches[i] = applyReadinessScoring(m, undefined, matchCargo, matchVessel);
     }
+  }
+
+  // ── Ballast + size realism cap (Wave C, levers 3 + 4) ──────────────────────
+  // Scores are now final. Demote any 'good' match whose vessel must ballast
+  // beyond its class radius (lever 3) or whose cargo fills too little of the
+  // vessel — deadfreight (lever 4) — to 'possible'. Part-cargo loads are exempt
+  // from the size cut. Runs BEFORE the realism partition so a capped match stays
+  // in the main list as 'possible' (it still shows, flagged), never bucketed by
+  // this step. Only ever lowers the tier (see applyBallastSizeCap).
+  for (let i = 0; i < allMatches.length; i++) {
+    const m = allMatches[i];
+    if (m.matchLevel !== 'good') continue;
+    const analysis = analysisMap.get(
+      pairKey(m.cargoEmailId, m.cargoItemIndex, m.vesselEmailId, m.vesselItemIndex),
+    );
+    const capCargo = cargos.find(
+      (c) => c.emailId === m.cargoEmailId && c.itemIndex === m.cargoItemIndex,
+    );
+    const capVessel = vessels.find(
+      (v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex,
+    );
+    allMatches[i] = applyBallastSizeCap({
+      match: m,
+      distanceNm: analysis?.readiness?.distanceNm ?? null,
+      vesselDwt: capVessel ? cfValue(capVessel.dwtSummer) : null,
+      vesselDwcc: capVessel ? cfValue(capVessel.dwcc) : null,
+      cargoWeightMax: capCargo ? (capCargo.weightMtMax ?? cfValue(capCargo.weightMt)) : null,
+      cargoDescription: capCargo ? cfValue(capCargo.cargoDescription) : null,
+    });
   }
 
   // Dedupe: pairs in blockedMatches must not appear in matches

--- a/lib/sailing/__tests__/match-scoring.test.ts
+++ b/lib/sailing/__tests__/match-scoring.test.ts
@@ -890,6 +890,20 @@ describe('isPartCargo', () => {
     expect(isPartCargo('grain, part load')).toBe(true);
     expect(isPartCargo('part lot of pipes')).toBe(true);
   });
+  it('matches real broker variants — plurals, p/c, loose separators', () => {
+    expect(isPartCargo('2 part cargoes of steel coils')).toBe(true);
+    expect(isPartCargo('vessel can take 2 part loads')).toBe(true);
+    expect(isPartCargo('steel, p/c basis')).toBe(true);
+    expect(isPartCargo('part  cargo of bagged urea')).toBe(true); // double space
+    expect(isPartCargo('part_cargo')).toBe(true);
+    expect(isPartCargo('partcargo')).toBe(true); // no separator
+  });
+  it('does not false-positive on near-miss substrings', () => {
+    expect(isPartCargo('counterpart cargo')).toBe(false);
+    expect(isPartCargo('departure cargo nomination')).toBe(false);
+    expect(isPartCargo('partial cargo')).toBe(false);
+    expect(isPartCargo('parcel of wheat')).toBe(false);
+  });
   it('does not match full-cargo or unrelated descriptions', () => {
     expect(isPartCargo('full cargo of wheat')).toBe(false);
     expect(isPartCargo('steel slabs')).toBe(false);
@@ -931,6 +945,12 @@ describe('applyBallastSizeCap — ballast + size realism cap', () => {
     it('skips the ballast guard when distance is unknown', () => {
       const out = applyBallastSizeCap(capInput({ distanceNm: null }));
       expect(out.matchLevel).toBe('good');
+    });
+
+    it('skips the ballast guard when vessel DWT is unknown (no class → no assumption)', () => {
+      const out = applyBallastSizeCap(capInput({ distanceNm: 1600, vesselDwt: null }));
+      expect(out.matchLevel).toBe('good');
+      expect(out.issues?.some((i) => i.startsWith('BALLAST:'))).toBe(false);
     });
 
     it('uses the documented per-class thresholds', () => {

--- a/lib/sailing/__tests__/match-scoring.test.ts
+++ b/lib/sailing/__tests__/match-scoring.test.ts
@@ -1042,11 +1042,67 @@ describe('applyBallastSizeCap — ballast + size realism cap', () => {
       expect(ballastIssues).toHaveLength(1);
     });
 
+    it('dedup: a still-good match already carrying a BALLAST: note gets no duplicate (and is still demoted)', () => {
+      // Exercises the dedup filter directly (score ≥ 70, so not the early-return path):
+      // a prior BALLAST: issue must suppress the new one, but the score still drops.
+      const out = applyBallastSizeCap({
+        match: { ...mkMatch(81, 'good'), issues: ['BALLAST: prior note'] },
+        distanceNm: 1580,
+        vesselDwt: 5200,
+        vesselDwcc: null,
+        cargoWeightMax: null,
+        cargoDescription: null,
+      });
+      expect(out.score).toBe(69);
+      expect(out.matchLevel).toBe('possible');
+      expect((out.issues ?? []).filter((i) => i.startsWith('BALLAST:'))).toHaveLength(1);
+    });
+
     it('does not mutate the input match', () => {
       const input = mkMatch(81, 'good');
       applyBallastSizeCap({ ...capInput({ distanceNm: 1580 }), match: input });
       expect(input.score).toBe(81);
       expect(input.matchLevel).toBe('good');
+    });
+  });
+
+  describe('numeric edges & combined triggers', () => {
+    it('skips the ballast guard on non-finite or negative distance', () => {
+      for (const d of [NaN, Infinity, -500]) {
+        expect(applyBallastSizeCap(capInput({ distanceNm: d })).matchLevel).toBe('good');
+      }
+    });
+
+    it('skips the size guard on zero/negative cargo weight or negative capacity', () => {
+      expect(applyBallastSizeCap(capInput({ distanceNm: 100, vesselDwt: 10000, cargoWeightMax: 0 })).matchLevel).toBe('good');
+      expect(applyBallastSizeCap(capInput({ distanceNm: 100, vesselDwt: 10000, cargoWeightMax: -500 })).matchLevel).toBe('good');
+      expect(applyBallastSizeCap(capInput({ distanceNm: 100, vesselDwt: -1, vesselDwcc: -1, cargoWeightMax: 5000 })).matchLevel).toBe('good');
+    });
+
+    it('treats DWCC of 0 as missing and falls back to DWT', () => {
+      // dwcc 0 → use dwt 10000; 4000/10000 = 40% < 0.5 → capped on size.
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 100, vesselDwt: 10000, vesselDwcc: 0, cargoWeightMax: 4000 }),
+      );
+      expect(out.matchLevel).toBe('possible');
+      expect(out.issues?.some((i) => i.startsWith('SIZE:'))).toBe(true);
+    });
+
+    it('caps a barely-good (score exactly 70) match to 69', () => {
+      const out = applyBallastSizeCap({ ...capInput({ distanceNm: 5000 }), match: mkMatch(70, 'good') });
+      expect(out.score).toBe(69);
+      expect(out.matchLevel).toBe('possible');
+    });
+
+    it('both ballast and size trigger → single cap to 69, both issues present', () => {
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 5000, vesselDwt: 8000, cargoWeightMax: 2000, cargoDescription: 'bulk wheat' }), // 25% util
+      );
+      expect(out.score).toBe(69);
+      expect(out.matchLevel).toBe('possible');
+      const issues = out.issues ?? [];
+      expect(issues.some((i) => i.startsWith('BALLAST:'))).toBe(true);
+      expect(issues.some((i) => i.startsWith('SIZE:'))).toBe(true);
     });
   });
 });

--- a/lib/sailing/__tests__/match-scoring.test.ts
+++ b/lib/sailing/__tests__/match-scoring.test.ts
@@ -857,3 +857,176 @@ describe('Vague-region penalty — Phase D2', () => {
     expect(geoComponent(bCargo).reason).toMatch(/cargo origin/);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ballast + size realism cap (Wave C — levers 3 + 4, handover 2026-05-30)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import {
+  applyBallastSizeCap,
+  isPartCargo,
+  BALLAST_GOOD_MAX_NM,
+  PROPORTION_GOOD_MIN_UTIL,
+  type BallastSizeCapInput,
+} from '../match-scoring';
+
+function capInput(over: Partial<BallastSizeCapInput> = {}): BallastSizeCapInput {
+  return {
+    match: mkMatch(81, 'good'),
+    distanceNm: null,
+    vesselDwt: 5200, // handysize
+    vesselDwcc: null,
+    cargoWeightMax: null,
+    cargoDescription: null,
+    ...over,
+  };
+}
+
+describe('isPartCargo', () => {
+  it('matches explicit part-cargo phrasing', () => {
+    expect(isPartCargo('Mobile machinery, part cargo')).toBe(true);
+    expect(isPartCargo('steel coils part-cargo')).toBe(true);
+    expect(isPartCargo('PART CARGO of bagged urea')).toBe(true);
+    expect(isPartCargo('grain, part load')).toBe(true);
+    expect(isPartCargo('part lot of pipes')).toBe(true);
+  });
+  it('does not match full-cargo or unrelated descriptions', () => {
+    expect(isPartCargo('full cargo of wheat')).toBe(false);
+    expect(isPartCargo('steel slabs')).toBe(false);
+    expect(isPartCargo('PC strand 2500mt')).toBe(false);
+    expect(isPartCargo(null)).toBe(false);
+    expect(isPartCargo(undefined)).toBe(false);
+    expect(isPartCargo('')).toBe(false);
+  });
+});
+
+describe('applyBallastSizeCap — ballast + size realism cap', () => {
+  describe('lever 3 — ballast distance, class-aware', () => {
+    it('caps a good handysize match with far ballast (1580nm) to possible', () => {
+      const out = applyBallastSizeCap(capInput({ distanceNm: 1580 }));
+      expect(out.score).toBeLessThan(70);
+      expect(out.matchLevel).toBe('possible');
+      expect(out.issues?.some((i) => i.startsWith('BALLAST:'))).toBe(true);
+    });
+
+    it('keeps a good handysize match with short ballast (580nm) as good', () => {
+      const out = applyBallastSizeCap(capInput({ distanceNm: 580 }));
+      expect(out.score).toBe(81);
+      expect(out.matchLevel).toBe('good');
+      expect(out.issues ?? []).toHaveLength(0);
+    });
+
+    it('keeps a good handysize match with very short ballast (205nm) as good', () => {
+      const out = applyBallastSizeCap(capInput({ distanceNm: 205 }));
+      expect(out.matchLevel).toBe('good');
+    });
+
+    it('does not cap a capesize at 3000nm but caps a handysize at the same distance', () => {
+      const cape = applyBallastSizeCap(capInput({ distanceNm: 3000, vesselDwt: 120000 }));
+      expect(cape.matchLevel).toBe('good');
+      const handy = applyBallastSizeCap(capInput({ distanceNm: 3000, vesselDwt: 5200 }));
+      expect(handy.matchLevel).toBe('possible');
+    });
+
+    it('skips the ballast guard when distance is unknown', () => {
+      const out = applyBallastSizeCap(capInput({ distanceNm: null }));
+      expect(out.matchLevel).toBe('good');
+    });
+
+    it('uses the documented per-class thresholds', () => {
+      expect(BALLAST_GOOD_MAX_NM.handysize).toBe(1500);
+      expect(BALLAST_GOOD_MAX_NM.supramax).toBeGreaterThan(BALLAST_GOOD_MAX_NM.handysize);
+      expect(BALLAST_GOOD_MAX_NM.panamax).toBeGreaterThan(BALLAST_GOOD_MAX_NM.supramax);
+      expect(BALLAST_GOOD_MAX_NM.capesize).toBeGreaterThan(BALLAST_GOOD_MAX_NM.panamax);
+    });
+  });
+
+  describe('lever 4 — size proportion, part-cargo exempt', () => {
+    it('caps a good low-util (34%) non-part-cargo match to possible', () => {
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: 7300, cargoWeightMax: 2500, cargoDescription: 'PC strand' }),
+      );
+      expect(out.matchLevel).toBe('possible');
+      expect(out.issues?.some((i) => i.startsWith('SIZE:'))).toBe(true);
+    });
+
+    it('keeps a good low-util (5%) PART-CARGO match as good (exempt)', () => {
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: 50000, cargoWeightMax: 2500, cargoDescription: 'Mobile machinery, part cargo' }),
+      );
+      expect(out.matchLevel).toBe('good');
+      expect(out.issues?.some((i) => i.startsWith('SIZE:'))).toBe(false);
+    });
+
+    it('keeps a good high-util (75%) match as good', () => {
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: 8000, cargoWeightMax: 6000, cargoDescription: 'wheat in bulk' }),
+      );
+      expect(out.matchLevel).toBe('good');
+    });
+
+    it('uses DWCC over DWT for utilisation when present', () => {
+      // cargo 4000 / dwcc 5000 = 80% (good) even though /dwt 9000 = 44% would cap
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: 9000, vesselDwcc: 5000, cargoWeightMax: 4000 }),
+      );
+      expect(out.matchLevel).toBe('good');
+    });
+
+    it('treats exactly the threshold util as good, just below as capped', () => {
+      expect(PROPORTION_GOOD_MIN_UTIL).toBe(0.5);
+      const atThreshold = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: 10000, cargoWeightMax: 5000 }), // 0.50
+      );
+      expect(atThreshold.matchLevel).toBe('good');
+      const justBelow = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: 10000, cargoWeightMax: 4900 }), // 0.49
+      );
+      expect(justBelow.matchLevel).toBe('possible');
+    });
+
+    it('skips the size guard when capacity is unknown', () => {
+      const out = applyBallastSizeCap(
+        capInput({ distanceNm: 200, vesselDwt: null, vesselDwcc: null, cargoWeightMax: 2500 }),
+      );
+      expect(out.matchLevel).toBe('good');
+    });
+  });
+
+  describe('invariants', () => {
+    it('never raises a lower tier — a possible match is left untouched', () => {
+      const out = applyBallastSizeCap({
+        match: mkMatch(60, 'possible'),
+        distanceNm: 5000,
+        vesselDwt: 5200,
+        vesselDwcc: null,
+        cargoWeightMax: 100,
+        cargoDescription: null,
+      });
+      expect(out.score).toBe(60);
+      expect(out.matchLevel).toBe('possible');
+      expect(out.issues ?? []).toHaveLength(0);
+    });
+
+    it('is idempotent — a second pass does not duplicate the issue', () => {
+      const once = applyBallastSizeCap(capInput({ distanceNm: 1580 }));
+      const twice = applyBallastSizeCap({
+        match: once,
+        distanceNm: 1580,
+        vesselDwt: 5200,
+        vesselDwcc: null,
+        cargoWeightMax: null,
+        cargoDescription: null,
+      });
+      const ballastIssues = (twice.issues ?? []).filter((i) => i.startsWith('BALLAST:'));
+      expect(ballastIssues).toHaveLength(1);
+    });
+
+    it('does not mutate the input match', () => {
+      const input = mkMatch(81, 'good');
+      applyBallastSizeCap({ ...capInput({ distanceNm: 1580 }), match: input });
+      expect(input.score).toBe(81);
+      expect(input.matchLevel).toBe('good');
+    });
+  });
+});

--- a/lib/sailing/match-scoring.ts
+++ b/lib/sailing/match-scoring.ts
@@ -195,11 +195,18 @@ const GOOD_CAP_SCORE = 69;
 /** True when the cargo is explicitly flagged as a part cargo / part load / part
  *  lot. In handysize/breakbulk one vessel routinely lifts several small parcels,
  *  so low utilisation is expected and must NOT be penalised as disproportion.
- *  Bare "parcel" is intentionally not matched — it would over-exempt full small
- *  lots and let genuinely disproportionate matches survive as 'good'. */
+ *
+ *  Tolerant of real broker phrasing: plurals ("part cargoes", "part loads"),
+ *  the "p/c" abbreviation, and arbitrary separators (space/underscore/hyphen,
+ *  zero or more — "partcargo", "part_cargo", "part  cargo"). The left `\bpart`
+ *  boundary keeps it from firing on "counterpart cargo" / "departure cargo" /
+ *  "partial cargo". Bare "parcel" is intentionally not matched — it would
+ *  over-exempt full small lots and let disproportionate matches survive 'good'. */
 export function isPartCargo(cargoDescription: string | null | undefined): boolean {
   if (!cargoDescription) return false;
-  return /\bpart[\s-]?cargo\b|\bpart[\s-]?load\b|\bpart[\s-]?lot\b/i.test(cargoDescription);
+  return /\bpart[\s_-]*(?:cargo(?:es|s)?|load(?:s)?|lot(?:s)?)\b|\bp\s*\/\s*c\b/i.test(
+    cargoDescription,
+  );
 }
 
 export interface BallastSizeCapInput {
@@ -219,9 +226,9 @@ export interface BallastSizeCapInput {
  *
  * Pure — returns a shallow copy; only ever lowers the tier, never raises it;
  * idempotent (won't duplicate BALLAST:/SIZE: issue text). Missing data never
- * triggers a cap (conservative): unknown distance skips the ballast guard,
- * unknown capacity skips the size guard. Part-cargo loads are exempt from the
- * size guard.
+ * triggers a cap (conservative): unknown distance OR unknown vessel DWT skips
+ * the ballast guard (we can't pick a class radius without a DWT), unknown
+ * capacity skips the size guard. Part-cargo loads are exempt from the size guard.
  */
 export function applyBallastSizeCap(input: BallastSizeCapInput): Match {
   const { match, distanceNm, vesselDwt, vesselDwcc, cargoWeightMax, cargoDescription } = input;
@@ -231,8 +238,10 @@ export function applyBallastSizeCap(input: BallastSizeCapInput): Match {
 
   const newIssues: string[] = [];
 
-  // Lever 3 — ballast distance vs the vessel-class radius.
-  if (distanceNm != null && Number.isFinite(distanceNm)) {
+  // Lever 3 — ballast distance vs the vessel-class radius. Skip when DWT is
+  // unknown: classifyVesselByDwt would default to handysize (the strictest
+  // radius) and demote on an assumption — not conservative on missing data.
+  if (vesselDwt != null && distanceNm != null && Number.isFinite(distanceNm)) {
     const cls = classifyVesselByDwt(vesselDwt);
     const maxNm = BALLAST_GOOD_MAX_NM[cls];
     if (distanceNm > maxNm) {

--- a/lib/sailing/match-scoring.ts
+++ b/lib/sailing/match-scoring.ts
@@ -29,6 +29,8 @@ function getMinMultiplier(...fields: (ConfidenceField<unknown> | null | undefine
 import { portHasShoreCranes } from './port-master';
 import { STOWAGE_FACTORS, checkCargoVesselCompat } from './match-filters';
 import { isVagueRegion } from './vague-region-detector';
+import { classifyVesselByDwt } from './readiness-gap';
+import type { VesselClassName } from '@/lib/constants';
 
 // ────────────────────────────────────────────────────────────────────────────
 // Cargo history keyword sets for scoring quality within compatible pairs
@@ -155,6 +157,118 @@ export function deriveMatchLevel(score: number): MatchLevel {
   if (score >= 70) return 'good';
   if (score >= 40) return 'possible';
   return 'weak';
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Ballast + size realism cap (Wave C — levers 3 + 4, handover 2026-05-30)
+//
+// Ballast distance and cargo/vessel size proportion previously only nudged the
+// score. A 'good' match that needs an uneconomic ballast leg for its vessel
+// class (lever 3), or whose cargo fills too little of the vessel — deadfreight
+// (lever 4) — is not a candidate a broker would call. These guards cap such a
+// match to 'possible' (never below — the pair still shows, flagged with an
+// issue), EXCEPT legitimate part-cargo loads, where low utilisation is normal
+// in handysize/breakbulk trade (one vessel lifts several small parcels).
+// Research basis: docs/research/match-realism-2026-05/README.md (levers 3+4).
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Class-aware maximum ballast distance (nm) for a match to still rank 'good'.
+ *  The demo fleet is small geared/near-sea tonnage (median ~7k DWT), region-bound
+ *  with a SHORT ballast radius; larger vessels cross basins under a ballast bonus.
+ *  handysize 1500nm is the research "worth-calling" ballast cap (match-realism funnel). */
+export const BALLAST_GOOD_MAX_NM: Record<VesselClassName, number> = {
+  handysize: 1500,
+  supramax: 2000,
+  panamax: 2500,
+  capesize: 4000,
+};
+
+/** Minimum cargo/vessel utilisation for a non-part-cargo match to rank 'good'.
+ *  Below this the vessel sails largely empty (deadfreight). A full cargo loads
+ *  85–98% of DWT; <50% is disproportion. util at exactly the threshold stays good. */
+export const PROPORTION_GOOD_MIN_UTIL = 0.5;
+
+/** Score a capped match is lowered to — just under the 'good' (≥70) threshold,
+ *  so deriveMatchLevel returns 'possible' while preserving relative order. */
+const GOOD_CAP_SCORE = 69;
+
+/** True when the cargo is explicitly flagged as a part cargo / part load / part
+ *  lot. In handysize/breakbulk one vessel routinely lifts several small parcels,
+ *  so low utilisation is expected and must NOT be penalised as disproportion.
+ *  Bare "parcel" is intentionally not matched — it would over-exempt full small
+ *  lots and let genuinely disproportionate matches survive as 'good'. */
+export function isPartCargo(cargoDescription: string | null | undefined): boolean {
+  if (!cargoDescription) return false;
+  return /\bpart[\s-]?cargo\b|\bpart[\s-]?load\b|\bpart[\s-]?lot\b/i.test(cargoDescription);
+}
+
+export interface BallastSizeCapInput {
+  match: Match;
+  /** Ballast distance (open position → load port), from readiness.distanceNm. */
+  distanceNm: number | null;
+  vesselDwt: number | null;
+  vesselDwcc: number | null;
+  /** Cargo upper-bound weight (weightMtMax ?? weightMt). */
+  cargoWeightMax: number | null;
+  cargoDescription: string | null;
+}
+
+/**
+ * Cap a 'good' match to 'possible' on ballast distance (lever 3) or size
+ * disproportion (lever 4).
+ *
+ * Pure — returns a shallow copy; only ever lowers the tier, never raises it;
+ * idempotent (won't duplicate BALLAST:/SIZE: issue text). Missing data never
+ * triggers a cap (conservative): unknown distance skips the ballast guard,
+ * unknown capacity skips the size guard. Part-cargo loads are exempt from the
+ * size guard.
+ */
+export function applyBallastSizeCap(input: BallastSizeCapInput): Match {
+  const { match, distanceNm, vesselDwt, vesselDwcc, cargoWeightMax, cargoDescription } = input;
+
+  // Only a 'good'-tier match (score ≥ 70) can be capped; never raise a lower tier.
+  if (match.score < 70) return match;
+
+  const newIssues: string[] = [];
+
+  // Lever 3 — ballast distance vs the vessel-class radius.
+  if (distanceNm != null && Number.isFinite(distanceNm)) {
+    const cls = classifyVesselByDwt(vesselDwt);
+    const maxNm = BALLAST_GOOD_MAX_NM[cls];
+    if (distanceNm > maxNm) {
+      newIssues.push(
+        `BALLAST: ${Math.round(distanceNm)}nm exceeds ${cls} ballast radius ${maxNm}nm — uneconomic, capped to possible`,
+      );
+    }
+  }
+
+  // Lever 4 — size proportion (utilisation), with part-cargo exemption.
+  const capacity = vesselDwcc != null && vesselDwcc > 0
+    ? vesselDwcc
+    : vesselDwt != null && vesselDwt > 0
+      ? vesselDwt
+      : null;
+  if (capacity != null && cargoWeightMax != null && cargoWeightMax > 0) {
+    const util = cargoWeightMax / capacity;
+    if (util < PROPORTION_GOOD_MIN_UTIL && !isPartCargo(cargoDescription)) {
+      newIssues.push(
+        `SIZE: cargo fills only ${Math.round(util * 100)}% of vessel (deadfreight) — disproportion, capped to possible`,
+      );
+    }
+  }
+
+  if (newIssues.length === 0) return match;
+
+  const updated: Match = { ...match };
+  updated.score = Math.min(updated.score, GOOD_CAP_SCORE);
+  updated.matchLevel = deriveMatchLevel(updated.score);
+  const existing = Array.isArray(updated.issues) ? updated.issues : [];
+  // Idempotent: drop any new issue whose tag (BALLAST:/SIZE:) is already present.
+  const fresh = newIssues.filter(
+    (i) => !existing.some((e) => e.startsWith(i.slice(0, i.indexOf(':') + 1))),
+  );
+  updated.issues = [...existing, ...fresh];
+  return updated;
 }
 
 /**

--- a/scripts/research/top-matches-broker-view.ts
+++ b/scripts/research/top-matches-broker-view.ts
@@ -1,0 +1,139 @@
+/**
+ * Research / acceptance harness (2026-05-30, Wave C) — top matches, broker view.
+ *
+ * Runs the REAL engine (`analyzePairs` with a no-op aiScorer → deterministic
+ * sweep path) on the demo fixtures, then ranks the main "worth calling" list the
+ * way a broker reads it: utilisation %, ballast leg (nm), readiness verdict, and
+ * the final tier (good/possible). It flags which 'good' candidates were demoted
+ * by the Wave C ballast + size cap (levers 3 + 4) and asserts the acceptance
+ * invariant: no surviving 'good' match has a far ballast for its vessel class or
+ * a low-util disproportion (unless it is a legitimate part-cargo).
+ *
+ * This replaces the brief's referenced `top-matches-broker-view.ts`, which was
+ * absent from the worktree (only `match-realism-funnel.ts` shipped). Same data,
+ * same engine math — the broker-readable ranking the acceptance criteria need.
+ *
+ * Run: npx tsx scripts/research/top-matches-broker-view.ts
+ */
+import cargoesFixture from '../../lib/sample-data/demo-parsed-cargoes.json';
+import vesselsFixture from '../../lib/sample-data/demo-parsed-vessels.json';
+import type { Match, ParsedCargo, ParsedVessel } from '../../lib/types';
+import { cfValue } from '../../lib/types';
+import { analyzePairs, type AiScorer } from '../../lib/matching/pair-analyzer';
+import { classifyVesselByDwt } from '../../lib/sailing/readiness-gap';
+import {
+  BALLAST_GOOD_MAX_NM,
+  PROPORTION_GOOD_MIN_UTIL,
+  isPartCargo,
+} from '../../lib/sailing/match-scoring';
+import { rebaseParsedCargoes, rebaseParsedVessels } from '../../lib/sample-data/rebase-parsed';
+
+// 2026-05-01 = the funnel's best-case reference date (fewest expired laycans).
+const TODAY = new Date(Date.UTC(2026, 4, 1));
+const REF_YEAR = 2026;
+
+const cargos = rebaseParsedCargoes(cargoesFixture as unknown as ParsedCargo[], TODAY);
+const vessels = rebaseParsedVessels(vesselsFixture as unknown as ParsedVessel[], TODAY);
+
+const offline: AiScorer = async () => [];
+
+function findCargo(m: Match): ParsedCargo | undefined {
+  return cargos.find((c) => c.emailId === m.cargoEmailId && c.itemIndex === m.cargoItemIndex);
+}
+function findVessel(m: Match): ParsedVessel | undefined {
+  return vessels.find((v) => v.emailId === m.vesselEmailId && v.itemIndex === m.vesselItemIndex);
+}
+
+function vesselCapacity(v: ParsedVessel | undefined): number | null {
+  if (!v) return null;
+  const dwcc = cfValue(v.dwcc);
+  if (dwcc != null && dwcc > 0) return dwcc;
+  const dwt = cfValue(v.dwtSummer);
+  return dwt != null && dwt > 0 ? dwt : null;
+}
+function cargoWeight(c: ParsedCargo | undefined): number | null {
+  if (!c) return null;
+  return c.weightMtMax ?? cfValue(c.weightMt);
+}
+function utilOf(m: Match): number | null {
+  const cap = vesselCapacity(findVessel(m));
+  const wt = cargoWeight(findCargo(m));
+  return cap != null && wt != null && wt > 0 ? wt / cap : null;
+}
+function capFlag(m: Match): string {
+  const issues = m.issues ?? [];
+  const b = issues.some((i) => i.startsWith('BALLAST:'));
+  const s = issues.some((i) => i.startsWith('SIZE:'));
+  return b && s ? 'B+S' : b ? 'BAL' : s ? 'SIZE' : '';
+}
+
+async function main() {
+  const result = await analyzePairs(cargos, vessels, offline, { refYear: REF_YEAR, today: TODAY });
+
+  // Rank by the UNCAPPED score (scoreBreakdown.finalScore) so demoted false-goods
+  // still appear where the broker would have first seen them — now marked.
+  const ranked = [...result.matches].sort(
+    (a, b) => (b.scoreBreakdown?.finalScore ?? b.score) - (a.scoreBreakdown?.finalScore ?? a.score),
+  );
+
+  const out: string[] = [];
+  const p = (s: string) => out.push(s);
+
+  p('═══════════════════════════════════════════════════════════════════════════');
+  p(`TOP MATCHES — BROKER VIEW  (today=${TODAY.toISOString().slice(0, 10)}, refYear=${REF_YEAR})`);
+  p('═══════════════════════════════════════════════════════════════════════════');
+  const good = result.matches.filter((m) => m.matchLevel === 'good');
+  const possible = result.matches.filter((m) => m.matchLevel === 'possible');
+  const cappedBallast = result.matches.filter((m) => (m.issues ?? []).some((i) => i.startsWith('BALLAST:')));
+  const cappedSize = result.matches.filter((m) => (m.issues ?? []).some((i) => i.startsWith('SIZE:')));
+  p(`Main list: ${result.matches.length}   good: ${good.length}   possible: ${possible.length}`);
+  p(`Capped good→possible:  ballast(lever 3)=${cappedBallast.length}   size(lever 4)=${cappedSize.length}`);
+  p(`Buckets: lowConfidence=${result.lowConfidenceMatches.length}  insufficient=${result.insufficientData.length}  blocked=${result.blockedMatches.length}`);
+  p('');
+  p('Top 30 by uncapped score — CAP column shows the Wave C demotion (BAL/SIZE/B+S):');
+  p('  #  rawScore  tier      CAP   util%  ballast  verdict   class       cargo');
+  p('  ─────────────────────────────────────────────────────────────────────────────');
+  ranked.slice(0, 30).forEach((m, idx) => {
+    const c = findCargo(m);
+    const v = findVessel(m);
+    const raw = Math.round((m.scoreBreakdown?.finalScore ?? m.score) * 10) / 10;
+    const util = utilOf(m);
+    const dist = m.readiness?.distanceNm;
+    const cls = classifyVesselByDwt(v ? cfValue(v.dwtSummer) : null);
+    const desc = (cfValue(c?.cargoDescription ?? null) ?? '').slice(0, 30);
+    p(
+      `  ${String(idx + 1).padStart(2)}  ${String(raw).padStart(7)}  ${m.matchLevel.padEnd(8)}  ${capFlag(m).padEnd(4)}  ${(util != null ? Math.round(util * 100) + '%' : '—').padStart(5)}  ${(dist != null ? Math.round(dist) + 'nm' : '—').padStart(7)}  ${(m.readiness?.verdict ?? '—').padEnd(7)}  ${cls.padEnd(10)}  ${desc}`,
+    );
+  });
+  p('');
+
+  // ── Acceptance invariant ───────────────────────────────────────────────────
+  const ballastOffenders = good.filter((m) => {
+    const dist = m.readiness?.distanceNm;
+    if (dist == null) return false;
+    const cls = classifyVesselByDwt(findVessel(m) ? cfValue(findVessel(m)!.dwtSummer) : null);
+    return dist > BALLAST_GOOD_MAX_NM[cls];
+  });
+  const sizeOffenders = good.filter((m) => {
+    const c = findCargo(m);
+    if (!c || isPartCargo(cfValue(c.cargoDescription))) return false;
+    const util = utilOf(m);
+    return util != null && util < PROPORTION_GOOD_MIN_UTIL;
+  });
+  const partCargoSurvivors = result.matches.filter(
+    (m) => isPartCargo(cfValue(findCargo(m)?.cargoDescription ?? null)) && !(m.issues ?? []).some((i) => i.startsWith('SIZE:')),
+  );
+
+  p('── ACCEPTANCE ──────────────────────────────────────────────────────────────');
+  p(`  good with far ballast for class (must be 0):     ${ballastOffenders.length}`);
+  p(`  good with low-util non-part-cargo (must be 0):   ${sizeOffenders.length}`);
+  p(`  part-cargo NOT size-capped (exemption holds):    ${partCargoSurvivors.length}`);
+  const pass = ballastOffenders.length === 0 && sizeOffenders.length === 0;
+  p(`  VERDICT: ${pass ? 'PASS — every surviving good is within ballast radius + util≥50% (or part-cargo)' : 'FAIL'}`);
+  p('═══════════════════════════════════════════════════════════════════════════');
+
+  console.log(out.join('\n'));
+  if (!pass) process.exitCode = 1;
+}
+
+main();

--- a/tests/regression/ballast-size-cap-adversarial.test.ts
+++ b/tests/regression/ballast-size-cap-adversarial.test.ts
@@ -1,0 +1,350 @@
+/**
+ * COLD-START adversarial QA — applyBallastSizeCap + isPartCargo (Wave C levers 3+4).
+ *
+ * Target module: lib/sailing/match-scoring.ts (PR a28b4a5 / 2b9e4f1).
+ * The dev-authored happy-path suite lives in lib/sailing/__tests__/match-scoring.test.ts.
+ * This file attacks the gaps that suite does NOT cover.
+ *
+ * Each `it` is labelled:
+ *   [BUG]      — asserts the CORRECT behavior per the acceptance contract; FAILS today => PR bug.
+ *   [BEHAVIOR] — pins down actual current behavior (passes); flags a soundness concern in a comment.
+ */
+import {
+  applyBallastSizeCap,
+  isPartCargo,
+  BALLAST_GOOD_MAX_NM,
+  type BallastSizeCapInput,
+} from '@/lib/sailing/match-scoring';
+import type { Match } from '@/lib/types';
+
+function mkMatch(score = 81, level: Match['matchLevel'] = 'good', issues: string[] = []): Match {
+  return {
+    cargoEmailId: 'c1',
+    cargoItemIndex: 0,
+    vesselEmailId: 'v1',
+    vesselItemIndex: 0,
+    score,
+    matchLevel: level,
+    matchReasons: [],
+    issues,
+  };
+}
+
+function capInput(over: Partial<BallastSizeCapInput> = {}): BallastSizeCapInput {
+  return {
+    match: mkMatch(81, 'good'),
+    distanceNm: null,
+    vesselDwt: 5200, // handysize
+    vesselDwcc: null,
+    cargoWeightMax: null,
+    cargoDescription: null,
+    ...over,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A. isPartCargo — FALSE NEGATIVES (legit part-cargo wrongly demoted = HIGH)
+// The acceptance contract: a legitimate part-cargo MUST NOT be demoted.
+// A false-negative means isPartCargo returns false for a real part-cargo phrase,
+// so the size guard fires and the 'good' match is wrongly capped to 'possible'.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('isPartCargo — adversarial false-negatives (HIGH)', () => {
+  it('[BUG] plural "part cargoes" is a real part-cargo phrase', () => {
+    // "2 part cargoes of steel" — extremely common broker phrasing.
+    // \bcargo\b does not match "cargoes" => regex misses it.
+    expect(isPartCargo('2 part cargoes of steel coils')).toBe(true);
+  });
+
+  it('[BUG] plural "part loads" is a real part-cargo phrase', () => {
+    expect(isPartCargo('vessel can take 2 part loads')).toBe(true);
+  });
+
+  it('[BUG] "p/c" is the standard broker abbreviation for part cargo', () => {
+    // Brokers routinely write "p/c basis" for part-cargo basis.
+    expect(isPartCargo('steel, p/c basis')).toBe(true);
+  });
+
+  it('[BUG] double-space "part  cargo" (whitespace variance) is part cargo', () => {
+    // [\s-]? allows only ONE separator char; two spaces breaks the match.
+    expect(isPartCargo('part  cargo of bagged urea')).toBe(true);
+  });
+
+  it('[BUG] underscore-joined "part_cargo" is part cargo', () => {
+    expect(isPartCargo('part_cargo')).toBe(true);
+  });
+});
+
+describe('isPartCargo — confirmed-correct cases (regression guards)', () => {
+  it('matches the canonical forms the dev suite relies on', () => {
+    expect(isPartCargo('part cargo')).toBe(true);
+    expect(isPartCargo('part-cargo basis')).toBe(true);
+    expect(isPartCargo('in part cargo')).toBe(true);
+    expect(isPartCargo('part load')).toBe(true);
+    expect(isPartCargo('part lot')).toBe(true);
+    expect(isPartCargo('PART CARGO')).toBe(true);
+    expect(isPartCargo('partcargo')).toBe(true); // no-space variant DOES match
+  });
+
+  it('[BEHAVIOR] does NOT false-positive on substrings — "counterpart cargo", "departure cargo"', () => {
+    // \bpart guards the left boundary, so "counterpart cargo"/"departure cargo" are safe.
+    // GOOD: a disproportionate full cargo with these words is NOT wrongly exempted.
+    expect(isPartCargo('counterpart cargo')).toBe(false);
+    expect(isPartCargo('departure cargo nomination')).toBe(false);
+    expect(isPartCargo('parcel of wheat')).toBe(false); // bare "parcel" intentionally excluded
+    expect(isPartCargo('partial cargo')).toBe(false); // "partial" intentionally excluded
+  });
+
+  it('null / undefined / empty → false (no crash)', () => {
+    expect(isPartCargo(null)).toBe(false);
+    expect(isPartCargo(undefined)).toBe(false);
+    expect(isPartCargo('')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B. End-to-end demotion: a legit part-cargo wrongly capped via the false-negative
+// This proves the isPartCargo bug propagates to the acceptance-contract violation.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('applyBallastSizeCap — legit part-cargo wrongly demoted (HIGH)', () => {
+  it('[BUG] "2 part cargoes" low-util match must stay good (part-cargo exempt)', () => {
+    // 2500mt cargo on a 50000 DWT vessel = 5% util — would be capped UNLESS exempt.
+    const out = applyBallastSizeCap(
+      capInput({
+        distanceNm: 200,
+        vesselDwt: 50000,
+        cargoWeightMax: 2500,
+        cargoDescription: '2 part cargoes of steel',
+      }),
+    );
+    expect(out.matchLevel).toBe('good');
+    expect((out.issues ?? []).some((i) => i.startsWith('SIZE:'))).toBe(false);
+  });
+
+  it('[BUG] "p/c basis" low-util match must stay good (part-cargo exempt)', () => {
+    const out = applyBallastSizeCap(
+      capInput({
+        distanceNm: 200,
+        vesselDwt: 50000,
+        cargoWeightMax: 2500,
+        cargoDescription: 'steel coils, p/c basis',
+      }),
+    );
+    expect(out.matchLevel).toBe('good');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C. Numeric edges of applyBallastSizeCap
+// ─────────────────────────────────────────────────────────────────────────────
+describe('applyBallastSizeCap — numeric edges (lever 3 ballast)', () => {
+  it('[BEHAVIOR] off-by-one: distance EXACTLY at handysize cap (1500nm) stays good (strict >)', () => {
+    const out = applyBallastSizeCap(capInput({ distanceNm: 1500 }));
+    expect(out.matchLevel).toBe('good'); // > maxNm, so 1500 is NOT capped
+    const justOver = applyBallastSizeCap(capInput({ distanceNm: 1501 }));
+    expect(justOver.matchLevel).toBe('possible');
+  });
+
+  it('NaN distance does not trigger the ballast guard', () => {
+    const out = applyBallastSizeCap(capInput({ distanceNm: NaN }));
+    expect(out.matchLevel).toBe('good');
+  });
+
+  it('Infinity distance does not trigger the ballast guard (Number.isFinite guard)', () => {
+    const out = applyBallastSizeCap(capInput({ distanceNm: Infinity }));
+    expect(out.matchLevel).toBe('good');
+  });
+
+  it('negative distance does not trigger the ballast guard', () => {
+    const out = applyBallastSizeCap(capInput({ distanceNm: -500 }));
+    expect(out.matchLevel).toBe('good');
+  });
+
+  it('[FIXED] null DWT skips the ballast guard (conservative on missing data)', () => {
+    // Resolves the MEDIUM concern: an unknown-DWT vessel must NOT be demoted on the
+    // handysize-default assumption. With no DWT we cannot pick a class radius, so the
+    // ballast guard is skipped — honest to "missing data never triggers a cap".
+    const out = applyBallastSizeCap(capInput({ distanceNm: 1600, vesselDwt: null }));
+    expect(out.matchLevel).toBe('good');
+    expect((out.issues ?? []).some((i) => i.startsWith('BALLAST:'))).toBe(false);
+  });
+
+  it('[BEHAVIOR] 95000 DWT (kamsarmax/post-panamax) → classified capesize → LOOSEST 4000nm cap', () => {
+    // CONCERN: classifyVesselByDwt has a gap 90001..99999 that falls through to capesize.
+    // A ~95k DWT vessel gets the 4000nm cap (capesize), so a 3500nm ballast survives as good.
+    // Pre-existing classifier behavior, not introduced by this PR — flagged for awareness.
+    const out = applyBallastSizeCap(capInput({ distanceNm: 3500, vesselDwt: 95000 }));
+    expect(out.matchLevel).toBe('good');
+  });
+});
+
+describe('applyBallastSizeCap — numeric edges (lever 4 size)', () => {
+  it('vesselDwcc present but 0 falls back to DWT', () => {
+    // dwcc=0 -> use dwt=10000; cargo 4000/10000 = 40% < 0.5 -> capped.
+    const out = applyBallastSizeCap(
+      capInput({ distanceNm: 100, vesselDwt: 10000, vesselDwcc: 0, cargoWeightMax: 4000 }),
+    );
+    expect(out.matchLevel).toBe('possible');
+    expect((out.issues ?? []).some((i) => i.startsWith('SIZE:'))).toBe(true);
+  });
+
+  it('cargoWeightMax = 0 does not trigger the size guard (guarded by > 0)', () => {
+    const out = applyBallastSizeCap(
+      capInput({ distanceNm: 100, vesselDwt: 10000, cargoWeightMax: 0 }),
+    );
+    expect(out.matchLevel).toBe('good');
+  });
+
+  it('negative cargoWeightMax does not trigger the size guard', () => {
+    const out = applyBallastSizeCap(
+      capInput({ distanceNm: 100, vesselDwt: 10000, cargoWeightMax: -500 }),
+    );
+    expect(out.matchLevel).toBe('good');
+  });
+
+  it('negative capacity (dwcc<0, dwt<0) does not trigger the size guard', () => {
+    const out = applyBallastSizeCap(
+      capInput({ distanceNm: 100, vesselDwt: -1, vesselDwcc: -1, cargoWeightMax: 5000 }),
+    );
+    expect(out.matchLevel).toBe('good');
+  });
+
+  it('util exactly 0.5 stays good; just below caps', () => {
+    expect(
+      applyBallastSizeCap(capInput({ distanceNm: 100, vesselDwt: 10000, cargoWeightMax: 5000 })).matchLevel,
+    ).toBe('good');
+    expect(
+      applyBallastSizeCap(capInput({ distanceNm: 100, vesselDwt: 10000, cargoWeightMax: 4999 })).matchLevel,
+    ).toBe('possible');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// D. Tier / score invariants
+// ─────────────────────────────────────────────────────────────────────────────
+describe('applyBallastSizeCap — tier & score invariants', () => {
+  it('never raises a lower tier — possible match with awful ballast+size stays possible', () => {
+    const out = applyBallastSizeCap({
+      match: mkMatch(60, 'possible'),
+      distanceNm: 9999,
+      vesselDwt: 5200,
+      vesselDwcc: null,
+      cargoWeightMax: 10,
+      cargoDescription: null,
+    });
+    expect(out.matchLevel).toBe('possible');
+    expect(out.score).toBe(60);
+    expect(out.issues ?? []).toHaveLength(0);
+  });
+
+  it('weak match (score 30) is never touched even with both triggers', () => {
+    const m = mkMatch(30, 'weak');
+    const out = applyBallastSizeCap({
+      match: m,
+      distanceNm: 9999,
+      vesselDwt: 5200,
+      vesselDwcc: null,
+      cargoWeightMax: 10,
+      cargoDescription: null,
+    });
+    expect(out).toBe(m); // returns the SAME object (early return), no copy, no issue
+  });
+
+  it('[BEHAVIOR] inconsistent input: score 65 but matchLevel "good" → guard uses SCORE not level, returns as-is', () => {
+    // The cap gate is `match.score < 70`, NOT `matchLevel`. A malformed match with
+    // score 65 but level 'good' is returned untouched — it never gets re-derived to 'possible'.
+    // In the real pipeline the wiring gates on matchLevel==='good' first, so a 65/'good'
+    // mismatch could slip past the wiring filter yet be ignored by the function => no demotion.
+    const out = applyBallastSizeCap({
+      match: mkMatch(65, 'good'),
+      distanceNm: 9999,
+      vesselDwt: 5200,
+      vesselDwcc: null,
+      cargoWeightMax: 10,
+      cargoDescription: null,
+    });
+    expect(out.matchLevel).toBe('good'); // unchanged — score<70 early-return
+    expect(out.score).toBe(65);
+  });
+
+  it('both ballast AND size trigger → score capped once to 69, BOTH issues present', () => {
+    const out = applyBallastSizeCap(
+      capInput({
+        distanceNm: 5000,
+        vesselDwt: 8000,
+        cargoWeightMax: 2000, // 25% util
+        cargoDescription: 'bulk wheat',
+      }),
+    );
+    expect(out.score).toBe(69);
+    expect(out.matchLevel).toBe('possible');
+    const issues = out.issues ?? [];
+    expect(issues.some((i) => i.startsWith('BALLAST:'))).toBe(true);
+    expect(issues.some((i) => i.startsWith('SIZE:'))).toBe(true);
+  });
+
+  it('caps to 69 even when original score was barely above threshold (70)', () => {
+    const out = applyBallastSizeCap(capInput({ match: mkMatch(70, 'good'), distanceNm: 5000 }));
+    expect(out.score).toBe(69);
+    expect(out.matchLevel).toBe('possible');
+  });
+
+  it('does not mutate the input match or its issues array', () => {
+    const issues = ['EXISTING: keep me'];
+    const input = mkMatch(81, 'good', issues);
+    const out = applyBallastSizeCap({
+      match: input,
+      distanceNm: 5000,
+      vesselDwt: 5200,
+      vesselDwcc: null,
+      cargoWeightMax: null,
+      cargoDescription: null,
+    });
+    expect(input.score).toBe(81); // input untouched
+    expect(input.matchLevel).toBe('good');
+    expect(input.issues).toEqual(['EXISTING: keep me']); // original array length unchanged
+    expect(out.issues).not.toBe(input.issues); // new array
+    expect(out.issues).toContain('EXISTING: keep me'); // preserves prior issues
+  });
+
+  it('idempotent — second pass adds no duplicate BALLAST issue', () => {
+    const once = applyBallastSizeCap(capInput({ distanceNm: 5000 }));
+    const twice = applyBallastSizeCap({
+      match: once,
+      distanceNm: 5000,
+      vesselDwt: 5200,
+      vesselDwcc: null,
+      cargoWeightMax: null,
+      cargoDescription: null,
+    });
+    expect((twice.issues ?? []).filter((i) => i.startsWith('BALLAST:'))).toHaveLength(1);
+  });
+
+  it('[BEHAVIOR] idempotency dedup is by TAG prefix, not full text — a pre-existing BALLAST issue suppresses a new one', () => {
+    // existing.some(e => e.startsWith("BALLAST:")) — so ANY prior "BALLAST:" issue
+    // blocks the cap from appending its own. The score is STILL lowered. Verify the
+    // demotion still happens (score drops) even though the issue text is suppressed.
+    const out = applyBallastSizeCap({
+      match: mkMatch(81, 'good', ['BALLAST: some unrelated prior note']),
+      distanceNm: 5000,
+      vesselDwt: 5200,
+      vesselDwcc: null,
+      cargoWeightMax: null,
+      cargoDescription: null,
+    });
+    expect(out.score).toBe(69); // demotion still applies
+    expect(out.matchLevel).toBe('possible');
+    expect((out.issues ?? []).filter((i) => i.startsWith('BALLAST:'))).toHaveLength(1); // not duplicated
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E. Threshold table sanity
+// ─────────────────────────────────────────────────────────────────────────────
+describe('BALLAST_GOOD_MAX_NM table', () => {
+  it('is monotonic increasing by class and handysize=1500', () => {
+    expect(BALLAST_GOOD_MAX_NM.handysize).toBe(1500);
+    expect(BALLAST_GOOD_MAX_NM.supramax).toBeGreaterThan(BALLAST_GOOD_MAX_NM.handysize);
+    expect(BALLAST_GOOD_MAX_NM.panamax).toBeGreaterThan(BALLAST_GOOD_MAX_NM.supramax);
+    expect(BALLAST_GOOD_MAX_NM.capesize).toBeGreaterThan(BALLAST_GOOD_MAX_NM.panamax);
+  });
+});

--- a/tests/regression/ballast-size-cap-adversarial.test.ts
+++ b/tests/regression/ballast-size-cap-adversarial.test.ts
@@ -6,8 +6,15 @@
  * This file attacks the gaps that suite does NOT cover.
  *
  * Each `it` is labelled:
- *   [BUG]      — asserts the CORRECT behavior per the acceptance contract; FAILS today => PR bug.
- *   [BEHAVIOR] — pins down actual current behavior (passes); flags a soundness concern in a comment.
+ *   [BUG]      — found a real defect on first QA pass; the fix (commit 0962133)
+ *                hardened isPartCargo + the null-DWT guard, so these now PASS and
+ *                stand as regression guards. The "misses it" comments below describe
+ *                the PRE-FIX regex (`[\s-]?`, `\bcargo\b`), kept for provenance.
+ *   [FIXED]    — a soundness concern from the first pass, now resolved in code.
+ *
+ * NOTE: jest.config.mjs excludes /tests/regression/ from `npm test`; the
+ * contract-critical cases are mirrored in lib/sailing/__tests__/match-scoring.test.ts
+ * (which DOES run in CI). This file is the cold-start QA artifact.
  */
 import {
   applyBallastSizeCap,


### PR DESCRIPTION
## Summary

Wave C — makes **ballast distance** (lever 3) and **cargo/vessel proportionality** (lever 4) hard criteria instead of soft score nudges. A `good` match that needs an uneconomic ballast leg for its vessel class, or whose cargo fills too little of the vessel (deadfreight), is **capped to `possible`** (stays in the main list, flagged) — **except legitimate part-cargo loads**, where low utilisation is normal in handysize/breakbulk.

- `lib/sailing/match-scoring.ts` — new pure `applyBallastSizeCap()` + `isPartCargo()` + thresholds `BALLAST_GOOD_MAX_NM` (handysize 1500 / supramax 2000 / panamax 2500 / capesize 4000 nm) and `PROPORTION_GOOD_MIN_UTIL` 0.5. Peer of `applyOverloadGuard`: pure, idempotent, only ever lowers a tier, never on missing data.
- `lib/matching/pair-analyzer.ts` — cap loop runs after final scoring, before the realism partition, so a capped match stays in `mainMatches` as `possible`.
- `scripts/research/top-matches-broker-view.ts` — broker-view acceptance harness (the brief's referenced script was absent from the worktree).

## Acceptance (broker-view harness, rebased demo data)

```
good with far ballast for class (must be 0):     0
good with low-util non-part-cargo (must be 0):   0
part-cargo NOT size-capped (exemption holds):    2
VERDICT: PASS — every surviving good is within ballast radius + util>=50% (or part-cargo)
```

- False goods demoted: util 21% / 34% (non-part-cargo) → `possible` with `SIZE:` flag.
- `#1` steel billets (89% util, 205nm) **stays good**; far-ballast pairs (1643–2026nm) all `possible`.
- `"Mobile machinery … part cargo"` at 7% / 30% util **not** size-capped (exemption holds).
- `good` count collapses from ~61 to a small, honest set.

## Cold-start adversarial QA (test-skill) — addressed

- **HIGH:** `isPartCargo` missed real broker phrasings (plural `part cargoes`/`part loads`, `p/c`, loose separators) → legit part-cargo wrongly demoted. Regex hardened; left boundary still rejects counterpart/departure/partial/parcel.
- **MEDIUM:** null DWT defaulted to handysize (strictest radius) → demotion on assumption. Ballast guard now skips when DWT unknown.
- **Code review:** `tests/regression/` is excluded from CI (`jest.config.mjs`); contract-critical cases mirrored into the CI-collected `match-scoring.test.ts`; one tautological integration test dropped.

## Test Plan

- [x] `lib/sailing/__tests__/match-scoring.test.ts` — 75 pass (unit: cap logic, part-cargo, edges, dedup)
- [x] `lib/__tests__/matching/match-realism-buckets.test.ts` — 10 pass (real-engine invariants: 0 ballast/util offenders post-fix)
- [x] `tests/regression/ballast-size-cap-adversarial.test.ts` — 30 pass (cold-start QA, manual suite)
- [x] `NODE_OPTIONS='--max-old-space-size=8192' npm test` — 737 suites / 7978 pass / 0 fail
- [x] `npx tsx scripts/research/top-matches-broker-view.ts` — acceptance PASS
- [x] tsc + eslint clean

## Notes / assumptions

- The brief referenced `scripts/research/top-matches-broker-view.ts` and `docs/research/match-realism-2026-05/ROADMAP-to-100.md` — **neither existed** in this worktree (only `match-realism-funnel.ts` + `README.md`). Built the broker-view harness on the real engine; acceptance is invariant-based rather than tied to the original script's exact ranking.
- Out of scope (noted, not fixed): `classifyVesselByDwt` 90k–100k DWT gap → capesize (pre-existing); `scoreBreakdown.finalScore` not re-synced on cap (consistent with existing `applyOverloadGuard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)