### PR TITLE
feat(market): daily Baltic indices scraper (HandyBulk + TE fallback, range-validated)

### DIFF
--- a/__tests__/integration/knowledge-phase1.test.ts
+++ b/__tests__/integration/knowledge-phase1.test.ts
@@ -113,11 +113,11 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     const count = (
       db.prepare('SELECT COUNT(*) AS c FROM knowledge_sources').get() as any
     ).c;
-    expect(count).toBe(18);
-    expect(KNOWLEDGE_REGISTRY).toHaveLength(18);
+    expect(count).toBe(19);
+    expect(KNOWLEDGE_REGISTRY).toHaveLength(19);
 
     const sources = listSources(db);
-    expect(sources).toHaveLength(18);
+    expect(sources).toHaveLength(19);
 
     // Verify Phase 1 sources are registered
     const slugs = sources.map((s) => s.slug);
@@ -234,7 +234,7 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.status).toBe('healthy');
-    expect(json.sources_fresh).toBe(18);
+    expect(json.sources_fresh).toBe(19);
     expect(json.sources_failed).toBe(0);
   });
 
@@ -269,6 +269,6 @@ describe('Knowledge Phase 1 Integration Smoke', () => {
     // Since OFAC is fresh but others are never_synced, status should be degraded
     // (never_synced sources don't fail health check but are counted as stale)
     expect(json.sources_fresh).toBe(1); // Only OFAC
-    expect(json.sources_stale).toBe(17); // Others never synced
+    expect(json.sources_stale).toBe(18); // Others never synced (18 = 17 + market-handybulk added)
   });
 });

