### PR TITLE
feat(economics): on-route bunker port recommendation + savings (wire optimizeSplitBunker)

### DIFF
--- a/__tests__/api/voyage/bunker-reco-adversarial.test.ts
+++ b/__tests__/api/voyage/bunker-reco-adversarial.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Adversarial regression tests for GET /api/voyage/bunker-recommendation
+ * Written by cold-start QA reviewer (test-skill).
+ *
+ * Tests H1-H5 from attack plan:
+ *   H1: off-route exclusion assertion is substantive (not vacuous)
+ *   H2: geometric fallback (all ports priced but all off-route → fallback)
+ *   H3: MGO grade uses MGO prices for comparison
+ *   H4: threshold boundary — detour == threshold → included
+ *   H5: fail-open when directNm is null (unknown route)
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/voyage/bunker-recommendation/route';
+
+// ── DB setup ──────────────────────────────────────────────────────────────────
+
+let db: Database.Database;
+
+function createDb(): Database.Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE bunker_prices (
+      port_unlocode    TEXT NOT NULL,
+      fuel_grade       TEXT NOT NULL,
+      price_usd_per_mt REAL NOT NULL,
+      price_date       TEXT NOT NULL,
+      source           TEXT NOT NULL,
+      fetched_at       TEXT NOT NULL,
+      UNIQUE(port_unlocode, fuel_grade, price_date)
+    );
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('AEFJR', 'VLSFO', 880, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USHOU', 'VLSFO', 806, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'MGO',  1192, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'MGO',  1172, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'MGO',  1144, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('AEFJR', 'MGO',  1482, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USHOU', 'MGO',  1170, '2026-05-09', 'seed', datetime('now'));
+  `);
+  return d;
+}
+
+beforeAll(() => { db = createDb(); });
+afterAll(() => db.close());
+
+const mockGetPortDistance = jest.fn();
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDb: () => db })),
+}));
+
+jest.mock('@/lib/sailing/port-distances', () => ({
+  getPortDistance: (...args: [string, string]) => mockGetPortDistance(...args),
+}));
+
+function makeReq(from: string, to: string, grade = 'VLSFO'): NextRequest {
+  const url = `http://localhost/api/voyage/bunker-recommendation?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&grade=${grade}`;
+  return new NextRequest(url, { method: 'GET' });
+}
+
+// ── H1: Off-route exclusion — substantive assertion ───────────────────────────
+
+describe('H1 — off-route SGSIN excluded (substantive assertion)', () => {
+  beforeEach(() => {
+    // Route: TRNBT → GBLIVP (3900 NM)
+    // GIGIB: detour = 2100+1600-3900 = -200 NM (on-route)
+    // NLRTM: detour = 2400+500-3900  = -1000 NM (on-route)
+    // SGSIN: detour = 7100+11000-3900 = 14200 NM (WAY off-route)
+    mockGetPortDistance.mockImplementation((from: string, to: string) => {
+      const key = `${from}|${to}`;
+      const table: Record<string, number> = {
+        'TRNBT|GBLIVP': 3900, 'GBLIVP|TRNBT': 3900,
+        'TRNBT|GIGIB': 2100, 'GIGIB|TRNBT': 2100,
+        'GIGIB|GBLIVP': 1600, 'GBLIVP|GIGIB': 1600,
+        'TRNBT|NLRTM': 2400, 'NLRTM|TRNBT': 2400,
+        'NLRTM|GBLIVP': 500, 'GBLIVP|NLRTM': 500,
+        'TRNBT|SGSIN': 7100, 'SGSIN|TRNBT': 7100,
+        'SGSIN|GBLIVP': 11000, 'GBLIVP|SGSIN': 11000,
+        'TRNBT|AEFJR': 1800, 'AEFJR|TRNBT': 1800,
+        'AEFJR|GBLIVP': 9500, 'GBLIVP|AEFJR': 9500,
+        'TRNBT|USHOU': 5600, 'USHOU|TRNBT': 5600,
+        'USHOU|GBLIVP': 4500, 'GBLIVP|USHOU': 4500,
+      };
+      const nm = table[key];
+      return nm != null ? { nm, exact: true } : null;
+    });
+  });
+
+  it('SGSIN is NOT the recommended port (not just absent from a specific string)', async () => {
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    const body = await res.json();
+    // Substantive: the port field must not be Singapore
+    expect(body.port).not.toBe('SGSIN');
+    // Substantive: SGSIN must not appear in the recommendation (it's off-route)
+    expect(body.recommendation ?? '').not.toContain('SGSIN');
+  });
+
+  it('recommended port is one of the two on-route candidates (GIGIB or NLRTM)', async () => {
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    const body = await res.json();
+    expect(['GIGIB', 'NLRTM']).toContain(body.port);
+  });
+
+  it('GIGIB wins because it is cheaper (771 < 791)', async () => {
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    const body = await res.json();
+    expect(body.port).toBe('GIGIB');
+    expect(body.priceUsdPerMt).toBe(771);
+  });
+});
+
+// ── H2: Geometric fallback — all ports priced but all off-route ───────────────
+
+describe('H2 — geometric fallback (all ports priced, all geometrically off-route)', () => {
+  beforeEach(() => {
+    // Route: 500 NM direct, every candidate has huge detour
+    // threshold = max(0.15*500, 200) = max(75, 200) = 200 NM
+    // All candidates: detour > 200 NM → all excluded
+    mockGetPortDistance.mockImplementation((from: string, to: string) => {
+      if (from === 'PORTA' && to === 'PORTB') return { nm: 500, exact: true };
+      if (from === 'PORTB' && to === 'PORTA') return { nm: 500, exact: true };
+      // All candidate legs: make each candidate add 300+ NM detour
+      // leg1 + leg2 - 500 > 200 → leg1 + leg2 > 700
+      // So each candidate: leg1=400, leg2=400 → detour = 300 (> 200 threshold)
+      const farCandidates = ['NLRTM', 'SGSIN', 'AEFJR', 'USHOU', 'GIGIB'];
+      for (const c of farCandidates) {
+        if ((from === 'PORTA' && to === c) || (from === c && to === 'PORTA')) return { nm: 400, exact: true };
+        if ((from === c && to === 'PORTB') || (from === 'PORTB' && to === c)) return { nm: 400, exact: true };
+      }
+      return null;
+    });
+  });
+
+  it('returns fallback=true when all priced ports are geometrically off-route', async () => {
+    const res = await GET(makeReq('PORTA', 'PORTB'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fallback).toBe(true);
+    expect(body.port).toBeNull();
+    expect(body.message).toBeTruthy();
+    // Must NOT silently default to Singapore
+    expect(body.port).not.toBe('SGSIN');
+  });
+});
+
+// ── H3: MGO grade uses MGO prices for comparison ─────────────────────────────
+
+describe('H3 — MGO grade passthrough', () => {
+  beforeEach(() => {
+    // Route: PORTA → PORTB, both NLRTM and GIGIB are on-route
+    // MGO prices: GIGIB=1172, NLRTM=1192
+    // GIGIB should win for MGO (cheaper MGO price)
+    mockGetPortDistance.mockImplementation((from: string, to: string) => {
+      const table: Record<string, number> = {
+        'PORTA|PORTB': 2000, 'PORTB|PORTA': 2000,
+        'PORTA|NLRTM': 900, 'NLRTM|PORTA': 900,
+        'NLRTM|PORTB': 900, 'PORTB|NLRTM': 900,  // detour = 1800-2000 = -200 (on-route)
+        'PORTA|GIGIB': 950, 'GIGIB|PORTA': 950,
+        'GIGIB|PORTB': 950, 'PORTB|GIGIB': 950,  // detour = 1900-2000 = -100 (on-route)
+        'PORTA|SGSIN': 5000, 'SGSIN|PORTA': 5000,
+        'SGSIN|PORTB': 5000, 'PORTB|SGSIN': 5000, // detour = 8000 (off-route)
+        'PORTA|AEFJR': 4000, 'AEFJR|PORTA': 4000,
+        'AEFJR|PORTB': 4000, 'PORTB|AEFJR': 4000, // detour = 6000 (off-route)
+        'PORTA|USHOU': 6000, 'USHOU|PORTA': 6000,
+        'USHOU|PORTB': 6000, 'PORTB|USHOU': 6000, // detour = 10000 (off-route)
+      };
+      const nm = table[`${from}|${to}`];
+      return nm != null ? { nm, exact: true } : null;
+    });
+  });
+
+  it('picks cheapest MGO port (GIGIB=1172) over NLRTM (1192) when grade=MGO', async () => {
+    const res = await GET(makeReq('PORTA', 'PORTB', 'MGO'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fallback).toBe(false);
+    expect(body.port).toBe('GIGIB');
+    expect(body.priceUsdPerMt).toBe(1172);
+  });
+
+  it('VLSFO recommendation also picks GIGIB (771) over NLRTM (791)', async () => {
+    const res = await GET(makeReq('PORTA', 'PORTB', 'VLSFO'));
+    const body = await res.json();
+    expect(body.port).toBe('GIGIB');
+    expect(body.priceUsdPerMt).toBe(771);
+  });
+});
+
+// ── H4: Threshold boundary — exactly at threshold → included ─────────────────
+
+describe('H4 — threshold boundary (detour == threshold → included)', () => {
+  it('port with detour exactly equal to threshold is INCLUDED (not excluded)', async () => {
+    // Direct: 1000 NM → threshold = max(150, 200) = 200 NM
+    // NLRTM: leg1=600, leg2=600 → detour = 1200-1000 = 200 == threshold → INCLUDED
+    // GIGIB: detour = 300 → EXCLUDED
+    mockGetPortDistance.mockImplementation((from: string, to: string) => {
+      const table: Record<string, number> = {
+        'P1|P2': 1000, 'P2|P1': 1000,
+        'P1|NLRTM': 600, 'NLRTM|P1': 600,
+        'NLRTM|P2': 600, 'P2|NLRTM': 600,  // detour = 200 == threshold → INCLUDED
+        'P1|GIGIB': 700, 'GIGIB|P1': 700,
+        'GIGIB|P2': 700, 'P2|GIGIB': 700,  // detour = 400 > 200 → EXCLUDED
+        'P1|SGSIN': 5000, 'SGSIN|P1': 5000,
+        'SGSIN|P2': 5000, 'P2|SGSIN': 5000,
+        'P1|AEFJR': 3000, 'AEFJR|P1': 3000,
+        'AEFJR|P2': 3000, 'P2|AEFJR': 3000,
+        'P1|USHOU': 4000, 'USHOU|P1': 4000,
+        'USHOU|P2': 4000, 'P2|USHOU': 4000,
+      };
+      const nm = table[`${from}|${to}`];
+      return nm != null ? { nm, exact: true } : null;
+    });
+
+    const res = await GET(makeReq('P1', 'P2'));
+    const body = await res.json();
+    // NLRTM at exactly the threshold should be included (not excluded)
+    expect(body.fallback).toBe(false);
+    expect(body.port).toBe('NLRTM'); // only on-route candidate
+  });
+});
+
+// ── H5: fail-open when directNm = null ────────────────────────────────────────
+
+describe('H5 — fail-open when from/to distance is unknown', () => {
+  it('includes all priced candidates when direct route distance is unknown', async () => {
+    // from/to unknown → getPortDistance(from, to) returns null → directNm = null
+    // All candidates have prices → all should be included (fail-open)
+    mockGetPortDistance.mockImplementation((from: string, to: string) => {
+      // Only candidate legs are known; the direct route is unknown
+      const candidates = ['NLRTM', 'SGSIN', 'AEFJR', 'USHOU', 'GIGIB'];
+      for (const c of candidates) {
+        if (from === 'UNKN' && to === c) return { nm: 1000, exact: false };
+        if (from === c && to === 'UNKN2') return { nm: 1000, exact: false };
+      }
+      // UNKN → UNKN2 direct: unknown
+      return null;
+    });
+
+    const res = await GET(makeReq('UNKN', 'UNKN2'));
+    const body = await res.json();
+    // All 5 candidates have prices and pass (fail-open), optimizer picks cheapest globally
+    expect(body.fallback).toBe(false);
+    // GIGIB is cheapest VLSFO (771)
+    expect(body.port).toBe('GIGIB');
+  });
+});

--- a/__tests__/api/voyage/bunker-recommendation.test.ts
+++ b/__tests__/api/voyage/bunker-recommendation.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Behavioral tests for GET /api/voyage/bunker-recommendation
+ *
+ * Covers (per risk-override mandate):
+ *   (a) off-route port excluded
+ *   (b) cheapest on-route port chosen
+ *   (c) savings match optimizeSplitBunker output
+ *   (d) no-on-route fallback (honest message, not Singapore default)
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/voyage/bunker-recommendation/route';
+
+// ── DB setup ──────────────────────────────────────────────────────────────────
+
+let db: Database.Database;
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE bunker_prices (
+      port_unlocode    TEXT NOT NULL,
+      fuel_grade       TEXT NOT NULL,
+      price_usd_per_mt REAL NOT NULL,
+      price_date       TEXT NOT NULL,
+      source           TEXT NOT NULL,
+      fetched_at       TEXT NOT NULL,
+      UNIQUE(port_unlocode, fuel_grade, price_date)
+    );
+    -- Seed all 5 standard bunker hubs
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('AEFJR', 'VLSFO', 880, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USHOU', 'VLSFO', 806, '2026-05-09', 'seed', datetime('now'));
+  `);
+});
+
+afterAll(() => db.close());
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDb: () => db })),
+}));
+
+// ── Mock port distances for deterministic test control ────────────────────────
+//
+// Route: Nemrut Bay (TRNBT) → Liverpool (GBLIVP) — 3 900 NM via Med + Gibraltar
+//
+// Controlled distances so we can assert inclusion/exclusion precisely:
+//   Nemrut → Liverpool direct: 3900 NM
+//   Nemrut → GIGIB: 2100 NM,  GIGIB → Liverpool: 1600 NM → detour = 3700 - 3900 = -200 NM (on-route)
+//   Nemrut → NLRTM: 2400 NM,  NLRTM → Liverpool:  500 NM → detour = 2900 - 3900 = -1000 NM (on-route)
+//   Nemrut → SGSIN: 7100 NM,  SGSIN → Liverpool: 11000 NM → detour = 18100 - 3900 = 14200 NM (off-route)
+//   Nemrut → AEFJR: 1800 NM,  AEFJR → Liverpool: 9500 NM → detour = 11300 - 3900 = 7400 NM (off-route)
+//   Nemrut → USHOU: 5600 NM,  USHOU → Liverpool: 4500 NM → detour = 10100 - 3900 = 6200 NM (off-route)
+
+const MOCK_DISTANCES: Record<string, number> = {
+  'TRNBT|GBLIVP': 3900, 'GBLIVP|TRNBT': 3900,
+  'TRNBT|GIGIB': 2100, 'GIGIB|TRNBT': 2100,
+  'GIGIB|GBLIVP': 1600, 'GBLIVP|GIGIB': 1600,
+  'TRNBT|NLRTM': 2400, 'NLRTM|TRNBT': 2400,
+  'NLRTM|GBLIVP': 500,  'GBLIVP|NLRTM': 500,
+  'TRNBT|SGSIN': 7100, 'SGSIN|TRNBT': 7100,
+  'SGSIN|GBLIVP': 11000, 'GBLIVP|SGSIN': 11000,
+  'TRNBT|AEFJR': 1800, 'AEFJR|TRNBT': 1800,
+  'AEFJR|GBLIVP': 9500, 'GBLIVP|AEFJR': 9500,
+  'TRNBT|USHOU': 5600, 'USHOU|TRNBT': 5600,
+  'USHOU|GBLIVP': 4500, 'GBLIVP|USHOU': 4500,
+};
+
+jest.mock('@/lib/sailing/port-distances', () => ({
+  getPortDistance: jest.fn((from: string, to: string) => {
+    const key = `${from}|${to}`;
+    const nm = MOCK_DISTANCES[key];
+    return nm != null ? { nm, exact: true } : null;
+  }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(from: string, to: string, grade = 'VLSFO'): NextRequest {
+  const url = `http://localhost/api/voyage/bunker-recommendation?from=${from}&to=${to}&grade=${grade}`;
+  return new NextRequest(url, { method: 'GET' });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/voyage/bunker-recommendation', () => {
+  it('(b) recommends cheapest on-route port — GIGIB (771) over NLRTM (791)', async () => {
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fallback).toBe(false);
+    expect(body.port).toBe('GIGIB');
+    expect(body.priceUsdPerMt).toBe(771);
+  });
+
+  it('(a) excludes off-route SGSIN — not in recommendation', async () => {
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    const body = await res.json();
+    // Singapore is off-route; it must not be the recommended port
+    expect(body.port).not.toBe('SGSIN');
+    // recommendation string must not mention Singapore as the bunker port
+    expect(body.recommendation).not.toContain('SGSIN is on route');
+  });
+
+  it('(c) recommendation string mentions GIGIB and savings vs NLRTM', async () => {
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    const body = await res.json();
+    expect(body.recommendation).toContain('GIGIB');
+    // GIGIB cheaper than NLRTM → positive savings
+    expect(body.savingsUsd).toBeGreaterThan(0);
+    expect(body.recommendation).toContain('saves');
+  });
+
+  it('(d) no-on-route fallback — honest message, port is null (not SGSIN)', async () => {
+    // Use a route with no distances known → all candidates return null distances → fail-open includes all
+    // To force a true no-on-route: mock a route where all candidates have huge detours
+    // We use unknown ports that getPortDistance returns null for → fail-open (include them)
+    // But to truly test fallback: provide a route where DB has no prices for any port
+    const emptyDb = new Database(':memory:');
+    emptyDb.exec(`
+      CREATE TABLE bunker_prices (
+        port_unlocode TEXT, fuel_grade TEXT, price_usd_per_mt REAL,
+        price_date TEXT, source TEXT, fetched_at TEXT,
+        UNIQUE(port_unlocode, fuel_grade, price_date)
+      );
+    `);
+    const { getStore } = jest.requireMock('@/lib/session-store') as { getStore: jest.Mock };
+    getStore.mockReturnValueOnce({ getDb: () => emptyDb });
+
+    const res = await GET(makeReq('TRNBT', 'GBLIVP'));
+    const body = await res.json();
+    expect(body.fallback).toBe(true);
+    expect(body.port).toBeNull();
+    expect(body.message).toBeTruthy();
+    emptyDb.close();
+  });
+
+  it('returns 400 when from or to is missing', async () => {
+    const req = new NextRequest('http://localhost/api/voyage/bunker-recommendation?from=NLRTM');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/voyage/bunker-recommendation/route.ts
+++ b/app/api/voyage/bunker-recommendation/route.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/voyage/bunker-recommendation
+ *
+ * Returns the cheapest on-route bunker port for a voyage, using port-master
+ * distances (no hardcoded coordinates). Falls back with an honest message when
+ * no candidate port is on the route.
+ *
+ * Query params:
+ *   from   – origin port (LOCODE or canonical name)
+ *   to     – destination port (LOCODE or canonical name)
+ *   grade  – VLSFO | MGO (default VLSFO)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getPortDistance } from '@/lib/sailing/port-distances';
+import { getStore } from '@/lib/session-store';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
+import { optimizeSplitBunker } from '@/lib/economics/split-bunker';
+import type { BunkerPrice } from '@/lib/economics/bunker';
+
+export const dynamic = 'force-dynamic';
+
+/** The 5 global bunker hubs available in the system. */
+const BUNKER_CANDIDATES = ['NLRTM', 'SGSIN', 'AEFJR', 'USHOU', 'GIGIB'] as const;
+
+/** Port is on-route if detour is within 15% of direct distance or under 200 NM. */
+const DETOUR_RATIO = 0.15;
+const DETOUR_ABS_CAP_NM = 200;
+
+export interface BunkerRecommendationResponse {
+  fallback: boolean;
+  message: string | null;
+  port: string | null;
+  priceUsdPerMt: number | null;
+  recommendation: string | null;
+  savingsUsd: number;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse<BunkerRecommendationResponse>> {
+  const url = new URL(req.url);
+  const from = url.searchParams.get('from');
+  const to = url.searchParams.get('to');
+  const gradeRaw = (url.searchParams.get('grade') ?? 'VLSFO').toUpperCase();
+  const grade = gradeRaw === 'MGO' ? 'MGO' : 'VLSFO';
+
+  if (!from || !to) {
+    return NextResponse.json(
+      { fallback: true, message: 'from and to required', port: null, priceUsdPerMt: null, recommendation: null, savingsUsd: 0 },
+      { status: 400 },
+    );
+  }
+
+  const directResult = getPortDistance(from, to);
+  const directNm = directResult?.nm ?? null;
+
+  const db = getStore().getDb();
+
+  const onRouteWithPrices: Array<{ port: string; price: BunkerPrice }> = [];
+
+  for (const candidate of BUNKER_CANDIDATES) {
+    const priceRow = getLatestBunkerPrice(db, candidate, grade);
+    if (!priceRow) continue;
+
+    if (directNm != null) {
+      const leg1 = getPortDistance(from, candidate);
+      const leg2 = getPortDistance(candidate, to);
+      if (leg1 && leg2) {
+        const detour = leg1.nm + leg2.nm - directNm;
+        const threshold = Math.max(DETOUR_RATIO * directNm, DETOUR_ABS_CAP_NM);
+        if (detour > threshold) continue;
+      }
+      // If either leg distance is unknown, include the candidate (fail-open)
+    }
+
+    onRouteWithPrices.push({
+      port: candidate,
+      price: {
+        port: candidate,
+        vlsfo: priceRow.price_usd_per_mt,
+        fetched_at: priceRow.fetched_at,
+      },
+    });
+  }
+
+  if (onRouteWithPrices.length === 0) {
+    return NextResponse.json({
+      fallback: true,
+      message: 'No bunker port on this route — enter price manually or select nearest port',
+      port: null,
+      priceUsdPerMt: null,
+      recommendation: null,
+      savingsUsd: 0,
+    });
+  }
+
+  const bunkerPrices = new Map<string, BunkerPrice>(
+    onRouteWithPrices.map(({ port, price }) => [port, price]),
+  );
+
+  const result = optimizeSplitBunker({
+    route: { fromPort: from, toPort: to, intermediatePorts: onRouteWithPrices.map(p => p.port) },
+    bunkerPrices,
+    consumptionMtPerDay: 28,
+  });
+
+  const recommendedPort = result.bunkerPlan[0]?.port ?? onRouteWithPrices[0].port;
+  const recommendedPrice = bunkerPrices.get(recommendedPort);
+
+  return NextResponse.json({
+    fallback: false,
+    message: null,
+    port: recommendedPort,
+    priceUsdPerMt: recommendedPrice?.vlsfo ?? null,
+    recommendation: result.recommendation,
+    savingsUsd: result.savingsUsd,
+  });
+}

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -71,6 +71,9 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const [resetting, setResetting] = useState(false);
   const [bunkerPort, setBunkerPort] = useState<BunkerPort>('SGSIN');
   const [bunkerGrade, setBunkerGrade] = useState<BunkerGrade>('VLSFO');
+  const [bunkerPortManual, setBunkerPortManual] = useState(false);
+  const [bunkerReco, setBunkerReco] = useState<{ port: string; priceUsdPerMt: number; recommendation: string } | null>(null);
+  const [bunkerFallback, setBunkerFallback] = useState<string | null>(null);
   const [displayCurrency, setDisplayCurrency] = useState<DisplayCurrency>('USD');
   const [fuelType, setFuelType] = useState('hfo');
   const [euaData, setEuaData] = useState<{ value: number; period: string; stale?: boolean } | null>(null);
@@ -95,6 +98,31 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
       .catch(() => { if (!cancelled) setEuaPhase('unavailable'); });
     return () => { cancelled = true; };
   }, []);
+
+  const recoFrom = cargo?.originPort?.value;
+  const recoTo = cargo?.destinationPort?.value;
+  useEffect(() => {
+    if (!recoFrom || !recoTo) return;
+    let cancelled = false;
+    const url = `/api/voyage/bunker-recommendation?from=${encodeURIComponent(recoFrom)}&to=${encodeURIComponent(recoTo)}&grade=${bunkerGrade}`;
+    fetch(url)
+      .then((r) => r.ok ? r.json() : null)
+      .then((data: { fallback: boolean; message: string | null; port: string | null; priceUsdPerMt: number | null; recommendation: string | null; savingsUsd: number } | null) => {
+        if (cancelled || !data) return;
+        if (data.fallback) {
+          setBunkerFallback(data.message);
+          setBunkerReco(null);
+        } else if (data.port && data.priceUsdPerMt != null && data.recommendation) {
+          setBunkerFallback(null);
+          setBunkerReco({ port: data.port, priceUsdPerMt: data.priceUsdPerMt, recommendation: data.recommendation });
+          if (!bunkerPortManual && BUNKER_PORTS.some(p => p.value === data.port)) {
+            setBunkerPort(data.port as BunkerPort);
+          }
+        }
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [recoFrom, recoTo, bunkerGrade, bunkerPortManual]);
 
   const handleOverrideSubmit = useCallback(async () => {
     if (!matchDbId) return;
@@ -412,7 +440,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
         <div className="flex gap-2 mt-2">
           <select
             value={bunkerPort}
-            onChange={(e) => setBunkerPort(e.target.value as BunkerPort)}
+            onChange={(e) => { setBunkerPort(e.target.value as BunkerPort); setBunkerPortManual(true); }}
             aria-label="Bunker port"
             className="flex-1 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:border-blue-400"
           >
@@ -435,6 +463,16 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
             ))}
           </select>
         </div>
+        {bunkerReco && (
+          <p data-testid="bunker-reco" className="text-xs text-blue-700 bg-blue-50 rounded px-2 py-1 mt-1">
+            {bunkerReco.recommendation}
+          </p>
+        )}
+        {bunkerFallback && (
+          <p data-testid="bunker-fallback" className="text-xs text-amber-600 mt-1">
+            {bunkerFallback}
+          </p>
+        )}
       </div>
 
       {MULTI_CURRENCY_V2_ENABLED && (

--- a/docs/superpowers/plans/2026-06-01-econ-bunker-route.md
+++ b/docs/superpowers/plans/2026-06-01-econ-bunker-route.md
@@ -1,0 +1,38 @@
+# Plan: Econ #1 — bunker port "on-route" recommendation + savings (wire optimizeSplitBunker)
+
+## Context
+Economics tab, Bunker price section. `BUNKER_PORTS` (components/match/EconomicsTab.tsx ~L48) = 5 global ports, default SGSIN (Singapore). For routes like Nemrut Bay -> Liverpool, Singapore is NOT on the voyage path. The engine ALREADY EXISTS: `lib/economics/split-bunker.ts` `optimizeSplitBunker` — picks the cheapest on-route port + computes savings — but it is NOT wired to the UI. Distance is now available in Economics (route distance landed via the prior Economics task that is already merged): `getPortDistance` / port-master + `distanceNm` are in scope on main.
+
+## Goal
+Replace the static 5-port / default-Singapore picker with an ON-ROUTE recommendation: pick the cheapest bunker port actually on the voyage path, show a recommendation line "Bunker: <port> — save ~$<N> vs <port2>", default the TCE bunker input to that port+price (manual override stays), and an HONEST fallback if none on-route.
+
+## Scope (Tier M, <= ~5 files)
+- `components/match/EconomicsTab.tsx` — bunker section: replace default-Singapore logic with the on-route recommendation; render the recommendation line; feed recommended port+price as the TCE bunker default.
+- `lib/economics/split-bunker.ts` — `optimizeSplitBunker` (exists; WIRE it; extend ONLY if strictly needed to surface a single-port recommendation + savings).
+- distance: `getPortDistance` / port-master (READ distances; NO hardcoded coordinates).
+- bunker prices: `getLatestBunkerPrice` (per candidate port).
+- one small helper for the on-route filter IF it keeps EconomicsTab clean.
+
+## Logic
+1. On-route filter: detour = dist(from->port) + dist(port->to) - dist(from->to). Port is "on-route" if detour < ~15% of the direct distance (or an absolute cap). Distances from getPortDistance/port-master ONLY (no hardcoded coords).
+2. Candidates = BUNKER_PORTS that have an available price (getLatestBunkerPrice), filtered by on-route.
+3. Run candidates through optimizeSplitBunker -> recommendation string "Bunker: <port> — save ~$<N> vs <port2>".
+4. Recommended port+price = DEFAULT bunker input to TCE (not Singapore). Manual override remains functional.
+5. If NO port is on-route -> honest fallback message (NOT a silent Singapore default).
+
+## Out-of-scope (orchestrator-set)
+- NOT multi-point split (Variant C) — single recommended port only.
+- Do NOT change TCE logic beyond the bunker-price SOURCE/default.
+- estimateVoyageDays — use the real distance (already in Economics), not the "20 days" placeholder — ONLY if trivially in scope; otherwise leave it.
+- Do NOT touch the P&L chart code or voyage fixtures or the match-page declutter files (page.tsx, MatchDetailPanel.tsx, SourceAttributionSection.tsx) — those are other in-flight PRs.
+
+## Risk-override (financial: distance thresholds + savings calc) — MANDATORY /test-skill
+After impl passes, run /test-skill cold-session adversarial QA. Tests must cover: (a) a clearly off-route port is EXCLUDED; (b) the cheapest on-route port is chosen; (c) savings vs the alternative matches optimizeSplitBunker; (d) the no-on-route fallback path (no silent Singapore). Require an explicit <<EXIT_STATUS>> PASS|FAIL in the QA report.
+
+## Acceptance
+- Bunker section recommends an ON-ROUTE port with savings vs an alternative, not a static Singapore default.
+- TCE bunker input defaults to the recommended port+price; manual override still works.
+- No-on-route case shows an honest fallback.
+- All distances come from port-master (no hardcoded coords).
+- /test-skill PASS; npx tsc --noEmit + npm run lint clean.
+UI-PR -> Gate 3 (founder prod Gate 5).


### PR DESCRIPTION
## Что
Бункер-секция Economics: вместо статичных 5 портов с дефолтом Сингапур — рекомендация порта **по пути** с экономией.

- On-route фильтр: detour = dist(from→port)+dist(port→to)−dist(from→to) < ~15% прямого (дистанции из port-master, без хардкода координат).
- Кандидаты = BUNKER_PORTS с ценами (getLatestBunkerPrice), фильтр on-route.
- Прогон через существующий optimizeSplitBunker → строка-рекомендация + экономия vs альтернативы.
- Рекомендованный порт+цена = дефолт бункер-входа в TCE (не Сингапур); ручной override сохранён.
- Нет on-route порта → честный фоллбэк (не молчаливый Сингапур).

## QA
13/13 тестов (5 базовых + 8 adversarial: off-route exclusion, cheapest on-route, fallback, MGO passthrough, threshold boundary). EXIT_STATUS=PASS.

## Out of scope
Не многоточечный split; TCE не менялся кроме источника бункер-цены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)