### PR TITLE
fix(cargo): QTY column width — range quantities no longer overlap LOAD

### DIFF
--- a/__tests__/components/cargo-table-columns.test.tsx
+++ b/__tests__/components/cargo-table-columns.test.tsx
@@ -65,4 +65,19 @@ describe('/cargo table column layout (#606 R2)', () => {
     // must have overflow control — either truncate, overflow-hidden, or max-w-[220px]
     expect(cargotd!.className).toMatch(/truncate|overflow-hidden|max-w-\[220px\]/);
   });
+
+  it('TDD-4: QTY td has min-w so range quantities like "45,000–60,000" do not overflow into LOAD (#734)', () => {
+    const rangeRow: CargoRow = {
+      ...makeRow(0),
+      quantity: '45,000–60,000 mt',
+    };
+    render(<CargoClient rows={[rangeRow]} total={1} />);
+    const firstBodyRow = document.querySelector('tbody tr');
+    expect(firstBodyRow).toBeTruthy();
+    // QTY is the 2nd td (index 1)
+    const qtytd = firstBodyRow!.querySelectorAll('td')[1];
+    expect(qtytd).toBeTruthy();
+    // must have a min-w class to prevent range values from overlapping LOAD column
+    expect(qtytd!.className).toMatch(/min-w-\[/);
+  });
 });

--- a/app/cargo/CargoClient.tsx
+++ b/app/cargo/CargoClient.tsx
@@ -586,7 +586,7 @@ export default function CargoClient({ rows, total }: Props) {
                         </div>
                       </div>
                     </td>
-                    <td className="px-3.5 py-3.5 text-right font-mono text-[13.5px] text-[#0f172a] tabular-nums whitespace-nowrap">
+                    <td className="px-3.5 py-3.5 text-right font-mono text-[13.5px] text-[#0f172a] tabular-nums whitespace-nowrap min-w-[8rem]">
                       {row.quantity ?? <span className="text-[#94a3b8]">—</span>}
                     </td>
                     <td className="px-3.5 py-3.5 text-[13.5px] text-[#0f172a] break-words">


### PR DESCRIPTION
Tier S UI: QTY-колонка на /cargo налезала на LOAD при диапазонных значениях. Фикс ширины/переноса.

🤖 Generated with [Claude Code](https://claude.com/claude-code)