### PR TITLE
feat(match): collapsible 'Показать расчёт' under Fit Score

### DIFF
--- a/__tests__/components/match/MatchDetailPanel-show-calc.test.tsx
+++ b/__tests__/components/match/MatchDetailPanel-show-calc.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests: MatchDetailPanel — collapsible «Показать расчёт» under Fit Score (#fit-show-calc)
+ *
+ * Behavioral: renders component, clicks toggle, verifies DOM content.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+jest.mock('lucide-react', () => ({
+  X: () => null,
+  FileText: () => null,
+  XCircle: () => null,
+  ChevronUp: () => null,
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, className, ...rest }: any) => (
+    <button onClick={onClick} disabled={disabled} className={className} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/components/ui/card', () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children, className }: any) => <div className={className}>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/lib/csrf-client', () => ({ csrfFetch: jest.fn() }));
+jest.mock('@/components/match/CounterModal', () => ({ CounterModal: () => null }));
+
+import { MatchDetailPanel } from '@/components/match/MatchDetailPanel';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+const BASE_PROPS = {
+  matchDbId: 1,
+  score: 70,
+  status: 'pending',
+  loadPort: 'Rotterdam',
+  dischargePort: 'Hamburg',
+  cargoType: 'Coal',
+  vesselDwt: 50000,
+  laycanDisplay: '01 Jun – 15 Jun',
+  hasSessionMatch: true,
+};
+
+const mkBreakdown = (overrides?: object) =>
+  JSON.stringify({
+    components: [
+      { factor: 'size', label: 'Size / utilisation', weight: 18, score: 11.9, rationale: 'Utilisation 72%' },
+      { factor: 'laycan', label: 'Laycan fit', weight: 16, score: 14.0, rationale: 'Tight window' },
+    ],
+    totalWeight: 100,
+    fitPercent: 72,
+    sanctionsPenalty: 0,
+    appliedCap: null,
+    ...overrides,
+  });
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('MatchDetailPanel — Показать расчёт toggle', () => {
+  it('расчёт СВЁРНУТ по умолчанию: toggle button visible, calc строки не видны', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Показать расчёт' })).toBeInTheDocument();
+    expect(screen.queryByText(/Сумма факторов/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Итог.*Fit/)).not.toBeInTheDocument();
+  });
+
+  it('после клика: label меняется на «Скрыть расчёт», строки факторов и ИТОГ видны', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+
+    expect(screen.getByRole('button', { name: 'Скрыть расчёт' })).toBeInTheDocument();
+    // per-factor labels visible (appear in both bar chart + calc rows, so getAllByText)
+    expect(screen.getAllByText('Size / utilisation').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Laycan fit').length).toBeGreaterThanOrEqual(1);
+    // unique calc-section format: score / weight
+    expect(screen.getByText(/11\.9 \/ 18/)).toBeInTheDocument();
+    // reconciliation section
+    expect(screen.getByText(/Сумма факторов/)).toBeInTheDocument();
+    expect(screen.getByText(/Итог \(Fit\)/)).toBeInTheDocument();
+    // итог value matches headline fitPercent (72%)
+    expect(screen.getAllByText(/72%/).length).toBeGreaterThanOrEqual(1);
+    // no sanctions / cap lines
+    expect(screen.queryByText(/Штраф за санкции/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/потолок/i)).not.toBeInTheDocument();
+  });
+
+  it('повторный клик сворачивает (toggle закрывается)', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Скрыть расчёт' }));
+    expect(screen.queryByText(/Сумма факторов/)).not.toBeInTheDocument();
+  });
+
+  it('sanctionsPenalty=8 → строка «Штраф за санкции» с −8 видна после раскрытия', () => {
+    const breakdown = mkBreakdown({ sanctionsPenalty: 8, fitPercent: 64 });
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={64} fitBreakdown={breakdown} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+    expect(screen.getByText(/Штраф за санкции/)).toBeInTheDocument();
+    expect(screen.getByText(/−8/)).toBeInTheDocument();
+  });
+
+  it('sanctionsPenalty=0 → строка штрафа НЕ рендерится', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+    expect(screen.queryByText(/Штраф за санкции/)).not.toBeInTheDocument();
+  });
+
+  it('appliedCap → строка потолка с reason и ceiling видна после раскрытия', () => {
+    const breakdown = mkBreakdown({
+      appliedCap: { reason: 'Unvetted vessel', ceiling: 85 },
+      fitPercent: 85,
+    });
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={85} fitBreakdown={breakdown} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+    expect(screen.getByText(/потолок/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unvetted vessel/)).toBeInTheDocument();
+  });
+
+  it('appliedCap=null → строка потолка НЕ рендерится', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+    expect(screen.queryByText(/потолок/i)).not.toBeInTheDocument();
+  });
+
+  it('fitPercent=null → секция Fit Score и toggle НЕ рендерятся', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={null} fitBreakdown={mkBreakdown()} />,
+    );
+    expect(screen.queryByText('Показать расчёт')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Сумма факторов/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Fit Score/)).not.toBeInTheDocument();
+  });
+
+  it('aria-expanded отражает состояние toggle', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    const btn = screen.getByRole('button', { name: 'Показать расчёт' });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(btn);
+    expect(screen.getByRole('button', { name: 'Скрыть расчёт' })).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/components/match/MatchDetailPanel.tsx
+++ b/components/match/MatchDetailPanel.tsx
@@ -38,6 +38,7 @@ function PanelContent({
 }: MatchDetailPanelProps) {
   const [declining, setDeclining] = useState(false);
   const [declineError, setDeclineError] = useState<string | null>(null);
+  const [showCalc, setShowCalc] = useState(false);
 
   async function handleDecline() {
     if (!confirm('Mark this match as dismissed?')) return;
@@ -185,6 +186,54 @@ function PanelContent({
                     </div>
                   ))}
                 </div>
+                <button
+                  type="button"
+                  className="mt-2 text-xs text-ds-text-muted underline underline-offset-2"
+                  aria-expanded={showCalc}
+                  onClick={() => setShowCalc(v => !v)}
+                >
+                  {showCalc ? 'Скрыть расчёт' : 'Показать расчёт'}
+                </button>
+                {showCalc && (() => {
+                  const rawSum = Math.round(components.reduce((s, c) => s + c.score, 0) * 10) / 10;
+                  const totalWeight: number = fbData?.totalWeight ?? 100;
+                  const sanctionsPenalty: number = fbData?.sanctionsPenalty ?? 0;
+                  const appliedCap: { reason: string; ceiling: number } | null = fbData?.appliedCap ?? null;
+                  return (
+                    <div className="mt-3 border-t border-ds-border pt-2 space-y-1">
+                      {components.map((c, i) => (
+                        <div key={i} className="flex justify-between text-[11px] text-ds-text-muted gap-2">
+                          <span>{c.label}</span>
+                          <span className="font-mono shrink-0">
+                            {c.score} / {c.weight} ({Math.round(c.score / c.weight * 100)}%)
+                          </span>
+                        </div>
+                      ))}
+                      <div className="border-t border-ds-border-subtle pt-1 mt-1 space-y-0.5">
+                        <div className="flex justify-between text-[11px]">
+                          <span className="text-ds-text-muted">Сумма факторов:</span>
+                          <span className="font-mono">{rawSum} / {totalWeight}</span>
+                        </div>
+                        {sanctionsPenalty > 0 && (
+                          <div className="flex justify-between text-[11px] text-red-500">
+                            <span>Штраф за санкции:</span>
+                            <span className="font-mono">−{sanctionsPenalty}</span>
+                          </div>
+                        )}
+                        {appliedCap && (
+                          <div className="flex justify-between text-[11px] text-amber-600">
+                            <span>Применён потолок: {appliedCap.reason}</span>
+                            <span className="font-mono">→ {appliedCap.ceiling}</span>
+                          </div>
+                        )}
+                        <div className="flex justify-between text-[11px] font-semibold text-ds-text">
+                          <span>Итог (Fit):</span>
+                          <span className="font-mono">{Math.round(fitPercent!)}%</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })()}
               </CardContent>
             )}
           </Card>

--- a/docs/superpowers/plans/2026-06-01-fit-show-calc.md
+++ b/docs/superpowers/plans/2026-06-01-fit-show-calc.md
@@ -1,0 +1,49 @@
+# Plan: match Fit Score — раскрывающийся «Показать расчёт» (2026-06-01)
+
+## Goal
+Под карточкой Fit Score на /match/[id] добавить свёрнутый-по-умолчанию toggle «Показать расчёт», раскрывающий полную арифметику из УЖЕ распарсенного fitBreakdown JSON: по каждому фактору вес+очки+%, и итоговую реконсиляцию. Рендер существующих данных, БЕЗ изменения движка/формул/чисел.
+
+## Точная форма fbData (fitBreakdown JSON, уже JSON.parse в MatchDetailPanel ~стр.150)
+- `components: [{ factor, label, weight, score, rationale }]` — 9 факторов; score ∈ [0, weight] (напр. {label:'Size / utilisation', weight:18, score:11.9})
+- `totalWeight` (=100), `fitPercent` (headline, число), `partCargo`, `vesselClass`
+- `sanctionsPenalty: number` (0 или 8)
+- `appliedCap: { reason: string, ceiling: number } | null`
+- `inputs: {...}` (для этой задачи НЕ нужно)
+
+Арифметика строки ИТОГ — это СУММИРОВАНИЕ уже готовых чисел (не новый расчёт):
+- rawSum = Σ components[].score
+- fit = rawSum − sanctionsPenalty
+- если appliedCap и fit > appliedCap.ceiling → fit = appliedCap.ceiling
+- финал = fitPercent (headline, УЖЕ в fbData — использовать его как итог, не пересчитывать клемпинг)
+
+## ФАЙЛ
+`components/match/MatchDetailPanel.tsx` — секция «Fit Breakdown» (~148-190). fbData/components уже распарсены. Компонент 'use client', useState уже импортирован.
+
+## Changes
+1. Локальный state `const [showCalc, setShowCalc] = useState(false)` в PanelContent.
+2. Под списком факторов ВНУТРИ Fit Score Card — toggle-кнопка «Показать расчёт»/«Скрыть расчёт» (button-ссылка, стиль text-ds-text-muted, aria-expanded={showCalc}).
+3. При showCalc — компактная таблица/строки по КАЖДОМУ фактору: label · вес (weight) · очки (формат «{score} / {weight}») · {Math.round(score/weight*100)}%.
+4. Строки реконсиляции ИТОГ внизу:
+   - «Сумма факторов: {rawSum1dp} / {totalWeight}»
+   - если sanctionsPenalty > 0 → «Штраф за санкции: −{sanctionsPenalty}»
+   - если appliedCap → «Применён потолок: {appliedCap.reason} → {appliedCap.ceiling}»
+   - «Итог (Fit): {Math.round(fitPercent)}%» — обязан совпасть с headline в шапке карточки.
+   rawSum округлять до 1 знака (Math.round(x*10)/10), как score.
+
+## Tests (TDD, RED->GREEN) — добавить в __tests__/components/match/MatchDetailPanel*.test.*
+- default: расчёт СВЁРНУТ (per-factor weight/score-строки скрыты до клика).
+- sanctionsPenalty=0 + appliedCap=null: после показа видны weight+score per factor, «Сумма факторов», «Итог» = fitPercent; НЕТ строк штрафа/потолка.
+- sanctionsPenalty=8 → строка «Штраф за санкции: −8» видна.
+- appliedCap={reason,ceiling} → строка потолка видна.
+- fitPercent==null → секция (и toggle) не рендерится (всё под `fitPercent != null`).
+- per-factor % в развёрнутом виде совпадают с уже показанными (нет регрессии чисел).
+
+## Out-of-scope (orchestrator)
+- НЕ показывать 5 под-сигналов ветинга (флаг/класс/возраст/P&I/CII) — их НЕТ в fitBreakdown; отдельный follow-up (правка lib/sailing/fit-breakdown.ts + пересев demo-seed).
+- НЕ менять движок/формулы/веса/числа; НЕ трогать lib/sailing/*.
+- НЕ трогать app/matches/MatchesClient.tsx (свой рендер) — переиспользование общего под-компонента опционально/минимально, по умолчанию НЕ трогать.
+- Только Fit Score карточка в MatchDetailPanel.tsx.
+
+## Verify
+- npx jest по затронутым тестам — зелёное; tsc clean.
+- Открой PR в main: "feat(match): collapsible 'Показать расчёт' under Fit Score (render existing fitBreakdown)". (Gate 3 visual + Gate 5 — на стороне оркестратора.)


### PR DESCRIPTION
## Что
Под карточкой Fit Score на /match/[id] — свёрнутый по умолчанию toggle **«Показать расчёт»**. При раскрытии по каждому фактору видно вес + очки (`score / weight`) + %, и строка ИТОГ: Σ факторов → −штраф санкций (если есть) → потолок (если применён) → = headline Fit %.

Только рендер уже распарсенного fitBreakdown — движок/формулы/числа не тронуты. Ветинг-подсигналы (флаг/класс/возраст/P&I/CII) НЕ входят (их нет в fitBreakdown) — отдельный follow-up.

## Тесты
9 новых + 14 related green · tsc clean · TDD (план: docs/superpowers/plans/2026-06-01-fit-show-calc.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)