### PR TITLE
feat(econ): render war-risk JWC breakdown in EconomicsTab

### DIFF
--- a/__tests__/components/match/EconomicsTab-warrisk.test.tsx
+++ b/__tests__/components/match/EconomicsTab-warrisk.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ *
+ * PI2 behavioral tests for JWC war-risk section in EconomicsTab.
+ * Replaces "coming in Wave 2" placeholder with real breakdown render.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { EconomicsTab } from '@/components/match/EconomicsTab';
+import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
+
+function mockEuaFetch() {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ value: 65.0, period: '2026-05-31', stale: false }),
+  } as Response);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const WAR_RISK_BREAKDOWN: WarRiskBreakdown = {
+  hullPremiumUsd: 6_000,
+  crewWarBonusUsd: 10_000,
+  piSurchargeUsd: 20_000,
+  totalPremiumUsd: 36_000,
+};
+
+describe('EconomicsTab — JWC war-risk section', () => {
+  it('renders JWC zone names when war risk zones are present', async () => {
+    mockEuaFetch();
+    await act(async () => {
+      render(
+        <EconomicsTab
+          warRiskPremium={6_000}
+          warRiskZones={['Red Sea / Bab al-Mandeb HRA']}
+          warRiskBreakdown={WAR_RISK_BREAKDOWN}
+        />,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('warrisk-section')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('warrisk-section')).toHaveTextContent(
+      'Red Sea / Bab al-Mandeb HRA',
+    );
+  });
+
+  it('renders hull, crew, P&I, and total breakdown rows', async () => {
+    mockEuaFetch();
+    await act(async () => {
+      render(
+        <EconomicsTab
+          warRiskPremium={6_000}
+          warRiskZones={['Red Sea / Bab al-Mandeb HRA']}
+          warRiskBreakdown={WAR_RISK_BREAKDOWN}
+        />,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('warrisk-section')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('warrisk-hull')).toHaveTextContent('6,000');
+    expect(screen.getByTestId('warrisk-crew')).toHaveTextContent('10,000');
+    expect(screen.getByTestId('warrisk-pi')).toHaveTextContent('20,000');
+    expect(screen.getByTestId('warrisk-total')).toHaveTextContent('36,000');
+  });
+
+  it('does NOT show the Wave 2 placeholder when war risk data is provided', async () => {
+    mockEuaFetch();
+    await act(async () => {
+      render(
+        <EconomicsTab
+          warRiskPremium={6_000}
+          warRiskZones={['Gulf of Guinea HRA']}
+          warRiskBreakdown={WAR_RISK_BREAKDOWN}
+        />,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('warrisk-section')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/coming in spec-08/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Wave 2/i)).not.toBeInTheDocument();
+  });
+
+  it('shows no-risk message when warRiskPremium is 0', async () => {
+    mockEuaFetch();
+    await act(async () => {
+      render(
+        <EconomicsTab
+          warRiskPremium={0}
+          warRiskZones={[]}
+          warRiskBreakdown={undefined}
+        />,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('warrisk-none')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('warrisk-section')).not.toBeInTheDocument();
+  });
+
+  it('shows no-risk message when warRiskPremium is undefined (not passed)', async () => {
+    mockEuaFetch();
+    await act(async () => { render(<EconomicsTab />); });
+    await waitFor(() =>
+      expect(screen.getByTestId('warrisk-none')).toBeInTheDocument(),
+    );
+  });
+
+  it('handles multiple zones in the same route', async () => {
+    mockEuaFetch();
+    const breakdown: WarRiskBreakdown = {
+      hullPremiumUsd: 12_000,
+      crewWarBonusUsd: 10_000,
+      piSurchargeUsd: 20_000,
+      totalPremiumUsd: 42_000,
+    };
+    await act(async () => {
+      render(
+        <EconomicsTab
+          warRiskPremium={12_000}
+          warRiskZones={['Red Sea / Bab al-Mandeb HRA', 'Gulf of Guinea HRA']}
+          warRiskBreakdown={breakdown}
+        />,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('warrisk-section')).toBeInTheDocument(),
+    );
+    const section = screen.getByTestId('warrisk-section');
+    expect(section).toHaveTextContent('Red Sea / Bab al-Mandeb HRA');
+    expect(section).toHaveTextContent('Gulf of Guinea HRA');
+  });
+});

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -6,6 +6,7 @@ import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
 import { calculateFuelEu } from '@/lib/economics/fueleu';
 import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
+import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
 
 interface EconomicsTabProps {
   commissionPercent?: number | null;
@@ -20,6 +21,9 @@ interface EconomicsTabProps {
   matchDbId?: number | null;
   storedFreightRate?: number | null;
   freightRateSource?: string | null;
+  warRiskPremium?: number | null;
+  warRiskZones?: string[] | null;
+  warRiskBreakdown?: WarRiskBreakdown | null;
 }
 
 function parseLeadingNumber(s: string | null | undefined): number {
@@ -52,7 +56,7 @@ const DISPLAY_RATES: Record<DisplayCurrency, number> = {
   USD: 1, EUR: 0.926, GBP: 0.787, NOK: 10.87, AED: 3.67,
 };
 
-export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm, matchDbId, storedFreightRate, freightRateSource }: EconomicsTabProps) {
+export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm, matchDbId, storedFreightRate, freightRateSource, warRiskPremium, warRiskZones, warRiskBreakdown }: EconomicsTabProps) {
   const [open, setOpen] = useState(false);
   const [bunkerPriceUsdPerMt, setBunkerPriceUsdPerMt] = useState('');
   const [overrideRate, setOverrideRate] = useState(storedFreightRate != null ? String(storedFreightRate) : '');
@@ -484,9 +488,54 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
         </button>
       </div>
 
-      <div className="rounded border border-dashed border-gray-300 p-4 text-gray-400 text-center text-xs">
-        Bunker / ETS / war-risk costs — coming in spec-08 (Wave 2)
-      </div>
+      {/* JWC war-risk breakdown */}
+      {warRiskPremium != null && warRiskPremium > 0 && warRiskBreakdown ? (
+        <div data-testid="warrisk-section" className="rounded border border-orange-200 bg-orange-50 p-3 space-y-2">
+          <h3 className="text-xs font-semibold text-orange-900">JWC War Risk (per voyage)</h3>
+          {warRiskZones && warRiskZones.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {warRiskZones.map((zone) => (
+                <span
+                  key={zone}
+                  className="px-1.5 py-0.5 rounded bg-orange-100 text-orange-800 text-xs"
+                >
+                  {zone}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="space-y-1 text-xs">
+            <div className="flex justify-between">
+              <span className="text-gray-600">Hull premium:</span>
+              <span data-testid="warrisk-hull" className="font-medium">
+                ${warRiskBreakdown.hullPremiumUsd.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">Crew war bonus:</span>
+              <span data-testid="warrisk-crew" className="font-medium">
+                ${warRiskBreakdown.crewWarBonusUsd.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">P&amp;I surcharge:</span>
+              <span data-testid="warrisk-pi" className="font-medium">
+                ${warRiskBreakdown.piSurchargeUsd.toLocaleString()}
+              </span>
+            </div>
+            <div className="flex justify-between pt-1 border-t border-orange-200">
+              <span className="text-gray-700 font-medium">Total:</span>
+              <span data-testid="warrisk-total" className="font-semibold text-orange-900">
+                ${warRiskBreakdown.totalPremiumUsd.toLocaleString()}
+              </span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div data-testid="warrisk-none" className="rounded border border-gray-200 bg-gray-50 p-3 text-xs text-gray-500">
+          No JWC war risk zones on this route
+        </div>
+      )}
 
       {compareInputs.ready && (
         <RouteCompareModal

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -77,6 +77,9 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, store
             matchDbId={matchDbId}
             storedFreightRate={storedFreightRate}
             freightRateSource={freightRateSource}
+            warRiskPremium={match.economics?.breakdown?.warRiskPremium ?? null}
+            warRiskZones={match.economics?.breakdown?.warRiskZones ?? null}
+            warRiskBreakdown={match.economics?.breakdown?.warRiskBreakdown ?? null}
           />
         )}
         {activeTab === 'passport' && (


### PR DESCRIPTION
Render war-risk JWC breakdown (warRiskBreakdown + warRiskZones from match.economics) instead of the spec-08 placeholder. Display-only, computation untouched (tce-calculator). 6 new behavioral tests, 55/55 green, tsc clean. Becomes visible in demo after seed rebuild bakes economics fields via engine. Out-of-scope: bunker/ETS, reseed.