### PR TITLE
feat(passport): Demo-data badge on vessel Passport tab

### DIFF
--- a/components/match/PassportTab.tsx
+++ b/components/match/PassportTab.tsx
@@ -10,10 +10,24 @@ interface CheckRow {
   missing?: boolean;
 }
 
+function DemoDataBadge() {
+  return (
+    <span
+      data-testid="passport-demo-badge"
+      className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 border border-amber-300"
+    >
+      Demo data
+    </span>
+  );
+}
+
 export function PassportTab({ vessel }: PassportTabProps) {
   if (!vessel) {
     return (
       <div data-testid="tab-passport" className="text-sm text-gray-500">
+        <div className="mb-2">
+          <DemoDataBadge />
+        </div>
         No vessel data available.
       </div>
     );
@@ -29,6 +43,9 @@ export function PassportTab({ vessel }: PassportTabProps) {
 
   return (
     <div data-testid="tab-passport" className="space-y-2 text-sm">
+      <div className="mb-2">
+        <DemoDataBadge />
+      </div>
       <div className="divide-y">
         {rows.map(({ label, value }) => (
           <div key={label} className="flex justify-between py-2">

--- a/components/match/__tests__/PassportTab.test.tsx
+++ b/components/match/__tests__/PassportTab.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PassportTab } from '../PassportTab';
+import { MatchTabs } from '../MatchTabs';
+import type { Match } from '@/lib/types';
+
+jest.mock('@/components/audit-trail', () => ({
+  __esModule: true,
+  default: ({ inquiryId }: { inquiryId: string }) => (
+    <div data-testid="audit-trail" data-inquiry-id={inquiryId}>Audit Trail</div>
+  ),
+}));
+
+const baseMatch: Match = {
+  cargoEmailId: 'cargo-email-1',
+  cargoItemIndex: 0,
+  vesselEmailId: 'vessel-email-1',
+  vesselItemIndex: 0,
+  score: 85,
+  matchLevel: 'good',
+  matchReasons: ['DWT matches cargo'],
+  issues: [],
+};
+
+describe('PassportTab — Demo data badge', () => {
+  it('renders "Demo data" badge when vessel is provided', () => {
+    render(
+      <PassportTab
+        vessel={{
+          name: 'Test Vessel',
+          flag: 'Panama',
+          classSociety: 'Bureau Veritas',
+          pandi: 'Skuld',
+          restrictions: [],
+          lastCargoes: 'Coal',
+        } as any}
+      />
+    );
+    expect(screen.getByTestId('passport-demo-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('passport-demo-badge')).toHaveTextContent(/demo data/i);
+  });
+
+  it('renders "Demo data" badge when no vessel is provided', () => {
+    render(<PassportTab />);
+    expect(screen.getByTestId('passport-demo-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('passport-demo-badge')).toHaveTextContent(/demo data/i);
+  });
+
+  it('shows Demo data badge on Passport tab via MatchTabs (behavioral)', () => {
+    render(<MatchTabs match={baseMatch} />);
+    fireEvent.click(screen.getByRole('tab', { name: /passport/i }));
+    expect(screen.getByTestId('passport-demo-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('passport-demo-badge')).toHaveTextContent(/demo data/i);
+  });
+});


### PR DESCRIPTION
Add Demo-data badge to Passport tab (vessel meta is hardcoded, not real Equasis) so it reads as illustrative. tsc + tests clean. Out-of-scope: real Equasis integration, reseed.