### PR TITLE
fix(demo): freeze dashboard greeting + EUA as-of date to frozen demo date

### DIFF
--- a/app/api/market/benchmark/route.ts
+++ b/app/api/market/benchmark/route.ts
@@ -5,6 +5,8 @@ import { getLatestIndex } from '@/lib/market/market-indices-repository';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { getStore } from '@/lib/session-store';
+import { today } from '@/lib/clock';
+import { isDemoMode } from '@/lib/demo-mode';
 
 const VALID_INDICATORS: ReadonlySet<string> = new Set<MarketIndicator>([
   'TOEPFER_TMI',
@@ -84,7 +86,7 @@ export async function GET(request: Request): Promise<NextResponse> {
         indicator: typedIndicator,
         value: row.price_eur_per_tco2,
         unit: 'EUR/tCO₂',
-        period: row.price_date,
+        period: isDemoMode() ? today() : row.price_date,
         sourceUrl: row.source,
         fetchedAt: new Date().toISOString(),
         stale: ageMs > STALE_THRESHOLD_MS,

--- a/components/dashboard/MorningHeader.tsx
+++ b/components/dashboard/MorningHeader.tsx
@@ -1,3 +1,5 @@
+import { now } from '@/lib/clock';
+
 interface MorningHeaderProps {
   userName?: string;
   alertCount: number;
@@ -15,7 +17,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-GB', {
 });
 
 export function MorningHeader({ userName, alertCount }: MorningHeaderProps) {
-  const today = dateFormatter.format(new Date());
+  const today = dateFormatter.format(now());
   const greeting = userName ? `Good morning, ${userName} 👋` : 'Good morning! 👋';
 
   return (


### PR DESCRIPTION
follow-up to #744 demo-clock — freeze dashboard greeting + EUA as-of date to frozen demo date; real clocks untouched

## What

Two demo-display dates were still showing the real system date after #744:

1. **Dashboard greeting** (`components/dashboard/MorningHeader.tsx`) — "Monday, 1 June 2026" used `new Date()` directly; replaced with `now()` from `lib/clock.ts` so it renders the frozen demo day (~2026-05-28) consistent with the market widgets.

2. **Economics EUA as-of date** (`app/api/market/benchmark/route.ts`) — `period: row.price_date` exposed the live scraper's real fetch date (2026-06-01); in DEMO_MODE now overrides to `today()` (frozen date). Real clocks untouched: stale threshold check, `fetchedAt`, session expiry, trial, currency TTL — all unchanged.

## Acceptance

- Dashboard greeting date = frozen demo day, consistent with market widgets
- EUA / EU ETS Price as-of date = frozen demo day, not real 1 Jun
- No real-time clocks frozen (`session-store`, `trial`, `currency` untouched)

## Test plan

- [ ] `npx jest --findRelatedTests components/dashboard/MorningHeader.tsx app/api/market/benchmark/route.ts` — 25/25 green
- [ ] `npx tsc --noEmit` — clean
- [ ] Dashboard: greeting shows ~28 May 2026
- [ ] Match economics: EUA row shows ~28 May 2026 date

🤖 Generated with [Claude Code](https://claude.com/claude-code)