### PR TITLE
feat(quote): Send Quote / Save Draft demo handlers

### DIFF
--- a/__tests__/components/QuoteTab.test.tsx
+++ b/__tests__/components/QuoteTab.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral tests for QuoteTab Save Draft and Send Quote handlers.
+ * PI2: tests real click → handler → toast (ToastProvider + ToastContainer rendering).
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ToastProvider } from '@/components/ui/toast/toast-context';
+import { ToastContainer } from '@/components/ui/toast/toast-container';
+
+jest.mock('@/lib/csrf-client', () => ({
+  csrfFetch: jest.fn(),
+}));
+
+jest.mock('@/components/audit-trail', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { QuoteTab } from '@/components/match/QuoteTab';
+
+function renderQuoteTab(props: Partial<React.ComponentProps<typeof QuoteTab>> = {}) {
+  return render(
+    <ToastProvider>
+      <QuoteTab cargoEmailId="email-1" {...props} />
+      <ToastContainer />
+    </ToastProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.clear();
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+  ) as jest.Mock;
+});
+
+describe('QuoteTab — Save Draft + Send Quote handlers', () => {
+  it('Save Draft click shows "Сохранено" toast', async () => {
+    const user = userEvent.setup();
+    renderQuoteTab();
+
+    await user.click(screen.getByRole('button', { name: 'Save Draft' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Сохранено')
+    );
+  });
+
+  it('Save Draft persists draft text to sessionStorage', async () => {
+    const user = userEvent.setup();
+    renderQuoteTab({ cargoEmailId: 'email-42' });
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'Rate: $15,000/day');
+
+    await user.click(screen.getByRole('button', { name: 'Save Draft' }));
+
+    expect(sessionStorage.getItem('quote_draft_email-42')).toBe('Rate: $15,000/day');
+  });
+
+  it('Send Quote click shows "Отправлено" toast when draft is non-empty', async () => {
+    const user = userEvent.setup();
+    renderQuoteTab();
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'Demo quote text');
+
+    await user.click(screen.getByRole('button', { name: 'Send Quote' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Отправлено')
+    );
+  });
+
+  it('Send Quote is disabled when draft is empty', () => {
+    renderQuoteTab();
+    expect(screen.getByRole('button', { name: 'Send Quote' })).toBeDisabled();
+  });
+
+  it('Send Quote is disabled when blockSend=true even with draft', async () => {
+    const user = userEvent.setup();
+    renderQuoteTab({
+      confidence: {
+        level: 'uncertain',
+        blockSend: true,
+        blockedFields: ['port'],
+        fieldConfidences: [],
+      },
+    });
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'Some quote text');
+
+    expect(screen.getByRole('button', { name: 'Send Quote' })).toBeDisabled();
+  });
+});

--- a/__tests__/components/quote-tab-benchmark-link.test.tsx
+++ b/__tests__/components/quote-tab-benchmark-link.test.tsx
@@ -9,6 +9,14 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { QuoteTab } from '@/components/match/QuoteTab';
+import { ToastProvider } from '@/components/ui/toast/toast-context';
+import { ToastContainer } from '@/components/ui/toast/toast-container';
+
+function renderWithToast(ui: React.ReactElement) {
+  return render(
+    <ToastProvider>{ui}<ToastContainer /></ToastProvider>
+  );
+}
 
 function mockFetch(sourceUrl: string) {
   global.fetch = jest.fn().mockResolvedValue({
@@ -31,7 +39,7 @@ afterEach(() => {
 describe('QuoteTab benchmark source link (PI2 — #360)', () => {
   it('does NOT render an anchor when sourceUrl is "static-seed"', async () => {
     mockFetch('static-seed');
-    render(<QuoteTab />);
+    renderWithToast(<QuoteTab />);
 
     await waitFor(() => {
       expect(screen.queryByText('source')).not.toBeInTheDocument();
@@ -40,7 +48,7 @@ describe('QuoteTab benchmark source link (PI2 — #360)', () => {
 
   it('does NOT render an anchor when sourceUrl is a relative path', async () => {
     mockFetch('/some/relative/path');
-    render(<QuoteTab />);
+    renderWithToast(<QuoteTab />);
 
     await waitFor(() => {
       expect(screen.queryByText('source')).not.toBeInTheDocument();
@@ -50,7 +58,7 @@ describe('QuoteTab benchmark source link (PI2 — #360)', () => {
   it('renders anchor with correct href when sourceUrl is a valid https URL', async () => {
     const realUrl = 'https://heavyliftpfi.com/market-data/';
     mockFetch(realUrl);
-    render(<QuoteTab />);
+    renderWithToast(<QuoteTab />);
 
     await waitFor(() => {
       const link = screen.getByText('source');

--- a/components/__tests__/quote-tab-generate-draft.test.tsx
+++ b/components/__tests__/quote-tab-generate-draft.test.tsx
@@ -8,6 +8,14 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { QuoteTab } from '@/components/match/QuoteTab';
+import { ToastProvider } from '@/components/ui/toast/toast-context';
+import { ToastContainer } from '@/components/ui/toast/toast-container';
+
+function renderWithToast(ui: React.ReactElement) {
+  return render(
+    <ToastProvider>{ui}<ToastContainer /></ToastProvider>
+  );
+}
 
 function mockFetchResponses(draftText: string) {
   global.fetch = jest.fn().mockImplementation((url: string) => {
@@ -34,13 +42,13 @@ afterEach(() => {
 describe('QuoteTab — Generate Draft button (fix #351)', () => {
   it('shows Generate button when cargoEmailId is provided', () => {
     mockFetchResponses('');
-    render(<QuoteTab cargoEmailId="email-001" />);
+    renderWithToast(<QuoteTab cargoEmailId="email-001" />);
     expect(screen.getByRole('button', { name: /generate/i })).toBeInTheDocument();
   });
 
   it('shows Generate button as disabled when cargoEmailId is absent', () => {
     mockFetchResponses('');
-    render(<QuoteTab />);
+    renderWithToast(<QuoteTab />);
     const btn = screen.getByRole('button', { name: /generate/i });
     expect(btn).toBeInTheDocument();
     expect(btn).toBeDisabled();
@@ -49,7 +57,7 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
   it('POSTs to /api/ai/draft-quote with emailId on click', async () => {
     const draftText = 'Dear Captain, we offer USD 15/MT for the cargo.';
     mockFetchResponses(draftText);
-    render(<QuoteTab cargoEmailId="email-abc" />);
+    renderWithToast(<QuoteTab cargoEmailId="email-abc" />);
 
     fireEvent.click(screen.getByRole('button', { name: /generate/i }));
 
@@ -67,7 +75,7 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
   it('populates the draft textarea with the API response', async () => {
     const draftText = 'Dear Captain, we offer USD 15/MT for the cargo.';
     mockFetchResponses(draftText);
-    render(<QuoteTab cargoEmailId="email-abc" />);
+    renderWithToast(<QuoteTab cargoEmailId="email-abc" />);
 
     fireEvent.click(screen.getByRole('button', { name: /generate/i }));
 
@@ -88,7 +96,7 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
       return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
     });
 
-    render(<QuoteTab cargoEmailId="email-abc" />);
+    renderWithToast(<QuoteTab cargoEmailId="email-abc" />);
     fireEvent.click(screen.getByRole('button', { name: /generate/i }));
 
     await waitFor(() => {
@@ -98,14 +106,14 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
 
   it('Send Quote is disabled when draft textarea is empty', () => {
     mockFetchResponses('');
-    render(<QuoteTab cargoEmailId="email-001" />);
+    renderWithToast(<QuoteTab cargoEmailId="email-001" />);
     const sendBtn = screen.getByRole('button', { name: /send quote/i });
     expect(sendBtn).toBeDisabled();
   });
 
   it('Send Quote is enabled after draft textarea is filled', () => {
     mockFetchResponses('');
-    render(<QuoteTab cargoEmailId="email-001" />);
+    renderWithToast(<QuoteTab cargoEmailId="email-001" />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT' } });
     const sendBtn = screen.getByRole('button', { name: /send quote/i });
     expect(sendBtn).not.toBeDisabled();

--- a/components/match/QuoteTab.tsx
+++ b/components/match/QuoteTab.tsx
@@ -7,6 +7,7 @@ import type { MatchConfidence } from '@/lib/confidence';
 import type { MarketBenchmark } from '@/lib/types';
 import { formatBenchmarkReference } from '@/lib/market/benchmark';
 import { csrfFetch } from '@/lib/csrf-client';
+import { useToast } from '@/components/ui/toast';
 
 interface QuoteTabProps {
   cargoEmailId?: string;
@@ -20,6 +21,17 @@ export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
   const [benchmark, setBenchmark] = useState<MarketBenchmark | null | 'loading'>('loading');
   const blockSend = confidence?.blockSend ?? false;
   const blockedFields = confidence?.blockedFields ?? [];
+  const toast = useToast();
+
+  function handleSaveDraft() {
+    const key = `quote_draft_${cargoEmailId ?? 'no-id'}`;
+    sessionStorage.setItem(key, draft);
+    toast.success('Сохранено');
+  }
+
+  function handleSendQuote() {
+    toast.success('Отправлено');
+  }
 
   async function generateDraft() {
     if (!cargoEmailId) return;
@@ -80,10 +92,14 @@ export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
           className="rounded bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
           disabled={blockSend || !draft.trim()}
           title={blockSend ? `${blockedFields.length} critical field(s) uncertain: ${blockedFields.join(', ')}` : undefined}
+          onClick={handleSendQuote}
         >
           Send Quote
         </button>
-        <button className="rounded border border-gray-200 px-4 py-2 text-sm">
+        <button
+          className="rounded border border-gray-200 px-4 py-2 text-sm"
+          onClick={handleSaveDraft}
+        >
           Save Draft
         </button>
       </div>

--- a/components/match/__tests__/MatchTabs.test.tsx
+++ b/components/match/__tests__/MatchTabs.test.tsx
@@ -7,6 +7,14 @@ import '@testing-library/jest-dom';
 import { MatchTabs } from '../MatchTabs';
 import type { Match } from '@/lib/types';
 import type { MatchConfidence } from '@/lib/confidence';
+import { ToastProvider } from '@/components/ui/toast/toast-context';
+import { ToastContainer } from '@/components/ui/toast/toast-container';
+
+function renderWithToast(ui: React.ReactElement) {
+  return render(
+    <ToastProvider>{ui}<ToastContainer /></ToastProvider>
+  );
+}
 
 // Mock AuditTrail to avoid real fetch calls
 jest.mock('@/components/audit-trail', () => ({
@@ -45,7 +53,7 @@ const baseMatch: Match = {
 describe('MatchTabs', () => {
   describe('tab navigation', () => {
     it('renders all 4 tab buttons', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       expect(screen.getByRole('tab', { name: /vessels/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /economics/i })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: /passport/i })).toBeInTheDocument();
@@ -53,26 +61,26 @@ describe('MatchTabs', () => {
     });
 
     it('shows Vessels tab content by default', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       expect(screen.getByTestId('tab-vessels')).toBeInTheDocument();
       expect(screen.queryByTestId('tab-economics')).not.toBeInTheDocument();
     });
 
     it('switches to Economics tab on click', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       fireEvent.click(screen.getByRole('tab', { name: /economics/i }));
       expect(screen.getByTestId('tab-economics')).toBeInTheDocument();
       expect(screen.queryByTestId('tab-vessels')).not.toBeInTheDocument();
     });
 
     it('switches to Passport tab on click', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       fireEvent.click(screen.getByRole('tab', { name: /passport/i }));
       expect(screen.getByTestId('tab-passport')).toBeInTheDocument();
     });
 
     it('switches to Quote tab on click', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       expect(screen.getByTestId('tab-quote')).toBeInTheDocument();
     });
@@ -80,13 +88,13 @@ describe('MatchTabs', () => {
 
   describe('a11y tabpanel markup (stab/tabpanels-render)', () => {
     it('renders exactly one [role="tabpanel"] for the active tab', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       const panels = screen.getAllByRole('tabpanel');
       expect(panels).toHaveLength(1);
     });
 
     it('active tabpanel is linked to the active tab via aria-labelledby/id', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       const panel = screen.getByRole('tabpanel');
       const labelledBy = panel.getAttribute('aria-labelledby');
       expect(labelledBy).toBeTruthy();
@@ -97,7 +105,7 @@ describe('MatchTabs', () => {
     });
 
     it('active tab links to its panel via aria-controls', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       const activeTab = screen.getByRole('tab', { selected: true });
       const controls = activeTab.getAttribute('aria-controls');
       expect(controls).toBeTruthy();
@@ -107,7 +115,7 @@ describe('MatchTabs', () => {
     });
 
     it('switches tabpanel when another tab is clicked', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       fireEvent.click(screen.getByRole('tab', { name: /economics/i }));
       const panel = screen.getByRole('tabpanel');
       const labelledBy = panel.getAttribute('aria-labelledby');
@@ -119,32 +127,32 @@ describe('MatchTabs', () => {
   describe('confidence border', () => {
     it('applies verified border class when confidence level is verified', () => {
       const match = { ...baseMatch, confidence: mockConfidenceVerified };
-      const { container } = render(<MatchTabs match={match} />);
+      const { container } = renderWithToast(<MatchTabs match={match} />);
       expect(container.firstChild).toHaveClass('border-blue-500');
     });
 
     it('applies missing border class when no confidence data', () => {
-      const { container } = render(<MatchTabs match={baseMatch} />);
+      const { container } = renderWithToast(<MatchTabs match={baseMatch} />);
       expect(container.firstChild).toHaveClass('border-gray-400');
     });
 
     it('applies uncertain border class when confidence level is uncertain', () => {
       const match = { ...baseMatch, confidence: mockConfidenceBlocked };
-      const { container } = render(<MatchTabs match={match} />);
+      const { container } = renderWithToast(<MatchTabs match={match} />);
       expect(container.firstChild).toHaveClass('border-orange-500');
     });
   });
 
   describe('Generate button in Quote tab (fix #638)', () => {
     it('is enabled when cargoEmailId prop is passed', () => {
-      render(<MatchTabs match={baseMatch} cargoEmailId="cargo-email-1" />);
+      renderWithToast(<MatchTabs match={baseMatch} cargoEmailId="cargo-email-1" />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       const btn = screen.getByRole('button', { name: /generate/i });
       expect(btn).not.toBeDisabled();
     });
 
     it('is disabled when cargoEmailId prop is absent', () => {
-      render(<MatchTabs match={baseMatch} />);
+      renderWithToast(<MatchTabs match={baseMatch} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       const btn = screen.getByRole('button', { name: /generate/i });
       expect(btn).toBeDisabled();
@@ -154,7 +162,7 @@ describe('MatchTabs', () => {
   describe('Send Quote button', () => {
     it('is disabled when draft is empty (blockSend=false)', () => {
       const match = { ...baseMatch, confidence: mockConfidenceVerified };
-      render(<MatchTabs match={match} />);
+      renderWithToast(<MatchTabs match={match} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       const btn = screen.getByRole('button', { name: /send quote/i });
       expect(btn).toBeDisabled();
@@ -162,7 +170,7 @@ describe('MatchTabs', () => {
 
     it('is enabled when draft has content and blockSend is false', () => {
       const match = { ...baseMatch, confidence: mockConfidenceVerified };
-      render(<MatchTabs match={match} />);
+      renderWithToast(<MatchTabs match={match} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT offer' } });
       const btn = screen.getByRole('button', { name: /send quote/i });
@@ -171,7 +179,7 @@ describe('MatchTabs', () => {
 
     it('is disabled when blockSend is true even with draft content', () => {
       const match = { ...baseMatch, confidence: mockConfidenceBlocked };
-      render(<MatchTabs match={match} />);
+      renderWithToast(<MatchTabs match={match} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT offer' } });
       const btn = screen.getByRole('button', { name: /send quote/i });


### PR DESCRIPTION
Wire Send Quote and Save Draft buttons in QuoteTab (were no-op): Save Draft to sessionStorage + toast Сохранено; Send Quote demo toast Отправлено (no real email). 5 new tests + 3 files wrapped ToastProvider, 36/36 green. Out-of-scope: real email send, reseed.