--- a/lib/knowledge/bootstrap.ts
+++ b/lib/knowledge/bootstrap.ts
@@ -214,6 +214,18 @@ export const KNOWLEDGE_REGISTRY: RegisterSourceInput[] = [
     primary_table: 'market_indices',
   },
   {
+    slug: 'market-handybulk',
+    name: 'Baltic indices — HandyBulk daily (BDI/BCI/BSI/BHSI/BPI + TE fallback)',
+    kind: 'structured_rows',
+    category: 'market',
+    source_url: 'https://www.handybulk.com/baltic-dry-index/',
+    license: 'Public scrape (fair use)',
+    refresh_mode: 'auto-daily',
+    stale_threshold_days: 3,
+    refresh_command: 'npx tsx scripts/knowledge/cron/refresh-market-indices.ts',
+    primary_table: 'baltic_indices',
+  },
+  {
     slug: 'market-drewry-wci',
     name: 'Drewry World Container Index composite',
     kind: 'structured_rows',

--- a/lib/market/__tests__/handybulk-scraper.test.ts
+++ b/lib/market/__tests__/handybulk-scraper.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Behavioral tests for lib/market/handybulk-scraper.ts
+ *
+ * PI2: all tests call the real parser or the real refresh function with
+ * injectable mock fetchers — no string-match-only assertions.
+ *
+ * Coverage (plan-required):
+ * 1. parseHandybulkHtml — parses all 5 indices from first dated section
+ * 2. parseTradingEconomicsHtml — parses 4 indices (no BHSI) from TE JSON
+ * 3. Out-of-range value → not stored, last good preserved, console.warn
+ * 4. HandyBulk throw → TE fallback fires
+ * 5. HandyBulk returns 0 valid → TE fallback fires
+ * 6. Both sources fail → no throw, old DB values intact, rowsChanged=0
+ * 7. Upsert idempotent — same price_date twice creates no duplicates
+ */
+
+import Database from 'better-sqlite3';
+import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
+import migration027 from '@/lib/migrations/027-market-indices';
+import {
+  parseHandybulkHtml,
+  parseTradingEconomicsHtml,
+  refreshAllBalticIndices,
+  RANGE_BOUNDS,
+  HANDYBULK_URL,
+  TE_COMMODITY_URL,
+} from '../handybulk-scraper';
+import { getLatestBalticIndex, upsertBalticIndex } from '../baltic-repository';
+import { getLatestIndex } from '../market-indices-repository';
+
+// ─── Mock HTML ────────────────────────────────────────────────────────────────
+
+/** Full 5-index HandyBulk page — two dated sections; first is most recent. */
+const HB_HTML = `<!DOCTYPE html>
+<html><body>
+<div class="entry-content">
+  <p>28-May-2026</p>
+  <div>
+    <p>The Baltic Dry Index (BDI) increased by 27 points to reach 1,842 points.
+    The Baltic Capesize Index (BCI) increased by 120 points to 4,954 points.
+    The Baltic Supramax Index (BSI) decreased by 4 points to 962 points.
+    The Baltic Handysize Index (BHSI) decreased by 3 points to 530 points.
+    The Baltic Panamax Index (BPI) increased by 50 points to 3,456 points.</p>
+  </div>
+  <p>27-May-2026</p>
+  <div>
+    <p>The Baltic Dry Index (BDI) decreased by 41 points to 1,815 points.</p>
+  </div>
+</div>
+</body></html>`;
+
+/** BDI value is out of the valid range (99,999 > 15,000). */
+const HB_HTML_OUT_OF_RANGE_BDI = `<!DOCTYPE html>
+<html><body>
+<div class="entry-content">
+  <p>28-May-2026</p>
+  <div>
+    <p>The Baltic Dry Index (BDI) surged to 99,999 points.
+    The Baltic Capesize Index (BCI) increased by 120 points to 4,954 points.
+    The Baltic Supramax Index (BSI) decreased by 4 points to 962 points.
+    The Baltic Handysize Index (BHSI) decreased by 3 points to 530 points.</p>
+  </div>
+</div>
+</body></html>`;
+
+/** Trading Economics page — BDI/BCI/BSI/BPI, no BHSI. */
+const TE_HTML = `<html><body>
+<script>
+(function(){var te=[
+  {"Symbol":"BDI","Last":1842,"Date":"2026-05-28"},
+  {"Symbol":"BCI","Last":4954,"Date":"2026-05-28"},
+  {"Symbol":"BSI","Last":962,"Date":"2026-05-28"},
+  {"Symbol":"BPI","Last":3456,"Date":"2026-05-28"}
+];}())
+</script>
+</body></html>`;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  migration019.up(db);
+  migration027.up(db);
+  return db;
+}
+
+// ─── parseHandybulkHtml ───────────────────────────────────────────────────────
+
+describe('parseHandybulkHtml', () => {
+  it('parses all 5 indices from the first dated section (PI2: real parser)', () => {
+    const result = parseHandybulkHtml(HB_HTML);
+    expect(result.BDI).toEqual({ value: 1842, price_date: '2026-05-28' });
+    expect(result.BCI).toEqual({ value: 4954, price_date: '2026-05-28' });
+    expect(result.BSI).toEqual({ value: 962,  price_date: '2026-05-28' });
+    expect(result.BHSI).toEqual({ value: 530,  price_date: '2026-05-28' });
+    expect(result.BPI).toEqual({ value: 3456, price_date: '2026-05-28' });
+  });
+
+  it('uses only the first (most-recent) dated section — ignores older entries', () => {
+    const result = parseHandybulkHtml(HB_HTML);
+    // First section: BDI=1842; second (older) section: BDI=1815
+    expect(result.BDI?.value).toBe(1842);
+    expect(result.BDI?.price_date).toBe('2026-05-28');
+  });
+
+  it('returns {} for empty HTML', () => {
+    expect(parseHandybulkHtml('')).toEqual({});
+  });
+
+  it('returns partial result when some indices are absent', () => {
+    const html = `<html><body>
+<p>28-May-2026</p>
+<p>The Baltic Dry Index (BDI) increased by 10 points to reach 1,842 points.</p>
+</body></html>`;
+    const result = parseHandybulkHtml(html);
+    expect(result.BDI).toBeDefined();
+    expect(result.BCI).toBeUndefined();
+    expect(result.BPI).toBeUndefined();
+  });
+
+  it('parses comma-formatted values correctly', () => {
+    const result = parseHandybulkHtml(HB_HTML);
+    expect(result.BCI?.value).toBe(4954);
+    expect(result.BPI?.value).toBe(3456);
+  });
+});
+
+// ─── parseTradingEconomicsHtml ────────────────────────────────────────────────
+
+describe('parseTradingEconomicsHtml', () => {
+  it('parses BDI/BCI/BSI/BPI from TE JSON (PI2: real parser)', () => {
+    const result = parseTradingEconomicsHtml(TE_HTML);
+    expect(result.BDI).toEqual({ value: 1842, price_date: '2026-05-28' });
+    expect(result.BCI).toEqual({ value: 4954, price_date: '2026-05-28' });
+    expect(result.BSI).toEqual({ value: 962,  price_date: '2026-05-28' });
+    expect(result.BPI).toEqual({ value: 3456, price_date: '2026-05-28' });
+  });
+
+  it('does not return BHSI (not available on TE Baltic page)', () => {
+    const result = parseTradingEconomicsHtml(TE_HTML);
+    expect(result.BHSI).toBeUndefined();
+  });
+
+  it('returns {} for empty HTML', () => {
+    expect(parseTradingEconomicsHtml('')).toEqual({});
+  });
+});
+
+// ─── refreshAllBalticIndices ──────────────────────────────────────────────────
+
+describe('refreshAllBalticIndices', () => {
+  let db: Database.Database;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    db = makeDb();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    db.close();
+    warnSpy.mockRestore();
+  });
+
+  it('fetches HandyBulk once, upserts all 5 valid indices', async () => {
+    const hbFetch = jest.fn().mockResolvedValue(HB_HTML);
+    const teFetch = jest.fn();
+
+    const r = await refreshAllBalticIndices(db, { hb: hbFetch, te: teFetch });
+
+    expect(hbFetch).toHaveBeenCalledTimes(1);
+    expect(hbFetch).toHaveBeenCalledWith(HANDYBULK_URL);
+    expect(teFetch).not.toHaveBeenCalled();
+    expect(r.rowsChanged).toBe(5);
+
+    expect(getLatestBalticIndex(db, 'BDI')?.value).toBe(1842);
+    expect(getLatestBalticIndex(db, 'BSI')?.value).toBe(962);
+    expect(getLatestBalticIndex(db, 'BPI')?.value).toBe(3456);
+  });
+
+  it('also writes BHSI to market_indices (benchmark API compat)', async () => {
+    const hbFetch = jest.fn().mockResolvedValue(HB_HTML);
+    await refreshAllBalticIndices(db, { hb: hbFetch });
+
+    const row = getLatestIndex(db, 'bhsi');
+    expect(row?.value).toBe(530);
+    expect(row?.index_date).toBe('2026-05-28');
+    expect(row?.unit).toBe('USD/day');
+  });
+
+  it('out-of-range BDI not stored, last good value preserved, warns', async () => {
+    upsertBalticIndex(db, { index_code: 'BDI', value: 1500, price_date: '2026-05-27', source: 'seed' });
+
+    const hbFetch = jest.fn().mockResolvedValue(HB_HTML_OUT_OF_RANGE_BDI);
+    await refreshAllBalticIndices(db, { hb: hbFetch });
+
+    const bdi = getLatestBalticIndex(db, 'BDI');
+    expect(bdi?.value).toBe(1500);
+    expect(bdi?.price_date).toBe('2026-05-27');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('BDI=99999'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('out of range'),
+    );
+
+    // Other valid indices from the same HTML are still stored
+    expect(getLatestBalticIndex(db, 'BCI')?.value).toBe(4954);
+    expect(getLatestBalticIndex(db, 'BSI')?.value).toBe(962);
+  });
+
+  it('falls back to Trading Economics when HandyBulk throws', async () => {
+    const hbFetch = jest.fn().mockRejectedValue(new Error('Network timeout'));
+    const teFetch = jest.fn().mockResolvedValue(TE_HTML);
+
+    const r = await refreshAllBalticIndices(db, { hb: hbFetch, te: teFetch });
+
+    expect(teFetch).toHaveBeenCalledTimes(1);
+    expect(teFetch).toHaveBeenCalledWith(TE_COMMODITY_URL);
+    expect(r.rowsChanged).toBeGreaterThan(0);
+    expect(getLatestBalticIndex(db, 'BDI')?.value).toBe(1842);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('HandyBulk unavailable'),
+    );
+  });
+
+  it('falls back to TE when HandyBulk returns 0 valid (empty parse)', async () => {
+    const hbFetch = jest.fn().mockResolvedValue('<html><body>no Baltic data here</body></html>');
+    const teFetch = jest.fn().mockResolvedValue(TE_HTML);
+
+    const r = await refreshAllBalticIndices(db, { hb: hbFetch, te: teFetch });
+
+    expect(teFetch).toHaveBeenCalledTimes(1);
+    expect(r.rowsChanged).toBeGreaterThan(0);
+  });
+
+  it('both sources fail — no throw, rowsChanged=0, old DB values intact', async () => {
+    upsertBalticIndex(db, { index_code: 'BDI', value: 1500, price_date: '2026-05-27', source: 'seed' });
+
+    const hbFetch = jest.fn().mockRejectedValue(new Error('HB down'));
+    const teFetch = jest.fn().mockRejectedValue(new Error('TE down'));
+
+    await expect(
+      refreshAllBalticIndices(db, { hb: hbFetch, te: teFetch }),
+    ).resolves.toEqual({ rowsChanged: 0 });
+
+    expect(getLatestBalticIndex(db, 'BDI')?.value).toBe(1500);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('upsert is idempotent — same price_date twice creates no duplicate rows', async () => {
+    const hbFetch = jest.fn().mockResolvedValue(HB_HTML);
+
+    await refreshAllBalticIndices(db, { hb: hbFetch });
+    await refreshAllBalticIndices(db, { hb: hbFetch });
+
+    const n = (
+      db
+        .prepare("SELECT COUNT(*) as n FROM baltic_indices WHERE price_date='2026-05-28'")
+        .get() as { n: number }
+    ).n;
+    expect(n).toBe(5);
+  });
+
+  it('RANGE_BOUNDS covers all 5 expected index codes', () => {
+    expect(RANGE_BOUNDS).toMatchObject({
+      BDI:  expect.any(Array),
+      BCI:  expect.any(Array),
+      BSI:  expect.any(Array),
+      BHSI: expect.any(Array),
+      BPI:  expect.any(Array),
+    });
+  });
+});

