### PR TITLE
fix(match): show FIT% as primary score (retire opaque AI score)

### DIFF
--- a/__tests__/components/match/MatchDetailPanel-fit.test.ts
+++ b/__tests__/components/match/MatchDetailPanel-fit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests — components/match/MatchDetailPanel.tsx AI Summary fit% (#fit-primary)
+ *
+ * Strategy: static source analysis (testEnvironment: 'node').
+ *
+ * Verifies:
+ *   - AI Summary no longer shows opaque "Score NN reflects…" text
+ *   - When fitPercent != null: shows "Fit NN% — взвешено по факторам ниже"
+ *   - When !hasSessionMatch: reload fallback text preserved
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const panelPath = path.join(ROOT, 'components/match/MatchDetailPanel.tsx');
+
+function readSource(p: string): string {
+  return fs.readFileSync(p, 'utf8');
+}
+
+describe('MatchDetailPanel.tsx — AI Summary fit% (#fit-primary)', () => {
+  it('file exists', () => {
+    expect(fs.existsSync(panelPath)).toBe(true);
+  });
+
+  it('does NOT contain opaque "Score … reflects" text', () => {
+    const src = readSource(panelPath);
+    expect(src).not.toMatch(/Score.*reflects/);
+  });
+
+  it('shows "Fit" label with fit percent when fitPercent is set', () => {
+    const src = readSource(panelPath);
+    // Must render something like: Fit ${Math.round(fitPercent)}%
+    expect(src).toMatch(/Fit.*fitPercent|fitPercent.*Fit/);
+  });
+
+  it('uses Math.round for fitPercent display in AI Summary', () => {
+    const src = readSource(panelPath);
+    expect(src).toMatch(/Math\.round.*fitPercent/);
+  });
+
+  it('preserves reload fallback text for !hasSessionMatch', () => {
+    const src = readSource(panelPath);
+    expect(src).toMatch(/Reload to refresh match data/);
+  });
+
+  it('data-testid="match-detail-panel" still present', () => {
+    const src = readSource(panelPath);
+    expect(src).toMatch(/data-testid="match-detail-panel"/);
+  });
+});

--- a/__tests__/match-detail.test.tsx
+++ b/__tests__/match-detail.test.tsx
@@ -135,6 +135,49 @@ describe('app/match/[id]/page.tsx — navigation', () => {
   });
 });
 
