### PR TITLE
feat(economics): full voyage P&L chart via /api/voyage/tce (VoyageBreakdownChart)

### DIFF
--- a/__tests__/components/match/EconomicsTab-pnl.test.tsx
+++ b/__tests__/components/match/EconomicsTab-pnl.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ *
+ * PI2 behavioral tests — voyage P&L chart in EconomicsTab.
+ * Covers: VoyageInput assembly, breakdown render, missing-fields message, formula invariant.
+ */
+import '@testing-library/jest-dom';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { EconomicsTab } from '@/components/match/EconomicsTab';
+
+const MOCK_BREAKDOWN = {
+  breakdown: {
+    bunker_usd: 120000,
+    canal_usd: 0,
+    da_usd: 5000,
+    war_risk_usd: 0,
+    ets_usd: 0,
+    ets_eur: 0,
+    gross_freight_usd: 700000,
+    total_costs_usd: 125000,
+    net_voyage_usd: 575000,
+    daily_tce_usd: 23000,
+    applicable: { bunker: true, canal: false, da: true, war_risk: false, ets: false },
+  },
+  daily_tce_usd: 23000,
+  total_usd: 125000,
+};
+
+const FULL_VESSEL = {
+  emailId: 'e1', itemIndex: 0,
+  dwtSummer: { value: 50000, confidence: 'confirmed' as const },
+  speedLaden: '13.5 kn',
+  consumption: '28 mt/day',
+  restrictions: [], specialFeatures: [],
+};
+
+const FULL_CARGO = {
+  emailId: 'e1', itemIndex: 0,
+  originPort: { value: 'NLRTM', confidence: 'confirmed' as const },
+  destinationPort: { value: 'SGSIN', confidence: 'confirmed' as const },
+  weightMt: { value: 45000, confidence: 'confirmed' as const },
+  cargoType: 'bulk' as const,
+  missingInfo: [],
+};
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function setupFetch(tceOk = true) {
+  mockFetch.mockImplementation((url: string) => {
+    if ((url as string).includes('/api/market/benchmark')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ value: 75, period: 'Q1 2026' }) });
+    }
+    if ((url as string).includes('/api/voyage/tce')) {
+      if (!tceOk) return Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'bunker_price_unavailable' }) });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_BREAKDOWN) });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupFetch();
+});
+
+describe('EconomicsTab — voyage P&L chart', () => {
+  it('renders voyage-breakdown-chart when all required fields present', async () => {
+    await act(async () => {
+      render(
+        <EconomicsTab
+          vessel={FULL_VESSEL as any}
+          cargo={FULL_CARGO as any}
+          routeDistanceNm={8500}
+          storedFreightRate={15}
+          matchDbId={1}
+        />,
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('voyage-breakdown-chart')).toBeInTheDocument());
+  });
+
+  it('posts correct VoyageInput to /api/voyage/tce', async () => {
+    await act(async () => {
+      render(
+        <EconomicsTab
+          vessel={FULL_VESSEL as any}
+          cargo={FULL_CARGO as any}
+          routeDistanceNm={8500}
+          storedFreightRate={15}
+          matchDbId={1}
+        />,
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('voyage-breakdown-chart')).toBeInTheDocument());
+    const tceCalls = mockFetch.mock.calls.filter(([url]: [string]) => (url as string).includes('/api/voyage/tce'));
+    expect(tceCalls.length).toBeGreaterThanOrEqual(1);
+    const body = JSON.parse(tceCalls[0][1].body);
+    expect(body.vessel.dwt).toBe(50000);
+    expect(body.vessel.speedKts).toBe(13.5);
+    expect(body.vessel.consumptionMtPerDay).toBe(28);
+    expect(body.route.distanceNm).toBe(8500);
+    expect(body.cargo.freightRateUsdPerMt).toBe(15);
+    expect(body.durationDays).toBeGreaterThan(0);
+  });
+
+  it('shows missing-hint when vessel speed absent', async () => {
+    const noSpeed = { ...FULL_VESSEL, speedLaden: null };
+    await act(async () => {
+      render(
+        <EconomicsTab
+          vessel={noSpeed as any}
+          cargo={FULL_CARGO as any}
+          routeDistanceNm={8500}
+          storedFreightRate={15}
+        />,
+      );
+    });
+    expect(screen.getByTestId('voyage-missing-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('voyage-missing-hint')).toHaveTextContent(/vessel speed/i);
+    expect(screen.queryByTestId('voyage-breakdown-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows missing-hint when consumption absent', async () => {
+    const noConsumption = { ...FULL_VESSEL, consumption: null };
+    await act(async () => {
+      render(
+        <EconomicsTab
+          vessel={noConsumption as any}
+          cargo={FULL_CARGO as any}
+          routeDistanceNm={8500}
+          storedFreightRate={15}
+        />,
+      );
+    });
+    expect(screen.getByTestId('voyage-missing-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('voyage-missing-hint')).toHaveTextContent(/fuel consumption/i);
+  });
+
+  it('shows missing-hint when routeDistanceNm is null', async () => {
+    await act(async () => {
+      render(
+        <EconomicsTab
+          vessel={FULL_VESSEL as any}
+          cargo={FULL_CARGO as any}
+          routeDistanceNm={null}
+          storedFreightRate={15}
+        />,
+      );
+    });
+    expect(screen.getByTestId('voyage-missing-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('voyage-missing-hint')).toHaveTextContent(/route distance/i);
+  });
+
+  it('shows missing-hint with no vessel/cargo at all', async () => {
+    await act(async () => { render(<EconomicsTab />); });
+    expect(screen.getByTestId('voyage-missing-hint')).toBeInTheDocument();
+  });
+
+  it('uses estimateVesselValueUsd(dwt) for vessel valueUsd', async () => {
+    await act(async () => {
+      render(
+        <EconomicsTab
+          vessel={FULL_VESSEL as any}
+          cargo={FULL_CARGO as any}
+          routeDistanceNm={8500}
+          storedFreightRate={15}
+        />,
+      );
+    });
+    await waitFor(() => expect(screen.getByTestId('voyage-breakdown-chart')).toBeInTheDocument());
+    const tceCalls = mockFetch.mock.calls.filter(([url]: [string]) => (url as string).includes('/api/voyage/tce'));
+    const body = JSON.parse(tceCalls[0][1].body);
+    // estimateVesselValueUsd(50000) = 50000 * 260 = 13_000_000 (Supramax class)
+    expect(body.vessel.valueUsd).toBe(13_000_000);
+  });
+
+  it('INVARIANT: calculateTCE and VoyageInput not structurally changed', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('path');
+    const src: string = fs.readFileSync(
+      path.join(process.cwd(), 'lib/economics/voyage-calculator.ts'),
+      'utf8',
+    );
+    expect(src).toContain('export function calculateTCE(input: VoyageInput): TCEResult');
+    expect(src).toContain('export interface VoyageInput');
+    expect(src).toContain('export interface TCEBreakdown');
+    expect(src).toContain('daily_tce_usd');
+  });
+});

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -3,11 +3,13 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import type { ParsedVessel, ParsedCargo } from '@/lib/types';
 import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
+import { VoyageBreakdownChart } from '@/components/economics/VoyageBreakdownChart';
 import { calculateFuelEu } from '@/lib/economics/fueleu';
 import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
+import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';
 
 interface EconomicsTabProps {
   commissionPercent?: number | null;
@@ -73,6 +75,9 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const [fuelType, setFuelType] = useState('hfo');
   const [euaData, setEuaData] = useState<{ value: number; period: string; stale?: boolean } | null>(null);
   const [euaPhase, setEuaPhase] = useState<'loading' | 'ok' | 'unavailable'>('loading');
+  const [voyageBreakdown, setVoyageBreakdown] = useState<TCEBreakdown | null>(null);
+  const [voyageLoading, setVoyageLoading] = useState(false);
+  const [voyageError, setVoyageError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -228,6 +233,80 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const speedKnots = parseLeadingNumber(vessel?.speedLaden);
     return estimateVoyageDays(routeDistanceNm, speedKnots);
   }, [vessel, routeDistanceNm, fuelEuEnabled]);
+
+  const voyageInputData = useMemo(() => {
+    const dwt = vessel?.dwtSummer?.value ?? 0;
+    const speedKts = parseLeadingNumber(vessel?.speedLaden);
+    const consumptionMtPerDay = parseLeadingNumber(vessel?.consumption);
+    const originPort = cargo?.originPort?.value ?? '';
+    const destinationPort = cargo?.destinationPort?.value ?? '';
+    const quantityMt = cargo?.weightMt?.value ?? 0;
+    const distanceNm = routeDistanceNm ?? 0;
+    const freightRateUsdPerMt = currentRate ?? storedFreightRate ?? 28;
+    const durationDays = estimateVoyageDays(distanceNm, speedKts);
+
+    const missing: string[] = [];
+    if (!speedKts) missing.push('vessel speed');
+    if (!consumptionMtPerDay) missing.push('fuel consumption');
+    if (!distanceNm) missing.push('route distance');
+
+    const ready =
+      missing.length === 0 &&
+      dwt > 0 &&
+      originPort.length > 0 &&
+      destinationPort.length > 0 &&
+      quantityMt > 0 &&
+      durationDays > 0;
+
+    return {
+      ready,
+      missing,
+      input: ready
+        ? {
+            vessel: { dwt, valueUsd: estimateVesselValueUsd(dwt), speedKts, consumptionMtPerDay },
+            route: { originPort, destinationPort, distanceNm },
+            cargo: { quantityMt, freightRateUsdPerMt },
+            bunkerPort,
+            bunkerGrade,
+            ...(bunkerPriceUsdPerMt !== '' ? { bunkerPriceUsdPerMt: Number(bunkerPriceUsdPerMt) } : {}),
+            durationDays,
+          }
+        : null,
+    };
+  }, [vessel, cargo, routeDistanceNm, currentRate, storedFreightRate, bunkerPort, bunkerGrade, bunkerPriceUsdPerMt]);
+
+  useEffect(() => {
+    if (!voyageInputData.ready || !voyageInputData.input) {
+      setVoyageBreakdown(null);
+      setVoyageError(null);
+      return;
+    }
+    let cancelled = false;
+    setVoyageLoading(true);
+    setVoyageError(null);
+    fetch('/api/voyage/tce', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(voyageInputData.input),
+    })
+      .then((r) => r.json().then((d: unknown) => ({ ok: r.ok, d })))
+      .then(({ ok, d }: { ok: boolean; d: unknown }) => {
+        if (cancelled) return;
+        if (!ok) {
+          const err = d as { error?: string };
+          setVoyageError(typeof err.error === 'string' ? err.error : 'Calculation failed');
+          setVoyageLoading(false);
+          return;
+        }
+        const result = d as { breakdown: TCEBreakdown };
+        setVoyageBreakdown(result.breakdown ?? null);
+        setVoyageLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) { setVoyageError('Network error'); setVoyageLoading(false); }
+      });
+    return () => { cancelled = true; };
+  }, [voyageInputData]);
 
   return (
     <div data-testid="tab-economics" className="space-y-4 text-sm">
@@ -551,6 +630,24 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
           No JWC war risk zones on this route
         </div>
       )}
+
+      {/* Voyage P&L breakdown */}
+      <div data-testid="voyage-pnl-section" className="rounded border border-gray-200 bg-gray-50 p-3">
+        <h3 className="text-xs font-semibold text-gray-700 mb-2">Voyage P&amp;L</h3>
+        {voyageInputData.ready ? (
+          voyageLoading ? (
+            <p className="text-xs text-gray-400 animate-pulse">Calculating…</p>
+          ) : voyageError ? (
+            <p data-testid="voyage-error" className="text-xs text-red-600">{voyageError}</p>
+          ) : voyageBreakdown ? (
+            <VoyageBreakdownChart breakdown={voyageBreakdown} />
+          ) : null
+        ) : voyageInputData.missing.length > 0 ? (
+          <p data-testid="voyage-missing-hint" className="text-xs text-gray-500">
+            Missing: {voyageInputData.missing.join(', ')}
+          </p>
+        ) : null}
+      </div>
 
       {compareInputs.ready && (
         <RouteCompareModal

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -277,6 +277,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
 
   useEffect(() => {
     if (!voyageInputData.ready || !voyageInputData.input) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset of async-derived state when inputs become invalid
       setVoyageBreakdown(null);
       setVoyageError(null);
       return;

--- a/docs/superpowers/plans/2026-06-01-econ-engine-pnl.md
+++ b/docs/superpowers/plans/2026-06-01-econ-engine-pnl.md
@@ -1,0 +1,29 @@
+# Plan: Economics #3 — voyage P&L chart via engine (2026-06-01)
+
+## Goal
+Economics-вкладка (/match/[id]) сейчас зовёт PATCH /api/matches (одно число TCE). Подключить готовый движок POST /api/voyage/tce (calculateTCE→TCEBreakdown) + отрендерить готовый <VoyageBreakdownChart> (стопка Бункер/Канал/Порт/War-risk/ETS + Daily TCE). Сейчас компонент нигде не импортирован.
+
+## Probe (origin/main c396093b — после #736)
+- EconomicsTab.tsx: уже есть routeDistanceNm, currentRate/storedFreightRate, estimateVesselValueUsd (добавлен #736). Сейчас рендерит одно TCE через PATCH.
+- POST /api/voyage/tce → TCEBreakdown {bunker_usd,canal_usd,da_usd,war_risk_usd,ets_usd,total_costs_usd,net_voyage_usd,daily_tce_usd}. lib/economics/voyage-calculator.ts calculateTCE + VoyageInput type.
+- components/economics/VoyageBreakdownChart.tsx — готов, не импортирован (проверь его Props: breakdown=TCEBreakdown).
+
+## Changes (components/match/EconomicsTab.tsx)
+1. Собрать VoyageInput из матча: vessel{dwt, valueUsd=estimateVesselValueUsd(dwt,type), speedKts=parseLeadingNumber(vessel.speedLaden), consumptionMtPerDay=parseLeadingNumber(vessel.consumption)}, route{originPort, destinationPort, distanceNm=routeDistanceNm, viaSuez/viaCanal опц}, cargo{quantityMt, freightRateUsdPerMt=currentRate (РЕАЛЬНАЯ)}, bunkerPort/grade или manual, durationDays.
+2. POST /api/voyage/tce → TCEBreakdown.
+3. Отрендерить <VoyageBreakdownChart breakdown={result}/> в вкладке. Пересчёт по Recalculate / смене инпутов (useEffect/useMemo).
+4. valueUsd: переиспользовать estimateVesselValueUsd (#736) с документированным допущением.
+5. Нет speed/consumption/distance → показать чего не хватает (как disabled-reason у Compare), не пустоту/краш.
+
+## Tests (TDD) + /test-skill (risk-override economics)
+- VoyageInput собирается корректно из матча (valueUsd из estimateVesselValueUsd, rate=currentRate, distance=routeDistanceNm).
+- POST /api/voyage/tce замокан → VoyageBreakdownChart рендерит стопку с полями TCEBreakdown.
+- Нет speed/consumption → сообщение «чего не хватает», не краш.
+- ИНВАРИАНТ: формулы движка НЕ изменены (только вызов + рендер); RouteCompareModal не тронут.
+- tsc + jest зелёное.
+
+## Out-of-scope
+- НЕ менять формулы движка (calculateTCE/ets/voyage math); route-aware бункер = Econ №1 (после); FuelEU/Suez-Cape = №2 (merged); НЕ трогать RouteCompareModal, Fit Score, MatchWorksheet, war-risk.
+
+## Verify
+- PR в main: "feat(economics): full voyage P&L chart via /api/voyage/tce (VoyageBreakdownChart)". /test-skill обязателен. Gate3/Gate5 — оркестратор/founder.


### PR DESCRIPTION
Econ №3: EconomicsTab собирает VoyageInput → POST /api/voyage/tce → рендерит VoyageBreakdownChart (стопка Бункер/Канал/Порт/War-risk/ETS + Daily TCE). Формулы движка не тронуты. risk-override → QA pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)