--- a/lib/market/handybulk-scraper.ts
+++ b/lib/market/handybulk-scraper.ts
@@ -1,0 +1,219 @@
+/**
+ * Baltic indices unified scraper.
+ *
+ * Fetches handybulk.com/baltic-dry-index/ ONCE and parses BDI/BCI/BSI/BHSI/BPI
+ * from the most-recent dated section. Range-validates each value; out-of-range
+ * values are skipped (keeps last good row in DB). Falls back to
+ * tradingeconomics.com/commodity/baltic (BDI/BCI/BSI/BPI, no BHSI) if HandyBulk
+ * is unreachable or yields 0 valid indices. If both sources fail, existing rows
+ * are preserved — never throws.
+ *
+ * INTERIM SCRAPE for demo: Baltic Exchange data requires a licensed feed in prod.
+ */
+
+import type Database from 'better-sqlite3';
+import { upsertBalticIndex, getLatestBalticIndex } from './baltic-repository';
+import { upsertIndex } from './market-indices-repository';
+
+export const HANDYBULK_URL = 'https://www.handybulk.com/baltic-dry-index/';
+export const TE_COMMODITY_URL = 'https://tradingeconomics.com/commodity/baltic';
+
+export const RANGE_BOUNDS: Readonly<Record<string, readonly [number, number]>> = {
+  BDI:  [300, 15000],
+  BCI:  [300, 20000],
+  BSI:  [200,  8000],
+  BHSI: [200,  4000],
+  BPI:  [300, 15000],
+};
+
+const MONTH_MAP: Record<string, string> = {
+  january: '01', february: '02', march: '03', april: '04',
+  may: '05', june: '06', july: '07', august: '08',
+  september: '09', october: '10', november: '11', december: '12',
+};
+
+// DD-Month-YYYY format used on handybulk.com (e.g. "22-May-2026")
+const HB_DATE_SOURCE =
+  '(\\d{1,2})-(January|February|March|April|May|June|July|August|September|October|November|December)-(\\d{4})';
+
+// Each pattern anchors on "to [reach] VALUE points" to avoid matching the delta.
+const HB_PATTERNS: Record<string, RegExp> = {
+  BDI:  /Baltic Dry Index[^(]*\(BDI\)[^.]*?\bto\s+(?:reach\s+)?(\d{1,2},\d{3}|\d{4,5})\s*points/i,
+  BCI:  /Baltic Capesize Index[^(]*\(BCI\)[^.]*?\bto\s+(?:reach\s+)?(\d{1,2},\d{3}|\d{3,5})\s*points/i,
+  BSI:  /Baltic Supramax Index[^(]*\(BSI\)[^.]*?\bto\s+(?:reach\s+)?(\d{1,2},\d{3}|\d{3,5})\s*points/i,
+  BHSI: /Baltic Handysize Index[^(]*\(BHSI\)[^.]*?\bto\s+(?:reach\s+)?(\d{1,2},\d{3}|\d{3,4})\s*points/i,
+  BPI:  /Baltic Panamax Index[^(]*\(BPI\)[^.]*?\bto\s+(?:reach\s+)?(\d{1,2},\d{3}|\d{3,5})\s*points/i,
+};
+
+// Trading Economics embedded JSON: {"Symbol":"BDI","Last":1842,"Date":"2026-05-28"}
+// Symbol map: TE uses Bloomberg tickers for some indices
+const TE_SYMBOL_MAP: Record<string, string> = {
+  BDI: 'BDI', BALDRY: 'BDI',
+  BCI: 'BCI',
+  BSI: 'BSI',
+  BPI: 'BPI',
+  // BHSI intentionally absent — TE fallback covers only 4 indices
+};
+
+export interface ParsedIndex {
+  value: number;
+  price_date: string;
+}
+
+export type ParsedIndices = Partial<Record<string, ParsedIndex>>;
+
+/**
+ * Parses Baltic indices from the most-recent dated section of HandyBulk HTML.
+ * Returns a map of {code → {value, price_date}}. Missing indices are absent.
+ */
+export function parseHandybulkHtml(html: string): ParsedIndices {
+  const result: ParsedIndices = {};
+  const dateRe = new RegExp(HB_DATE_SOURCE, 'gi');
+
+  const firstMatch = dateRe.exec(html);
+  if (!firstMatch) return result;
+
+  const [, day, monthName, year] = firstMatch;
+  const month = MONTH_MAP[monthName.toLowerCase()];
+  if (!month) return result;
+  const date = `${year}-${month}-${day.padStart(2, '0')}`;
+
+  // Bound the context to this section only (stops at next date heading).
+  const nextMatch = dateRe.exec(html);
+  const ctxEnd = nextMatch ? nextMatch.index : firstMatch.index + 5000;
+  const ctx = html.slice(firstMatch.index, ctxEnd);
+
+  for (const [code, pattern] of Object.entries(HB_PATTERNS)) {
+    const m = ctx.match(pattern);
+    if (!m) continue;
+    const value = parseFloat(m[1].replace(/,/g, ''));
+    if (Number.isFinite(value) && value > 0) {
+      result[code] = { value, price_date: date };
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Parses Baltic indices from Trading Economics embedded JSON.
+ * Covers BDI/BCI/BSI/BPI — BHSI is not available on this page.
+ * Expected format in script tags: [{"Symbol":"BDI","Last":1842,"Date":"2026-05-28"}, ...]
+ */
+export function parseTradingEconomicsHtml(html: string): ParsedIndices {
+  const result: ParsedIndices = {};
+  // Match JSON-like objects; fields can be in any order within each object.
+  const blockRe = /\{[^{}]{5,400}\}/g;
+
+  let m: RegExpExecArray | null;
+  while ((m = blockRe.exec(html)) !== null) {
+    const block = m[0];
+    const symM = /"Symbol"\s*:\s*"([A-Z]{2,6})"/.exec(block);
+    const lastM = /"Last"\s*:\s*([\d.]+)/.exec(block);
+    const dateM = /"Date"\s*:\s*"(\d{4}-\d{2}-\d{2})/.exec(block);
+
+    if (!symM || !lastM) continue;
+
+    const code = TE_SYMBOL_MAP[symM[1].toUpperCase()];
+    if (!code || result[code]) continue;
+
+    const value = parseFloat(lastM[1]);
+    if (!Number.isFinite(value) || value <= 0) continue;
+
+    result[code] = {
+      value,
+      price_date: dateM ? dateM[1] : new Date().toISOString().slice(0, 10),
+    };
+  }
+
+  return result;
+}
+
+export type HtmlFetcher = (url: string) => Promise<string>;
+
+const defaultFetcher: HtmlFetcher = async (url) => {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'Quantika-Demo/1.0 (+https://demo.quantika.org)' },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) throw new Error(`fetch ${url} HTTP ${res.status}`);
+  return res.text();
+};
+
+function inRange(code: string, value: number): boolean {
+  const bounds = RANGE_BOUNDS[code];
+  return !!bounds && value >= bounds[0] && value <= bounds[1];
+}
+
+function upsertValidIndices(
+  db: Database.Database,
+  parsed: ParsedIndices,
+  source: string,
+): number {
+  let count = 0;
+  for (const [code, entry] of Object.entries(parsed)) {
+    if (!entry) continue;
+    const { value, price_date } = entry;
+    if (!inRange(code, value)) {
+      const latest = getLatestBalticIndex(db, code);
+      console.warn(
+        `[market-handybulk] ${code}=${value} out of range [${RANGE_BOUNDS[code]?.join('-')}] — skipping (last good: ${latest?.value ?? 'none'} on ${latest?.price_date ?? '-'})`,
+      );
+      continue;
+    }
+    upsertBalticIndex(db, { index_code: code, value, price_date, source });
+    // BHSI must also be in market_indices — /api/market/benchmark reads from there.
+    if (code === 'BHSI') {
+      upsertIndex(db, {
+        id: `bhsi-${price_date}`,
+        index_name: 'bhsi',
+        index_date: price_date,
+        value,
+        unit: 'USD/day',
+        source,
+        fetched_at: new Date().toISOString(),
+      });
+    }
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Fetches HandyBulk (primary) once and upserts all valid Baltic indices.
+ * Falls back to Trading Economics if HandyBulk is unreachable or yields 0 valid.
+ * Never throws — both sources failing leaves existing DB rows intact.
+ */
+export async function refreshAllBalticIndices(
+  db: Database.Database,
+  fetchers: { hb?: HtmlFetcher; te?: HtmlFetcher } = {},
+): Promise<{ rowsChanged: number }> {
+  const hbFetch = fetchers.hb ?? defaultFetcher;
+  const teFetch = fetchers.te ?? defaultFetcher;
+
+  // Primary: HandyBulk
+  let hbCount = 0;
+  try {
+    const html = await hbFetch(HANDYBULK_URL);
+    hbCount = upsertValidIndices(db, parseHandybulkHtml(html), HANDYBULK_URL);
+  } catch (e) {
+    console.warn(`[market-handybulk] HandyBulk unavailable: ${(e as Error).message}`);
+  }
+
+  if (hbCount > 0) return { rowsChanged: hbCount };
+
+  // Fallback: Trading Economics (BDI/BCI/BSI/BPI — no BHSI)
+  let teCount = 0;
+  try {
+    const html = await teFetch(TE_COMMODITY_URL);
+    teCount = upsertValidIndices(db, parseTradingEconomicsHtml(html), TE_COMMODITY_URL);
+  } catch (e) {
+    console.warn(`[market-handybulk] Trading Economics fallback unavailable: ${(e as Error).message}`);
+  }
+
+  if (teCount === 0) {
+    console.warn('[market-handybulk] Both sources unavailable — retaining existing Baltic indices');
+  }
+
+  return { rowsChanged: teCount };
+}

--- a/ops/systemd/quantika-market-indices-refresh.timer
+++ b/ops/systemd/quantika-market-indices-refresh.timer
@@ -1,11 +1,11 @@
 [Unit]
-Description=Daily Quantika market indices refresh (BHSI + Drewry WCI)
+Description=Daily Quantika market indices refresh (BDI/BCI/BSI/BHSI/BPI + Drewry WCI)
 Requires=quantika-market-indices-refresh.service
 
 [Timer]
 # Daily at 06:00 UTC — Baltic Exchange publishes around 12:30 London time;
-# Drewry WCI is weekly (Thursday). Timer runs daily so BHSI is fresh;
-# WCI upsert is idempotent and will re-fetch but not create duplicates.
+# Drewry WCI is weekly (Thursday). Timer runs daily so Baltic indices are fresh;
+# all upserts are idempotent (ON CONFLICT) and do not create duplicates.
 OnCalendar=*-*-* 06:00:00 UTC
 RandomizedDelaySec=5min
 Persistent=true

--- a/scripts/knowledge/cron/refresh-market-indices.ts
+++ b/scripts/knowledge/cron/refresh-market-indices.ts
@@ -20,9 +20,7 @@ import {
   reportSyncSuccess,
   reportSyncFailure,
 } from '@/lib/knowledge/governance';
-import { refreshBhsi } from '@/lib/market/bhsi-adapter';
-import { refreshBdi } from '@/lib/market/bdi-adapter';
-import { refreshBci } from '@/lib/market/bci-adapter';
+import { refreshAllBalticIndices } from '@/lib/market/handybulk-scraper';
 import { refreshDrewryWci } from '@/lib/market/drewry-adapter';
 import type Database from 'better-sqlite3';
 
@@ -51,12 +49,10 @@ export async function main(): Promise<void> {
 
   const db = getStore().getDb();
 
-  const okBdi = await runOne(db, 'market-bdi', (d) => refreshBdi(d));
-  const okBci = await runOne(db, 'market-bci', (d) => refreshBci(d));
-  const okBhsi = await runOne(db, 'market-bhsi', (d) => refreshBhsi(d));
+  const okHandybulk = await runOne(db, 'market-handybulk', (d) => refreshAllBalticIndices(d));
   const okDrewry = await runOne(db, 'market-drewry-wci', (d) => refreshDrewryWci(d));
 
-  const success = okBdi || okBci || okBhsi || okDrewry;
+  const success = okHandybulk || okDrewry;
   console.log(
     `[${CRON_NAME}] ${success ? '✓ Completed successfully' : '✗ All sources failed'}`,
   );


### PR DESCRIPTION
## Summary

- **New** `lib/market/handybulk-scraper.ts`: fetches HandyBulk once → parses BDI/BCI/BSI/BHSI/BPI from the most-recent dated section → range-validates each (BDI 300–15000, BCI 300–20000, BSI 200–8000, BHSI 200–4000, BPI 300–15000) → out-of-range values skipped with `console.warn`, last DB value preserved. Falls back to `tradingeconomics.com/commodity/baltic` (BDI/BCI/BSI/BPI, no BHSI) if HandyBulk yields 0 valid or throws. Both sources fail → no throw, existing rows untouched.
- **Updated** `refresh-market-indices.ts`: replaces 3 separate adapter calls (refreshBdi/refreshBci/refreshBhsi) with one `refreshAllBalticIndices()` — single HTTP request for all 5 Baltic indices. Drewry WCI unchanged.
- **Updated** `lib/knowledge/bootstrap.ts`: adds `market-handybulk` slug.
- **Updated** `ops/systemd/quantika-market-indices-refresh.timer`: description updated. Timer already runs daily at 06:00 UTC — no schedule change needed.
- **16 PI2 behavioral tests**: mocked HTML for both sources, range-validation, TE fallback, both-fail no-throw, idempotency.

> INTERIM SCRAPE comment inline: Baltic Exchange data requires licensed feed for production.

## Notes

- BHSI is additionally written to `market_indices` (not just `baltic_indices`) to preserve backward compat with `/api/market/benchmark?indicator=BHSI`.
- `knowledge-phase1.test.ts` count assertions updated 18→19 (new registry entry).
- Old individual slugs (`market-bdi`, `market-bci`, `market-bhsi`) remain in KNOWLEDGE_REGISTRY for backward compat (regression test RC-592 still passes).

## Test plan

- [ ] `npx jest lib/market/__tests__/handybulk-scraper.test.ts` — 16 tests green
- [ ] `npx jest __tests__/integration/knowledge-phase1.test.ts` — 8 tests green
- [ ] `npx jest __tests__/regression/RC-592-bci-fk-constraint.test.ts` — 4 tests green
- [ ] Post-merge on VPS: `npx tsx scripts/knowledge/cron/refresh-market-indices.ts` → verify `baltic_indices` rows for today's date
- [ ] `/market` stale indicator disappears after successful refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)