### PR TITLE
feat(market): enable full benchmark dashboard + demo indices

### DIFF
--- a/__tests__/market/market-page.test.ts
+++ b/__tests__/market/market-page.test.ts
@@ -159,8 +159,47 @@ describe('MarketPage — sync badge staleness', () => {
       expect(screen.getByText(/last sync:/i)).toBeInTheDocument();
     });
 
-    // The label should show bdiDate, not indicesDate (scope to badge to avoid collision with KnowledgeFeed hardcoded dates)
+    // The label should show bdiDate, not indicesDate
     expect(screen.getByText(/last sync:/i).textContent).toContain(bdiDate);
-    expect(screen.queryByText(new RegExp(indicesDate))).not.toBeInTheDocument();
+    // Check badge text specifically — indicesDate may appear in chart table rows (not in the badge)
+    expect(screen.getByText(/last sync:/i).textContent).not.toContain(indicesDate);
+  });
+});
+
+describe('MarketPage — index charts show numeric values when flag enabled', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_MARKET_BENCHMARK_FULL_ENABLED = 'true';
+  });
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_MARKET_BENCHMARK_FULL_ENABLED = ORIGINAL_ENV;
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders BHSI, TMI, Drewry charts with numeric values when indices API returns data', async () => {
+    const mockIndexData = [
+      { index_date: '2026-05-30', value: 512, unit: 'USD/day', source: 'seed-synthetic' },
+      { index_date: '2026-05-29', value: 498, unit: 'USD/day', source: 'seed-synthetic' },
+    ];
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockIndexData) })
+    ) as jest.Mock;
+
+    render(React.createElement(MarketPage));
+
+    await waitFor(() => {
+      expect(screen.getByText('Market Benchmarks')).toBeInTheDocument();
+    });
+
+    // All three index chart headings must appear
+    expect(screen.getByRole('heading', { name: /bhsi/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /tmi/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /drewry-bb/i })).toBeInTheDocument();
+
+    // Numeric values from mock data must be visible (Current row shows validData[0])
+    const currentLabels = screen.getAllByText(/current:/i);
+    expect(currentLabels.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { MarketKpiTile } from '@/components/market/MarketKpiTile';
+import { MarketBenchmarkChart } from '@/components/market/MarketBenchmarkChart';
 import { MetricHistoryPanel } from '@/components/market/MetricHistoryPanel';
 import { RoutesSection } from '@/components/market/RoutesSection';
 import { FixturesSection } from '@/components/market/FixturesSection';
@@ -296,6 +297,38 @@ export default function MarketPage() {
             />
           ) : null;
         })()}
+
+        {/* Freight market index charts — BHSI, TMI, Drewry breakbulk */}
+        {(bhsiData?.length || tmiData?.length || drewryData?.length) ? (
+          <section aria-label="Market index charts" className="mb-10">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+              {bhsiData && bhsiData.length > 0 && (
+                <MarketBenchmarkChart
+                  indexName="bhsi"
+                  data={bhsiData.map((d) => ({ date: d.index_date, value: d.value }))}
+                  asOfDate={latestIndexDate(bhsiData) ?? undefined}
+                  unit={bhsiData[0]?.unit}
+                />
+              )}
+              {tmiData && tmiData.length > 0 && (
+                <MarketBenchmarkChart
+                  indexName="tmi"
+                  data={tmiData.map((d) => ({ date: d.index_date, value: d.value }))}
+                  asOfDate={latestIndexDate(tmiData) ?? undefined}
+                  unit={tmiData[0]?.unit}
+                />
+              )}
+              {drewryData && drewryData.length > 0 && (
+                <MarketBenchmarkChart
+                  indexName="drewry-bb"
+                  data={drewryData.map((d) => ({ date: d.index_date, value: d.value }))}
+                  asOfDate={latestIndexDate(drewryData) ?? undefined}
+                  unit={drewryData[0]?.unit}
+                />
+              )}
+            </div>
+          </section>
+        ) : null}
 
         {/* Routes section */}
         <RoutesSection />


### PR DESCRIPTION
Enable /market dashboard + /api/market/indices behind MARKET_BENCHMARK_FULL_ENABLED, seeded with realistic demo indices (BHSI/TMI/Drewry). Tests green. Out-of-scope: paid granular feed, prod flag flip (final), reseed.