### PR TITLE
refactor(match): declutter /match/<id> — slim cards, remove Key Facts, unify laycan+utilisation

### DIFF
--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -94,11 +94,6 @@ export default async function MatchDetailPage({ params }: Props) {
     matchDbId: storedMatch.id,
     score: storedMatch.score,
     status: storedMatch.status,
-    loadPort: storedMatch.load_port,
-    dischargePort: storedMatch.discharge_port,
-    cargoType: storedMatch.cargo_type,
-    vesselDwt: storedMatch.vessel_dwt,
-    laycanDisplay,
     cargoEmailId: effectiveCargoEmailId,
     hasSessionMatch: !!sessionMatch,
     fitPercent: storedMatch.fit_percent ?? null,
@@ -196,7 +191,7 @@ export default async function MatchDetailPage({ params }: Props) {
 
             {/* Match overview cards — Vessel + Cargo */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {/* Vessel card */}
+              {/* Vessel card — Name + Fit% + Status only (DWT lives in Svodka) */}
               <div className="bg-ds-surface rounded-xl ring-1 ring-ds-border p-4 space-y-2">
                 <h2 className="text-xs font-semibold uppercase tracking-wide text-ds-text-muted">
                   Vessel
@@ -206,14 +201,6 @@ export default async function MatchDetailPage({ params }: Props) {
                     <dt className="text-ds-text-muted">Name</dt>
                     <dd className="font-medium text-ds-text truncate">{storedMatch.vessel_name ?? storedMatch.vessel_id}</dd>
                   </div>
-                  {storedMatch.vessel_dwt && (
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-ds-text-muted">DWT</dt>
-                      <dd className="font-medium text-ds-text">
-                        {storedMatch.vessel_dwt.toLocaleString()} MT
-                      </dd>
-                    </div>
-                  )}
                   <div className="flex justify-between gap-2">
                     <dt className="text-ds-text-muted">Status</dt>
                     <dd className="font-medium text-ds-text capitalize">{storedMatch.status}</dd>
@@ -227,28 +214,16 @@ export default async function MatchDetailPage({ params }: Props) {
                 </dl>
               </div>
 
-              {/* Cargo card */}
+              {/* Cargo card — Route + Laycan only (details in Svodka) */}
               <div className="bg-ds-surface rounded-xl ring-1 ring-ds-border p-4 space-y-2">
                 <h2 className="text-xs font-semibold uppercase tracking-wide text-ds-text-muted">
                   Cargo
                 </h2>
                 <dl className="space-y-1 text-sm">
-                  {storedMatch.cargo_type && (
+                  {routeMeta && (
                     <div className="flex justify-between gap-2">
-                      <dt className="text-ds-text-muted">Type</dt>
-                      <dd className="font-medium text-ds-text capitalize">{storedMatch.cargo_type}</dd>
-                    </div>
-                  )}
-                  {storedMatch.load_port && (
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-ds-text-muted">Load Port</dt>
-                      <dd className="font-medium text-ds-text truncate">{storedMatch.load_port}</dd>
-                    </div>
-                  )}
-                  {storedMatch.discharge_port && (
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-ds-text-muted">Discharge</dt>
-                      <dd className="font-medium text-ds-text truncate">{storedMatch.discharge_port}</dd>
+                      <dt className="text-ds-text-muted">Route</dt>
+                      <dd className="font-medium text-ds-text truncate">{routeMeta}</dd>
                     </div>
                   )}
                   {laycanDisplay && (
@@ -294,7 +269,11 @@ export default async function MatchDetailPage({ params }: Props) {
                       ...(cargo.weightMt ? [{ label: 'Weight', value: cargo.weightMt }] : []),
                       ...(cargo.originPort ? [{ label: 'Load Port', value: cargo.originPort }] : []),
                       ...(cargo.destinationPort ? [{ label: 'Discharge Port', value: cargo.destinationPort }] : []),
-                      ...(cargo.preferredDates ? [{ label: 'Laycan', value: cargo.preferredDates }] : []),
+                      ...(laycanDisplay
+                    ? [{ label: 'Laycan', value: { value: laycanDisplay, confidence: 'confirmed' as const, sourceText: cargo.preferredDates?.sourceText } }]
+                    : cargo.preferredDates
+                      ? [{ label: 'Laycan', value: cargo.preferredDates }]
+                      : []),
                     ]}
                     originalEmail={cargoEmail.body}
                   />

--- a/components/match/MatchDetailPanel.tsx
+++ b/components/match/MatchDetailPanel.tsx
@@ -11,11 +11,16 @@ export interface MatchDetailPanelProps {
   matchDbId: number;
   score: number;
   status: string;
-  loadPort: string | null;
-  dischargePort: string | null;
-  cargoType: string | null;
-  vesselDwt: number | null;
-  laycanDisplay: string | null;
+  /** @deprecated no longer rendered — kept for test fixture compatibility */
+  loadPort?: string | null;
+  /** @deprecated no longer rendered — kept for test fixture compatibility */
+  dischargePort?: string | null;
+  /** @deprecated no longer rendered — kept for test fixture compatibility */
+  cargoType?: string | null;
+  /** @deprecated no longer rendered — kept for test fixture compatibility */
+  vesselDwt?: number | null;
+  /** @deprecated no longer rendered — kept for test fixture compatibility */
+  laycanDisplay?: string | null;
   cargoEmailId?: string;
   hasSessionMatch: boolean;
   fitPercent?: number | null;
@@ -24,13 +29,7 @@ export interface MatchDetailPanelProps {
 
 function PanelContent({
   matchDbId,
-  score,
   status,
-  loadPort,
-  dischargePort,
-  cargoType,
-  vesselDwt,
-  laycanDisplay,
   cargoEmailId,
   hasSessionMatch,
   fitPercent,
@@ -57,18 +56,22 @@ function PanelContent({
     }
   }
 
-  const keyFacts = [
-    loadPort && { label: 'Load Port', value: loadPort },
-    dischargePort && { label: 'Discharge Port', value: dischargePort },
-    cargoType && { label: 'Cargo', value: cargoType },
-    vesselDwt && { label: 'Vessel DWT', value: `${vesselDwt.toLocaleString('en-US')} MT` },
-    laycanDisplay && { label: 'Laycan', value: laycanDisplay },
-    { label: 'Status', value: status },
-  ].filter(Boolean) as { label: string; value: string }[];
+  const watchItem: string | null = (() => {
+    if (!fitBreakdown || fitPercent == null) return null;
+    try {
+      const fb = JSON.parse(fitBreakdown);
+      const comps: Array<{ label: string; weight: number; score: number; rationale: string }> =
+        fb.components ?? [];
+      const worst = comps
+        .filter(c => c.weight > 0 && c.rationale)
+        .sort((a, b) => (a.score / a.weight) - (b.score / b.weight))[0];
+      return worst?.rationale ?? null;
+    } catch { return null; }
+  })();
 
   return (
     <div className="space-y-3" data-testid="match-detail-panel">
-      {/* AI Summary */}
+      {/* AI Summary — one real watch-item insight from fit breakdown */}
       <Card size="sm">
         <CardHeader>
           <CardTitle className="text-xs uppercase tracking-wide text-ds-text-muted">
@@ -78,7 +81,7 @@ function PanelContent({
         <CardContent>
           <p className="text-xs text-ds-text-muted leading-relaxed">
             {fitPercent != null
-              ? `Fit ${Math.round(fitPercent)}% — взвешено по факторам ниже (сумма весов = 100).`
+              ? `Fit ${Math.round(fitPercent)}%${watchItem ? ` — Watch: ${watchItem}` : ''}`
               : !hasSessionMatch
                 ? 'Session enrichment unavailable. Reload to refresh match data.'
                 : null}
@@ -126,27 +129,6 @@ function PanelContent({
           )}
         </CardContent>
       </Card>
-
-      {/* Key Facts */}
-      {keyFacts.length > 0 && (
-        <Card size="sm">
-          <CardHeader>
-            <CardTitle className="text-xs uppercase tracking-wide text-ds-text-muted">
-              Key Facts
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <dl className="space-y-1.5">
-              {keyFacts.map(({ label, value }) => (
-                <div key={label} className="flex justify-between gap-2 text-xs">
-                  <dt className="text-ds-text-muted shrink-0">{label}</dt>
-                  <dd className="font-medium text-ds-text text-right truncate">{value}</dd>
-                </div>
-              ))}
-            </dl>
-          </CardContent>
-        </Card>
-      )}
 
       {/* Fit Breakdown */}
       {fitPercent != null && (() => {

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -29,9 +29,10 @@ export function MatchWorksheet({ worksheet }: Props) {
 
   const { readiness: r, vessel: v, cargo: c, hardFilters: hf } = worksheet;
 
+  const capacityMt = v.dwcc ?? v.dwtSummer;
   const util =
-    v.dwtSummer != null && c.weightMt != null && v.dwtSummer > 0
-      ? Math.round((c.weightMt / v.dwtSummer) * 100)
+    capacityMt != null && capacityMt > 0 && c.weightMt != null
+      ? Math.round((c.weightMt / capacityMt) * 100)
       : null;
 
   const transitChain = (() => {

--- a/components/match/SourceAttributionSection.tsx
+++ b/components/match/SourceAttributionSection.tsx
@@ -24,6 +24,7 @@ export function SourceAttributionSection({
   originalEmail,
 }: SourceAttributionSectionProps) {
   const [active, setActive] = useState<AttributableField | null>(null);
+  const [expanded, setExpanded] = useState(false);
 
   const attributableFields = fields.filter(f => f.value.sourceText);
 
@@ -31,63 +32,77 @@ export function SourceAttributionSection({
 
   return (
     <div className="rounded-lg border bg-white p-4 text-sm space-y-3">
-      <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-        Source Attribution
-      </p>
-
-      <div className="grid grid-cols-2 gap-x-6 gap-y-2">
-        {attributableFields.map((field) => (
-          <div key={field.label}>
-            <span className="text-gray-500">{field.label}</span>
-            <p className="font-medium">
-              {String(field.value.value)}
-              <button
-                type="button"
-                onClick={() => setActive(field)}
-                className="ms-1 text-blue-500 hover:text-blue-700 text-xs align-super"
-                title={`View source for ${field.label}`}
-                aria-label={`View source for ${field.label}`}
-              >
-                [¹]
-              </button>
-            </p>
-          </div>
-        ))}
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+          Source Attribution
+        </p>
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          className="text-xs text-blue-500 hover:text-blue-700 underline underline-offset-2"
+          aria-expanded={expanded}
+        >
+          {expanded ? 'Hide' : `Show sources (${attributableFields.length})`}
+        </button>
       </div>
 
-      {/* Attribution dialog */}
-      {active && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label={`Source attribution for ${active.label}`}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-          onClick={() => setActive(null)}
-        >
-          <div
-            className="bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 p-5 space-y-3"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between">
-              <p className="font-semibold text-sm">{active.label}</p>
-              <button
-                type="button"
-                className="text-gray-400 hover:text-gray-600 text-lg leading-none"
-                onClick={() => setActive(null)}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </div>
-            <SourceAttribution
-              parsedField={{
-                value: active.value.value,
-                sourceQuote: active.value.sourceText,
-                originalEmail,
-              }}
-            />
+      {expanded && (
+        <>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+            {attributableFields.map((field) => (
+              <div key={field.label}>
+                <span className="text-gray-500">{field.label}</span>
+                <p className="font-medium">
+                  {String(field.value.value)}
+                  <button
+                    type="button"
+                    onClick={() => setActive(field)}
+                    className="ms-1 text-blue-500 hover:text-blue-700 text-xs align-super"
+                    title={`View source for ${field.label}`}
+                    aria-label={`View source for ${field.label}`}
+                  >
+                    [¹]
+                  </button>
+                </p>
+              </div>
+            ))}
           </div>
-        </div>
+
+          {/* Attribution dialog */}
+          {active && (
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label={`Source attribution for ${active.label}`}
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+              onClick={() => setActive(null)}
+            >
+              <div
+                className="bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 p-5 space-y-3"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="flex items-center justify-between">
+                  <p className="font-semibold text-sm">{active.label}</p>
+                  <button
+                    type="button"
+                    className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+                    onClick={() => setActive(null)}
+                    aria-label="Close"
+                  >
+                    ×
+                  </button>
+                </div>
+                <SourceAttribution
+                  parsedField={{
+                    value: active.value.value,
+                    sourceQuote: active.value.sourceText,
+                    originalEmail,
+                  }}
+                />
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/match/__tests__/MatchDetailPanel.test.tsx
+++ b/components/match/__tests__/MatchDetailPanel.test.tsx
@@ -46,26 +46,13 @@ describe('MatchDetailPanel — Generate Quote button visibility (#633)', () => {
   });
 });
 
-describe('MatchDetailPanel hydration safety (#616)', () => {
-  it('renders DWT with stable locale formatting (guards SSR/CSR hydration mismatch)', () => {
-    // Simulate Node.js small-ICU behavior: toLocaleString() without an explicit locale
-    // returns bare digits with no thousands separator. Browsers add "," → React error 418.
-    const origFn = Number.prototype.toLocaleString;
-    jest.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
-      this: number,
-      ...args: Parameters<typeof origFn>
-    ) {
-      if (!args[0]) return String(this); // mimic small-ICU Node: no separator
-      return origFn.apply(this, args);
-    });
-
+describe('MatchDetailPanel hydration safety (#616 — DWT moved to Svodka)', () => {
+  it('does NOT render DWT/MT in panel — DWT lives in server-side Svodka only', () => {
+    // DWT was removed from the client panel (Key Facts declutter). It now renders
+    // only in MatchWorksheet (server component) — no SSR/CSR hydration concern.
     render(<MatchDetailPanel {...BASE_PROPS} />);
-
-    // Without fix (no locale): renders "75000 MT" — test fails, exposing hydration bug.
-    // After fix (locale='en-US'): renders "75,000 MT" — test passes.
-    expect(screen.getByText(/75,000 MT/)).toBeInTheDocument();
-
-    jest.restoreAllMocks();
+    expect(screen.queryByText(/75,?000 MT/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\bMT\b/)).not.toBeInTheDocument();
   });
 
   it('renders panel without DWT when vesselDwt is null', () => {

--- a/docs/superpowers/plans/2026-06-01-match-declutter.md
+++ b/docs/superpowers/plans/2026-06-01-match-declutter.md
@@ -1,0 +1,45 @@
+# Plan: match-page declutter + laycan-source unify (founder tasks 1+2 folded)
+
+## Context
+The /match/<id> page repeats the same fields 3-4x across layers: top VESSEL/CARGO cards + Svodka(worksheet) + KEY FACTS + AI SUMMARY + SOURCE ATTRIBUTION + FIT SCORE. The Svodka (worksheet, shipped earlier) is now the richest view -> make it the single source; remove the duplicating layers. ALSO the CARGO card shows TWO different laycans: page.tsx L254 uses the correct computed `laycanDisplay`, but L297 uses raw `cargo.preferredDates` (old wide window, no year, e.g. "Jan 19-Apr 7") -> unify to `laycanDisplay`.
+
+## Goal
+Declutter so each fact appears once (in Svodka/tabs); top cards become compact identity-only; KEY FACTS removed; AI SUMMARY removed-or-real-insight; SOURCE ATTRIBUTION collapsed; utilisation number consistent between Svodka and FIT SCORE; CARGO-card laycan uses the same computed window everywhere.
+
+## Files (probed on origin/main @ today)
+- `app/match/[id]/page.tsx`:
+  - L74-75 `laycanDisplay = fmtLaycan(laycan_start, laycan_end)` (in scope — KEEP, it is correct).
+  - L209-213 VESSEL card "DWT ... MT" -> REMOVE (DWT lives in Svodka/Vessels tab). Keep Name + Fit% + Status only.
+  - CARGO card: keep route (Load->Discharge) + Laycan one line. L297 `...(cargo.preferredDates ? [{label:'Laycan', value: cargo.preferredDates}] : [])` -> replace source with `laycanDisplay` (this is folded task 1). Remove cargo fields already shown in Svodka.
+  - L84 + L100-101 `keyFacts` array (incl. laycanDisplay) passed to the panel -> becomes DEAD once Key Facts block removed -> delete the dead array + prop.
+- `components/match/MatchDetailPanel.tsx`:
+  - L130+ "Key Facts" block -> REMOVE (100% duplicate of Svodka: Load/Discharge/Cargo/DWT/Laycan/Status all in worksheet).
+  - L71-81 "AI Summary" (`Fit X% — vzvesheno po faktoram nizhe`) -> REMOVE the filler card; OR replace with ONE real insight (top watch-items from gap-notes/vetting) IF that data is readily available on the match object; if not readily available, just REMOVE.
+- `components/match/SourceAttributionSection.tsx`:
+  - Collapse by default (expandable "Istochniki" disclosure). KEEP the unique [*] citations inside. Do NOT delete the section.
+- utilisation sync (step 5): Svodka(Weight) shows "85% utilisation" (DWT-based); FIT SCORE shows "Size/utilisation 100%" (capacity/DWCC-based). Make the Svodka utilisation render the SAME capacity-based value the fit-engine uses (read it from fit_breakdown / the same source FIT SCORE uses, at render time).
+  - HARD CONSTRAINT: if the 85% value is baked into `worksheet_json` (demo-seed DB) and cannot be made consistent at render time without REGENERATING the seed -> STOP, write QUESTIONS.md, report it. Do NOT regenerate demo-seed.db (separate founder-gated task).
+
+## Steps (subagent-driven-development)
+1. Read page.tsx + MatchDetailPanel.tsx + SourceAttributionSection.tsx + the worksheet/Svodka component to map EVERY field render and where utilisation comes from.
+2. Remove KEY FACTS (panel) + the now-dead keyFacts array/prop (page). Grep to confirm nothing else consumes it.
+3. AI Summary: real insight if trivially available, else remove the card.
+4. Slim VESSEL card (Name+Fit+Status) and CARGO card (route + laycanDisplay one line). Fix L297 laycan source -> laycanDisplay.
+5. Collapse SOURCE ATTRIBUTION (default-collapsed; preserve citations).
+6. Utilisation: Svodka utilisation == fit-engine capacity-based value (render-time). If blocked by seed -> STOP + QUESTIONS.md.
+7. Build; visual self-check that every removed field is STILL present in Svodka/tabs (zero data loss). `npx tsc --noEmit` + `npm run lint` clean.
+
+## Out-of-scope (orchestrator-set)
+- Do NOT touch `fmtLaycan` / structural dates (they are correct).
+- Do NOT touch FIT SCORE / "pokazat raschet", Vessels/Economics/Passport/Quote tabs, Quick Actions, or the Svodka's own internal content.
+- Do NOT regenerate demo-seed.db. If utilisation requires it -> report, do not do it.
+- Do NOT touch `components/match/EconomicsTab.tsx` (in-flight PR) or `tests/fixtures/voyage-tce/*` (in-flight PR).
+
+## Acceptance (founder, on prod)
+1. No KEY FACTS block; ports/DWT/laycan not repeated 3-4x.
+2. Top cards compact (name/Fit/status + route/laycan).
+3. SOURCE ATTRIBUTION collapsed, expands on click.
+4. utilisation in Svodka == FIT SCORE (one number).
+5. CARGO-card laycan == Svodka laycan == everywhere (format "2026-06-03-06-06"; no "Jan 19-Apr 7").
+6. No real data lost — everything still in Svodka/tabs.
+UI-PR -> Gate 3 (before/after screenshot of /match/<id>) MANDATORY + Gate 5.


### PR DESCRIPTION
## Summary

**Founder tasks 1+2 folded into one coherent change.** The /match/<id> page was showing the same facts 3-4× across layers (top cards, Key Facts, Svodka). The Svodka is now the single source of truth; top cards are compact identity-only.

- **Remove Key Facts block** from right panel — 100% duplicate of Svodka (Load/Discharge/DWT/Laycan/Status)
- **Replace AI Summary filler** with one real watch-item insight from `fit_breakdown` (worst-scoring factor's rationale)
- **VESSEL card**: Name + Status + Fit% only (DWT removed — lives in Svodka ⚖️ Weight row)
- **CARGO card**: Route (Load→Discharge) + Laycan only (Type/ports removed — live in Svodka)
- **Laycan source unified**: SourceAttributionSection now shows `laycanDisplay` (computed window "2026-06-03 – 2026-06-06") instead of raw `cargo.preferredDates` ("Jan 19-Apr 7")
- **Source Attribution**: collapsed by default, expands with "Show sources (N)" toggle — keeps all [¹] citations
- **Svodka utilisation**: now DWCC-primary at render time (`v.dwcc ?? v.dwtSummer`) — matches FIT SCORE capacity basis. No seed regeneration needed (dwcc already present in worksheet_json).

## Before / After

**Before**: VESSEL card showed Name + DWT + Status + Fit%; CARGO card showed Type + Load Port + Discharge + Laycan (raw); right panel had a third "Key Facts" card repeating all of it; Source Attribution always expanded.

**After**: VESSEL card = Name + Status + Fit%; CARGO card = Route + Laycan (computed); Key Facts gone; Source Attribution collapsed by default; Svodka utilisation aligned with FIT SCORE.

## Zero data loss

Every removed field is still visible in Svodka or tabs:
- DWT → Svodka ⚖️ Weight row
- Load/Discharge Port → Svodka 📍 Where/Transit + MatchTabs
- Cargo Type → Svodka 🚢 Type row
- Laycan → Svodka ⏱ Time row

## Test plan

- [ ] `npx tsc --noEmit` — clean (no errors)
- [ ] `npx jest --findRelatedTests components/match/MatchDetailPanel.tsx ...` — 15/15 green
- [ ] `npm run lint` — 0 errors
- [ ] Visual: navigate to `/match/<id>` — top cards compact, no Key Facts panel, Source Attribution collapsed, Svodka utilisation matches FIT SCORE percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)