+describe('app/match/[id]/page.tsx — FIT% hero circle (#fit-primary)', () => {
+  it('data-testid="score-pill" is always present', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/data-testid="score-pill"/);
+  });
+
+  it('hero reads fit_percent from storedMatch', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/fit_percent/);
+  });
+
+  it('hero shows "fit" label when fit_percent is set (not "score")', () => {
+    const src = readSource(pagePath);
+    // The "fit" label must appear inside the score-pill block conditionally
+    // Pattern: fit_percent != null branch contains jsx text >fit<
+    expect(src).toMatch(/fit_percent.*!=.*null[\s\S]{0,1000}>fit</);
+  });
+
+  it('hero uses Math.round(fit_percent) when fit_percent != null', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/Math\.round.*fit_percent|fit_percent.*Math\.round/);
+  });
+
+  it('hero falls back to storedMatch.score + "score" when fit_percent is null', () => {
+    const src = readSource(pagePath);
+    // null branch still has "score" JSX text label
+    expect(src).toMatch(/>score</);
+  });
+});
+
+describe('app/match/[id]/page.tsx — Vessel card FIT% (#fit-primary)', () => {
+  it('vessel card shows "Fit" label when fit_percent is set', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/"Fit"|'Fit'/);
+  });
+
+  it('vessel card shows fit_percent value with % suffix when fit_percent is set', () => {
+    const src = readSource(pagePath);
+    // Pattern: fit_percent in vessel card with % in the template
+    expect(src).toMatch(/fit_percent[\s\S]{0,200}%/);
+  });
+});
+
 describe('app/api/matches/[id]/route.ts — GET handler', () => {
   it('exports GET function', () => {
     const src = readSource(routePath);

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -120,17 +120,38 @@ export default async function MatchDetailPage({ params }: Props) {
           </Link>
 
           <div className="flex items-center gap-4 sm:gap-6">
-            {/* Amber score pill */}
-            <div
-              className="flex-shrink-0 flex flex-col items-center justify-center rounded-full bg-ds-accent-soft text-ds-accent-soft-fg w-20 h-20 sm:w-24 sm:h-24"
-              data-testid="score-pill"
-              aria-label={`Match score: ${storedMatch.score}`}
-            >
-              <span className="font-mono text-3xl sm:text-4xl font-semibold leading-none">
-                {storedMatch.score}
-              </span>
-              <span className="text-xs font-medium opacity-60 mt-0.5">score</span>
-            </div>
+            {/* Score / Fit pill */}
+            {storedMatch.fit_percent != null ? (() => {
+              const fitPct = Math.round(storedMatch.fit_percent!);
+              const fitColor = fitPct >= 85
+                ? 'bg-emerald-100 text-emerald-800'
+                : fitPct >= 60
+                  ? 'bg-amber-100 text-amber-800'
+                  : 'bg-slate-100 text-slate-600';
+              return (
+                <div
+                  className={`flex-shrink-0 flex flex-col items-center justify-center rounded-full w-20 h-20 sm:w-24 sm:h-24 ${fitColor}`}
+                  data-testid="score-pill"
+                  aria-label={`Fit score: ${fitPct}%`}
+                >
+                  <span className="font-mono text-3xl sm:text-4xl font-semibold leading-none">
+                    {fitPct}%
+                  </span>
+                  <span className="text-xs font-medium opacity-60 mt-0.5">fit</span>
+                </div>
+              );
+            })() : (
+              <div
+                className="flex-shrink-0 flex flex-col items-center justify-center rounded-full bg-ds-accent-soft text-ds-accent-soft-fg w-20 h-20 sm:w-24 sm:h-24"
+                data-testid="score-pill"
+                aria-label={`Match score: ${storedMatch.score}`}
+              >
+                <span className="font-mono text-3xl sm:text-4xl font-semibold leading-none">
+                  {storedMatch.score}
+                </span>
+                <span className="text-xs font-medium opacity-60 mt-0.5">score</span>
+              </div>
+            )}
 
             {/* Headline + meta */}
             <div className="min-w-0 flex-1">
@@ -187,9 +208,9 @@ export default async function MatchDetailPage({ params }: Props) {
                     <dd className="font-medium text-ds-text capitalize">{storedMatch.status}</dd>
                   </div>
                   <div className="flex justify-between gap-2">
-                    <dt className="text-ds-text-muted">Score</dt>
+                    <dt className="text-ds-text-muted">{storedMatch.fit_percent != null ? 'Fit' : 'Score'}</dt>
                     <dd className="font-mono font-semibold text-ds-accent-soft-fg">
-                      {storedMatch.score}
+                      {storedMatch.fit_percent != null ? `${Math.round(storedMatch.fit_percent)}%` : storedMatch.score}
                     </dd>
                   </div>
                 </dl>

--- a/components/match/MatchDetailPanel.tsx
+++ b/components/match/MatchDetailPanel.tsx
@@ -76,9 +76,11 @@ function PanelContent({
         </CardHeader>
         <CardContent>
           <p className="text-xs text-ds-text-muted leading-relaxed">
-            {hasSessionMatch
-              ? `Score ${score} reflects cargo/vessel compatibility — DWT, route alignment, and laycan window.`
-              : 'Session enrichment unavailable. Reload to refresh match data.'}
+            {fitPercent != null
+              ? `Fit ${Math.round(fitPercent)}% — взвешено по факторам ниже (сумма весов = 100).`
+              : !hasSessionMatch
+                ? 'Session enrichment unavailable. Reload to refresh match data.'
+                : null}
           </p>
         </CardContent>
       </Card>

--- a/docs/superpowers/plans/2026-06-01-match-fit-score-primary.md
+++ b/docs/superpowers/plans/2026-06-01-match-fit-score-primary.md
@@ -1,0 +1,36 @@
+# Plan: match detail — FIT% как единственный балл (2026-06-01)
+
+## Goal
+На матч-детали старый непрозрачный AI-балл (напр. 92) показан в 4 местах. Заменить его на прозрачный FIT% (89%) ВЕЗДЕ в шапке/левой колонке. FIT SCORE-панель справа (9 факторов) уже есть — её разметку/формулу НЕ трогать. Founder выбрал "Заменить на FIT% везде".
+
+## Context (важно)
+- `app/match/[id]/page.tsx` уже имеет `storedMatch.fit_percent` (прокидывает в panel, ~стр.102) и `storedMatch.score`.
+- 4 места старого балла:
+  - hero-кружок ~стр.123-133 (`{storedMatch.score}` + подпись "score", data-testid="score-pill")
+  - бейдж "Good Match" ~стр.141 (matchLevel-label — ОСТАВИТЬ как есть)
+  - Score-строка в Vessel-карточке ~стр.189-194
+  - текст "Score NN reflects…" в AI Summary — `components/match/MatchDetailPanel.tsx` ~стр.78-83
+- FIT SCORE-карточка с разбивкой — `MatchDetailPanel.tsx` ~стр.149-190 — НЕ трогать.
+
+## Changes (2 файла + тесты)
+1. `app/match/[id]/page.tsx`
+   - Hero-кружок: когда `fit_percent != null` → показывать `Math.round(fit_percent)` + подпись "fit", цвет по fit-tier (>=85 emerald / >=60 amber / иначе slate). Когда `fit_percent == null` → fallback на `storedMatch.score` + подпись "score" (старое поведение). Обновить aria-label ("Fit score: NN%" либо "Match score: NN"). data-testid="score-pill" СОХРАНИТЬ.
+   - Vessel-карточка Score-строка (189-194): когда fit_percent != null → dt "Fit" / dd "${Math.round(fit_percent)}%"; иначе оставить "Score"/score.
+   - Бейдж "Good Match" (141) — НЕ трогать.
+2. `components/match/MatchDetailPanel.tsx`
+   - AI Summary (78-83): убрать непрозрачный "Score ${score} reflects…". Когда `fitPercent != null` → текст вида "Fit ${Math.round(fitPercent)}% — взвешено по факторам ниже (сумма весов = 100)." Иначе сохранить текущий fallback (`!hasSessionMatch` → "…Reload to refresh match data."). Старый score-текст НЕ показывать.
+
+## Tests (TDD, RED->GREEN)
+- При заданном fit_percent: hero показывает "fit" + округлённый %, НЕ старый score; Vessel-карточка показывает "Fit"; AI Summary без слова "reflects". При fit_percent=null: fallback на score + "score" сохраняется.
+- Существующие data-testid (score-pill, match-detail-panel) не ломать.
+
+## Out-of-scope (orchestrator)
+- НЕ трогать бейдж "Good Match" / matchLevel (founder: бейдж остаётся).
+- НЕ трогать FIT SCORE-панель разбивки (149-190) и её формулу.
+- НЕ менять источник данных score/fit_percent, sorting, matches-repository, движок матчинга.
+- НЕ трогать /matches list и dashboard.
+- Только display-замена на странице матч-детали.
+
+## Verify
+- `npx jest` по затронутым тестам — зелёное.
+- UI PR → Gate 3 preview /match/[id]: кружок = FIT%, нет "Score … reflects", Vessel показывает "Fit". PR title: "fix(match): show FIT% as primary score (retire opaque AI score)".


### PR DESCRIPTION
## Что
На странице матч-детали старый непрозрачный AI-балл (92) заменён на прозрачный **FIT%** везде в шапке/левой колонке:
- Hero-кружок → FIT% (цвет по tier; fallback на score когда fit=null)
- Vessel-карточка: строка "Score" → "Fit / NN%"
- AI Summary: "Score NN reflects…" → "Fit NN% — взвешено по факторам ниже"
- Бейдж "Good Match" и FIT-панель разбивки — не тронуты

## Тесты
36/36 green · tsc clean · TDD (план: docs/superpowers/plans/2026-06-01-match-fit-score-primary.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)