### PR TITLE
feat(matching): wire hold-cleanliness compatibility check into matching

### DIFF
--- a/__tests__/hold-cleanliness-check.test.ts
+++ b/__tests__/hold-cleanliness-check.test.ts
@@ -1,0 +1,120 @@
+import { applyHoldCleanliness } from '@/lib/matching/hold-cleanliness';
+import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+
+function makeMatch(overrides: Partial<Match> = {}): Match {
+  return {
+    cargoEmailId: 'c1',
+    cargoItemIndex: 0,
+    vesselEmailId: 'v1',
+    vesselItemIndex: 0,
+    score: 75,
+    matchLevel: 'good',
+    matchReasons: [],
+    issues: [],
+    ...overrides,
+  };
+}
+
+function makeCargo(description: string): ParsedCargo {
+  return {
+    emailId: 'c1',
+    itemIndex: 0,
+    cargoDescription: { value: description, confidence: 'confirmed', sourceQuote: null },
+    cargoType: 'BULK',
+    originPort: null,
+    originCountry: null,
+    destinationPort: null,
+    destinationCountry: null,
+    weightMt: null,
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+  } as unknown as ParsedCargo;
+}
+
+function makeVessel(lastCargoes: string | null): Pick<ParsedVessel, 'lastCargoes'> {
+  return { lastCargoes };
+}
+
+describe('applyHoldCleanliness', () => {
+  describe('incompatible pair: coal lastCargo → grain cargo', () => {
+    it('adds a cleanliness issue', () => {
+      const m = makeMatch();
+      applyHoldCleanliness(m, makeCargo('grain'), makeVessel('coal') as ParsedVessel);
+      expect(m.issues.some((i) => /cleanliness|incompatible/i.test(i))).toBe(true);
+    });
+
+    it('demotes confidence to uncertain', () => {
+      const m = makeMatch({
+        confidence: {
+          level: 'verified',
+          blockSend: false,
+          blockedFields: [],
+          fieldConfidences: [],
+        },
+      });
+      applyHoldCleanliness(m, makeCargo('grain'), makeVessel('coal') as ParsedVessel);
+      expect(m.confidence?.level).toBe('uncertain');
+      expect(m.confidence?.blockSend).toBe(true);
+    });
+
+    it('slash-separated lastCargoes parses correctly', () => {
+      const m = makeMatch();
+      applyHoldCleanliness(m, makeCargo('grain'), makeVessel('petcoke/coal') as ParsedVessel);
+      expect(m.issues.some((i) => /cleanliness|incompatible/i.test(i))).toBe(true);
+    });
+  });
+
+  describe('compatible pair', () => {
+    it('does not add cleanliness incompatibility issue for wheat → wheat', () => {
+      const m = makeMatch({
+        confidence: { level: 'inferred', blockSend: false, blockedFields: [], fieldConfidences: [] },
+      });
+      applyHoldCleanliness(m, makeCargo('wheat'), makeVessel('wheat') as ParsedVessel);
+      expect(m.issues.filter((i) => /incompatible/i.test(i))).toHaveLength(0);
+      expect(m.confidence?.level).toBe('inferred');
+    });
+
+    it('does nothing when vessel.lastCargoes is null', () => {
+      const m = makeMatch();
+      applyHoldCleanliness(m, makeCargo('grain'), makeVessel(null) as ParsedVessel);
+      expect(m.issues).toHaveLength(0);
+    });
+
+    it('does nothing when cargo description is missing', () => {
+      const m = makeMatch();
+      const cargo = makeCargo('grain');
+      cargo.cargoDescription = null;
+      applyHoldCleanliness(m, cargo, makeVessel('coal') as ParsedVessel);
+      expect(m.issues).toHaveLength(0);
+    });
+  });
+
+  describe('extra_clean caution (compatible but requires cleaning)', () => {
+    it('adds caution issue for extra_clean pair without demotion', () => {
+      // * → DRI triggers extra_clean=true but compatible=true in l5c-matrix
+      const m = makeMatch({
+        confidence: { level: 'inferred', blockSend: false, blockedFields: [], fieldConfidences: [] },
+      });
+      applyHoldCleanliness(m, makeCargo('DRI'), makeVessel('wheat') as ParsedVessel);
+      const hasExtraClean = m.issues.some((i) => /extra clean|caution/i.test(i));
+      expect(hasExtraClean).toBe(true);
+      // confidence must NOT be demoted for compatible+extra_clean
+      expect(m.confidence?.level).toBe('inferred');
+      expect(m.confidence?.blockSend).toBe(false);
+    });
+  });
+});

