### PR TITLE
fix(email): strip +++ separator noise from email body view

### DIFF
--- a/__tests__/components/email-body-viewer-sanitize.test.tsx
+++ b/__tests__/components/email-body-viewer-sanitize.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EmailBodyViewer, Highlight } from '../../components/email-body-viewer';
+
+describe('EmailBodyViewer — plus-separator sanitization', () => {
+  it('strips +++ separator from rendered body', () => {
+    const body = 'Section A\n+++\nSection B';
+    const { container } = render(<EmailBodyViewer body={body} highlights={[]} />);
+    expect(container.textContent).not.toContain('+++');
+  });
+
+  it('both highlights resolve after +++ separator is removed', () => {
+    const body = 'Vessel: MV Kilo\n++++++\nCargo: iron ore';
+    const highlights: Highlight[] = [
+      { text: 'MV Kilo', color: 'bg-blue-200', label: 'vessel' },
+      { text: 'iron ore', color: 'bg-green-200', label: 'cargo' },
+    ];
+    const { container } = render(
+      <EmailBodyViewer body={body} highlights={highlights} />
+    );
+    const marks = container.querySelectorAll('mark');
+    expect(marks.length).toBe(2);
+    const titles = Array.from(marks).map(m => m.getAttribute('title'));
+    expect(titles).toContain('vessel');
+    expect(titles).toContain('cargo');
+  });
+
+  it('preserves "do not recirculate" text', () => {
+    const body = 'do not recirculate\n+++\nsome info';
+    const { container } = render(<EmailBodyViewer body={body} highlights={[]} />);
+    expect(container.textContent).toContain('do not recirculate');
+  });
+
+  it('preserves inline C++ in body', () => {
+    const body = 'Built with C++ framework\n+++\nEnd';
+    const { container } = render(<EmailBodyViewer body={body} highlights={[]} />);
+    expect(container.textContent).toContain('C++');
+  });
+});

--- a/components/email-body-viewer.tsx
+++ b/components/email-body-viewer.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useEffect, useRef } from 'react';
 import { detectTextDirection } from '@/lib/i18n/rtl-detect';
-import { decodeHtmlEntities } from '@/lib/utils';
+import { decodeHtmlEntities, sanitizeEmailBody } from '@/lib/utils';
 
 export interface Highlight {
   text: string;
@@ -50,9 +50,9 @@ function buildTree(body: string, highlights: Highlight[]): Node[] {
 export function EmailBodyViewer({ body, highlights }: Props) {
   const firstMarkRef = useRef<HTMLElement | null>(null);
 
-  // Decode HTML entities first (fix #474), then normalize CRLF → LF.
-  // decodeHtmlEntities is safe: no innerHTML, pure string replacement.
-  const normalizedBody = decodeHtmlEntities(body).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  // Decode HTML entities first (fix #474), normalize CRLF → LF, then sanitize.
+  // sanitizeEmailBody strips +++ separator lines and antivirus footers.
+  const normalizedBody = sanitizeEmailBody(decodeHtmlEntities(body).replace(/\r\n/g, '\n').replace(/\r/g, '\n'));
 
   useEffect(() => {
     if (window.location.hash === '#highlight' && firstMarkRef.current) {

--- a/lib/__tests__/sanitize-email-body.test.ts
+++ b/lib/__tests__/sanitize-email-body.test.ts
@@ -1,0 +1,55 @@
+import { sanitizeEmailBody } from '@/lib/utils';
+
+describe('sanitizeEmailBody — plus-separator stripping', () => {
+  it('removes a line of 3 pluses', () => {
+    expect(sanitizeEmailBody('before\n+++\nafter')).not.toContain('+++');
+  });
+
+  it('removes a line of 8 pluses', () => {
+    expect(sanitizeEmailBody('before\n++++++++\nafter')).not.toContain('++++++++');
+  });
+
+  it('removes a separator line with surrounding spaces/tabs', () => {
+    const result = sanitizeEmailBody('before\n   +++   \nafter');
+    expect(result).not.toMatch(/\+\+\+/);
+  });
+
+  it('preserves inline "C++" — not a separator line', () => {
+    expect(sanitizeEmailBody('compiled with C++ compiler')).toContain('C++');
+  });
+
+  it('preserves inline "a+b" — not a separator line', () => {
+    expect(sanitizeEmailBody('formula: a+b=c')).toContain('a+b');
+  });
+
+  it('preserves "++" — below threshold of 3', () => {
+    expect(sanitizeEmailBody('only two: ++\nnext line')).toContain('++');
+  });
+
+  it('preserves "do not recirculate"', () => {
+    expect(sanitizeEmailBody('do not recirculate\n+++\nbye')).toContain('do not recirculate');
+  });
+
+  it('strips separator then collapses resulting blank lines', () => {
+    const input = 'hello\n\n+++\n\nworld';
+    const result = sanitizeEmailBody(input);
+    expect(result).not.toMatch(/\+\+\+/);
+    // collapsed to max one blank line
+    expect(result).not.toMatch(/\n{3,}/);
+  });
+
+  it('preserves existing file:// rule — still stripped', () => {
+    expect(sanitizeEmailBody('<file:///tmp/foo.txt>')).not.toContain('file://');
+  });
+
+  it('preserves existing antivirus-footer rule', () => {
+    const footer = 'Checked by AVG antivirus software';
+    expect(sanitizeEmailBody(footer)).not.toContain('AVG');
+  });
+
+  it('preserves existing mailto rule', () => {
+    const result = sanitizeEmailBody('<mailto:user@example.com>');
+    expect(result).toContain('user@example.com');
+    expect(result).not.toContain('mailto:');
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,6 +60,7 @@ export function sanitizeEmailBody(body: string): string {
     .replace(/<mailto:([^>]+)>/gi, '$1')
     .replace(/<(https?:\/\/[^>]+)>/gi, '$1')
     .replace(/^.*(AVG|Avast|Norton|Kaspersky|ESET|McAfee).*virus.*$/gim, '')
+    .replace(/^[ \t]*\+{3,}[ \t]*$/gm, '')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
 }


### PR DESCRIPTION
## Summary
- Extends `sanitizeEmailBody` in `lib/utils.ts` with `/^[ \t]*\+{3,}[ \t]*$/gm` — strips whole-line plus-separator rows (3+) before blank-line collapsing
- Applies sanitizer in `EmailBodyViewer.normalizedBody` so `/email/[id]` no longer renders `+++`/`++++++++` noise from re-forwarded sections
- Highlights unaffected — resolved by `body.indexOf(h.text)` on sanitized body; verified by test

## Test plan
- [ ] `npx jest --findRelatedTests lib/utils.ts components/email-body-viewer.tsx` — 694/98 suites green
- [ ] `lib/__tests__/sanitize-email-body.test.ts` — 11 unit tests (inline C++ preserved, do-not-recirculate preserved, existing rules no-regress)
- [ ] `__tests__/components/email-body-viewer-sanitize.test.tsx` — 4 component tests (highlights resolve after strip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)