### PR TITLE
feat(demo-seed): patch-vessel-speed-consumption — backfill speed/consumption defaults (#736 unblock)

### DIFF
--- a/__tests__/patch-vessel-speed.test.ts
+++ b/__tests__/patch-vessel-speed.test.ts
@@ -1,0 +1,234 @@
+import {
+  defaultSpeedConsumption,
+  extractDwt,
+  asItems,
+  patchVesselItem,
+} from '../scripts/demo-seed/patch-vessel-speed-consumption';
+
+// ── defaultSpeedConsumption ───────────────────────────────────────────────────
+
+describe('defaultSpeedConsumption', () => {
+  it('returns null for null dwt', () => {
+    expect(defaultSpeedConsumption(null)).toBeNull();
+  });
+
+  it('returns null for zero dwt', () => {
+    expect(defaultSpeedConsumption(0)).toBeNull();
+  });
+
+  it('returns null for negative dwt', () => {
+    expect(defaultSpeedConsumption(-1000)).toBeNull();
+  });
+
+  it('small vessel <40k DWT → 12.5 kts / 22 mt/day', () => {
+    expect(defaultSpeedConsumption(28_000)).toEqual({
+      speedLaden: '12.5 kts',
+      consumption: '22 mt/day',
+    });
+  });
+
+  it('handymax 40k-64k DWT → 13 kts / 26 mt/day', () => {
+    expect(defaultSpeedConsumption(56_000)).toEqual({
+      speedLaden: '13 kts',
+      consumption: '26 mt/day',
+    });
+  });
+
+  it('panamax 65k-99k DWT → 13.5 kts / 30 mt/day', () => {
+    expect(defaultSpeedConsumption(75_000)).toEqual({
+      speedLaden: '13.5 kts',
+      consumption: '30 mt/day',
+    });
+  });
+
+  it('capesize >=100k DWT → 14.5 kts / 38 mt/day', () => {
+    expect(defaultSpeedConsumption(180_000)).toEqual({
+      speedLaden: '14.5 kts',
+      consumption: '38 mt/day',
+    });
+  });
+
+  it('boundary: exactly 40_000 → handymax tier', () => {
+    expect(defaultSpeedConsumption(40_000)).toEqual({
+      speedLaden: '13 kts',
+      consumption: '26 mt/day',
+    });
+  });
+
+  it('boundary: exactly 65_000 → panamax tier', () => {
+    expect(defaultSpeedConsumption(65_000)).toEqual({
+      speedLaden: '13.5 kts',
+      consumption: '30 mt/day',
+    });
+  });
+
+  it('boundary: exactly 100_000 → capesize tier', () => {
+    expect(defaultSpeedConsumption(100_000)).toEqual({
+      speedLaden: '14.5 kts',
+      consumption: '38 mt/day',
+    });
+  });
+});
+
+// ── extractDwt ────────────────────────────────────────────────────────────────
+
+describe('extractDwt', () => {
+  it('extracts plain number', () => {
+    expect(extractDwt(75_000)).toBe(75_000);
+  });
+
+  it('extracts ConfidenceField value', () => {
+    expect(extractDwt({ value: 56_000, confidence: 'confirmed', sourceText: '56000' })).toBe(56_000);
+  });
+
+  it('returns null for null', () => {
+    expect(extractDwt(null)).toBeNull();
+  });
+
+  it('returns null for zero', () => {
+    expect(extractDwt(0)).toBeNull();
+  });
+
+  it('returns null for ConfidenceField with 0', () => {
+    expect(extractDwt({ value: 0, confidence: 'estimated' })).toBeNull();
+  });
+
+  it('returns null for non-numeric ConfidenceField', () => {
+    expect(extractDwt({ value: '75000', confidence: 'confirmed' })).toBeNull();
+  });
+});
+
+// ── asItems ───────────────────────────────────────────────────────────────────
+
+describe('asItems', () => {
+  it('parses array result_json', () => {
+    const items = asItems('[{"vesselName":"mv Test"},{"vesselName":"mv Two"}]');
+    expect(items).toHaveLength(2);
+    expect(items[0].vesselName).toBe('mv Test');
+  });
+
+  it('wraps single-object result_json in array', () => {
+    const items = asItems('{"vesselName":"mv Legacy"}');
+    expect(items).toHaveLength(1);
+    expect(items[0].vesselName).toBe('mv Legacy');
+  });
+});
+
+// ── patchVesselItem (core logic) ──────────────────────────────────────────────
+
+describe('patchVesselItem', () => {
+  it('patches vessel lacking both fields — adds build.ts #736 defaults', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV MARIA',
+      dwtSummer: { value: 75_000, confidence: 'confirmed', sourceText: '75000' },
+      openDate: '2026-06-10',
+      speedLaden: null,
+      consumption: null,
+    };
+    const modified = patchVesselItem(vessel);
+    expect(modified).toBe(true);
+    expect(vessel.speedLaden).toBe('13.5 kts');   // panamax tier
+    expect(vessel.consumption).toBe('30 mt/day');
+  });
+
+  it('idempotent — vessel already having both fields is untouched', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV SOFIA',
+      dwtSummer: { value: 75_000, confidence: 'confirmed', sourceText: '75000' },
+      speedLaden: '14 kts',
+      consumption: '32 mt/day',
+    };
+    const modified = patchVesselItem(vessel);
+    expect(modified).toBe(false);
+    expect(vessel.speedLaden).toBe('14 kts');     // original preserved
+    expect(vessel.consumption).toBe('32 mt/day');
+  });
+
+  it('does not overwrite existing speedLaden when only consumption missing', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV ANNA',
+      dwtSummer: { value: 56_000, confidence: 'confirmed' },
+      speedLaden: '12 kts',   // already set (custom value)
+      consumption: null,
+    };
+    patchVesselItem(vessel);
+    expect(vessel.speedLaden).toBe('12 kts');    // not overwritten
+    expect(vessel.consumption).toBe('26 mt/day'); // patched
+  });
+
+  it('does not overwrite existing consumption when only speedLaden missing', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV BORIS',
+      dwtSummer: { value: 56_000, confidence: 'confirmed' },
+      speedLaden: null,
+      consumption: '28 mt/day',
+    };
+    patchVesselItem(vessel);
+    expect(vessel.speedLaden).toBe('13 kts');     // patched
+    expect(vessel.consumption).toBe('28 mt/day'); // not overwritten
+  });
+
+  it('does not patch when DWT is unknown (null dwt → null defaults)', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV UNKNOWN',
+      dwtSummer: null,
+      dwcc: null,
+      speedLaden: null,
+      consumption: null,
+    };
+    const modified = patchVesselItem(vessel);
+    expect(modified).toBe(false);
+    expect(vessel.speedLaden).toBeNull();
+    expect(vessel.consumption).toBeNull();
+  });
+
+  it('falls back to dwcc when dwtSummer absent', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV CAPESIZE',
+      dwtSummer: null,
+      dwcc: { value: 150_000, confidence: 'estimated' },
+      speedLaden: null,
+      consumption: null,
+    };
+    patchVesselItem(vessel);
+    expect(vessel.speedLaden).toBe('14.5 kts');  // capesize
+    expect(vessel.consumption).toBe('38 mt/day');
+  });
+
+  it('does not corrupt other vessel fields', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV TEST',
+      openDate: '2026-07-01',
+      openPosition: 'Rotterdam',
+      dwtSummer: { value: 28_000, confidence: 'confirmed' },
+      speedLaden: null,
+      consumption: null,
+      imo: '1234567',
+      flag: 'Liberia',
+    };
+    patchVesselItem(vessel);
+    expect(vessel.vesselName).toBe('MV TEST');
+    expect(vessel.openDate).toBe('2026-07-01');
+    expect(vessel.openPosition).toBe('Rotterdam');
+    expect(vessel.imo).toBe('1234567');
+    expect(vessel.flag).toBe('Liberia');
+    // patched fields
+    expect(vessel.speedLaden).toBe('12.5 kts');
+    expect(vessel.consumption).toBe('22 mt/day');
+  });
+
+  it('re-run after first patch is a no-op (idempotency)', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV REPEAT',
+      dwtSummer: { value: 56_000, confidence: 'confirmed' },
+      speedLaden: null,
+      consumption: null,
+    };
+    const first = patchVesselItem(vessel);
+    expect(first).toBe(true);
+    const second = patchVesselItem(vessel);
+    expect(second).toBe(false);   // already populated → no-op
+    expect(vessel.speedLaden).toBe('13 kts');
+    expect(vessel.consumption).toBe('26 mt/day');
+  });
+});

