### PR TITLE
feat(demo): broker-polish — fit-sort, fit>=60 floor, gap notes

### DIFF
--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -37,11 +37,11 @@ interface ScoreComponent {
 }
 
 type QuickFilter = 'all' | 'fresh' | 'score80' | 'dwt50_60';
-type SortBy = 'score' | 'freshness' | 'tce';
+type SortBy = 'fit' | 'score' | 'freshness' | 'tce';
 type Density = 'table' | 'cards';
 type Tab = 'matches' | 'review' | 'insufficient';
 
-const SORT_LABELS: Record<SortBy, string> = { score: 'Score', freshness: 'Freshness', tce: 'TCE/day' };
+const SORT_LABELS: Record<SortBy, string> = { fit: 'Fit %', score: 'Score', freshness: 'Freshness', tce: 'TCE/day' };
 
 function scoreClass(score: number): string {
   if (score >= 93) return 'bg-emerald-50 text-emerald-700 border border-emerald-200';
@@ -129,12 +129,12 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   const [expandedFitBreakdown, setExpandedFitBreakdown] = useState<number | null>(null);
   const [showModal, setShowModal] = useState<{ action: string; count: number } | null>(null);
   const [bulkError, setBulkError] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<SortBy>(() => isOwner ? 'tce' : 'score');
+  const [sortBy, setSortBy] = useState<SortBy>(() => isOwner ? 'tce' : 'fit');
   // Derived-state-during-render resets sort on mode switch without cascading renders.
   const [prevIsOwner, setPrevIsOwner] = useState(isOwner);
   if (prevIsOwner !== isOwner) {
     setPrevIsOwner(isOwner);
-    setSortBy(isOwner ? 'tce' : 'score');
+    setSortBy(isOwner ? 'tce' : 'fit');
   }
 
   // CD design state
@@ -350,6 +350,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
     .sort((a, b) => {
       if (sortBy === 'freshness') return b.created_at - a.created_at;
       if (sortBy === 'tce') return (b.tce_usd_per_day ?? 0) - (a.tce_usd_per_day ?? 0);
+      if (sortBy === 'fit') return (b.fit_percent ?? 0) - (a.fit_percent ?? 0);
       return b.score - a.score;
     });
 
@@ -514,6 +515,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                 onChange={(e) => setSortBy(e.target.value as SortBy)}
                 className="h-8 px-2 border border-ds-border rounded-lg bg-ds-surface text-ds-text text-xs font-mono cursor-pointer hover:border-ds-border-strong transition-colors"
               >
+                <option data-testid="sort-fit" value="fit">Fit %</option>
                 <option data-testid="sort-score" value="score">Score</option>
                 <option data-testid="sort-freshness" value="freshness">Freshness</option>
                 <option data-testid="sort-tce" value="tce">TCE/day</option>

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -128,21 +128,60 @@ async function main() {
     return [...best.values()];
   }
 
-  // Insufficient = passed hard gates but timing unknown (vague port/date). There
-  // are ~1000 such email-pairs; showing them all is noise, so cap to a
-  // representative top-N by score. Main + review are shown in full.
+  // Broker-facing one-line note: tier headline + the weakest 1-2 factors, so the
+  // broker sees AT A GLANCE what is missing on a non-perfect match (stored in
+  // `reason`, shown on the row + detail). The full per-factor breakdown is the
+  // expandable fit panel; this is the summary.
+  function gapNote(m: Match): string {
+    const fb = m.fitBreakdown;
+    const fit = Math.round(m.fitPercent ?? 0);
+    if (!fb) return m.matchReasons[0] ?? '';
+    const verdict = fb.inputs?.verdict;
+    if (verdict === 'unknown') return 'Timing unconfirmed — vague port/date; verify before calling';
+    const util = fb.inputs?.utilisation, dist = fb.inputs?.distanceNm, gap = fb.inputs?.gapDays;
+    const short = (factor: string): string => {
+      switch (factor) {
+        case 'utilisation': return util != null ? `under-utilised ${Math.round(util * 100)}%` : 'low utilisation';
+        case 'timing': return verdict === 'idle' ? `vessel idle ~${Math.abs(Math.round(gap ?? 0))}d pre-laycan` : verdict === 'tight' ? 'tight laycan timing' : 'timing risk';
+        case 'ballast': return dist != null ? `long ballast ~${Math.round(dist)}nm` : 'long ballast leg';
+        case 'vetting': return 'vetting unconfirmed';
+        case 'cranes': return 'crane availability unverified';
+        case 'classFit': return 'vessel size mismatch';
+        case 'volume': return 'hold volume tight';
+        case 'draft': return 'draft unverified';
+        case 'cargoType': return 'cargo-type fit marginal';
+        default: return factor;
+      }
+    };
+    const weak = (fb.components ?? [])
+      .filter((c) => c.weight >= 4 && c.score / c.weight < 0.72)
+      .sort((a, b) => a.score / a.weight - b.score / b.weight)
+      .slice(0, 2)
+      .map((c) => short(c.factor));
+    const cap = fb.appliedCap ? ` (capped: ${fb.appliedCap.reason})` : '';
+    if (fit >= 80 && weak.length === 0) return 'Strong fit — clean across factors';
+    const head = fit >= 80 ? 'Strong fit' : fit >= 70 ? 'Good fit' : 'Workable';
+    return weak.length ? `${head} — watch: ${weak.join(', ')}${cap}` : `${head}${cap}`;
+  }
+
+  // Main board = fit >= floor (broker audit); the weaker sub-floor tail (mostly
+  // deadfreight) is demoted to the review tab rather than hidden. Insufficient
+  // (timing unknown — vague port/date) is capped to a representative sample.
+  const MAIN_FIT_FLOOR = Number(arg('--fit-floor') ?? 60);
   const INSUF_CAP = Number(arg('--insuf-cap') ?? 60);
-  const mainClean = dedup(result.matches.filter((m) => m.confidence?.blockSend !== true));
-  const review = dedup(result.lowConfidenceMatches);
+  const mainAll = dedup(result.matches.filter((m) => m.confidence?.blockSend !== true));
+  const mainClean = mainAll.filter((m) => (m.fitPercent ?? 0) >= MAIN_FIT_FLOOR);
+  const demoted = mainAll.filter((m) => (m.fitPercent ?? 0) < MAIN_FIT_FLOOR);
+  const review = dedup([...result.lowConfidenceMatches, ...demoted]);
   const insufficient = dedup(result.insufficientData)
     .sort((a, b) => b.score - a.score)
     .slice(0, INSUF_CAP);
 
   const fits = (arr: Match[]) => arr.map((m) => m.fitPercent ?? 0).filter((n) => n > 0).sort((a, b) => a - b);
   const fm = fits(mainClean);
-  console.log(`[regen] BUCKETS (deduped to email-pair):`);
-  console.log(`  main (NULL):            ${mainClean.length}  · fit min ${fm[0]?.toFixed(0)} med ${fm[Math.floor(fm.length/2)]?.toFixed(0)} max ${fm[fm.length-1]?.toFixed(0)} · ≥70:${fm.filter(x=>x>=70).length} ≥60:${fm.filter(x=>x>=60).length}`);
-  console.log(`  review (__demo_review__):       ${review.length}`);
+  console.log(`[regen] BUCKETS (deduped to email-pair · main floor fit>=${MAIN_FIT_FLOOR}):`);
+  console.log(`  main (NULL):            ${mainClean.length}  · fit min ${fm[0]?.toFixed(0)} med ${fm[Math.floor(fm.length/2)]?.toFixed(0)} max ${fm[fm.length-1]?.toFixed(0)} · ≥80:${fm.filter(x=>x>=80).length} ≥70:${fm.filter(x=>x>=70).length}`);
+  console.log(`  review (__demo_review__):       ${review.length}  (engine-low ${dedup(result.lowConfidenceMatches).length} + demoted sub-floor ${demoted.length})`);
   console.log(`  insufficient (__demo_insufficient__): ${insufficient.length}`);
   console.log(`  (dropped main cleanliness-blocked: ${result.matches.filter((m) => m.confidence?.blockSend === true).length}; engine blocked total: ${result.blockedMatches.length})`);
 
@@ -170,7 +209,7 @@ async function main() {
       const voyage = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
       insert.run(
         m.cargoEmailId, m.vesselEmailId, m.cargoItemIndex, m.vesselItemIndex,
-        Math.max(0, Math.min(100, Math.round(m.score))), m.matchReasons[0] ?? '', userId,
+        Math.max(0, Math.min(100, Math.round(m.score))), gapNote(m), userId,
         nowMs, nowMs,
         m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
         cargo ? cargoTypeStr(cargo) : null,


### PR DESCRIPTION
По итогам брокерского аудита 200 матчей.

- **MatchesClient**: добавлена сортировка **Fit %** + она по умолчанию для демо-зрителя (было Score) — лист читается «от лучшего» по главной брокерской метрике.
- **regenerate-matches**: главный лист теперь только **fit ≥ 60** (отрезан deadfreight-хвост); под-планочные матчи спущены во вкладку «на проверку», а не спрятаны. В `reason` каждого матча — брокерская пометка (тир + 1-2 слабых фактора, напр. «Good fit — watch: under-utilised 58%, vetting unconfirmed»), чтобы на неидеальном матче было видно, что проверить.

После merge: deploy, затем повторный прогон regenerate-matches на проде (main≈133, review≈178, insufficient=60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)