### PR TITLE
feat(matching): IMSBC structural group table + loadability gate (L3)

### DIFF
--- a/lib/cargo/imsbc-groups.json
+++ b/lib/cargo/imsbc-groups.json
@@ -1,0 +1,407 @@
+{
+  "_meta": {
+    "version": "imsbc-groups-v1",
+    "source": "IMSBC Code (IMO) — individual cargo schedules cross-validated with BIMCO, UK P&I Club, Marine Insight dry-bulk guides. Fail-closed: dual-group or ambiguous cargoes assigned most operationally restrictive group.",
+    "method": "Structural per-cargo group assignment from IMSBC Code schedules (IMO 2009+). Group A = liquefaction risk (TML cert required). Group B = chemical hazard (IMDG class). Group C = neither. Unknown cargo not in table → neutral (no restriction). Aliases resolved at runtime in lib/sailing/imsbc-check.ts TAXONOMY.",
+    "count": 74,
+    "date": "2026-05-31",
+    "coverageNote": "Covers all demo-parsed-cargoes.json cargoes + top bulk commodities. Excludes niche specialty chemicals and liquid/project cargo."
+  },
+  "cargoes": {
+    "iron ore": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port",
+        "monitoring for liquefaction during voyage"
+      ]
+    },
+    "zinc concentrate": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port",
+        "monitoring for liquefaction during voyage"
+      ]
+    },
+    "lead concentrate": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port",
+        "monitoring for liquefaction during voyage"
+      ]
+    },
+    "nickel ore": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port",
+        "high liquefaction risk — strict moisture control mandatory"
+      ]
+    },
+    "bauxite": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port",
+        "monitoring for liquefaction during voyage"
+      ]
+    },
+    "fluorspar": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "manganese ore": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "rock phosphate": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "mineral sand": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "ilmenite": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "iron sand": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "kaolin": {
+      "group": "A",
+      "requirements": [
+        "TML certificate required before loading (wet/fine grade)",
+        "moisture content declaration at loading port"
+      ]
+    },
+    "copper concentrate": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "H2S gas monitoring required (toxic gas hazard)",
+        "TML certificate required (also Group A liquefaction risk)",
+        "moisture content declaration at loading",
+        "self-heating monitoring during voyage",
+        "dedicated voyage strongly preferred (dual Group A+B hazard)"
+      ]
+    },
+    "pyrite": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating risk: temperature monitoring required",
+        "TML certificate required (also Group A liquefaction risk)",
+        "gas detector for H2S/SO2"
+      ]
+    },
+    "coal": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "gas detector for methane (CH4) and CO required",
+        "self-heating monitoring during loading and voyage",
+        "holds ventilation required",
+        "no open flames near holds"
+      ]
+    },
+    "anthracite": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating monitoring during loading and voyage",
+        "gas monitoring for CO",
+        "holds ventilation required"
+      ]
+    },
+    "coal tar pitch": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating monitoring required",
+        "no ignition sources near holds",
+        "ventilation required"
+      ]
+    },
+    "met coke": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating monitoring during loading and voyage",
+        "gas monitoring for CO",
+        "holds ventilation required"
+      ]
+    },
+    "petroleum coke": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating monitoring required",
+        "CO gas monitoring",
+        "holds ventilation required"
+      ]
+    },
+    "dri": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "dedicated voyage — no mixing with other cargoes",
+        "holds must be dry (moisture triggers self-heating and H2 gas)",
+        "temperature monitoring throughout voyage",
+        "inert gas atmosphere may be required",
+        "no contact with water — fire/explosion hazard"
+      ]
+    },
+    "sulphur": {
+      "group": "B",
+      "imoClass": "4.1",
+      "requirements": [
+        "flammable solid — no ignition sources",
+        "fire watch required",
+        "dust control during loading/discharge",
+        "SO2 gas monitoring recommended"
+      ]
+    },
+    "ammonium nitrate": {
+      "group": "B",
+      "imoClass": "5.1",
+      "requirements": [
+        "oxidizer — dedicated clean holds, no combustible residues",
+        "no contact with heat, oil, or flammable materials",
+        "temperature monitoring to prevent detonation risk",
+        "special approval from flag state may be required"
+      ]
+    },
+    "fertilizer": {
+      "group": "B",
+      "imoClass": "5.1",
+      "requirements": [
+        "ammonium nitrate based fertilizers: oxidizer — dedicated clean holds",
+        "verify fertilizer type: urea/potash/DAP may be Group C",
+        "no contact with heat, oil, or flammable materials"
+      ]
+    },
+    "ferrosilicon": {
+      "group": "B",
+      "imoClass": "4.3",
+      "requirements": [
+        "no contact with water or moisture (produces hydrogen gas)",
+        "holds must be completely dry before loading",
+        "gas monitoring for H2 required"
+      ]
+    },
+    "fishmeal": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating risk (spontaneous combustion)",
+        "temperature monitoring during voyage",
+        "holds ventilation required",
+        "only stabilised fishmeal may be shipped in bulk"
+      ]
+    },
+    "rapeseed meal": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating risk from oil content",
+        "temperature monitoring during voyage",
+        "holds ventilation required"
+      ]
+    },
+    "olive pomace": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "high oil content — self-heating risk",
+        "temperature monitoring required",
+        "holds ventilation required"
+      ]
+    },
+    "charcoal": {
+      "group": "B",
+      "imoClass": "4.2",
+      "requirements": [
+        "self-heating monitoring required",
+        "CO gas monitoring",
+        "no ignition sources"
+      ]
+    },
+    "calcium carbide": {
+      "group": "B",
+      "imoClass": "4.3",
+      "requirements": [
+        "no contact with water (produces acetylene — explosive)",
+        "holds must be completely dry",
+        "special packaging required"
+      ]
+    },
+    "wheat": {
+      "group": "C"
+    },
+    "corn": {
+      "group": "C"
+    },
+    "rice": {
+      "group": "C"
+    },
+    "barley": {
+      "group": "C"
+    },
+    "soybean": {
+      "group": "C"
+    },
+    "oats": {
+      "group": "C"
+    },
+    "rye": {
+      "group": "C"
+    },
+    "sorghum": {
+      "group": "C"
+    },
+    "rapeseed": {
+      "group": "C"
+    },
+    "sunflower seeds": {
+      "group": "C"
+    },
+    "sesame seeds": {
+      "group": "C"
+    },
+    "malt": {
+      "group": "C"
+    },
+    "bran": {
+      "group": "C"
+    },
+    "cement": {
+      "group": "C"
+    },
+    "clinker": {
+      "group": "C"
+    },
+    "alumina": {
+      "group": "C"
+    },
+    "salt": {
+      "group": "C"
+    },
+    "gypsum": {
+      "group": "C"
+    },
+    "gypsum boards": {
+      "group": "C"
+    },
+    "sugar": {
+      "group": "C"
+    },
+    "limestone": {
+      "group": "C"
+    },
+    "marble": {
+      "group": "C"
+    },
+    "granite": {
+      "group": "C"
+    },
+    "sand": {
+      "group": "C"
+    },
+    "gravel": {
+      "group": "C"
+    },
+    "woodchips": {
+      "group": "C"
+    },
+    "wood pellets": {
+      "group": "C"
+    },
+    "timber": {
+      "group": "C"
+    },
+    "potash": {
+      "group": "C"
+    },
+    "urea": {
+      "group": "C"
+    },
+    "dap": {
+      "group": "C"
+    },
+    "map": {
+      "group": "C"
+    },
+    "soda ash": {
+      "group": "C"
+    },
+    "barite": {
+      "group": "C"
+    },
+    "clay": {
+      "group": "C"
+    },
+    "bentonite": {
+      "group": "C"
+    },
+    "slag": {
+      "group": "C"
+    },
+    "iron ore pellets": {
+      "group": "C"
+    },
+    "steel": {
+      "group": "C"
+    },
+    "pig iron": {
+      "group": "C"
+    },
+    "scrap": {
+      "group": "C"
+    },
+    "magnesite": {
+      "group": "C"
+    },
+    "talc": {
+      "group": "C"
+    },
+    "sodium nitrate": {
+      "group": "B",
+      "imoClass": "5.1",
+      "requirements": [
+        "oxidizer — keep away from combustibles and heat",
+        "dedicated clean holds required"
+      ]
+    },
+    "calcium hypochlorite": {
+      "group": "B",
+      "imoClass": "5.1",
+      "requirements": [
+        "oxidizer — dedicated clean holds",
+        "no contact with combustible materials"
+      ]
+    }
+  }
+}

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -14,6 +14,7 @@ import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
 import { applyReadinessScoring, computeScoreBreakdown, deriveMatchLevel, applyBallastSizeCap } from '@/lib/sailing/match-scoring';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
 import { runHardFilters } from '@/lib/sailing/match-filters';
