### PR TITLE
feat(match): plain-English per-factor rationale in Fit Score calc + EN labels

### DIFF
--- a/__tests__/components/match/MatchDetailPanel-show-calc.test.tsx
+++ b/__tests__/components/match/MatchDetailPanel-show-calc.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  *
- * Tests: MatchDetailPanel — collapsible «Показать расчёт» under Fit Score (#fit-show-calc)
+ * Tests: MatchDetailPanel — collapsible 'Show calculation' under Fit Score (#fit-show-calc)
  *
  * Behavioral: renders component, clicks toggle, verifies DOM content.
  */
@@ -64,66 +64,76 @@ const mkBreakdown = (overrides?: object) =>
   });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
-describe('MatchDetailPanel — Показать расчёт toggle', () => {
-  it('расчёт СВЁРНУТ по умолчанию: toggle button visible, calc строки не видны', () => {
+describe('MatchDetailPanel — Show calculation toggle', () => {
+  it('calc collapsed by default: toggle button visible, calc rows not visible', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
     );
-    expect(screen.getByRole('button', { name: 'Показать расчёт' })).toBeInTheDocument();
-    expect(screen.queryByText(/Сумма факторов/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Итог.*Fit/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show calculation' })).toBeInTheDocument();
+    expect(screen.queryByText(/Subtotal/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Fit score:/)).not.toBeInTheDocument();
   });
 
-  it('после клика: label меняется на «Скрыть расчёт», строки факторов и ИТОГ видны', () => {
+  it('after click: label changes to Hide calculation, factor rows and total visible', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
 
-    expect(screen.getByRole('button', { name: 'Скрыть расчёт' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide calculation' })).toBeInTheDocument();
     // per-factor labels visible (appear in both bar chart + calc rows, so getAllByText)
     expect(screen.getAllByText('Size / utilisation').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Laycan fit').length).toBeGreaterThanOrEqual(1);
     // unique calc-section format: score / weight
     expect(screen.getByText(/11\.9 \/ 18/)).toBeInTheDocument();
     // reconciliation section
-    expect(screen.getByText(/Сумма факторов/)).toBeInTheDocument();
-    expect(screen.getByText(/Итог \(Fit\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Subtotal/)).toBeInTheDocument();
+    expect(screen.getByText(/Fit score:/)).toBeInTheDocument();
     // итог value matches headline fitPercent (72%)
     expect(screen.getAllByText(/72%/).length).toBeGreaterThanOrEqual(1);
     // no sanctions / cap lines
-    expect(screen.queryByText(/Штраф за санкции/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/потолок/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Sanctions penalty/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Capped/i)).not.toBeInTheDocument();
   });
 
-  it('повторный клик сворачивает (toggle закрывается)', () => {
+  it('rationale appears under each factor row in expanded calc section', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Скрыть расчёт' }));
-    expect(screen.queryByText(/Сумма факторов/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
+    // rationale text is visible (rendered at least once — also in bar chart above)
+    expect(screen.getAllByText('Utilisation 72%').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Tight window').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('sanctionsPenalty=8 → строка «Штраф за санкции» с −8 видна после раскрытия', () => {
+  it('second click collapses (toggle closes)', () => {
+    render(
+      <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hide calculation' }));
+    expect(screen.queryByText(/Subtotal/)).not.toBeInTheDocument();
+  });
+
+  it('sanctionsPenalty=8 → Sanctions penalty row with −8 visible after expand', () => {
     const breakdown = mkBreakdown({ sanctionsPenalty: 8, fitPercent: 64 });
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={64} fitBreakdown={breakdown} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
-    expect(screen.getByText(/Штраф за санкции/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
+    expect(screen.getByText(/Sanctions penalty/)).toBeInTheDocument();
     expect(screen.getByText(/−8/)).toBeInTheDocument();
   });
 
-  it('sanctionsPenalty=0 → строка штрафа НЕ рендерится', () => {
+  it('sanctionsPenalty=0 → sanctions row not rendered', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
-    expect(screen.queryByText(/Штраф за санкции/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
+    expect(screen.queryByText(/Sanctions penalty/)).not.toBeInTheDocument();
   });
 
-  it('appliedCap → строка потолка с reason и ceiling видна после раскрытия', () => {
+  it('appliedCap → Capped row with reason and ceiling visible after expand', () => {
     const breakdown = mkBreakdown({
       appliedCap: { reason: 'Unvetted vessel', ceiling: 85 },
       fitPercent: 85,
@@ -131,35 +141,35 @@ describe('MatchDetailPanel — Показать расчёт toggle', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={85} fitBreakdown={breakdown} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
-    expect(screen.getByText(/потолок/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
+    expect(screen.getByText(/Capped/i)).toBeInTheDocument();
     expect(screen.getByText(/Unvetted vessel/)).toBeInTheDocument();
   });
 
-  it('appliedCap=null → строка потолка НЕ рендерится', () => {
+  it('appliedCap=null → Capped row not rendered', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Показать расчёт' }));
-    expect(screen.queryByText(/потолок/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show calculation' }));
+    expect(screen.queryByText(/Capped/i)).not.toBeInTheDocument();
   });
 
-  it('fitPercent=null → секция Fit Score и toggle НЕ рендерятся', () => {
+  it('fitPercent=null → Fit Score section and toggle not rendered', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={null} fitBreakdown={mkBreakdown()} />,
     );
-    expect(screen.queryByText('Показать расчёт')).not.toBeInTheDocument();
-    expect(screen.queryByText(/Сумма факторов/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Show calculation')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Subtotal/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Fit Score/)).not.toBeInTheDocument();
   });
 
-  it('aria-expanded отражает состояние toggle', () => {
+  it('aria-expanded reflects toggle state', () => {
     render(
       <MatchDetailPanel {...BASE_PROPS} fitPercent={72} fitBreakdown={mkBreakdown()} />,
     );
-    const btn = screen.getByRole('button', { name: 'Показать расчёт' });
+    const btn = screen.getByRole('button', { name: 'Show calculation' });
     expect(btn).toHaveAttribute('aria-expanded', 'false');
     fireEvent.click(btn);
-    expect(screen.getByRole('button', { name: 'Скрыть расчёт' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Hide calculation' })).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/components/match/MatchDetailPanel.tsx
+++ b/components/match/MatchDetailPanel.tsx
@@ -192,7 +192,7 @@ function PanelContent({
                   aria-expanded={showCalc}
                   onClick={() => setShowCalc(v => !v)}
                 >
-                  {showCalc ? 'Скрыть расчёт' : 'Показать расчёт'}
+                  {showCalc ? 'Hide calculation' : 'Show calculation'}
                 </button>
                 {showCalc && (() => {
                   const rawSum = Math.round(components.reduce((s, c) => s + c.score, 0) * 10) / 10;
@@ -202,32 +202,37 @@ function PanelContent({
                   return (
                     <div className="mt-3 border-t border-ds-border pt-2 space-y-1">
                       {components.map((c, i) => (
-                        <div key={i} className="flex justify-between text-[11px] text-ds-text-muted gap-2">
-                          <span>{c.label}</span>
-                          <span className="font-mono shrink-0">
-                            {c.score} / {c.weight} ({Math.round(c.score / c.weight * 100)}%)
-                          </span>
+                        <div key={i} className="space-y-0.5">
+                          <div className="flex justify-between text-[11px] text-ds-text-muted gap-2">
+                            <span>{c.label}</span>
+                            <span className="font-mono shrink-0">
+                              {c.score} / {c.weight} · {Math.round(c.score / c.weight * 100)}%
+                            </span>
+                          </div>
+                          {c.rationale && (
+                            <p className="text-[11px] text-ds-text-subtle leading-snug">{c.rationale}</p>
+                          )}
                         </div>
                       ))}
                       <div className="border-t border-ds-border-subtle pt-1 mt-1 space-y-0.5">
                         <div className="flex justify-between text-[11px]">
-                          <span className="text-ds-text-muted">Сумма факторов:</span>
+                          <span className="text-ds-text-muted">Subtotal:</span>
                           <span className="font-mono">{rawSum} / {totalWeight}</span>
                         </div>
                         {sanctionsPenalty > 0 && (
                           <div className="flex justify-between text-[11px] text-red-500">
-                            <span>Штраф за санкции:</span>
+                            <span>Sanctions penalty:</span>
                             <span className="font-mono">−{sanctionsPenalty}</span>
                           </div>
                         )}
                         {appliedCap && (
                           <div className="flex justify-between text-[11px] text-amber-600">
-                            <span>Применён потолок: {appliedCap.reason}</span>
+                            <span>Capped: {appliedCap.reason}</span>
                             <span className="font-mono">→ {appliedCap.ceiling}</span>
                           </div>
                         )}
                         <div className="flex justify-between text-[11px] font-semibold text-ds-text">
-                          <span>Итог (Fit):</span>
+                          <span>Fit score:</span>
                           <span className="font-mono">{Math.round(fitPercent!)}%</span>
                         </div>
                       </div>

--- a/docs/superpowers/plans/2026-06-01-fit-rationale-plain.md
+++ b/docs/superpowers/plans/2026-06-01-fit-rationale-plain.md
@@ -1,0 +1,40 @@
+# Plan: Fit Score «Show calculation» — plain-English per-factor rationale + EN (2026-06-01)
+
+## Goal
+Founder: расчёт под Fit Score должен по КАЖДОМУ фактору простыми словами объяснять «как получилось X/Y», и вся карточка — на английском. Сейчас «Показать расчёт» (#730) показывает только числа; rationale-тексты движка терсные/тех-жаргон. Переписать 9 факторов (все ветки) полными простыми англ-предложениями (что и почему), показать их под каждым фактором в «Show calculation», перевести подписи карточки на EN.
+
+## КРИТИЧЕСКИЙ инвариант (risk-override: fit-breakdown.ts = scoring engine)
+Меняем ТОЛЬКО строки `rationale`/`why` (и подписи UI). НИ ОДНО из: weight, share, score-математика, пороги (ratio/util/distance thresholds), FIT_WEIGHTS, caps, sanctionsPenalty — НЕ трогать. fitPercent и score каждого фактора обязаны остаться ПОБИТОВО теми же. /test-skill проверит, что числа не изменились.
+
+## Эталон стиля (gold standard — happy-path формулировки, утверждены founder'ом)
+Переписать в этом тоне ВСЕ ветки каждого scorer'а (полное предложение: что + почему; СОХРАНИТЬ интерполируемые числа ${...}):
+1. Size / utilisation: `Cargo fills ~${pct}% of the ship — a near-full load, almost no wasted space.` (для низкой util — `…— under-utilised, some deadfreight risk.`; part-cargo — `…— part cargo, deadfreight not charged.`)
+2. Laycan timing: clean→`Ship is free and arrives comfortably inside the loading window.`; tight→`Arrives just in time — cuts it fine but feasible.`; idle→`Ship would sit idle ~${d} days before laycan — owner carrying-cost risk.`; late→`Ship arrives after the laycan ends — would miss the window.`
+3. Ballast distance: `~${Math.round(distanceNm)} nm to reposition to load port — within a ${cls}'s range (~${radius} nm) but not on the doorstep.` (если очень близко — `…— practically on the doorstep.`)
+4. Class fit: `Ship ${vesselDwt} dwt vs cargo ${cargoWtMax} mt (ratio ${ratio.toFixed(2)}) — the right size class for this parcel.` (oversize/undersize — соответствующая концовка)
+5. Cargo type quality: MPP+breakbulk→`MPP ship suits breakbulk steel coils — small deduction (not a purpose-built carrier).`; bulk→`Bulk-class ship matched to bulk cargo.`; и т.д. по веткам.
+6. Cranes: gearless+shore→`Ship is gearless, but the port has shore cranes — workable.`; geared→`Ship is geared — no dependence on shore cranes.`; gearless+none→`Ship is gearless and the port has no cranes — not workable.`; unverified→`Ship is gearless; port crane availability not yet confirmed.`
+7. Volume / hold fit: `Cargo takes ~${pct}% of the ship's grain capacity — a tight but workable fit.` (comfortable/ideal/overflows — концовка по ветке)
+8. Draft / port headroom: ok→`Loaded ship sits within the port's draft limit.`; fail→`Ship draws too much for the port — ${reason}.`
+9. Vessel vetting: `Items to confirm before fixing: ${concerns}.` (если чисто — `Vetting clean — no open items.`) — сохранить перечень concerns.
+
+## ФАЙЛЫ
+1. `lib/sailing/fit-breakdown.ts` — переписать все `rationale:`/`why` строки в 9 scorer'ах по стилю выше. ТОЛЬКО строки. Обнови `unknown()` why-тексты тоже (в стиле «… not stated, scored conservatively.»).
+2. `components/match/MatchDetailPanel.tsx` — «Show calculation» (toggle #730): (а) перевести подписи на EN: «Показать расчёт»→`Show calculation`, «Скрыть расчёт»→`Hide calculation`, «Сумма факторов»→`Subtotal`, «Итог (Fit)»→`Fit score`, «Штраф за санкции»→`Sanctions penalty`, «Применён потолок»→`Capped`; (б) под каждым фактором в развёрнутом расчёте показать `c.rationale` (мелким текстом, как в правой панели). Формат строки: `<label>   <score> / <weight> · <pct>%` + строка rationale ниже.
+
+## Tests (TDD)
+- Обнови существующие тесты, которые ассертят старый rationale-текст (под новый).
+- ДОБАВЬ тест-инвариант: для фикстуры пары fitPercent и каждый component.score ОСТАЮТСЯ те же, что до правки (т.е. правка не сдвинула числа) — например снапшот числовых полей до/после, или явные ожидаемые значения.
+- MatchDetailPanel: в развёрнутом «Show calculation» под фактором виден его rationale; подписи на английском.
+- npx jest по затронутым + tsc clean.
+
+## Out-of-scope (orchestrator)
+- НЕ менять scoring-логику/веса/пороги/caps/sanctions — только тексты + UI EN.
+- НЕ запускать пересев demo-seed — это сделает ОРКЕСТРАТОР после merge+deploy (rationale запечён в seed JSON; прод-операция).
+- НЕ трогать app/matches/MatchesClient.tsx, dashboard, другие страницы.
+- НЕ менять структуру fitBreakdown (поля те же).
+
+## Verify
+- npx jest зелёное, tsc clean. PR в main: "feat(match): plain-English per-factor rationale in Fit Score calc + EN labels".
+- Risk-override → ОБЯЗАТЕЛЕН /test-skill: подтвердить, что fitPercent/score НЕ изменились (только текст).
+- Orchestrator post-merge: regenerate-matches.ts на проде (новый rationale в seed) + checkpoint + restart + Gate5.

--- a/lib/sailing/__tests__/fit-breakdown.test.ts
+++ b/lib/sailing/__tests__/fit-breakdown.test.ts
@@ -254,6 +254,39 @@ describe('computeFitBreakdown — anchor scorecard', () => {
     expect(fb2.components.map((c) => c.score)).toEqual(fb1.components.map((c) => c.score));
   });
 
+  it('SCORE-INVARIANT: rationale text changes must not shift any numeric score', () => {
+    // Fixed fixture — changing only rationale/why strings in fit-breakdown.ts
+    // must leave every component.score and fitPercent bit-for-bit identical.
+    const cargo = makeCargo({
+      cargoDescription: { value: 'steel slabs', confidence: 'confirmed' },
+      cargoType: 'BREAK_BULK',
+      weightMtMax: 4950,
+      weightMt: { value: 4950, confidence: 'confirmed' },
+    });
+    const vessel = makeVessel({
+      vesselType: 'MPP',
+      lastCargoes: 'steel slabs',
+      dwcc: { value: 5000, confidence: 'confirmed' },
+      dwtSummer: { value: 5200, confidence: 'confirmed' },
+      geared: true,
+    });
+    const readiness: MatchReadiness = { ...READY_IDEAL, distanceNm: 205 };
+    const fb = computeFitBreakdown({ cargo, vessel, readiness, sanctions: SANCTIONS_OK, hardFilters: HF_PASS });
+
+    expect(fb.fitPercent).toBe(91.8);
+    expect(fb.components.map((c) => ({ factor: c.factor, score: c.score }))).toEqual([
+      { factor: 'utilisation', score: 23 },
+      { factor: 'timing',      score: 18 },
+      { factor: 'ballast',     score: 14 },
+      { factor: 'classFit',    score: 11 },
+      { factor: 'cargoType',   score: 7 },
+      { factor: 'cranes',      score: 7 },
+      { factor: 'volume',      score: 3.4 },
+      { factor: 'draft',       score: 3 },
+      { factor: 'vetting',     score: 5.4 },
+    ]);
+  });
+
   it('breakdown lists all eight factors with non-null rationale', () => {
     const cargo = makeCargo();
     const vessel = makeVessel();

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -87,7 +87,7 @@ export function scoreUtilisation(
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.utilisation;
   if (cargoWtMax == null || cargoWtMax <= 0 || vesselCapacity == null || vesselCapacity <= 0) {
-    return unknown('utilisation', 'Size / utilisation', 'cargo weight or vessel capacity unknown');
+    return unknown('utilisation', 'Size / utilisation', 'Cargo weight or vessel capacity not stated, scored conservatively.');
   }
   const util = cargoWtMax / vesselCapacity;
   // Piecewise curve, peak at 0.85–1.05:
@@ -115,14 +115,22 @@ export function scoreUtilisation(
     else share = 0.10;
   }
   const pct = Math.round(util * 100);
+  let utilizationRationale: string;
+  if (partCargo) {
+    utilizationRationale = `Cargo fills ~${pct}% of the ship — part cargo, deadfreight not charged.`;
+  } else if (util >= 0.85 && util <= 1.05) {
+    utilizationRationale = `Cargo fills ~${pct}% of the ship — a near-full load, almost no wasted space.`;
+  } else if (util > 1.05) {
+    utilizationRationale = `Cargo fills ~${pct}% of the ship — over-tonnaged.`;
+  } else {
+    utilizationRationale = `Cargo fills ~${pct}% of the ship — under-utilised, some deadfreight risk.`;
+  }
   return {
     factor: 'utilisation',
     label: 'Size / utilisation',
     weight: w,
     score: Math.round(w * share * 10) / 10,
-    rationale: partCargo
-      ? `cargo fills ~${pct}% of vessel — part-cargo (exempt from deadfreight penalty)`
-      : `cargo fills ~${pct}% of vessel${share >= 1 ? ' — peak utilisation' : share <= 0.4 ? ' — deadfreight' : ''}`,
+    rationale: utilizationRationale,
   };
 }
 
@@ -133,39 +141,37 @@ export function scoreUtilisation(
 export function scoreTiming(readiness: MatchReadiness | undefined): FitBreakdownComponent {
   const w = FIT_WEIGHTS.timing;
   if (!readiness) {
-    return unknown('timing', 'Laycan timing', 'no readiness data');
+    return unknown('timing', 'Laycan timing', 'No readiness data available, scored conservatively.');
   }
   const { verdict, gapDays } = readiness;
   if (verdict === 'unknown') {
-    return unknown('timing', 'Laycan timing', 'timing unknown — missing dates or port');
+    return unknown('timing', 'Laycan timing', 'Timing unknown — missing dates or port, scored conservatively.');
   }
   let share: number;
   let why: string;
   switch (verdict) {
     case 'ideal':
       share = 1.0;
-      why = 'arrives cleanly within laycan window';
+      why = 'Ship is free and arrives comfortably inside the loading window.';
       break;
     case 'tight':
       share = 0.7;
-      why = 'tight — cuts it fine but feasible';
+      why = 'Arrives just in time — cuts it fine but feasible.';
       break;
     case 'idle': {
       // Continuous penalty by idle length: 5d ≈ 0.6, 14d ≈ 0.4, 30d ≈ 0.2, >30d ≈ 0.1.
       const d = Math.abs(gapDays ?? 5);
       share = d <= 5 ? 0.65 : d <= 14 ? 0.45 : d <= 30 ? 0.25 : 0.1;
-      why = `vessel idle ~${Math.round(d)}d before laycan — owner cost risk`;
+      why = `Ship would sit idle ~${Math.round(d)} days before laycan — owner carrying-cost risk.`;
       break;
     }
     case 'late':
       share = 0.05;
-      why = gapDays != null
-        ? `vessel arrives ~${Math.abs(Math.round(gapDays))}d after laycan — misses window`
-        : 'vessel misses laycan window';
+      why = 'Ship arrives after the laycan ends — would miss the window.';
       break;
     default:
       share = UNKNOWN_SHARE;
-      why = 'timing not classified';
+      why = 'Timing could not be classified, scored conservatively.';
   }
   return {
     factor: 'timing',
@@ -186,10 +192,10 @@ export function scoreBallast(
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.ballast;
   if (distanceNm == null || !Number.isFinite(distanceNm)) {
-    return unknown('ballast', 'Ballast distance', 'distance unknown (vague position or unmapped port)');
+    return unknown('ballast', 'Ballast distance', 'Distance to load port unknown — vessel position or port not mapped, scored conservatively.');
   }
   if (vesselDwt == null || !Number.isFinite(vesselDwt)) {
-    return unknown('ballast', 'Ballast distance', 'vessel DWT unknown — cannot pick class radius');
+    return unknown('ballast', 'Ballast distance', 'Vessel DWT not stated — cannot determine class range, scored conservatively.');
   }
   const cls = classifyVesselByDwt(vesselDwt);
   const radius = BALLAST_GOOD_MAX_NM[cls];
@@ -204,12 +210,17 @@ export function scoreBallast(
   else if (distanceNm <= radius) share = 1.0 - 0.6 * Math.sqrt(distanceNm / radius);
   else if (distanceNm <= radius * 2) share = 0.4 * (1 - (distanceNm - radius) / radius);
   else share = 0;
+  const ballastRationale = distanceNm <= 0
+    ? `~0 nm to reposition — practically on the doorstep.`
+    : share >= 0.9
+      ? `~${Math.round(distanceNm)} nm to reposition to load port — practically on the doorstep.`
+      : `~${Math.round(distanceNm)} nm to reposition to load port — within a ${cls}'s range (~${radius} nm) but not on the doorstep.`;
   return {
     factor: 'ballast',
     label: 'Ballast distance',
     weight: w,
     score: Math.round(w * Math.max(0, share) * 10) / 10,
-    rationale: `${Math.round(distanceNm)}nm ballast vs ${cls} radius ${radius}nm`,
+    rationale: ballastRationale,
   };
 }
 
@@ -224,7 +235,7 @@ export function scoreClassFit(
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.classFit;
   if (cargoWtMax == null || cargoWtMax <= 0 || vesselDwt == null || vesselDwt <= 0) {
-    return unknown('classFit', 'Class fit', 'cargo weight or vessel DWT unknown');
+    return unknown('classFit', 'Class fit', 'Cargo weight or vessel DWT not stated, scored conservatively.');
   }
   // Ideal: vessel DWT 1.05–1.35× cargo (small headroom for bunkers/stores).
   // 1.0–1.05 OK; 1.35–2.0 acceptable; >2 oversized; <1 cargo bigger than vessel.
@@ -240,12 +251,21 @@ export function scoreClassFit(
   else if (ratio <= 2.0) share = 0.75;
   else if (ratio <= 3.0) share = 0.5;
   else share = 0.25;
+  const classFitSuffix = partCargo
+    ? 'normal for part-cargo parcels'
+    : ratio < 1.0
+      ? 'cargo bigger than ship — overloaded'
+      : ratio <= 1.35
+        ? 'the right size class for this parcel'
+        : ratio <= 2.0
+          ? 'slightly oversized for this cargo'
+          : 'oversized — some deadfreight likely';
   return {
     factor: 'classFit',
     label: 'Class fit',
     weight: w,
     score: Math.round(w * share * 10) / 10,
-    rationale: `vessel DWT ${vesselDwt} vs cargo ${cargoWtMax}mt — ratio ${ratio.toFixed(2)}`,
+    rationale: `Ship ${vesselDwt} dwt vs cargo ${cargoWtMax} mt (ratio ${ratio.toFixed(2)}) — ${classFitSuffix}.`,
   };
 }
 
@@ -259,37 +279,37 @@ export function scoreCargoTypeQuality(
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.cargoType;
   if (!cargoType || !vesselType) {
-    return unknown('cargoType', 'Cargo type quality', 'cargo or vessel type unspecified');
+    return unknown('cargoType', 'Cargo type quality', 'Cargo or vessel type not stated, scored conservatively.');
   }
   const v = vesselType.toLowerCase();
   const lc = (lastCargoes ?? '').toLowerCase();
   let share = 0.7;
-  let why = `vessel: ${vesselType}`;
+  let why = `Vessel type ${vesselType} — compatibility not classified.`;
   if (cargoType === 'BULK') {
     if (/bulk|handysize|supramax|panamax|capesize|ultramax|handymax/.test(v)) {
       const hasBulkHistory = /grain|wheat|barley|coal|ore|fertilizer|urea|salt|sugar|cement|gypsum/.test(lc);
       share = hasBulkHistory ? 1.0 : 0.85;
-      why = hasBulkHistory ? 'bulk vessel + confirmed bulk cargo history' : 'bulk-class vessel';
+      why = hasBulkHistory ? 'Bulk-class ship matched to bulk cargo — confirmed loading history.' : 'Bulk-class ship matched to bulk cargo.';
     } else if (/mpp|multi-?purpose|general/.test(v)) {
       share = 0.55;
-      why = 'MPP vessel — fit marginal for bulk';
+      why = 'MPP vessel — fit marginal for bulk cargo.';
     }
   } else if (cargoType === 'BREAK_BULK' || cargoType === 'PROJECT') {
     if (/mpp|multi-?purpose|general|heavy.?lift/.test(v)) {
       const hasBBHistory = /steel|pipe|bagged|breakbulk|project|rebar|lumber|machinery/.test(lc);
       share = hasBBHistory ? 1.0 : 0.85;
-      why = hasBBHistory ? 'MPP + confirmed breakbulk/project history' : 'MPP — ideal for breakbulk';
+      why = hasBBHistory ? 'MPP ship suits breakbulk/project cargo — confirmed loading history.' : 'MPP ship suits breakbulk cargo — small deduction (not a purpose-built carrier).';
     } else if (/bulk/.test(v)) {
       share = 0.5;
-      why = 'bulker carrying breakbulk — geared bulker only';
+      why = 'Bulker carrying breakbulk — geared bulker only, small deduction.';
     }
   } else if (cargoType === 'FCL' || cargoType === 'LCL' || cargoType === 'CONTAINER') {
-    if (/container/.test(v)) { share = 1.0; why = 'container vessel'; }
+    if (/container/.test(v)) { share = 1.0; why = 'Container vessel matched to container cargo.'; }
   } else if (cargoType === 'RORO') {
-    if (/ro.?ro|car carrier/.test(v)) { share = 1.0; why = 'RORO vessel'; }
+    if (/ro.?ro|car carrier/.test(v)) { share = 1.0; why = 'RORO vessel matched to RORO cargo.'; }
   } else if (cargoType === 'OTHER') {
     share = 0.65;
-    why = 'cargo type unspecified — cannot grade';
+    why = 'Cargo type unspecified — cannot assess vessel suitability.';
   }
   return {
     factor: 'cargoType',
@@ -307,19 +327,19 @@ export function scoreCranes(
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.cranes;
   if (geared === true) {
-    return { factor: 'cranes', label: 'Cranes', weight: w, score: w, rationale: 'vessel geared — no shore-crane dependency' };
+    return { factor: 'cranes', label: 'Cranes', weight: w, score: w, rationale: 'Ship is geared — no dependence on shore cranes.' };
   }
   if (geared === false) {
     const portCranes = portHasShoreCranes(loadPort);
     if (portCranes === true) {
-      return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.85 * 10) / 10, rationale: 'gearless + shore cranes available' };
+      return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.85 * 10) / 10, rationale: 'Ship is gearless, but the port has shore cranes — workable.' };
     }
     if (portCranes === false) {
-      return { factor: 'cranes', label: 'Cranes', weight: w, score: 0, rationale: 'gearless + no shore cranes — incompatible' };
+      return { factor: 'cranes', label: 'Cranes', weight: w, score: 0, rationale: 'Ship is gearless and the port has no cranes — not workable.' };
     }
-    return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.55 * 10) / 10, rationale: 'gearless + port crane availability unverified' };
+    return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.55 * 10) / 10, rationale: 'Ship is gearless; port crane availability not yet confirmed.' };
   }
-  return unknown('cranes', 'Cranes', 'vessel gear unknown');
+  return unknown('cranes', 'Cranes', 'Vessel gear status not stated, scored conservatively.');
 }
 
 /** Volume / hold fit — stowage ratio of cargo m³ to vessel grain capacity. */
@@ -331,7 +351,7 @@ export function scoreVolume(
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.volume;
   if (!cargoWtMax || cargoWtMax <= 0 || !grainCapacity || grainCapacity <= 0) {
-    return unknown('volume', 'Volume / hold fit', 'cargo weight or vessel grain capacity unknown');
+    return unknown('volume', 'Volume / hold fit', 'Cargo weight or grain capacity not stated, scored conservatively.');
   }
   // Resolve stowage factor (explicit > keyword > default)
   let sf = 1.35;
@@ -351,10 +371,10 @@ export function scoreVolume(
   const ratio = requiredM3 / grainCapacity;
   let share: number;
   let why: string;
-  if (ratio <= 0.7) { share = 0.85; why = `~${Math.round(ratio * 100)}% of grain capacity — comfortable`; }
-  else if (ratio <= 0.9) { share = 1.0; why = `~${Math.round(ratio * 100)}% of grain capacity — ideal`; }
-  else if (ratio <= 1.0) { share = 0.85; why = `~${Math.round(ratio * 100)}% of grain capacity — tight fit`; }
-  else { share = 0.25; why = `~${Math.round(ratio * 100)}% of grain capacity — overflows`; }
+  if (ratio <= 0.7) { share = 0.85; why = `Cargo takes ~${Math.round(ratio * 100)}% of the ship's grain capacity — comfortable fit, room to spare.`; }
+  else if (ratio <= 0.9) { share = 1.0; why = `Cargo takes ~${Math.round(ratio * 100)}% of the ship's grain capacity — ideal fill.`; }
+  else if (ratio <= 1.0) { share = 0.85; why = `Cargo takes ~${Math.round(ratio * 100)}% of the ship's grain capacity — a tight but workable fit.`; }
+  else { share = 0.25; why = `Cargo takes ~${Math.round(ratio * 100)}% of the ship's grain capacity — cargo overflows the holds.`; }
   return {
     factor: 'volume',
     label: 'Volume / hold fit',
@@ -371,12 +391,12 @@ export function scoreDraft(hardFilters: MatchHardFilters | undefined): FitBreakd
   const w = FIT_WEIGHTS.draft;
   const draftCheck = hardFilters?.draft;
   if (!draftCheck) {
-    return unknown('draft', 'Draft / port headroom', 'draft check not performed');
+    return unknown('draft', 'Draft / port headroom', 'Draft check not performed, scored conservatively.');
   }
   if (draftCheck.pass) {
-    return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: w, rationale: 'vessel within port draft limit' };
+    return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: w, rationale: "Loaded ship sits within the port's draft limit." };
   }
-  return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: 0, rationale: draftCheck.reason ?? 'vessel exceeds port draft' };
+  return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: 0, rationale: `Ship draws too much for the port${draftCheck.reason ? ` — ${draftCheck.reason}` : ''}.` };
 }
 
 /** Vetting — 5-factor soft signal: flag (Paris MoU) / class (IACS) / age / P&I / CII.
@@ -393,10 +413,10 @@ export function scoreVetting(vessel: ParsedVessel, refYear?: number): FitBreakdo
   const effectiveRefYear = refYear ?? 0;
   const result = computeVesselVetting(effectiveVessel, { refYear: effectiveRefYear });
   const rationale = result.badges.length > 0
-    ? `vetting concerns: ${result.badges.join(', ')}`
+    ? `Items to confirm before fixing: ${result.badges.join(', ')}.`
     : result.factors.every((f) => f.verdict === 'unknown')
-      ? 'vetting data unavailable — scored neutral'
-      : 'vetting clean — no concerns flagged';
+      ? 'Vetting data unavailable — scored neutral.'
+      : 'Vetting clean — no open items.';
   return {
     factor: 'vetting',
     label: 'Vessel vetting',


### PR DESCRIPTION
## Что
9 факторов Fit Score получили полные простые англ-пояснения (что и почему); показаны под каждым фактором в «Show calculation»; подписи карточки переведены на английский (Show calculation / Subtotal / Fit score / …).

## Инвариант
Меняются ТОЛЬКО строки rationale + UI-подписи. weight/share/score-математика/пороги/caps — не тронуты; fitPercent и component.score без изменений (тест-инвариант добавлен).

## Примечание
rationale запечён в demo-seed → новый текст появится после пересева seed (оркестратор-операция после merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)