### PR TITLE
fix(match): guard non-string restrictions — hotfix a.match crash on Vessels tab

### DIFF
--- a/__tests__/components/match/VesselsTab-nonstring-restrictions.test.tsx
+++ b/__tests__/components/match/VesselsTab-nonstring-restrictions.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression: «a.match is not a function» when restrictions contains non-strings
+ * (objects/numbers from LLM parser). VesselsTab must not throw and must render
+ * only string entries.
+ *
+ * Hotfix: fix(match): guard non-string restrictions — PR #hotfix
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VesselsTab } from '@/components/match/VesselsTab';
+import type { ParsedVessel } from '@/lib/types';
+
+jest.mock('@/components/vessel/CiiRatingBadge', () => ({
+  CiiRatingBadge: () => null,
+}));
+
+jest.mock('@/lib/cargo/l5c-matrix', () => ({
+  checkCompatibility: jest.fn().mockReturnValue(null),
+  parseLastCargoes: jest.fn().mockReturnValue([]),
+}));
+
+function makeVessel(overrides: Partial<ParsedVessel> = {}): ParsedVessel {
+  return {
+    emailId: 'test-email-id',
+    itemIndex: 0,
+    vesselName: null,
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: null,
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: null,
+    speedBallast: null,
+    consumption: null,
+    deckCapacity: null,
+    specialFeatures: [],
+    ciiRating: null,
+    verificationWarning: null,
+    ...overrides,
+  };
+}
+
+describe('VesselsTab — non-string restrictions guard', () => {
+  it('does not throw when restrictions contains objects and numbers', () => {
+    const vessel = makeVessel({
+      restrictions: [{ x: 1 }, 123, 'no grain'] as unknown as string[],
+    });
+    expect(() => render(<VesselsTab vessel={vessel} />)).not.toThrow();
+  });
+
+  it('does not throw with mixed object/number/string restrictions (normal card path)', () => {
+    const vessel = makeVessel({
+      restrictions: [{ x: 1 }, 123, 'no grain', true, 'bulk only'] as unknown as string[],
+    });
+    expect(() => render(<VesselsTab vessel={vessel} />)).not.toThrow();
+  });
+
+  it('does not render objects as React children (no "Objects are not valid" error)', () => {
+    const vessel = makeVessel({
+      restrictions: [{ label: 'bad' }, 42, 'ok string'] as unknown as string[],
+    });
+    expect(() => render(<VesselsTab vessel={vessel} />)).not.toThrow();
+  });
+
+  it('renders without throw when all restrictions are strings', () => {
+    const vessel = makeVessel({
+      restrictions: ['no grain', 'max DWT 60000'],
+    });
+    expect(() => render(<VesselsTab vessel={vessel} />)).not.toThrow();
+  });
+
+  it('parseCiiDorE: skips non-string entries, still detects CII D/E from string entry', () => {
+    const vessel = makeVessel({
+      restrictions: [{ x: 1 }, 99, 'CII rating D — rejected', 'no grain'] as unknown as string[],
+    });
+    render(<VesselsTab vessel={vessel} />);
+    expect(screen.getByTestId('cii-reject-card')).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/parse-vessel-helpers-nonstring.test.ts
+++ b/__tests__/lib/parse-vessel-helpers-nonstring.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression: parseVesselAIResponse must strip non-string entries from restrictions
+ * when LLM returns objects or numbers instead of strings.
+ *
+ * Hotfix: fix(match): guard non-string restrictions — PR #hotfix
+ */
+import { parseVesselAIResponse } from '@/lib/parsing/parse-vessel-helpers';
+
+// parse-vessel-helpers reads no external I/O — no mocks needed
+describe('parseVesselAIResponse — non-string restrictions filter', () => {
+  const emailId = 'test-email-id';
+
+  function parse(restrictions: unknown) {
+    const raw = JSON.stringify({
+      vessel_name: 'MV Test',
+      imo: '1234567',
+      restrictions,
+    });
+    return parseVesselAIResponse(raw, emailId);
+  }
+
+  it('returns only strings when restrictions contains objects and numbers', () => {
+    const vessels = parse([{ x: 1 }, 123, 'no grain']);
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].restrictions).toEqual(['no grain']);
+  });
+
+  it('returns empty array when all restrictions are non-strings', () => {
+    const vessels = parse([{ type: 'ban' }, 42, true, null]);
+    expect(vessels[0].restrictions).toEqual([]);
+  });
+
+  it('returns all strings when all restrictions are strings', () => {
+    const vessels = parse(['no grain', 'max DWT 60000']);
+    expect(vessels[0].restrictions).toEqual(['no grain', 'max DWT 60000']);
+  });
+
+  it('returns empty array when restrictions is not an array', () => {
+    const vessels = parse('not an array');
+    expect(vessels[0].restrictions).toEqual([]);
+  });
+
+  it('returns empty array when restrictions is null', () => {
+    const vessels = parse(null);
+    expect(vessels[0].restrictions).toEqual([]);
+  });
+
+  it('mixed array: [{x:1}, 123, "no grain"] → only ["no grain"]', () => {
+    const vessels = parse([{ x: 1 }, 123, 'no grain']);
+    expect(vessels[0].restrictions).toHaveLength(1);
+    expect(vessels[0].restrictions[0]).toBe('no grain');
+  });
+});

--- a/components/match/VesselsTab.tsx
+++ b/components/match/VesselsTab.tsx
@@ -17,6 +17,7 @@ const CII_D_E_PATTERN = /\bCII\s+rating\s+([DE])\b/i;
 /** Extracts CII rating D or E from vessel restrictions array. Returns null if none found. */
 function parseCiiDorE(restrictions: string[]): CiiRating | null {
   for (const r of restrictions) {
+    if (typeof r !== 'string') continue;
     const m = r.match(CII_D_E_PATTERN);
     if (m) return m[1].toUpperCase() as 'D' | 'E';
   }
@@ -54,7 +55,7 @@ function RejectedDetails({ vessel }: { vessel: ParsedVessel }) {
       </div>
       {vessel.restrictions.length > 0 && (
         <ul className="text-xs text-gray-500 list-disc ml-4">
-          {vessel.restrictions.map((r, i) => <li key={i}>{r}</li>)}
+          {vessel.restrictions.filter((r) => typeof r === 'string').map((r, i) => <li key={i}>{r}</li>)}
         </ul>
       )}
     </div>

--- a/docs/superpowers/plans/2026-06-01-hotfix-restrictions.md
+++ b/docs/superpowers/plans/2026-06-01-hotfix-restrictions.md
@@ -1,0 +1,29 @@
+# Plan: HOTFIX «a.match is not a function» — non-string в restrictions (2026-06-01)
+
+## Goal (HOT — юзеру падает /match для части матчей)
+Страница матча крашится на ДЕФОЛТНОЙ вкладке Vessels: VesselsTab parseCiiDorE() зовёт r.match() на каждом элементе restrictions; если элемент НЕ строка (объект/число от LLM-парсера) → «a.match is not a function» → «Something went wrong». Фикс H1: фильтровать restrictions до строк (корень) + guard на краш-сайте (defense in depth, чинит уже засеянные битые записи БЕЗ пересева).
+
+## ⚠️ Orchestrator override (конфликт-авоиданс)
+Спек включал п.3 EconomicsTab.tsx parseLeadingNumber (H2) — НЕ делать в этом PR: EconomicsTab правит параллельная сессия Econ №2 (econ-distance-compare). H2-guard будет добавлен в Econ-эпопее (тот же файл + Econ №2 добавляет numeric speed/consumption, где guard и нужен). Здесь — ТОЛЬКО H1.
+
+## Changes (2 файла + тесты)
+1. КОРЕНЬ — `lib/parsing/parse-vessel-helpers.ts` (~стр.267): где `restrictions: Array.isArray(item.restrictions) ? item.restrictions : []` → добавить фильтр типа:
+   `restrictions: Array.isArray(item.restrictions) ? item.restrictions.filter((x) => typeof x === 'string') : []`
+2. КРАШ-САЙТ (defense in depth) — `components/match/VesselsTab.tsx`:
+   - parseCiiDorE (~стр.20): в начале итерации по элементу — `if (typeof r !== 'string') continue;` ПЕРЕД r.match().
+   - рендер списка restrictions (~стр.57): пропускать не-строки (filter typeof==='string') — иначе React «Objects are not valid as a React child».
+
+## Tests (TDD, RED→GREEN) + /test-skill (risk-override parser/validator — ОБЯЗАТЕЛЕН)
+- Regression: ParsedVessel с restrictions=[{x:1}, 123, "no grain"] → VesselsTab рендерится без throw; parseCiiDorE возвращает корректно (не падает); в рендере видна только "no grain".
+- parse-vessel-helpers: вход restrictions с не-строками ([{},5,"x"]) → на выходе ТОЛЬКО строки (["x"]).
+- Не сломать существующие parse-vessel-helpers тесты (restrictions со строками проходят как есть).
+- npx jest зелёное, tsc clean.
+
+## Out-of-scope
+- НЕ трогать EconomicsTab.tsx (H2 → Econ-эпопея, конфликт с in-flight Econ №2).
+- НЕ трогать движок/scoring/Fit Score/worksheet/MatchDetailPanel.
+- Пересев seed НЕ запускать (краш-сайт guard делает UI устойчивым к битым данным без пересева; root-фикс чистит будущие парсы).
+
+## Verify
+- npx jest + tsc. PR в main: "fix(match): guard non-string restrictions — hotfix a.match crash on Vessels tab".
+- Gate3 preview: открыть ранее падавший /match/28808 — рендерится. Gate5 founder.

--- a/lib/parsing/parse-vessel-helpers.ts
+++ b/lib/parsing/parse-vessel-helpers.ts
@@ -264,7 +264,7 @@ export function parseVesselAIResponse(raw: string, emailId: string, subject?: st
       openPosition: toConfidence<string>(item.open_position),
       openDate: toConfidence<string>(item.open_date),
       direction: extractStr(item.direction),
-      restrictions: Array.isArray(item.restrictions) ? item.restrictions : [],
+      restrictions: Array.isArray(item.restrictions) ? item.restrictions.filter((x) => typeof x === 'string') : [],
       lastCargoes: (() => {
         let lc = item.last_cargoes;
         if (!lc) return null;


### PR DESCRIPTION
## HOTFIX
Краш «a.match is not a function» на дефолтной Vessels-вкладке матча: restrictions содержал не-строку, parseCiiDorE звал .match(). Фикс H1: фильтр restrictions→string (parse-vessel-helpers) + guard в VesselsTab (defense in depth, чинит уже засеянные битые записи без пересева). H2 (EconomicsTab) — отдельно в Econ-эпопее.

🤖 Generated with [Claude Code](https://claude.com/claude-code)