+import { checkImsbcLoadability } from '@/lib/sailing/imsbc-check';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { validateDates, isLaycanValid } from '@/lib/sailing/date-sanity';
 import { checkSanctions } from '@/lib/validation/sanctions';
@@ -83,6 +84,7 @@ interface PairAnalysis {
   hardFilters: MatchHardFilters;
   sanctions: MatchSanctions;
   dateIssues: string[];
+  imsbcIssues: string[];
   filterOut: boolean;
   filterReason?: string;
 }
@@ -121,6 +123,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     grainCapacity: v.grainCapacity,
     dwtSummer: cfValue(v.dwtSummer),
     dwcc: cfValue(v.dwcc),
+    vesselRestrictions: v.restrictions ?? [],
   });
 
   const hardFilters: MatchHardFilters = {
@@ -131,7 +134,14 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     destDraft: hf.checks.destDraft,
     destCrane: hf.checks.destCrane,
     cargoWeight: hf.checks.cargoWeight,
+    imsbc: hf.checks.imsbc,
   };
+
+  const imsbcCheck = checkImsbcLoadability(cfValue(c.cargoDescription), { restrictions: v.restrictions ?? [] });
+  const imsbcIssues: string[] =
+    imsbcCheck.verdict === 'caution'
+      ? imsbcCheck.requirements.map((r) => `IMSBC Group ${imsbcCheck.group}: ${r}`)
+      : [];
 
   const parsedLaycan = parseLaycan(c.laycan, refYear);
   const parsedOpen = parseVesselOpenDate(cfValue(v.openDate), refYear, today);
