### PR TITLE
feat(charterer): enable credit tracker + 13 demo charterers

### DIFF
--- a/app/charterers/[id]/page.tsx
+++ b/app/charterers/[id]/page.tsx
@@ -165,7 +165,26 @@ export default function ChartererPage() {
         {/* Credit Info Card */}
         <Card>
           <CardHeader>
-            <CardTitle>Credit Information</CardTitle>
+            <div className="flex items-center justify-between">
+              <CardTitle>Credit Information</CardTitle>
+              <span
+                aria-label="Demo data"
+                style={{
+                  fontSize: 11,
+                  fontFamily: '"Geist Mono", ui-monospace, monospace',
+                  letterSpacing: '0.08em',
+                  fontWeight: 500,
+                  padding: '2px 8px',
+                  borderRadius: 4,
+                  background: '#fef9c3',
+                  color: '#854d0e',
+                  border: '1px solid #fde047',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Demo data
+              </span>
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex items-center gap-2">

--- a/app/charterers/__tests__/credit-panel.test.tsx
+++ b/app/charterers/__tests__/credit-panel.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral test: credit panel renders with Demo badge, tier, L/C flag,
+ * and payment history entries when NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED=true.
+ *
+ * Uses real client.get()-style fetch mock (behavioral PI2 requirement).
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn(() => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() })),
+}));
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+const DEMO_CHARTERER = {
+  id: 'charterer-abc123',
+  name: 'Glencore',
+  tier: 'blue-chip' as const,
+  require_lc: 0,
+  notes: 'Diversified commodity trader. Coal and grain. Strong credit.',
+  created_at: '2026-01-15T00:00:00.000Z',
+  payment_history: JSON.stringify([
+    { date: '2026-04-02', status: 'on-time', notes: 'MV Iron Eagle — Coal, $28/MT' },
+    { date: '2026-01-30', status: 'on-time', notes: 'MV Atlantic Crown — Grain, $41/MT' },
+  ]),
+};
+
+const WEAK_CHARTERER = {
+  id: 'charterer-weak01',
+  name: 'Medallion Shipping',
+  tier: 'weak' as const,
+  require_lc: 1,
+  notes: 'Repeated late payments and one unresolved demurrage. L/C mandatory.',
+  created_at: '2025-06-01T00:00:00.000Z',
+  payment_history: JSON.stringify([
+    { date: '2025-12-05', status: 'defaulted', notes: 'Unpaid demurrage $18,400 — legal pending' },
+    { date: '2025-08-30', status: 'late-10d' },
+  ]),
+};
+
+describe('Charterer credit panel', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('renders Demo data badge when flag is enabled', async () => {
+    process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED = 'true';
+    const { useParams } = await import('next/navigation');
+    (useParams as jest.Mock).mockReturnValue({ id: 'charterer-abc123' });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(DEMO_CHARTERER) })
+    ) as jest.Mock;
+
+    const ChartererPage = (await import('@/app/charterers/[id]/page')).default;
+    render(<ChartererPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Demo data')).toBeInTheDocument();
+    });
+  });
+
+  it('renders tier and L/C=NO for blue-chip charterer', async () => {
+    process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED = 'true';
+    const { useParams } = await import('next/navigation');
+    (useParams as jest.Mock).mockReturnValue({ id: 'charterer-abc123' });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(DEMO_CHARTERER) })
+    ) as jest.Mock;
+
+    const ChartererPage = (await import('@/app/charterers/[id]/page')).default;
+    render(<ChartererPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('BLUE-CHIP')).toBeInTheDocument();
+      expect(screen.getByText('NO')).toBeInTheDocument();
+    });
+  });
+
+  it('renders L/C=YES and payment history for weak charterer', async () => {
+    process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED = 'true';
+    const { useParams } = await import('next/navigation');
+    (useParams as jest.Mock).mockReturnValue({ id: 'charterer-weak01' });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(WEAK_CHARTERER) })
+    ) as jest.Mock;
+
+    const ChartererPage = (await import('@/app/charterers/[id]/page')).default;
+    render(<ChartererPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('YES')).toBeInTheDocument();
+      expect(screen.getByText('defaulted')).toBeInTheDocument();
+      expect(screen.getByText('late-10d')).toBeInTheDocument();
+    });
+  });
+
+  it('renders payment history entries with dates', async () => {
+    process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED = 'true';
+    const { useParams } = await import('next/navigation');
+    (useParams as jest.Mock).mockReturnValue({ id: 'charterer-abc123' });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(DEMO_CHARTERER) })
+    ) as jest.Mock;
+
+    const ChartererPage = (await import('@/app/charterers/[id]/page')).default;
+    render(<ChartererPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2026-04-02')).toBeInTheDocument();
+      expect(screen.getByText('2026-01-30')).toBeInTheDocument();
+    });
+  });
+
+  it('renders charterer notes when present', async () => {
+    process.env.NEXT_PUBLIC_CHARTERER_CREDIT_ENABLED = 'true';
+    const { useParams } = await import('next/navigation');
+    (useParams as jest.Mock).mockReturnValue({ id: 'charterer-abc123' });
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(DEMO_CHARTERER) })
+    ) as jest.Mock;
+
+    const ChartererPage = (await import('@/app/charterers/[id]/page')).default;
+    render(<ChartererPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/diversified commodity trader/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/scripts/knowledge/seeds/seed-charterers.ts
+++ b/scripts/knowledge/seeds/seed-charterers.ts
@@ -1,7 +1,8 @@
 /**
  * seed-charterers.ts
  *
- * Seeds the charterers table with 20 blue-chip charterers.
+ * Seeds the charterers table with realistic demo data (illustrative — no real credit feed).
+ * Covers all three tiers: blue-chip, second, weak — with payment history and L/C flags.
  *
  * Usage:
  *   npx tsx scripts/knowledge/seeds/seed-charterers.ts
@@ -9,57 +10,204 @@
  * Env:
  *   SESSIONS_DB_PATH — path to sqlite db (default: data/sessions.db)
  *
- * Idempotent: uses upsertCharterer (ON CONFLICT(id) DO UPDATE).
+ * Idempotent: deterministic IDs derived from name; ON CONFLICT(id) DO UPDATE.
  */
 
+import { createHash } from 'crypto';
 import { getStore } from '../../../lib/session-store';
 import { upsertCharterer } from '../../../lib/market/charterers-repository';
-import { randomBytes } from 'crypto';
 
-const BLUE_CHIP_CHARTERERS = [
-  'Cargill',
-  'ADM',
-  'Bunge',
-  'Louis Dreyfus',
-  'Glencore',
-  'Viterra',
-  'Trafigura',
-  'Gunvor',
-  'Mercuria',
-  'Koch Industries',
-  'COFCO',
-  'Olam',
-  'Noble Group',
-  'Wilmar',
-  'Pacific Basin',
-  'Stena',
-  'MOL',
-  'NYK',
-  'MSC',
-  'CMA CGM',
+function deterministicId(name: string): string {
+  return 'charterer-' + createHash('sha256').update(name).digest('hex').slice(0, 16);
+}
+
+interface DemoCharterer {
+  name: string;
+  tier: 'blue-chip' | 'second' | 'weak';
+  require_lc: 0 | 1;
+  notes: string | null;
+  payment_history: { date: string; status: string; notes?: string }[];
+}
+
+const DEMO_CHARTERERS: DemoCharterer[] = [
+  // ── Blue-chip ──────────────────────────────────────────────────────────────
+  {
+    name: 'Cargill',
+    tier: 'blue-chip',
+    require_lc: 0,
+    notes: 'Long-standing relationship. Prefers FOB fixtures. Prompt payer.',
+    payment_history: [
+      { date: '2026-04-15', status: 'on-time', notes: 'MV Athena — Grain, $42/MT' },
+      { date: '2026-02-10', status: 'on-time', notes: 'MV Pacific Star — Soya, $38/MT' },
+      { date: '2025-11-22', status: 'on-time', notes: 'MV Baltic Wind — Corn, $35/MT' },
+    ],
+  },
+  {
+    name: 'ADM',
+    tier: 'blue-chip',
+    require_lc: 0,
+    notes: 'Excellent track record. Handles large Panamax volumes.',
+    payment_history: [
+      { date: '2026-03-28', status: 'on-time', notes: 'MV Magellan — Wheat, $40/MT' },
+      { date: '2026-01-15', status: 'on-time', notes: 'MV Neptune — Soya, $39/MT' },
+      { date: '2025-10-05', status: 'on-time' },
+    ],
+  },
+  {
+    name: 'Glencore',
+    tier: 'blue-chip',
+    require_lc: 0,
+    notes: 'Diversified commodity trader. Coal and grain. Strong credit.',
+    payment_history: [
+      { date: '2026-04-02', status: 'on-time', notes: 'MV Iron Eagle — Coal, $28/MT' },
+      { date: '2026-01-30', status: 'on-time', notes: 'MV Atlantic Crown — Grain, $41/MT' },
+      { date: '2025-09-18', status: 'on-time' },
+    ],
+  },
+  {
+    name: 'Viterra',
+    tier: 'blue-chip',
+    require_lc: 0,
+    notes: 'Top global grain trader. Reliable payments within 5 days.',
+    payment_history: [
+      { date: '2026-04-20', status: 'on-time', notes: 'MV Golden Prairie — Barley, $36/MT' },
+      { date: '2026-02-14', status: 'on-time' },
+      { date: '2025-12-01', status: 'on-time' },
+    ],
+  },
+  {
+    name: 'Trafigura',
+    tier: 'blue-chip',
+    require_lc: 0,
+    notes: 'Metals and energy focus. Well-capitalized. No credit concerns.',
+    payment_history: [
+      { date: '2026-03-10', status: 'on-time', notes: 'MV Ore Carrier III — Iron ore, $18/MT' },
+      { date: '2025-12-15', status: 'on-time' },
+      { date: '2025-08-20', status: 'on-time' },
+    ],
+  },
+
+  // ── Second tier ────────────────────────────────────────────────────────────
+  {
+    name: 'Scorpio Tankers',
+    tier: 'second',
+    require_lc: 0,
+    notes: 'Mostly liquid bulk. Occasional 5–10 day delay on remittance.',
+    payment_history: [
+      { date: '2026-04-08', status: 'late-5d', notes: 'Payment received 5 days after laycan' },
+      { date: '2026-01-20', status: 'on-time' },
+      { date: '2025-10-30', status: 'late-3d' },
+    ],
+  },
+  {
+    name: 'Pacific Basin',
+    tier: 'second',
+    require_lc: 0,
+    notes: 'Minor bulk specialist. Good relationship but watch cashflow cycles.',
+    payment_history: [
+      { date: '2026-03-22', status: 'on-time' },
+      { date: '2025-11-11', status: 'late-7d', notes: 'Confirmed delay due to bank processing' },
+      { date: '2025-07-04', status: 'on-time' },
+    ],
+  },
+  {
+    name: 'Ultrabulk',
+    tier: 'second',
+    require_lc: 0,
+    notes: 'Handysize and Supramax specialist. Track record mostly clean.',
+    payment_history: [
+      { date: '2026-02-28', status: 'on-time' },
+      { date: '2025-12-10', status: 'on-time' },
+      { date: '2025-09-02', status: 'late-4d', notes: 'Minor delay, resolved without dispute' },
+    ],
+  },
+  {
+    name: 'Bunge',
+    tier: 'second',
+    require_lc: 1,
+    notes: 'Request L/C after two disputed demurrage claims in 2025.',
+    payment_history: [
+      { date: '2026-04-01', status: 'on-time', notes: 'L/C confirmed via Citi' },
+      { date: '2025-12-20', status: 'disputed', notes: 'Demurrage dispute — resolved after arbitration' },
+      { date: '2025-08-15', status: 'on-time' },
+    ],
+  },
+  {
+    name: 'COFCO',
+    tier: 'second',
+    require_lc: 0,
+    notes: 'Chinese state-backed. Sound credit but some FX transfer delays.',
+    payment_history: [
+      { date: '2026-03-05', status: 'late-8d', notes: 'SAFE approval delay' },
+      { date: '2025-10-18', status: 'on-time' },
+      { date: '2025-06-22', status: 'late-6d', notes: 'FX remittance held by correspondent bank' },
+    ],
+  },
+
+  // ── Weak ───────────────────────────────────────────────────────────────────
+  {
+    name: 'Medallion Shipping',
+    tier: 'weak',
+    require_lc: 1,
+    notes: 'Repeated late payments and one unresolved demurrage. L/C mandatory.',
+    payment_history: [
+      { date: '2026-04-12', status: 'late-14d', notes: 'L/C presented; still 2-week delay' },
+      { date: '2025-12-05', status: 'defaulted', notes: 'Unpaid demurrage $18,400 — legal pending' },
+      { date: '2025-08-30', status: 'late-10d' },
+    ],
+  },
+  {
+    name: 'Horizon Dry Bulk',
+    tier: 'weak',
+    require_lc: 1,
+    notes: 'Small operator with thin capitalisation. High counterparty risk.',
+    payment_history: [
+      { date: '2026-02-20', status: 'late-21d', notes: 'Required escalation to management' },
+      { date: '2025-11-08', status: 'late-12d' },
+      { date: '2025-06-15', status: 'on-time', notes: 'Early fixture before credit deterioration' },
+    ],
+  },
+  {
+    name: 'Levant Grain',
+    tier: 'weak',
+    require_lc: 1,
+    notes: 'Active in MENA grain trades. Credit rating downgraded Q1 2026.',
+    payment_history: [
+      { date: '2026-04-30', status: 'late-9d' },
+      { date: '2025-12-18', status: 'disputed', notes: 'Short-shipped claim unresolved' },
+      { date: '2025-09-10', status: 'on-time' },
+    ],
+  },
 ];
 
 export function seedCharterers(): void {
   const db = getStore().getDatabase();
 
-  console.log('Seeding charterers...');
+  console.log('Seeding charterers (demo data — illustrative, no real credit feed)...');
 
-  for (const name of BLUE_CHIP_CHARTERERS) {
-    const id = `charterer-${randomBytes(8).toString('hex')}`;
+  const byTier = { 'blue-chip': 0, second: 0, weak: 0 };
+
+  for (const c of DEMO_CHARTERERS) {
+    const id = deterministicId(c.name);
 
     upsertCharterer(db, {
       id,
-      name,
-      tier: 'blue-chip',
-      payment_history: '[]',
-      require_lc: 0,
-      notes: null,
+      name: c.name,
+      tier: c.tier,
+      payment_history: JSON.stringify(c.payment_history),
+      require_lc: c.require_lc,
+      notes: c.notes,
     });
 
-    console.log(`  ✓ Seeded: ${name} (${id})`);
+    byTier[c.tier]++;
+    console.log(`  ✓ ${c.tier.padEnd(10)} ${c.name} (${id})`);
   }
 
-  console.log(`\nSeeded ${BLUE_CHIP_CHARTERERS.length} blue-chip charterers.`);
+  console.log(
+    `\nSeeded ${DEMO_CHARTERERS.length} charterers:` +
+    ` ${byTier['blue-chip']} blue-chip, ${byTier.second} second, ${byTier.weak} weak.`
+  );
+  console.log('NOTE: Demo data only — illustrative credit ratings, no real feed.');
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Enable charterer credit tracker with 13 realistic demo charterers (blue-chip/second/weak tiers) + payment history + L/C flags + Demo-data badge. 32/32 green. Out-of-scope: real paid credit feed, prod flag flip (final), reseed.