### PR TITLE
feat(demo): item-aware matches + real-engine regeneration

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
@@ -64,6 +64,48 @@ describe('buildDemoSessionBlob', () => {
     db.close();
   });
 
+  it('reads cargo_item_index / vessel_item_index from seed rows (item-aware demo)', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE emails (
+        account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+        from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+        body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+      );
+      CREATE TABLE parsed_results (
+        account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+        result_json TEXT, parsed_at INTEGER
+      );
+      CREATE TABLE matches (
+        id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+        reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+        reason_structured TEXT, fit_percent REAL, fit_breakdown TEXT,
+        cargo_item_index INTEGER NOT NULL DEFAULT 0, vessel_item_index INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+      VALUES ('demo','e1','t1','a@demo.local','me@demo.local','Cargo X','2026-05-20','b','s','[]',0)`).run();
+    db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+      VALUES ('demo','e2','t2','b@demo.local','me@demo.local','Vessels','2026-05-21','b','s','[]',0)`).run();
+    // Vessel email e2 carries TWO vessel items (index 0 and 1).
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e1','cargo','v1','[{"emailId":"e1","itemIndex":0}]',0)`).run();
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e2','vessel','v1','[{"emailId":"e2","itemIndex":0},{"emailId":"e2","itemIndex":1}]',0)`).run();
+    // The match pairs cargo item 0 with vessel ITEM 1.
+    db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured, fit_percent, fit_breakdown, cargo_item_index, vessel_item_index)
+      VALUES ('e1','e2',77,'Real engine match','shortlist',NULL,0,0,NULL,72.5,NULL,0,1)`).run();
+
+    const blob = buildDemoSessionBlob(db);
+    expect(blob.matches).toHaveLength(1);
+    expect(blob.matches[0]).toMatchObject({
+      cargoEmailId: 'e1', cargoItemIndex: 0,
+      vesselEmailId: 'e2', vesselItemIndex: 1,
+      score: 77, fitPercent: 72.5,
+    });
+    db.close();
+  });
+
   it('skips a malformed result_json row but keeps the valid rows (and warns)', () => {
     const db = makeSeedDb();
     db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -26,6 +26,7 @@ interface MatchRow {
   cargo_id: string; vessel_id: string; score: number;
   reason: string | null; reason_structured: string | null;
   fit_percent: number | null; fit_breakdown: string | null;
+  cargo_item_index: number | null; vessel_item_index: number | null;
 }
 
 function safeJsonArray<T>(json: string, ctx: string): T[] {
@@ -84,10 +85,14 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
     }
   }
 
-  const hasFitCols = (db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>).some(c => c.name === 'fit_percent');
-  const selectCols = hasFitCols
-    ? 'cargo_id, vessel_id, score, reason, reason_structured, fit_percent, fit_breakdown'
-    : 'cargo_id, vessel_id, score, reason, reason_structured, NULL as fit_percent, NULL as fit_breakdown';
+  const colNames = new Set((db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>).map((c) => c.name));
+  const fitCols = colNames.has('fit_percent')
+    ? 'fit_percent, fit_breakdown'
+    : 'NULL as fit_percent, NULL as fit_breakdown';
+  const idxCols = colNames.has('cargo_item_index')
+    ? 'cargo_item_index, vessel_item_index'
+    : 'NULL as cargo_item_index, NULL as vessel_item_index';
+  const selectCols = `cargo_id, vessel_id, score, reason, reason_structured, ${fitCols}, ${idxCols}`;
 
   // Only the seeded snapshot rows (user_id IS NULL). Per-session copies that
   // persistSessionMatches writes (user_id = sessionId) must NOT be re-read here,
@@ -109,9 +114,9 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   function rowsToMatches(rows: MatchRow[]): Match[] {
     return rows.map((r) => ({
       cargoEmailId: r.cargo_id,
-      cargoItemIndex: 0,
+      cargoItemIndex: r.cargo_item_index ?? 0,
       vesselEmailId: r.vessel_id,
-      vesselItemIndex: 0,
+      vesselItemIndex: r.vessel_item_index ?? 0,
       score: r.score,
       matchLevel: deriveMatchLevel(r.score),
       matchReasons: r.reason ? [r.reason] : [],

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -28,6 +28,8 @@ export interface StoredMatch {
   cargo_ref: string | null;
   fit_percent?: number | null;
   fit_breakdown?: string | null;
+  cargo_item_index?: number | null;
+  vessel_item_index?: number | null;
 }
 
 export interface CreateMatchInput {
@@ -52,6 +54,8 @@ export interface CreateMatchInput {
   cargo_ref?: string | null;
   fit_percent?: number | null;
   fit_breakdown?: string | null;
+  cargo_item_index?: number | null;
+  vessel_item_index?: number | null;
 }
 
 export interface ListMatchesOptions {
@@ -102,6 +106,11 @@ function hasFitColumns(db: Database.Database): boolean {
   return cols.some((c) => c.name === 'fit_percent');
 }
 
+function hasItemIndexColumns(db: Database.Database): boolean {
+  const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+  return cols.some((c) => c.name === 'cargo_item_index');
+}
+
 export function createMatch(db: Database.Database, input: CreateMatchInput): StoredMatch {
   const now = Date.now();
   const status: MatchStatus = input.status ?? 'shortlist';
@@ -125,6 +134,11 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
     const cargo_ref = input.cargo_ref ?? null;
     const fit_percent = input.fit_percent ?? null;
     const fit_breakdown = input.fit_breakdown ?? null;
+    // Item-index columns (migration 044) — written only when present so a
+    // partially-migrated DB (older tests) still inserts via this branch.
+    const withIdx = hasItemIndexColumns(db);
+    const cargo_item_index = input.cargo_item_index ?? 0;
+    const vessel_item_index = input.vessel_item_index ?? 0;
 
     const stmt = db.prepare(
       `INSERT OR IGNORE INTO matches