@@ -183,6 +193,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     hardFilters,
     sanctions,
     dateIssues: dateValidation.issues,
+    imsbcIssues,
     filterOut,
     filterReason,
   };
@@ -474,6 +485,7 @@ export async function analyzePairs(
       issues: [
         'Not selected by AI for detailed evaluation — review manually',
         ...(analysis.dateIssues.length > 0 ? analysis.dateIssues : []),
+        ...(analysis.imsbcIssues.length > 0 ? analysis.imsbcIssues : []),
         ...(analysis.sanctions.risk === 'MEDIUM' && analysis.sanctions.reason
           ? [`Sanctions: ${analysis.sanctions.reason}`]
           : []),
@@ -519,6 +531,9 @@ export async function analyzePairs(
     withReadiness.sanctions = analysis.sanctions;
     if (analysis.dateIssues.length > 0) {
       withReadiness.issues = [...(withReadiness.issues ?? []), ...analysis.dateIssues];
+    }
+    if (analysis.imsbcIssues.length > 0) {
+      withReadiness.issues = [...(withReadiness.issues ?? []), ...analysis.imsbcIssues];
     }
     if (analysis.sanctions.risk === 'MEDIUM' && analysis.sanctions.reason) {
       withReadiness.issues = [

--- a/lib/sailing/__tests__/imsbc-check.test.ts
+++ b/lib/sailing/__tests__/imsbc-check.test.ts
@@ -1,0 +1,248 @@
+import { checkImsbcLoadability } from '../imsbc-check';
+
+describe('checkImsbcLoadability — Group C (safe)', () => {
+  it('wheat → Group C, ok, no requirements', () => {
+    const r = checkImsbcLoadability('wheat');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+    expect(r.requirements).toHaveLength(0);
+  });
+
+  it('steel slabs → Group C via steel alias', () => {
+    const r = checkImsbcLoadability('steel slabs');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('HRC (Hot Rolled Coils) → Group C via alias', () => {
+    const r = checkImsbcLoadability('HRC');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('cement → Group C', () => {
+    const r = checkImsbcLoadability('cement');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('clinker → Group C', () => {
+    const r = checkImsbcLoadability('Bulk clinker');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('soya in bulk → Group C (alias → soybean)', () => {
+    const r = checkImsbcLoadability('Soya in bulk');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('urea → Group C (not generic fertilizer)', () => {
+    const r = checkImsbcLoadability('urea');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('potash → Group C', () => {
+    const r = checkImsbcLoadability('muriate of potash');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('alumina → Group C (processed bauxite)', () => {
+    const r = checkImsbcLoadability('Alumina in bulk');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('scrap → Group C (HMS)', () => {
+    const r = checkImsbcLoadability('soft stainless scrap');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('salt → Group C', () => {
+    const r = checkImsbcLoadability('Salt in big bags');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('sugar → Group C', () => {
+    const r = checkImsbcLoadability('Bulk sugar');
+    expect(r.group).toBe('C');
+    expect(r.verdict).toBe('ok');
+  });
+});
+
+describe('checkImsbcLoadability — Group A (liquefaction risk)', () => {
+  it('iron ore → Group A, caution, TML cert required', () => {
+    const r = checkImsbcLoadability('iron ore');
+    expect(r.group).toBe('A');
+    expect(r.verdict).toBe('caution');
+    expect(r.requirements.some((req) => /TML/i.test(req))).toBe(true);
+    expect(r.rationale).toMatch(/liquefaction/i);
+  });
+
+  it('bauxite → Group A', () => {
+    const r = checkImsbcLoadability('Bauxite, quantity flexible');
+    expect(r.group).toBe('A');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('nickel ore → Group A (high liquefaction risk)', () => {
+    const r = checkImsbcLoadability('nickel ore');
+    expect(r.group).toBe('A');
+    expect(r.verdict).toBe('caution');
+    expect(r.requirements.some((req) => /TML/i.test(req))).toBe(true);
+  });
+
+  it('manganese ore → Group A', () => {
+    const r = checkImsbcLoadability('Bulk manganese ore');
+    expect(r.group).toBe('A');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('rock phosphate → Group A', () => {
+    const r = checkImsbcLoadability('Rock phosphate in bulk');
+    expect(r.group).toBe('A');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('copper concentrate → Group B (dual A+B: B is dominant hazard)', () => {
+    const r = checkImsbcLoadability('copper concentrate');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+    // Requirements should mention both TML and H2S
+    expect(r.requirements.some((req) => /TML/i.test(req))).toBe(true);
+    expect(r.requirements.some((req) => /H2S/i.test(req))).toBe(true);
+  });
+});
+
+describe('checkImsbcLoadability — Group B (chemical hazard)', () => {
+  it('coal → Group B, caution, gas monitoring required', () => {
+    const r = checkImsbcLoadability('coal in bulk');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+    expect(r.imoClass).toBe('4.2');
+    expect(r.requirements.some((req) => /methane|gas/i.test(req))).toBe(true);
+  });
+
+  it('anthracite → Group B, caution', () => {
+    const r = checkImsbcLoadability('Anthracite, stowage factor 43');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+    expect(r.imoClass).toBe('4.2');
+  });
+
+  it('metcoke → Group B via alias', () => {
+    const r = checkImsbcLoadability('Metcoke in bulk');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('DRI → Group B, caution, dedicated voyage note', () => {
+    const r = checkImsbcLoadability('dri');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+    expect(r.imoClass).toBe('4.2');
+    expect(r.requirements.some((req) => /dedicated|moisture|water/i.test(req))).toBe(true);
+  });
+
+  it('sulphur → Group B class 4.1', () => {
+    const r = checkImsbcLoadability('sulphur');
+    expect(r.group).toBe('B');
+    expect(r.imoClass).toBe('4.1');
+  });
+
+  it('fertilizers (generic) → Group B conservative', () => {
+    const r = checkImsbcLoadability('Fertilizers');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('rapeseed meal → Group B, self-heating risk', () => {
+    const r = checkImsbcLoadability('Rapeseed meal pellets in bulk');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('olive pomace → Group B, self-heating', () => {
+    const r = checkImsbcLoadability('Olive pomace, stowage factor 58');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('coal tar pitch → Group B', () => {
+    const r = checkImsbcLoadability('Coal tar pitch in big bags');
+    expect(r.group).toBe('B');
+    expect(r.verdict).toBe('caution');
+  });
+});
+
+describe('checkImsbcLoadability — incompatible (Group B + vessel DG restriction)', () => {
+  it('coal + vessel "no dangerous goods" → incompatible', () => {
+    const r = checkImsbcLoadability('coal', { restrictions: ['no dangerous goods'] });
+    expect(r.verdict).toBe('incompatible');
+    expect(r.rationale).toMatch(/vessel restrictions/i);
+  });
+
+  it('DRI + vessel "no self-heating cargo" → incompatible', () => {
+    const r = checkImsbcLoadability('dri', { restrictions: ['no self-heating cargo'] });
+    expect(r.verdict).toBe('incompatible');
+  });
+
+  it('Group A cargo (iron ore) + DG restriction → still caution (A not blocked by DG restriction)', () => {
+    const r = checkImsbcLoadability('iron ore', { restrictions: ['no dangerous goods'] });
+    expect(r.verdict).toBe('caution');
+    expect(r.group).toBe('A');
+  });
+
+  it('Group C cargo (wheat) + DG restriction → ok (group C never blocked)', () => {
+    const r = checkImsbcLoadability('wheat', { restrictions: ['no dangerous goods'] });
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('Group B cargo + unrelated restriction → caution (not blocked)', () => {
+    const r = checkImsbcLoadability('coal', { restrictions: ['no refrigerated cargo', 'min DWT 25000'] });
+    expect(r.verdict).toBe('caution');
+  });
+
+  it('Group B cargo + vessel no restrictions → caution', () => {
+    const r = checkImsbcLoadability('coal', { restrictions: [] });
+    expect(r.verdict).toBe('caution');
+  });
+});
+
+describe('checkImsbcLoadability — unknown cargo (neutral)', () => {
+  it('null cargo → ok (neutral)', () => {
+    const r = checkImsbcLoadability(null);
+    expect(r.group).toBe('unknown');
+    expect(r.verdict).toBe('ok');
+    expect(r.requirements).toHaveLength(0);
+  });
+
+  it('empty string → ok (neutral)', () => {
+    const r = checkImsbcLoadability('');
+    expect(r.group).toBe('unknown');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('"mobile machinery" → ok (not in IMSBC table — neutral)', () => {
+    const r = checkImsbcLoadability('Mobile machinery, 10 units, part cargo');
+    expect(r.group).toBe('unknown');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('"bulk cargo, commodity not specified" → ok (neutral)', () => {
+    const r = checkImsbcLoadability('Bulk cargo, commodity not specified');
+    expect(r.group).toBe('unknown');
+    expect(r.verdict).toBe('ok');
+  });
+
+  it('unknown + vessel DG restriction → still ok (not in table → no restriction)', () => {
+    const r = checkImsbcLoadability('exotic widget pellets', { restrictions: ['no dangerous goods'] });
+    expect(r.group).toBe('unknown');
+    expect(r.verdict).toBe('ok');
+  });
+});

--- a/lib/sailing/__tests__/match-filters.test.ts
+++ b/lib/sailing/__tests__/match-filters.test.ts
@@ -4,6 +4,7 @@ import {
   checkVolume,
   checkCargoVesselCompat,
   checkCargoWeight,
+  checkImsbc,
   runHardFilters,
   STOWAGE_FACTORS,
 } from '../match-filters';
@@ -377,5 +378,125 @@ describe('runHardFilters', () => {
     });
     expect(r.pass).toBe(false);
     expect(r.failures.length).toBeGreaterThanOrEqual(2); // draft + volume
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// IMSBC hard-gate (checkImsbc)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('checkImsbc — hard-gate', () => {
+  it('Group C cargo → always passes', () => {
+    const r = checkImsbc('wheat');
+    expect(r.pass).toBe(true);
+  });
+
+  it('Group A cargo (iron ore) + DG restriction → passes (group A is not hard-blocked)', () => {
+    const r = checkImsbc('iron ore', ['no dangerous goods']);
+    expect(r.pass).toBe(true);
+  });
+
+  it('Group B cargo + no vessel restrictions → passes (caution only, not block)', () => {
+    const r = checkImsbc('coal', []);
+    expect(r.pass).toBe(true);
+  });
+
+  it('Group B cargo + DG restriction → blocked', () => {
+    const r = checkImsbc('coal', ['no dangerous goods']);
+    expect(r.pass).toBe(false);
+    expect(r.reason).toMatch(/vessel restrictions/i);
+  });
+
+  it('DRI + self-heating restriction → blocked', () => {
+    const r = checkImsbc('dri', ['no self-heating cargo', 'gearless']);
+    expect(r.pass).toBe(false);
+  });
+
+  it('unknown cargo + DG restriction → passes (unknown is neutral)', () => {
+    const r = checkImsbc('exotic pellets', ['no dangerous goods']);
+    expect(r.pass).toBe(true);
+  });
+
+  it('null cargo description → passes (graceful)', () => {
+    const r = checkImsbc(null, ['no dangerous goods']);
+    expect(r.pass).toBe(true);
+  });
+});
+
+describe('runHardFilters — IMSBC integration', () => {
+  it('Group B cargo + vessel DG restriction → runHardFilters fails', () => {
+    const r = runHardFilters({
+      cargoType: 'BULK',
+      originPort: null,
+      weightMt: null,
+      cargoDescription: 'coal',
+      stowageFactor: null,
+      vesselType: 'bulk carrier',
+      geared: true,
+      draftMax: null,
+      grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
+      vesselRestrictions: ['no dangerous goods'],
+    });
+    expect(r.pass).toBe(false);
+    expect(r.checks.imsbc.pass).toBe(false);
+    expect(r.failures.some((f) => /vessel restrictions/i.test(f))).toBe(true);
+  });
+
+  it('Group B cargo + no restrictions → runHardFilters passes (caution only)', () => {
+    const r = runHardFilters({
+      cargoType: 'BULK',
+      originPort: null,
+      weightMt: null,
+      cargoDescription: 'coal',
+      stowageFactor: null,
+      vesselType: 'bulk carrier',
+      geared: true,
+      draftMax: null,
+      grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
+      vesselRestrictions: [],
+    });
+    expect(r.pass).toBe(true);
+    expect(r.checks.imsbc.pass).toBe(true);
+  });
+
+  it('Group A cargo (iron ore) + DG restriction → runHardFilters passes (A not blocked)', () => {
+    const r = runHardFilters({
+      cargoType: 'BULK',
+      originPort: null,
+      weightMt: null,
+      cargoDescription: 'iron ore',
+      stowageFactor: null,
+      vesselType: 'bulk carrier',
+      geared: true,
+      draftMax: null,
+      grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
+      vesselRestrictions: ['no dangerous goods'],
+    });
+    expect(r.pass).toBe(true);
+    expect(r.checks.imsbc.pass).toBe(true);
+  });
+
+  it('vesselRestrictions undefined → runHardFilters passes gracefully', () => {
+    const r = runHardFilters({
+      cargoType: 'BULK',
+      originPort: null,
+      weightMt: null,
+      cargoDescription: 'coal',
+      stowageFactor: null,
+      vesselType: 'bulk carrier',
+      geared: true,
+      draftMax: null,
+      grainCapacity: null,
+      dwtSummer: null,
+      dwcc: null,
+    });
+    expect(r.pass).toBe(true);
+    expect(r.checks.imsbc.pass).toBe(true);
   });
 });

--- a/lib/sailing/imsbc-check.ts
+++ b/lib/sailing/imsbc-check.ts
@@ -1,0 +1,338 @@
+/**
+ * IMSBC Code group lookup — structural per-cargo hazard classification.
+ *
+ * Group A: liquefaction risk — TML certificate required at loading.
+ * Group B: chemical hazard — IMDG class applies, special handling required.
+ * Group C: neither Group A nor B — no special bulk-carrier restriction.
+ * unknown: cargo not in the IMSBC table — neutral (not a block, not a caution).
+ *
+ * Design rules (mirror of l5c-matrix.ts):
+ *   - Pure functions; no IO, no side effects. JSON loaded lazily once at first call.
+ *   - Date-independent: verdict never depends on wall-clock.
+ *   - Group alone is NOT an incompatibility (coal, iron ore ship constantly).
+ *   - incompatible only when vessel explicitly restricts dangerous-goods carriage.
+ *   - unknown cargo → ok/neutral (fail-safe: no data ≠ can't carry).
+ */
+
+import type imsbcData from '../cargo/imsbc-groups.json';
+
+type ImsbcGroup = 'A' | 'B' | 'C';
+
+interface ImsbcEntry {
+  group: ImsbcGroup;
+  imoClass?: string;
+  requirements?: string[];
+}
+
+export interface ImsbcLoadabilityResult {
+  group: ImsbcGroup | 'unknown';
+  imoClass?: string;
+  verdict: 'ok' | 'caution' | 'incompatible';
+  requirements: string[];
+  rationale: string;
+}
+
+export interface VesselImsbcInfo {
+  restrictions?: string[];
+  specialFeatures?: string[];
+}
+
+// ── Taxonomy ──────────────────────────────────────────────────────────────────
+// Maps lowercase variant/alias → canonical JSON key.
+// Extend here when new cargo names appear in production data.
+const TAXONOMY: Record<string, string> = {
+  // coal variants
+  'coking coal': 'coal',
+  'thermal coal': 'coal',
+  'steam coal': 'coal',
+  'met coal': 'coal',
+  'bituminous coal': 'coal',
+  'sub-bituminous coal': 'coal',
+  'coal fines': 'coal',
+  // anthracite is its own entry
+  // coke variants
+  metcoke: 'met coke',
+  'met coke': 'met coke',
+  'metallurgical coke': 'met coke',
+  coke: 'met coke',
+  petcoke: 'petroleum coke',
+  'pet coke': 'petroleum coke',
+  'petroleum coke': 'petroleum coke',
+  'delayed coke': 'petroleum coke',
+  // coal tar pitch
+  'coal-tar pitch': 'coal tar pitch',
+  ctp: 'coal tar pitch',
+  // iron ore & pellets
+  'iron ore fines': 'iron ore',
+  'iron ore concentrate': 'iron ore',
+  'fe ore': 'iron ore',
+  ironore: 'iron ore',
+  'iron ore pellets': 'iron ore pellets',
+  'iron pellets': 'iron ore pellets',
+  'dr pellets': 'iron ore pellets',
+  // DRI / HBI
+  'direct reduced iron': 'dri',
+  hbi: 'dri',
+  'hot briquetted iron': 'dri',
+  'sponge iron': 'dri',
+  // concentrates
+  'copper conc': 'copper concentrate',
+  'cu concentrate': 'copper concentrate',
+  'zinc conc': 'zinc concentrate',
+  'lead conc': 'lead concentrate',
+  'laterite nickel ore': 'nickel ore',
+  saprolite: 'nickel ore',
+  // grain
+  maize: 'corn',
+  soya: 'soybean',
+  soyabean: 'soybean',
+  'unpeeled rice': 'rice',
+  'bagged rice': 'rice',
+  'soya in bulk': 'soybean',
+  'soybean meal': 'rapeseed meal', // NOT the same but similarly hazardous → conservative
+  // steel & metals
+  hrc: 'steel',
+  'hr coils': 'steel',
+  'cr coils': 'steel',
+  billets: 'steel',
+  slabs: 'steel',
+  rebar: 'steel',
+  rebars: 'steel',
+  'wire rod': 'steel',
+  'steel coils': 'steel',
+  'steel plates': 'steel',
+  'steel billets': 'steel',
+  'steel slabs': 'steel',
+  'steel sections': 'steel',
+  'steel products': 'steel',
+  'structural steel': 'steel',
+  'pc strand': 'steel',
+  'hot rolled coils': 'steel',
+  'hot rolled steel coils': 'steel',
+  'steel rebars': 'steel',
+  'pig iron': 'pig iron',
+  'cast iron': 'pig iron',
+  // scrap
+  hms: 'scrap',
+  'heavy melting scrap': 'scrap',
+  'shredded scrap': 'scrap',
+  'steel scrap': 'scrap',
+  'iron scrap': 'scrap',
+  'stainless scrap': 'scrap',
+  // cement/clinker
+  opc: 'cement',
+  'cement clinker': 'clinker',
+  'portland cement': 'cement',
+  // bauxite/alumina
+  'bauxite ore': 'bauxite',
+  'raw bauxite': 'bauxite',
+  'calcined alumina': 'alumina',
+  'aluminium oxide': 'alumina',
+  // fertilizers
+  fertilizers: 'fertilizer',
+  'compound fertilizer': 'fertilizer',
+  npk: 'fertilizer',
+  'mixed fertilizer': 'fertilizer',
+  'urea fertilizer': 'urea',
+  'prilled urea': 'urea',
+  'granular urea': 'urea',
+  an: 'ammonium nitrate',
+  can: 'ammonium nitrate',
+  'calcium ammonium nitrate': 'ammonium nitrate',
+  'ammonium nitrate fertilizer': 'ammonium nitrate',
+  mop: 'potash',
+  'muriate of potash': 'potash',
+  sop: 'potash',
+  'potassium chloride': 'potash',
+  'dap fertilizer': 'dap',
+  'diammonium phosphate': 'dap',
+  'map fertilizer': 'map',
+  'monoammonium phosphate': 'map',
+  // phosphate / minerals
+  'phosphate rock': 'rock phosphate',
+  'phosphate ore': 'rock phosphate',
+  'manganese ore': 'manganese ore',
+  'mn ore': 'manganese ore',
+  ilmenite: 'ilmenite',
+  'titanium ore': 'ilmenite',
+  fluorite: 'fluorspar',
+  'calcium fluoride': 'fluorspar',
+  // sulphur
+  sulfur: 'sulphur',
+  'elemental sulphur': 'sulphur',
+  // rapeseed
+  'rapeseed meal': 'rapeseed meal',
+  'rapeseed expellers': 'rapeseed meal',
+  'canola meal': 'rapeseed meal',
+  'canola expellers': 'rapeseed meal',
+  'rapeseed meal pellets': 'rapeseed meal',
+  // seeds (NOT meal — seeds are Group C)
+  canola: 'rapeseed',
+  'canola seeds': 'rapeseed',
+  'rapeseed seeds': 'rapeseed',
+  // sunflower
+  'sunflower seed': 'sunflower seeds',
+  // olive
+  'olive residue': 'olive pomace',
+  'olive cake': 'olive pomace',
+  // salt
+  'dry salt': 'salt',
+  'rock salt': 'salt',
+  'industrial salt': 'salt',
+  'sea salt': 'salt',
+  // sugar
+  'raw sugar': 'sugar',
+  'refined sugar': 'sugar',
+  'cane sugar': 'sugar',
+  // misc
+  'soda ash': 'soda ash',
+  'sodium carbonate': 'soda ash',
+  'dense soda ash': 'soda ash',
+  'light soda ash': 'soda ash',
+  'barium sulphate': 'barite',
+  baryte: 'barite',
+  'marble blocks': 'marble',
+  'granite blocks': 'granite',
+  'wood chips': 'woodchips',
+  'wood pellets': 'wood pellets',
+  kaolin: 'kaolin',
+  'kaolin clay': 'kaolin',
+  bentonite: 'bentonite',
+  'calcium carbide': 'calcium carbide',
+  ferrosilicon: 'ferrosilicon',
+  'ferro silicon': 'ferrosilicon',
+  'fish meal': 'fishmeal',
+  'fish powder': 'fishmeal',
+};
+
+// Lazy-loaded cargo map
+let _cargoes: Record<string, ImsbcEntry> | null = null;
+
+function getCargoes(): Record<string, ImsbcEntry> {
+  if (!_cargoes) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const data = require('../cargo/imsbc-groups.json') as typeof imsbcData;
+    _cargoes = data.cargoes as unknown as Record<string, ImsbcEntry>;
+  }
+  return _cargoes;
+}
+
+function normalize(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[-_]+/g, ' ')
+    .replace(/[,;:!?()\[\]]+/g, ' ')  // strip internal punctuation → space
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Resolve raw cargo description to a canonical JSON key.
+ * Tries: TAXONOMY alias → direct JSON key → prefix match on first 2 words.
+ */
+function resolveKey(desc: string): string | null {
+  const norm = normalize(desc);
+
+  // Exact taxonomy alias
+  if (TAXONOMY[norm]) return TAXONOMY[norm];
+
+  const cargoes = getCargoes();
+
+  // Direct key match
+  if (cargoes[norm]) return norm;
+
+  // Check if any word/phrase in the description matches a taxonomy alias
+  // Longest-match first: try 4-word then 3-word then 2-word substrings
+  const words = norm.split(' ');
+  for (let len = Math.min(4, words.length); len >= 2; len--) {
+    for (let start = 0; start + len <= words.length; start++) {
+      const phrase = words.slice(start, start + len).join(' ');
+      if (TAXONOMY[phrase]) return TAXONOMY[phrase];
+      if (cargoes[phrase]) return phrase;
+    }
+  }
+
+  // Single-word match (last resort)
+  for (const word of words) {
+    if (word.length >= 4) {
+      if (TAXONOMY[word]) return TAXONOMY[word];
+      if (cargoes[word]) return word;
+    }
+  }
+
+  return null;
+}
+
+// Vessel restriction patterns that indicate DG cargo is prohibited.
+const DG_RESTRICTION_RE = /\bno\b.{0,40}(?:dg\b|dangerous\s+goods?\b|hazmat\b|hazardous\b|self[- ]heat(?:ing)?\b|group\s*b\b|class\s*[45]\b)/i;
+
+/**
+ * Check whether a cargo is loadable on a vessel per IMSBC Code.
+ *
+ * - Group C or unknown cargo → ok (no restriction).
+ * - Group A → caution (TML certificate required).
+ * - Group B → caution unless vessel explicitly restricts DG → incompatible.
+ */
+export function checkImsbcLoadability(
+  cargoDescription: string | null | undefined,
+  vessel?: VesselImsbcInfo,
+): ImsbcLoadabilityResult {
+  const nullResult: ImsbcLoadabilityResult = {
+    group: 'unknown',
+    verdict: 'ok',
+    requirements: [],
+    rationale: 'cargo not identified — no IMSBC restriction applied',
+  };
+
+  if (!cargoDescription?.trim()) return nullResult;
+
+  const key = resolveKey(cargoDescription);
+  if (!key) return nullResult;
+
+  const cargoes = getCargoes();
+  const entry = cargoes[key];
+  if (!entry) return nullResult;
+
+  const { group, imoClass, requirements = [] } = entry;
+
+  if (group === 'C') {
+    return {
+      group: 'C',
+      verdict: 'ok',
+      requirements: [],
+      rationale: `IMSBC Group C — no special bulk-carrier restriction`,
+    };
+  }
+
+  if (group === 'A') {
+    return {
+      group: 'A',
+      verdict: 'caution',
+      requirements,
+      rationale: `IMSBC Group A (liquefaction risk) — TML certificate required before loading`,
+    };
+  }
+
+  // Group B
+  const restrictions = vessel?.restrictions ?? [];
+  const hasDgRestriction = restrictions.some((r) => DG_RESTRICTION_RE.test(r));
+
+  if (hasDgRestriction) {
+    return {
+      group: 'B',
+      imoClass,
+      verdict: 'incompatible',
+      requirements,
+      rationale: `IMSBC Group B (IMDG Class ${imoClass ?? 'chemical hazard'}) — vessel restrictions prohibit dangerous-goods carriage`,
+    };
+  }
+
+  return {
+    group: 'B',
+    imoClass,
+    verdict: 'caution',
+    requirements,
+    rationale: `IMSBC Group B (IMDG Class ${imoClass ?? 'chemical hazard'}) — special handling required`,
+  };
+}

--- a/lib/sailing/match-filters.ts
+++ b/lib/sailing/match-filters.ts
@@ -15,6 +15,7 @@
 
 import { getPortMaster, portCanHandleDraft, portHasShoreCranes } from './port-master';
 import { CargoType, Range, isRange } from '../types';
+import { checkImsbcLoadability } from './imsbc-check';
 
 export interface FilterResult {
   pass: boolean;
@@ -249,6 +250,21 @@ export function checkCargoVesselCompat(input: CargoVesselCompatInput): FilterRes
 // Unified runner
 // ────────────────────────────────────────────────────────────────────────────
 
+// ────────────────────────────────────────────────────────────────────────────
+// IMSBC check — hard-gate ONLY when vessel explicitly restricts DG carriage
+//   and cargo is IMSBC Group B (chemical hazard).
+//   Group A/C/unknown → always passes here (caution surfaced separately).
+// ────────────────────────────────────────────────────────────────────────────
+
+export function checkImsbc(
+  cargoDescription: string | null,
+  vesselRestrictions?: string[],
+): FilterResult {
+  const result = checkImsbcLoadability(cargoDescription, { restrictions: vesselRestrictions });
+  if (result.verdict !== 'incompatible') return { pass: true };
+  return { pass: false, reason: result.rationale };
+}
+
 export interface HardFilterInput {
   cargoType: CargoType;
   originPort: string | null;
@@ -262,6 +278,7 @@ export interface HardFilterInput {
   grainCapacity: number | null;
   dwtSummer: number | null;
   dwcc: number | null;
+  vesselRestrictions?: string[];
 }
 
 export interface HardFilterResult {
@@ -275,6 +292,7 @@ export interface HardFilterResult {
     destDraft: FilterResult;
     destCrane: FilterResult;
     cargoWeight: FilterResult;
+    imsbc: FilterResult;
   };
 }
 
@@ -298,6 +316,7 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
     dwtSummer: input.dwtSummer,
     dwcc: input.dwcc,
   });
+  const imsbc = checkImsbc(input.cargoDescription, input.vesselRestrictions);
 
   const failures: string[] = [];
   if (!draft.pass && draft.reason) failures.push(draft.reason);
@@ -307,11 +326,12 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
   if (!destDraft.pass && destDraft.reason) failures.push(destDraft.reason);
   if (!destCrane.pass && destCrane.reason) failures.push(destCrane.reason);
   if (!cargoWeight.pass && cargoWeight.reason) failures.push(cargoWeight.reason);
+  if (!imsbc.pass && imsbc.reason) failures.push(imsbc.reason);
 
   return {
     pass: failures.length === 0,
     failures,
-    checks: { draft, crane, volume, cargoVessel, destDraft, destCrane, cargoWeight },
+    checks: { draft, crane, volume, cargoVessel, destDraft, destCrane, cargoWeight, imsbc },
   };
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -375,6 +375,7 @@ export interface MatchHardFilters {
   destDraft: HardFilterCheck;
   destCrane: HardFilterCheck;
   cargoWeight: HardFilterCheck;
+  imsbc?: HardFilterCheck;
 }
 
 /** Sanctions screening (see lib/validation/sanctions.ts). */


### PR DESCRIPTION
Structured cargo→IMSBC group (A/B/C) + class table (lib/cargo/imsbc-groups.json, 74 cargoes — mirrors l5c-matrix pattern, NOT RAG). lib/sailing/imsbc-check.ts checkImsbcLoadability + hard-gate in match-filters.ts ONLY on explicit incompatibility; Group A/B = soft note, unknown = neutral, date-independent. 552/552 tests green.

⚠️ Founder review needed: hard-gate-vs-soft design choice + cargo coverage (74 cargoes). NOT auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)