### PR TITLE
feat(nav): Laytime calculator nav link (behind flag)

### DIFF
--- a/design-system/patterns/TopNav.tsx
+++ b/design-system/patterns/TopNav.tsx
@@ -72,7 +72,10 @@ function NavLink({ href, children }: { href: string; children: React.ReactNode }
 
 function MoreDropdown() {
   const pathname = usePathname();
-  const isMoreActive = pathname != null && MORE_ITEMS.some(
+  const items = MORE_ITEMS.filter(it =>
+    it.href !== '/laytime' || process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED === 'true',
+  );
+  const isMoreActive = pathname != null && items.some(
     (it) => pathname === it.href || pathname.startsWith(it.href + '/'),
   );
 
@@ -90,7 +93,7 @@ function MoreDropdown() {
         ⋯ More
       </summary>
       <ul className="absolute right-0 mt-2 min-w-[180px] bg-ds-surface border border-ds-border rounded-ds-md shadow-lg py-1 z-40">
-        {MORE_ITEMS.map((it) => {
+        {items.map((it) => {
           const isActive = pathname != null && (pathname === it.href || pathname.startsWith(it.href + '/'));
           return (
             <li key={it.href}>

--- a/design-system/patterns/__tests__/TopNav.test.tsx
+++ b/design-system/patterns/__tests__/TopNav.test.tsx
@@ -211,4 +211,40 @@ describe('TopNav', () => {
       expect(primaryActiveLinks(container)).toHaveLength(0);
     });
   });
+
+  describe('LAYTIME_ENGINE_ENABLED flag gate', () => {
+    const dropdownLinks = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('details a'));
+
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED;
+    });
+
+    it('Laytime link absent from More dropdown when flag is off', () => {
+      render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+      const links = dropdownLinks(document.body);
+      expect(links.find(l => l.getAttribute('href') === '/laytime')).toBeUndefined();
+    });
+
+    it('Laytime link present in More dropdown when flag is on', () => {
+      process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED = 'true';
+      render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+      const link = dropdownLinks(document.body).find(l => l.getAttribute('href') === '/laytime');
+      expect(link).toBeDefined();
+      expect(link).toHaveTextContent('Laytime');
+    });
+
+    it('More summary is highlighted on /laytime when flag is on', () => {
+      process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED = 'true';
+      mockUsePathname.mockReturnValue('/laytime');
+      const { container } = render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+      expect(container.querySelector('summary[aria-label="More"]')).toHaveAttribute('aria-current', 'true');
+    });
+
+    it('More summary is NOT highlighted on /laytime when flag is off', () => {
+      mockUsePathname.mockReturnValue('/laytime');
+      const { container } = render(<ModeProvider initial="charterer"><TopNav /></ModeProvider>);
+      expect(container.querySelector('summary[aria-label="More"]')).not.toHaveAttribute('aria-current');
+    });
+  });
 });


### PR DESCRIPTION
Add TopNav link to /laytime visible when LAYTIME_ENGINE_ENABLED. Page+engine pre-existed. 41 tests green. Out-of-scope: prod flag flip (final), reseed.