@@ -132,10 +146,10 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
           reason_structured, cargo_type, load_port, discharge_port,
           laycan_start, laycan_end, vessel_dwt, tce_usd_per_day, distance_nm,
           freight_rate_usd_per_mt, freight_rate_source, vessel_name, cargo_ref,
-          fit_percent, fit_breakdown)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          fit_percent, fit_breakdown${withIdx ? ', cargo_item_index, vessel_item_index' : ''})
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${withIdx ? ', ?, ?' : ''})`
     );
-    result = stmt.run(
+    const args: Array<string | number | null> = [
       input.cargo_id,
       input.vessel_id,
       input.score,
@@ -159,7 +173,9 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
       cargo_ref,
       fit_percent,
       fit_breakdown,
-    );
+    ];
+    if (withIdx) args.push(cargo_item_index, vessel_item_index);
+    result = stmt.run(...args);
   } else if (hasVesselNameColumns(db)) {
     const reason_structured = input.reason_structured ?? null;
     const cargo_type = input.cargo_type ?? null;

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -82,6 +82,8 @@ export function persistSessionMatches(
       cargo_ref: cargo ? (cfValue(cargo.cargoDescription) || null) : null,
       fit_percent: m.fitPercent ?? null,
       fit_breakdown: m.fitBreakdown ? JSON.stringify(m.fitBreakdown) : null,
+      cargo_item_index: m.cargoItemIndex,
+      vessel_item_index: m.vesselItemIndex,
     });
   }
 }

--- a/lib/migrations/044-matches-item-index.ts
+++ b/lib/migrations/044-matches-item-index.ts
@@ -1,0 +1,35 @@
+import type { Migration } from './types';
+
+/**
+ * Add cargo_item_index / vessel_item_index to matches.
+ *
+ * A single email can carry several parsed cargo/vessel items (itemIndex 0..N).
+ * Until now demo seed matches assumed item 0 of each email (hydrate-demo-session
+ * rowsToMatches hard-coded cargoItemIndex:0 / vesselItemIndex:0), so a match
+ * referencing item N could never be rendered with the correct cargo/vessel.
+ * These columns let a seed/session match record which item it pairs, so the
+ * detail panel resolves the right ParsedCargo/ParsedVessel.
+ *
+ * DEFAULT 0 keeps every existing row pointing at item 0 (the prior behaviour).
+ * The unique index stays (cargo_id, vessel_id, user_id) — matches are deduped
+ * to one per email-pair, so no item-level uniqueness is required.
+ */
+const migration044: Migration = {
+  version: 44,
+  name: 'matches-item-index',
+  up(db) {
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    if (!names.has('cargo_item_index')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN cargo_item_index INTEGER NOT NULL DEFAULT 0`);
+    }
+    if (!names.has('vessel_item_index')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN vessel_item_index INTEGER NOT NULL DEFAULT 0`);
+    }
+  },
+  down(db) {
+    void db;
+  },
+};
+
+export default migration044;

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -41,6 +41,7 @@ import migration040 from './040-counter-offers';
 import migration041 from './041-matches-vessel-name';
 import migration042 from './042-matches-fit';
 import migration043 from './043-baltic-tc-dayrates-seed';
+import migration044 from './044-matches-item-index';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043, migration044];

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * regenerate-matches.ts — rebuild the demo seed matches through the REAL
+ * production matching engine (analyzePairs), so the broker sees only matches
+ * that pass EVERY rule (draft, cranes, volume, weight/DWCC, cargo↔vessel type,
+ * IMSBC, laycan structure, timing, sanctions, hold cleanliness).
+ *
+ * Background — why the old seed was wrong
+ * ---------------------------------------
+ * scripts/demo-seed/build.ts paired cargo×vessel with a naive 90%-utilisation +
+ * ±7-day laycan heuristic, BYPASSING the real engine. It also stored the parsed
+ * data in shapes the engine can't read: cargo.laycan as a {start,end} OBJECT
+ * (canonical ParsedCargo.laycan is `string`), and vessel.openDate as a bare ISO
+ * STRING (canonical is ConfidenceField<string> — cfValue() yields null). With
+ * those shapes the engine classifies every pair as "unknown timing" → 0 broker
+ * matches. This script (a) normalises the parsed_results shapes to the canonical
+ * contract — which ALSO fixes the live render (persistSessionMatches.parseLaycan)
+ * — and (b) regenerates matches via analyzePairs.
+ *
+ * Output buckets → seed user_ids (read by buildDemoSessionBlob):
+ *   mainMatches (clean)              → user_id NULL            (main list)
+ *   lowConfidenceMatches             → '__demo_review__'       (review tab)
+ *   insufficientData                 → '__demo_insufficient__' (insufficient tab)
+ * Hold-cleanliness blockSend matches are DROPPED from the main list (rule violated).
+ * Each bucket is deduped to one match per (cargo email, vessel email) pair — the
+ * unique index is (cargo_id, vessel_id, user_id) and the detail page resolves a
+ * match by those email ids — keeping the highest-fit item combination, and the
+ * winning item indices are stored in cargo_item_index / vessel_item_index.
+ *
+ *   npx tsx scripts/demo-seed/regenerate-matches.ts [--db data/demo-seed.db] [--dry]
+ */
+import Database from 'better-sqlite3';
+import path from 'node:path';
+import { analyzePairs } from '@/lib/matching/pair-analyzer';
+import { parseLaycan } from '@/lib/sailing/date-parsing';
+import { getPortDistance } from '@/lib/sailing/port-distances';
+import { cfValue, type ParsedCargo, type ParsedVessel, type Match } from '@/lib/types';
+
+function arg(k: string): string | undefined {
+  const i = process.argv.indexOf(k);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+const DRY = process.argv.includes('--dry');
+
+/** Demo laycan is stored as {start,end} ISO object; parseLaycan needs a string. */
+function normalizeLaycan(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw === 'string') return raw || null;
+  if (typeof raw === 'object') {
+    const o = raw as { start?: string; end?: string };
+    const s = o.start ? String(o.start).slice(0, 10) : null;
+    const e = o.end ? String(o.end).slice(0, 10) : null;
+    if (s && e) return `${s} to ${e}`;
+    if (s) return s;
+  }
+  return null;
+}
+
+type CF = { value: string; confidence: string; sourceText: string };
+/** Demo openDate is a bare ISO string; canonical is ConfidenceField<string>. */
+function wrapOpenDate(raw: unknown): CF | unknown {
+  if (typeof raw === 'string' && raw) return { value: raw, confidence: 'confirmed', sourceText: raw };
+  return raw;
+}
+
+function cargoTypeStr(cargo: ParsedCargo): string | null {
+  const t = cargo.cargoType as unknown;
+  if (t && typeof t === 'object' && 'value' in (t as object)) return (t as { value: string }).value;
+  return (t as string) ?? null;
+}
+
+async function main() {
+  const dbPath = arg('--db') ?? path.resolve(process.cwd(), 'data/demo-seed.db');
+  console.log(`[regen] Opening ${dbPath}${DRY ? ' (DRY — no writes)' : ''}`);
+  const db = new Database(dbPath, DRY ? { readonly: true } : {});
+  if (!DRY) db.pragma('journal_mode = WAL');
+
+  const frozen = (db.prepare(`SELECT frozen_date f FROM demo_seed_meta WHERE id=1`).get() as { f?: string })?.f ?? '2026-05-28';
+  const today = new Date(frozen + 'T00:00:00.000Z');
+  const refYear = today.getUTCFullYear();
+  const nowMs = today.getTime();
+
+  // ── 1. Load + normalise parsed_results to the canonical engine contract ──
+  const cargos: ParsedCargo[] = [];
+  const vessels: ParsedVessel[] = [];
+  const updateParsed = db.prepare(`UPDATE parsed_results SET result_json = ? WHERE gmail_message_id = ? AND parse_type = ?`);
+  let normalizedRows = 0;
+
+  for (const r of db.prepare(
+    `SELECT gmail_message_id id, parse_type, result_json j FROM parsed_results WHERE parse_type IN ('cargo','vessel')`,
+  ).all() as Array<{ id: string; parse_type: string; j: string }>) {
+    const raw = JSON.parse(r.j);
+    const items: Record<string, unknown>[] = Array.isArray(raw) ? raw : [raw];
+    let changed = false;
+    items.forEach((it, idx) => {
+      it.emailId = r.id;
+      it.itemIndex = idx;
+      if (r.parse_type === 'cargo') {
+        const nl = normalizeLaycan(it.laycan);
+        if (nl !== it.laycan) { it.laycan = nl; changed = true; }
+        cargos.push(it as unknown as ParsedCargo);
+      } else {
+        const wrapped = wrapOpenDate(it.openDate);
+        if (wrapped !== it.openDate) { it.openDate = wrapped; changed = true; }
+        vessels.push(it as unknown as ParsedVessel);
+      }
+    });
+    if (changed && !DRY) { updateParsed.run(JSON.stringify(items), r.id, r.parse_type); normalizedRows++; }
+  }
+  console.log(`[regen] frozen=${frozen} refYear=${refYear} · cargos=${cargos.length} vessels=${vessels.length} · normalized parsed rows=${normalizedRows}`);
+
+  // ── 2. Run the real engine (no LLM — deterministic gates + sweep + fit) ──
+  const result = await analyzePairs(cargos, vessels, async () => [], { refYear, today, db });
+
+  // ── 3. Dedup each bucket to one match per (cargo email, vessel email) pair,
+  //        keeping the highest fit (then score). Drop cleanliness blockSend from main.
+  const cargoMap = new Map(cargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
+  const vesselMap = new Map(vessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
+
+  function dedup(matches: Match[]): Match[] {
+    const best = new Map<string, Match>();
+    for (const m of matches) {
+      const key = `${m.cargoEmailId}|${m.vesselEmailId}`;
+      const prev = best.get(key);
+      const f = m.fitPercent ?? -1, pf = prev?.fitPercent ?? -1;
+      if (!prev || f > pf || (f === pf && m.score > prev.score)) best.set(key, m);
+    }
+    return [...best.values()];
+  }
+
+  // Insufficient = passed hard gates but timing unknown (vague port/date). There
+  // are ~1000 such email-pairs; showing them all is noise, so cap to a
+  // representative top-N by score. Main + review are shown in full.
+  const INSUF_CAP = Number(arg('--insuf-cap') ?? 60);
+  const mainClean = dedup(result.matches.filter((m) => m.confidence?.blockSend !== true));
+  const review = dedup(result.lowConfidenceMatches);
+  const insufficient = dedup(result.insufficientData)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, INSUF_CAP);
+
+  const fits = (arr: Match[]) => arr.map((m) => m.fitPercent ?? 0).filter((n) => n > 0).sort((a, b) => a - b);
+  const fm = fits(mainClean);
+  console.log(`[regen] BUCKETS (deduped to email-pair):`);
+  console.log(`  main (NULL):            ${mainClean.length}  · fit min ${fm[0]?.toFixed(0)} med ${fm[Math.floor(fm.length/2)]?.toFixed(0)} max ${fm[fm.length-1]?.toFixed(0)} · ≥70:${fm.filter(x=>x>=70).length} ≥60:${fm.filter(x=>x>=60).length}`);
+  console.log(`  review (__demo_review__):       ${review.length}`);
+  console.log(`  insufficient (__demo_insufficient__): ${insufficient.length}`);
+  console.log(`  (dropped main cleanliness-blocked: ${result.matches.filter((m) => m.confidence?.blockSend === true).length}; engine blocked total: ${result.blockedMatches.length})`);
+
+  if (DRY) { db.close(); console.log('[regen] DRY — no writes.'); return; }
+
+  // ── 4. Write: replace the seed buckets (NULL + sentinels). Orphan per-session
+  //        UUID copies are left for the app's deleteOrphanSessionMatches to prune. ──
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO matches
+      (cargo_id, vessel_id, cargo_item_index, vessel_item_index, score, reason, status, user_id,
+       created_at, updated_at, reason_structured, cargo_type, load_port, discharge_port,
+       laycan_start, laycan_end, vessel_dwt, tce_usd_per_day, distance_nm, vessel_name, cargo_ref,
+       fit_percent, fit_breakdown)
+    VALUES (?, ?, ?, ?, ?, ?, 'shortlist', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  function writeBucket(matches: Match[], userId: string | null): number {
+    let n = 0;
+    for (const m of matches) {
+      const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);
+      const vessel = vesselMap.get(`${m.vesselEmailId}|${m.vesselItemIndex}`);
+      const loadPort = cargo ? cfValue(cargo.originPort) : null;
+      const dischargePort = cargo ? cfValue(cargo.destinationPort) : null;
+      const lay = cargo ? parseLaycan(cargo.laycan, refYear) : null;
+      const voyage = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+      insert.run(
+        m.cargoEmailId, m.vesselEmailId, m.cargoItemIndex, m.vesselItemIndex,
+        Math.max(0, Math.min(100, Math.round(m.score))), m.matchReasons[0] ?? '', userId,
+        nowMs, nowMs,
+        m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
+        cargo ? cargoTypeStr(cargo) : null,
+        loadPort, dischargePort,
+        lay ? lay.start.getTime() : null,
+        lay ? lay.end.getTime() : null,
+        vessel ? (cfValue(vessel.dwtSummer) ?? null) : null,
+        m.economics?.tceUsdPerDay ?? null,
+        voyage ? voyage.nm : null,
+        vessel ? (cfValue(vessel.vesselName) || null) : null,
+        cargo ? (cfValue(cargo.cargoDescription) || null) : null,
+        m.fitPercent ?? null,
+        m.fitBreakdown ? JSON.stringify(m.fitBreakdown) : null,
+      );
+      n++;
+    }
+    return n;
+  }
+
+  const tx = db.transaction(() => {
+    const del = db.prepare(`DELETE FROM matches WHERE user_id IS NULL OR user_id IN ('__demo_review__','__demo_insufficient__')`).run();
+    const a = writeBucket(mainClean, null);
+    const b = writeBucket(review, '__demo_review__');
+    const c = writeBucket(insufficient, '__demo_insufficient__');
+    console.log(`[regen] deleted ${del.changes} old seed rows · wrote main=${a} review=${b} insufficient=${c}`);
+  });
+  tx();
+
+  // verify
+  const v = db.prepare(`SELECT COUNT(*) n, SUM(fit_percent IS NOT NULL) withfit FROM matches WHERE user_id IS NULL`).get() as { n: number; withfit: number };
+  console.log(`[regen] verify main(NULL): ${v.n} rows, ${v.withfit} with fit`);
+  db.close();
+}
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Что и зачем

Демо-матчи строились наивной парой (утилизация ≤90% + laycan ±7д) **в обход настоящего движка матчинга**. Из-за этого брокер видел пары, нарушающие хард-правила (объём, осадка, краны, IMSBC, тип, тайминг, чистота трюмов) — то, что реально использовать нельзя.

Плюс корневой баг формы данных: demo хранил `cargo.laycan` объектом `{start,end}` (канон — строка) и `vessel.openDate` голой ISO-строкой (канон — `ConfidenceField`), поэтому движок классифицировал ВСЕ пары как «unknown timing» → 0 валидных матчей. `build.ts` это прятал, читая поля напрямую.

## Изменения

- **migration 044** — `cargo_item_index` / `vessel_item_index` в `matches` (DEFAULT 0). Письмо несёт несколько распознанных айтемов; seed должен помнить, какой именно cargo/vessel айтем спарен, чтобы detail-панель резолвила правильный.
- **hydrate-demo-session** — читает два индекс-столбца (NULL-safe для немигрированных БД) вместо хардкода item 0; расширен `selectCols` для всех трёх demo-бакетов.
- **matches-repository + persist-session-matches** — индексы протянуты сквозь (под guard'ом наличия колонок), чтобы per-session копии оставались item-корректными.
- **scripts/demo-seed/regenerate-matches.ts** — пересобирает seed через `analyzePairs` с no-op скорером: нормализует форму данных к каноническому контракту, оставляет только прошедшие ВСЕ правила, дедупит до одной пары писем (лучший fit), пишет бакеты main / review / insufficient с верными индексами.

## Результат прогона на реальных demo-данных

| Бакет | Кол-во |
|---|---|
| отсеяно по правилам | 13046 |
| main (валидные, брокерский лист) | 200 (fit 48–89, медиана 67) |
| review | 111 |
| insufficient (кап) | 60 |

## Применение на проде

После merge: deploy применяет migration 044 при рестарте сервиса, затем regenerate-matches прогоняется по prod demo-seed.db, рестарт, проверка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)