### PR TITLE
feat(demo-seed): compute fit/economics inline in build.ts

### DIFF
--- a/scripts/demo-seed/__tests__/build.test.ts
+++ b/scripts/demo-seed/__tests__/build.test.ts
@@ -131,6 +131,74 @@ describe('build (Task 18) — pre-compute matches', () => {
   });
 });
 
+describe('build with LLM cache → fit_breakdown + tce columns populated', () => {
+  let tmpDb: string;
+  beforeEach(() => { tmpDb = path.join(os.tmpdir(), `demo-seed-fit-${Date.now()}.db`); });
+  afterEach(() => { if (fs.existsSync(tmpDb)) fs.unlinkSync(tmpDb); });
+
+  it('seed matches have fit_breakdown NOT NULL and tce_usd_per_day set', async () => {
+    const { writeCache, corpusHash } = require('../llm-cache') as typeof import('../llm-cache');
+
+    const files = fs.readdirSync(FIXTURES).filter(f => f.endsWith('.json')).sort();
+    const ids = files.map(f => {
+      const raw = JSON.parse(fs.readFileSync(`${FIXTURES}/${f}`, 'utf8'));
+      return raw.messages?.[0]?.id ?? raw.id ?? f.replace('.json', '');
+    });
+    const [c1, , v1] = ids;
+
+    const hash = corpusHash(FIXTURES);
+    const cache = {
+      corpusHash: hash,
+      generatedAt: '2026-05-27T20:00:00.000Z',
+      classifications: [
+        { emailId: c1, category: 'CARGO_INQUIRY' },
+        { emailId: v1, category: 'VESSEL_POSITION' },
+      ],
+      parsedCargos: [
+        { emailId: c1, itemIndex: 0, laycan: '10-15 May 2026',
+          weightMt: { value: 25000, confidence: 'high' },
+          originPort: { value: 'Rotterdam', confidence: 'high' } },
+      ],
+      parsedVessels: [
+        { emailId: v1, itemIndex: 0,
+          openDate: { value: '2026-05-12', confidence: 'high' },
+          openPosition: { value: 'Hamburg', confidence: 'high' },
+          dwtSummer: { value: 30000, confidence: 'high' } },
+      ],
+      parsedFixtureRecaps: [],
+    };
+    writeCache(FIXTURES, cache as any);
+
+    try {
+      await build({ rawDir: FIXTURES, manifestPath: FIX_MANIFEST, outDb: tmpDb });
+      const db = new Database(tmpDb);
+      sqliteVec.load(db);
+
+      const match = db.prepare(
+        'SELECT fit_percent, fit_breakdown, tce_usd_per_day FROM matches LIMIT 1',
+      ).get() as { fit_percent: number | null; fit_breakdown: string | null; tce_usd_per_day: number | null };
+
+      expect(match).toBeTruthy();
+      expect(match.fit_breakdown).not.toBeNull();
+      expect(match.fit_percent).not.toBeNull();
+      expect(typeof match.fit_percent).toBe('number');
+
+      const breakdown = JSON.parse(match.fit_breakdown!);
+      expect(breakdown.components).toBeDefined();
+      expect(Array.isArray(breakdown.components)).toBe(true);
+      expect(breakdown.components.length).toBeGreaterThan(0);
+
+      expect(match.tce_usd_per_day).not.toBeNull();
+      expect(typeof match.tce_usd_per_day).toBe('number');
+
+      db.close();
+    } finally {
+      fs.unlinkSync(`${FIXTURES}/.llm-cache/${hash}.json`);
+      fs.rmdirSync(`${FIXTURES}/.llm-cache`);
+    }
+  });
+});
+
 describe('build with LLM cache → parsed_results from cache + matches', () => {
   let tmpDb: string;
   beforeEach(() => { tmpDb = path.join(os.tmpdir(), `demo-seed-cache-${Date.now()}.db`); });

--- a/scripts/demo-seed/build.ts
+++ b/scripts/demo-seed/build.ts
@@ -15,6 +15,10 @@ import {
   type ParsedFixtureRecap,
 } from '@/lib/types';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
+import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import { computeEstimatedTce, estimateFreightRate, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { getPortDistance } from '@/lib/sailing/port-distances';
+import type { MatchReadiness } from '@/lib/types';
 
 const PARSER_VERSION = 'demo-seed-v1';
 
@@ -614,8 +618,9 @@ export async function build(opts: BuildOptions): Promise<void> {
 
     const insertMatch = db.prepare(`
       INSERT INTO matches (cargo_id, vessel_id, score, reason, status, created_at, updated_at,
-                           laycan_start, laycan_end, vessel_dwt, load_port, discharge_port)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           laycan_start, laycan_end, vessel_dwt, load_port, discharge_port,
+                           tce_usd_per_day, distance_nm, fit_percent, fit_breakdown)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const nowMs = new Date(manifest.frozenDate + 'T00:00:00.000Z').getTime();
@@ -647,6 +652,7 @@ export async function build(opts: BuildOptions): Promise<void> {
     const allVessels: Array<{
       vesselId: string; openMs: number; openIso: string;
       dwt: number; openPosition: string | null;
+      vesselItem: Record<string, unknown>;
     }> = [];
     for (const v of vesselRows) {
       for (const vessel of asItems(v.result_json)) {
@@ -659,6 +665,7 @@ export async function build(opts: BuildOptions): Promise<void> {
           openIso: vessel.openDate,
           dwt,
           openPosition,
+          vesselItem: vessel,
         });
       }
     }
@@ -671,6 +678,8 @@ export async function build(opts: BuildOptions): Promise<void> {
         cargoId: string; vesselId: string; score: number; reason: string;
         layStart: number; layEnd: number; vesselDwt: number;
         loadPort: string | null; dischargePort: string | null;
+        fitPercent: number | null; fitBreakdown: string | null;
+        tceUsdPerDay: number | null; distanceNm: number | null;
       }
     >();
     for (const c of cargoRows) {
@@ -708,6 +717,54 @@ export async function build(opts: BuildOptions): Promise<void> {
           const key = `${c.cargo_id}|${v.vesselId}`;
           const prev = best.get(key);
           if (!prev || score > prev.score) {
+            // Compute readiness from pre-parsed dates + port distance
+            const loadPort = cargoOriginPort ?? v.openPosition;
+            const distanceResult = getPortDistance(v.openPosition, cargoOriginPort);
+            const distanceNm = distanceResult?.nm ?? null;
+            const speedKn = parseLeadingNumber(v.vesselItem.speedLaden) || 12;
+            const sailingDays = distanceNm != null ? distanceNm / (speedKn * 24) : null;
+            const arrivalMs = sailingDays != null ? v.openMs + sailingDays * 86_400_000 : null;
+            const gapDays = arrivalMs != null ? (layStart - arrivalMs) / 86_400_000 : null;
+            const verdict: MatchReadiness['verdict'] =
+              gapDays == null ? 'unknown' :
+              gapDays < -1 ? 'late' :
+              gapDays < 0.5 ? 'tight' :
+              gapDays <= 5 ? 'ideal' : 'idle';
+            const readiness: MatchReadiness = {
+              openDate: v.openIso.slice(0, 10),
+              laycanStart: new Date(layStart).toISOString().slice(0, 10),
+              laycanEnd: new Date(layEnd).toISOString().slice(0, 10),
+              distanceNm,
+              speedKn,
+              sailingDays,
+              arrivalDate: arrivalMs != null ? new Date(arrivalMs).toISOString().slice(0, 10) : null,
+              gapDays,
+              verdict,
+              explanation: verdict,
+            };
+
+            // Run offline fit engine
+            const fitResult = computeFitBreakdown({
+              cargo: cargo as unknown as ParsedCargo,
+              vessel: v.vesselItem as unknown as ParsedVessel,
+              readiness,
+              sanctions: undefined,
+              hardFilters: undefined,
+              refYear: new Date(nowMs).getUTCFullYear(),
+            });
+
+            // Compute TCE
+            const qty = unwrapNum(cargo.weightMt);
+            const freightRate = estimateFreightRate(unwrapStr(cargo.cargoType), distanceNm ?? 0, v.dwt);
+            const tceResult = computeEstimatedTce(
+              freightRate,
+              distanceNm ?? 0,
+              v.dwt,
+              qty,
+              speedKn,
+              parseLeadingNumber(v.vesselItem.consumption),
+            );
+
             best.set(key, {
               cargoId: c.cargo_id,
               vesselId: v.vesselId,
@@ -716,15 +773,19 @@ export async function build(opts: BuildOptions): Promise<void> {
               layStart,
               layEnd,
               vesselDwt: v.dwt,
-              loadPort: cargoOriginPort ?? v.openPosition,
+              loadPort: loadPort,
               dischargePort: cargoDestPort,
+              fitPercent: fitResult.fitPercent,
+              fitBreakdown: JSON.stringify(fitResult),
+              tceUsdPerDay: tceResult.tce_usd_per_day,
+              distanceNm,
             });
           }
         }
       }
     }
     // Cap fan-out: keep top 6 matches per cargo (by score desc) to avoid near-cartesian product
-    type BestEntry = { cargoId: string; vesselId: string; score: number; reason: string; layStart: number; layEnd: number; vesselDwt: number; loadPort: string | null; dischargePort: string | null };
+    type BestEntry = { cargoId: string; vesselId: string; score: number; reason: string; layStart: number; layEnd: number; vesselDwt: number; loadPort: string | null; dischargePort: string | null; fitPercent: number | null; fitBreakdown: string | null; tceUsdPerDay: number | null; distanceNm: number | null };
     const perCargo = new Map<string, BestEntry[]>();
     for (const m of best.values()) {
       const arr = perCargo.get(m.cargoId) ?? [];
@@ -740,6 +801,10 @@ export async function build(opts: BuildOptions): Promise<void> {
           m.vesselDwt || null,
           m.loadPort ?? null,
           m.dischargePort ?? null,
+          m.tceUsdPerDay ?? null,
+          m.distanceNm ?? null,
+          m.fitPercent ?? null,
+          m.fitBreakdown ?? null,
         );
       }
     }


### PR DESCRIPTION
build.ts runs the offline engine per seed match so demo-seed.db carries fit_percent, fit_breakdown and economics instead of NULL (this was why the demo showed old Score). demo-seed.db is gitignored, regenerated on prod via the seed-build script (LLM cache) or fit-patch fallback. Tests green. After merge: prod reveal = flip flags, rebuild seed, restart.