### PR TITLE
fix(dashboard): To do today — top-5 + See all link

### DIFF
--- a/components/dashboard/DashboardTodoSection.tsx
+++ b/components/dashboard/DashboardTodoSection.tsx
@@ -21,11 +21,15 @@ const PRIORITY_LABEL: Record<PriorityLevel, string> = {
   ok: 'OK',
 };
 
+const VISIBLE_LIMIT = 5;
+
 interface DashboardTodoSectionProps {
   cards: TodoCard[];
 }
 
 export function DashboardTodoSection({ cards }: DashboardTodoSectionProps) {
+  const visible = cards.slice(0, VISIBLE_LIMIT);
+
   return (
     <section aria-labelledby="todo-heading">
       <div className="flex items-center justify-between mb-3">
@@ -35,7 +39,17 @@ export function DashboardTodoSection({ cards }: DashboardTodoSectionProps) {
         >
           🎯 To do today
         </h2>
-        {cards.length > 0 && <Badge variant="outline">{cards.length}</Badge>}
+        <div className="flex items-center gap-2">
+          {cards.length > 0 && <Badge variant="outline">{cards.length}</Badge>}
+          {cards.length > VISIBLE_LIMIT && (
+            <Link
+              href="/matches"
+              className="text-xs text-ds-text-muted hover:text-ds-text transition-colors duration-ds-fast"
+            >
+              See all →
+            </Link>
+          )}
+        </div>
       </div>
 
       {cards.length === 0 ? (
@@ -46,7 +60,7 @@ export function DashboardTodoSection({ cards }: DashboardTodoSectionProps) {
         </Card>
       ) : (
         <div className="space-y-2">
-          {cards.map((card, i) => (
+          {visible.map((card, i) => (
             <Link
               key={i}
               href={card.href}

--- a/components/dashboard/__tests__/DashboardSections.test.tsx
+++ b/components/dashboard/__tests__/DashboardSections.test.tsx
@@ -67,6 +67,49 @@ describe('DashboardTodoSection', () => {
     // Badge renders with count
     expect(text).toContain('2');
   });
+
+  it('renders only first 5 cards when more than 5 provided', () => {
+    const manyCards = Array.from({ length: 8 }, (_, i) => ({
+      priority: 'ok' as const,
+      matchSummary: `Summary ${i}`,
+      keyInsight: `Insight ${i}`,
+      href: `/match/${i}`,
+    }));
+    const el = DashboardTodoSection({ cards: manyCards });
+    const text = JSON.stringify(el);
+    expect(text).toContain('Summary 0');
+    expect(text).toContain('Summary 1');
+    expect(text).toContain('Summary 2');
+    expect(text).toContain('Summary 3');
+    expect(text).toContain('Summary 4');
+    expect(text).not.toContain('Summary 5');
+  });
+
+  it('shows See all link and full badge count when cards exceed limit', () => {
+    const manyCards = Array.from({ length: 8 }, (_, i) => ({
+      priority: 'ok' as const,
+      matchSummary: `Summary ${i}`,
+      keyInsight: `Insight ${i}`,
+      href: `/match/${i}`,
+    }));
+    const el = DashboardTodoSection({ cards: manyCards });
+    const text = JSON.stringify(el);
+    expect(text).toContain('See all');
+    expect(text).toContain('/matches');
+    expect(text).toContain('8');
+  });
+
+  it('does not show See all link when cards are 5 or fewer', () => {
+    const fewCards = Array.from({ length: 5 }, (_, i) => ({
+      priority: 'ok' as const,
+      matchSummary: `Summary ${i}`,
+      keyInsight: `Insight ${i}`,
+      href: `/match/${i}`,
+    }));
+    const el = DashboardTodoSection({ cards: fewCards });
+    const text = JSON.stringify(el);
+    expect(text).not.toContain('See all');
+  });
 });
 
 describe('DashboardFreshMatches', () => {


### PR DESCRIPTION
## Summary
- Slice visible To-do cards to first 5 (`VISIBLE_LIMIT = 5`)
- Badge keeps full `cards.length` count (informative)
- "See all →" link to `/matches` appears in header when `cards.length > 5`, mirroring DashboardFreshMatches style
- Link hidden when ≤5 cards; empty "All clear" state unchanged

## Test plan
- [x] `npx jest components/dashboard/__tests__/DashboardSections.test.tsx` — 20/20 pass
- [x] RED→GREEN: 3 new tests (top-5 slicing, See-all present/absent)
- [x] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)