### PR TITLE
fix(demo): dedup re-circulated vessels/cargo in list views

### DIFF
--- a/app/cargo/page.tsx
+++ b/app/cargo/page.tsx
@@ -71,5 +71,27 @@ export default async function CargoPage() {
     };
   });
 
-  return <CargoClient rows={rows} total={rows.length} />;
+  // Collapse re-circulated duplicate cargoes (same parcel across several circular
+  // emails). Key on commodity + load port + quantity + laycan; discharge port is
+  // excluded (free-text wording noise splits true dupes). Genuinely different
+  // parcels (different route/qty/dates) stay separate; unknown-commodity rows are
+  // keyed by id. Prefer the row that already has a match.
+  const dedupedCargo = dedupRows(rows, (r) =>
+    r.commodity
+      ? `${r.commodity}|${r.originPort ?? ''}|${r.quantity ?? ''}|${JSON.stringify(r.laycan ?? '')}`
+      : r.id,
+  );
+
+  return <CargoClient rows={dedupedCargo} total={dedupedCargo.length} />;
+}
+
+/** Keep one row per content key, preferring a row that already has a match. */
+function dedupRows<T extends { status: 'open' | 'match' }>(rows: T[], key: (r: T) => string): T[] {
+  const seen = new Map<string, T>();
+  for (const r of rows) {
+    const k = key(r);
+    const prev = seen.get(k);
+    if (!prev || (r.status === 'match' && prev.status !== 'match')) seen.set(k, r);
+  }
+  return [...seen.values()];
 }

--- a/app/vessels/page.tsx
+++ b/app/vessels/page.tsx
@@ -71,5 +71,27 @@ export default async function VesselsPage() {
     };
   });
 
-  return <VesselsClient rows={rows} total={rows.length} />;
+  // Collapse re-circulated duplicate vessels: the demo corpus carries the same
+  // vessel as items across several circular emails. Key on identity (name +
+  // open position + open date); a vessel at a genuinely different position/date
+  // stays as a separate row. Unknown-named rows are never collapsed (keyed by id).
+  // Prefer the row that already has a match so matched vessels stay visible.
+  const dedupedVessels = dedupRows(rows, (r) =>
+    r.vesselName && r.vesselName !== 'Unknown vessel'
+      ? `${r.vesselName}|${r.openPosition ?? ''}|${r.openDate ?? ''}`
+      : r.id,
+  );
+
+  return <VesselsClient rows={dedupedVessels} total={dedupedVessels.length} />;
+}
+
+/** Keep one row per content key, preferring a row that already has a match. */
+function dedupRows<T extends { status: 'open' | 'match' }>(rows: T[], key: (r: T) => string): T[] {
+  const seen = new Map<string, T>();
+  for (const r of rows) {
+    const k = key(r);
+    const prev = seen.get(k);
+    if (!prev || (r.status === 'match' && prev.status !== 'match')) seen.set(k, r);
+  }
+  return [...seen.values()];
 }


### PR DESCRIPTION
Списки /vessels и /cargo показывали повторы (одно судно/груз из нескольких циркулярных писем): 115 айтемов судов / 89 уникальных, 142 груза / 107 уникальных. Добавлен дедуп при отображении на обеих страницах по контент-идентичности (судно: имя+позиция+дата открытия; груз: товар+порт погрузки+кол-во+лейкан, discharge исключён — wording-шум), с предпочтением строки, у которой уже есть матч. Данные не трогаются — сессия и резолв матчей без изменений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)