--- a/lib/cargo/l5c-matrix.ts
+++ b/lib/cargo/l5c-matrix.ts
@@ -254,6 +254,9 @@ export function checkCompatibility(
 
   for (const prev of prevCargoes) {
     if (!prev?.trim()) continue;
+    // Same normalized cargo is always compatible — skip matrix lookup to avoid
+    // false-positive fail-closed on self-pairs absent from the matrix (PR #708).
+    if (normalize(prev) === normalize(contaminationName)) continue;
     const lookup = lookupPair(prev, contaminationName);
     // extra_clean hint accumulates from BOTH matched and unmatched lookups —
     // inverted wildcards (e.g. *→DRI) contribute the hint even when verdict

--- a/lib/matching/hold-cleanliness.ts
+++ b/lib/matching/hold-cleanliness.ts
@@ -1,0 +1,36 @@
+import { checkCompatibility, parseLastCargoes } from '@/lib/cargo/l5c-matrix';
+import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+
+/**
+ * Applies hold cleanliness check (L5C-matrix) to a match in-place.
+ *
+ * - compatible=false → adds issue + demotes confidence to uncertain/blockSend
+ * - requires_extra_clean (compatible) → adds caution issue, no confidence change
+ * - no-ops when vessel.lastCargoes or cargo.cargoDescription is absent
+ */
+export function applyHoldCleanliness(
+  m: Match,
+  cargo: ParsedCargo,
+  vessel: ParsedVessel,
+): void {
+  const cargoName = cargo.cargoDescription?.value;
+  if (!cargoName || !vessel.lastCargoes) return;
+
+  const prevCargoes = parseLastCargoes(vessel.lastCargoes);
+  if (prevCargoes.length === 0) return;
+
+  const compat = checkCompatibility(prevCargoes, cargoName);
+
+  if (!compat.compatible) {
+    const blockers = compat.blocking_pairs.map((p) => p.previous).join(', ');
+    m.issues = [
+      ...(m.issues ?? []),
+      `Hold cleanliness: incompatible with last cargo (${blockers})`,
+    ];
+    if (m.confidence) {
+      m.confidence = { ...m.confidence, level: 'uncertain', blockSend: true };
+    }
+  } else if (compat.requires_extra_clean) {
+    m.issues = [...(m.issues ?? []), 'Hold cleanliness: extra cleaning required (caution)'];
+  }
+}

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -19,6 +19,7 @@ import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { validateDates, isLaycanValid } from '@/lib/sailing/date-sanity';
 import { checkSanctions } from '@/lib/validation/sanctions';
 import { enrichReasons } from '@/lib/matching/reason-enricher';
+import { applyHoldCleanliness } from '@/lib/matching/hold-cleanliness';
 import { buildMatchEconomics, parseLeadingNumber } from '@/lib/matching/tce-calculator';
 import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
@@ -657,6 +658,10 @@ export async function analyzePairs(
       });
       m.fitPercent = fb.fitPercent;
       m.fitBreakdown = fb;
+    }
+    // ── Hold cleanliness (L5C-matrix) ─────────────────────────────────────────
+    if (cargo && vessel) {
+      applyHoldCleanliness(m, cargo, vessel);
     }
   }
 

--- a/tests/cargo/l5c-matrix.test.ts
+++ b/tests/cargo/l5c-matrix.test.ts
@@ -116,4 +116,26 @@ describe('checkCompatibility — L5C matrix', () => {
       expect(prevs).toContain('coal');
     });
   });
+
+  describe('self-pair (same cargo) is always compatible', () => {
+    it('coal → coal: compatible (no self-pair in matrix, must not fail-closed)', () => {
+      const result = checkCompatibility(['coal'], 'coal');
+      expect(result.compatible).toBe(true);
+      expect(result.requires_manual_review).toBe(false);
+      expect(result.blocking_pairs).toHaveLength(0);
+    });
+
+    it('iron-ore → iron-ore: compatible', () => {
+      const result = checkCompatibility(['iron ore'], 'iron-ore');
+      expect(result.compatible).toBe(true);
+      expect(result.requires_manual_review).toBe(false);
+      expect(result.blocking_pairs).toHaveLength(0);
+    });
+
+    it('coal → grain: still prohibited (regression guard)', () => {
+      const result = checkCompatibility(['coal'], 'grain');
+      expect(result.compatible).toBe(false);
+      expect(result.blocking_pairs.map((bp) => bp.previous)).toContain('coal');
+    });
+  });
 });


### PR DESCRIPTION
Parse vessel.lastCargoes and call existing checkCompatibility; incompatible cargo pair adds warning to issues + lowers confidence. Existing fit factors/anchors untouched. 224 tests green. NOTE matching/validator change: run /test-skill cold-QA before merge (Rule #5). Out-of-scope: seed lastCargoes on demo vessels (final reseed), cleanliness UI tab.