--- a/docs/superpowers/plans/2026-06-01-vessel-speed-consumption.md
+++ b/docs/superpowers/plans/2026-06-01-vessel-speed-consumption.md
@@ -1,0 +1,30 @@
+# Plan: patch existing demo-seed vessels with speed/consumption (#740 unblock)
+
+## Context
+The voyage P&L (#740) needs vessel speedLaden + consumption. #736 (commit c396093b) seeds these in scripts/demo-seed/build.ts ("realistic speedLaden+consumption defaults in demo vessel"), BUT the prod demo-seed.db is frozen from BEFORE #736 -> existing parsed_results vessel rows lack speed/consumption -> EconomicsTab shows "Missing: vessel speed, fuel consumption" -> no P&L chart. build.ts CANNOT re-run on prod (raw emails + LLM cache are local-only, not in git). So we patch the existing seed in place.
+
+## Goal
+A targeted, IDEMPOTENT patch script that adds #736's exact speedLaden + consumption defaults to existing parsed_results vessel rows that lack them, so the voyage P&L renders. The orchestrator applies it on prod afterwards (--dry first).
+
+## Scope
+- NEW `scripts/demo-seed/patch-vessel-speed-consumption.ts`.
+- It must mirror build.ts's EXACT #736 speed/consumption default logic — READ build.ts (the #736 lines that set speedLaden+consumption on demo vessels) and reuse the SAME values/formula (by DWT / vessel type). Do NOT invent numbers.
+- Reads each parsed_results vessel (parse_type='vessel'); if speedLaden/consumption (the fields EconomicsTab reads) are absent/empty -> add the same default build.ts would produce. Idempotent (skip if already present). `--db <path>` flag (default data/demo-seed.db). `--dry` mode: report counts + 2-3 sample before/after, NO write.
+
+## Steps
+1. Read scripts/demo-seed/build.ts #736 logic — find the exact speedLaden + consumption defaults + how EconomicsTab reads them (field names on the parsed vessel: confirm via components/match/EconomicsTab.tsx — it does parseLeadingNumber(vessel?.consumption) etc.).
+2. Write patch-vessel-speed-consumption.ts mirroring it; UPDATE parsed_results.result_json for vessels to add the fields.
+3. Unit-test the patch logic (mock a vessel row lacking the fields -> patched correctly; a vessel already having them -> unchanged/idempotent). Since the real demo-seed.db is local-only (may be absent on this worktree), test the LOGIC with mock rows, not a real DB.
+4. tsc --noEmit + lint clean.
+
+## Out-of-scope
+- Do NOT re-parse / run build.ts / touch raw emails or the LLM cache.
+- Do NOT change EconomicsTab or the P&L calc (only the seed vessel data via the patch).
+- Do NOT change matches/cargo data — only vessel speed/consumption fields.
+- Do NOT apply to any real demo-seed.db yourself — the orchestrator applies on prod.
+
+## Risk-override -> /test-skill
+This feeds the financial P&L. /test-skill MUST verify: the defaults exactly match build.ts #736; idempotency (re-run = no-op); the patch does not corrupt other vessel fields; vessels that already have speed/consumption are untouched. Require explicit <<EXIT_STATUS=PASS|FAIL>>.
+
+## Acceptance
+- patch-vessel-speed-consumption.ts exists; --dry reports N vessels would get speed/consumption matching build.ts defaults; idempotent; unit tests + /test-skill PASS; tsc + lint clean. Commit + push + PR. (Orchestrator runs it on prod after merge.)

--- a/scripts/demo-seed/patch-vessel-speed-consumption.ts
+++ b/scripts/demo-seed/patch-vessel-speed-consumption.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * patch-vessel-speed-consumption.ts — add speedLaden + consumption defaults to
+ * existing demo-seed vessel rows that were parsed before #736.
+ *
+ * The prod demo-seed.db is frozen from before #736 (commit c396093b), which
+ * added realistic speed/consumption defaults in build.ts. This script applies
+ * the same logic in-place, idempotently.
+ *
+ * Usage:
+ *   npx tsx scripts/demo-seed/patch-vessel-speed-consumption.ts [--db <path>] [--dry]
+ *   Defaults: --db data/demo-seed.db
+ *
+ * --dry: print counts + 2-3 before/after samples, no DB writes.
+ */
+
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+// ── Mirrored exactly from build.ts #736 (defaultSpeedConsumption) ─────────────
+// DWT thresholds and string values are identical — do NOT change without
+// updating build.ts too.
+export function defaultSpeedConsumption(
+  dwt: number | null,
+): { speedLaden: string; consumption: string } | null {
+  if (!dwt || dwt <= 0) return null;
+  if (dwt < 40_000) return { speedLaden: '12.5 kts', consumption: '22 mt/day' };
+  if (dwt < 65_000) return { speedLaden: '13 kts', consumption: '26 mt/day' };
+  if (dwt < 100_000) return { speedLaden: '13.5 kts', consumption: '30 mt/day' };
+  return { speedLaden: '14.5 kts', consumption: '38 mt/day' };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Matches build.ts cfValue — unwraps ConfidenceField<number> or plain number.
+export function extractDwt(field: unknown): number | null {
+  if (typeof field === 'number') return field > 0 ? field : null;
+  if (field && typeof field === 'object' && 'value' in (field as object)) {
+    const v = (field as { value: unknown }).value;
+    if (typeof v === 'number') return v > 0 ? v : null;
+  }
+  return null;
+}
+
+// result_json is a JSON array of items per email (prod contract); tolerate
+// legacy single-object shape.
+export function asItems(json: string): Record<string, unknown>[] {
+  const parsed = JSON.parse(json) as unknown;
+  return Array.isArray(parsed) ? (parsed as Record<string, unknown>[]) : [parsed as Record<string, unknown>];
+}
+
+// Patch a single vessel item in-place. Returns true if modified.
+export function patchVesselItem(vessel: Record<string, unknown>): boolean {
+  const hasSpeed = typeof vessel.speedLaden === 'string' && vessel.speedLaden.trim() !== '';
+  const hasConsumption = typeof vessel.consumption === 'string' && vessel.consumption.trim() !== '';
+  if (hasSpeed && hasConsumption) return false;
+
+  const dwt = extractDwt(vessel.dwtSummer) ?? extractDwt(vessel.dwcc) ?? null;
+  const defaults = defaultSpeedConsumption(dwt);
+  if (!defaults) return false;
+
+  if (!hasSpeed) vessel.speedLaden = defaults.speedLaden;
+  if (!hasConsumption) vessel.consumption = defaults.consumption;
+  return true;
+}
+
+// ── CLI entry-point ───────────────────────────────────────────────────────────
+
+function arg(k: string): string | undefined {
+  const i = process.argv.indexOf(k);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+function main() {
+  const dbPath = arg('--db') ?? path.join(process.cwd(), 'data', 'demo-seed.db');
+  const dry = process.argv.includes('--dry');
+
+  const db = new Database(dbPath, { readonly: dry });
+
+  const rows = db
+    .prepare(
+      `SELECT rowid, gmail_message_id, result_json
+       FROM parsed_results
+       WHERE parse_type = 'vessel'`,
+    )
+    .all() as Array<{ rowid: number; gmail_message_id: string; result_json: string }>;
+
+  let totalVessels = 0;
+  let patched = 0;
+  let skipped = 0;
+  const samples: Array<{ id: string; before: Record<string, unknown>; after: Record<string, unknown> }> = [];
+
+  const update = dry
+    ? null
+    : db.prepare(`UPDATE parsed_results SET result_json = ? WHERE rowid = ?`);
+
+  for (const row of rows) {
+    const items = asItems(row.result_json);
+    let rowModified = false;
+
+    for (const vessel of items) {
+      totalVessels++;
+      const before = { speedLaden: vessel.speedLaden, consumption: vessel.consumption };
+      const modified = patchVesselItem(vessel);
+      if (modified) {
+        rowModified = true;
+        patched++;
+        if (samples.length < 3) {
+          samples.push({
+            id: row.gmail_message_id,
+            before,
+            after: { speedLaden: vessel.speedLaden, consumption: vessel.consumption },
+          });
+        }
+      } else {
+        skipped++;
+      }
+    }
+
+    if (rowModified && update) {
+      update.run(JSON.stringify(items), row.rowid);
+    }
+  }
+
+  console.log(`\nVessel rows read: ${rows.length}`);
+  console.log(`Total vessel items: ${totalVessels}`);
+  console.log(`  Would patch: ${patched}` + (dry ? ' (dry — no write)' : ''));
+  console.log(`  Already had speed+consumption: ${skipped}`);
+
+  if (samples.length > 0) {
+    console.log('\nSamples (before → after):');
+    for (const s of samples) {
+      console.log(
+        `  ${s.id}: speedLaden ${JSON.stringify(s.before.speedLaden)} → ${JSON.stringify(s.after.speedLaden)},` +
+        ` consumption ${JSON.stringify(s.before.consumption)} → ${JSON.stringify(s.after.consumption)}`,
+      );
+    }
+  }
+
+  if (!dry) {
+    console.log(`\nDone. Patched ${patched} vessel items in ${rows.length} rows.`);
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/demo-seed/patch-vessel-speed-consumption.ts` — idempotent script that backfills `speedLaden` + `consumption` into existing `parsed_results` vessel rows frozen before #736 (commit c396093b)
- Mirrors build.ts #736 `defaultSpeedConsumption()` exactly: same DWT thresholds, same string values
- Unblocks voyage P&L chart in EconomicsTab which reads `vessel.speedLaden` + `vessel.consumption` via `parseLeadingNumber()`
- 26 unit tests: DWT tier coverage, boundary conditions, ConfidenceField unwrap, idempotency, partial-field cases, dwcc fallback, no-DWT skip, field corruption guard

## Defaults mirrored from build.ts #736

| DWT range | speedLaden | consumption |
|-----------|-----------|-------------|
| < 40 000 | 12.5 kts | 22 mt/day |
| 40 000–64 999 | 13 kts | 26 mt/day |
| 65 000–99 999 | 13.5 kts | 30 mt/day |
| ≥ 100 000 | 14.5 kts | 38 mt/day |

## Usage (orchestrator applies on prod after merge)

```bash
# dry run first — prints counts + 2-3 before/after samples, no write
npx tsx scripts/demo-seed/patch-vessel-speed-consumption.ts --dry --db data/demo-seed.db

# apply
npx tsx scripts/demo-seed/patch-vessel-speed-consumption.ts --db data/demo-seed.db
```

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx jest --findRelatedTests` — 26/26 passed
- [x] lint clean (`eslint --max-warnings=0`)
- [x] Idempotency verified: second `patchVesselItem()` call on patched vessel → returns `false`, values unchanged
- [ ] Orchestrator: run `--dry` on prod db, review sample output, then run without `--dry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)