### PR TITLE
fix(cargo): compact QTY range k-notation — 4,300-4,500 → 4.3-4.5k

### DIFF
--- a/__tests__/lib/cargo-render.test.ts
+++ b/__tests__/lib/cargo-render.test.ts
@@ -9,7 +9,7 @@
  * Tests use pure-function calls, not string matching, satisfying PI2.
  */
 
-import { formatQuantity } from '@/lib/cargo-render';
+import { formatQuantity, formatQuantityCompact } from '@/lib/cargo-render';
 
 describe('formatQuantity', () => {
   // ── null / missing → field suppressed ──
@@ -64,6 +64,52 @@ describe('formatQuantity', () => {
   it('returns non-null for Range (field rendered when data present)', () => {
     const result = formatQuantity({ min: 5000, max: 10000 });
     expect(result).not.toBeNull();
+  });
+});
+
+describe('formatQuantityCompact', () => {
+  it('returns null when both weightMt and q are null', () => {
+    expect(formatQuantityCompact(null, null)).toBeNull();
+  });
+
+  it('returns null when both weightMt and q are undefined', () => {
+    expect(formatQuantityCompact(null, undefined)).toBeNull();
+  });
+
+  it('prefers weightMt over q — single weight compact', () => {
+    expect(formatQuantityCompact(22000, null)).toBe('22k');
+  });
+
+  it('compact k with one decimal — 4300 → "4.3k"', () => {
+    expect(formatQuantityCompact(4300, null)).toBe('4.3k');
+  });
+
+  it('drops trailing .0 — 10000 → "10k"', () => {
+    expect(formatQuantityCompact(10000, null)).toBe('10k');
+  });
+
+  it('range compact — founder example "4,300–4,500" → "4.3–4.5k"', () => {
+    expect(formatQuantityCompact(null, { min: 4300, max: 4500 })).toBe('4.3–4.5k');
+  });
+
+  it('range compact — "10,000–10,500" → "10–10.5k"', () => {
+    expect(formatQuantityCompact(null, { min: 10000, max: 10500 })).toBe('10–10.5k');
+  });
+
+  it('range compact — "3,000–3,500" → "3–3.5k"', () => {
+    expect(formatQuantityCompact(null, { min: 3000, max: 3500 })).toBe('3–3.5k');
+  });
+
+  it('range min===max → single compact value', () => {
+    expect(formatQuantityCompact(null, { min: 5000, max: 5000 })).toBe('5k');
+  });
+
+  it('plain number q fallback when weightMt is null', () => {
+    expect(formatQuantityCompact(null, 25000)).toBe('25k');
+  });
+
+  it('weightMt takes precedence over range q', () => {
+    expect(formatQuantityCompact(30000, { min: 4300, max: 4500 })).toBe('30k');
   });
 });
 

--- a/app/cargo/page.tsx
+++ b/app/cargo/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import Link from 'next/link';
 import { getSession } from '@/lib/session';
 import { cfValue } from '@/lib/types';
-import { formatQuantity } from '@/lib/cargo-render';
+import { formatQuantityCompact } from '@/lib/cargo-render';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { fmtLaycan } from '@/lib/utils/fmt-laycan';
 import CargoClient, { type CargoRow } from './CargoClient';
@@ -22,11 +22,6 @@ function getCommodityKey(desc: string | null): string {
   return 'bulk';
 }
 
-function fmtWeight(mt: number | null): string | null {
-  if (mt === null) return null;
-  if (mt >= 1000) return `${Math.round(mt / 1000)}k`;
-  return String(mt);
-}
 
 export default async function CargoPage() {
   const cookieStore = await cookies();
@@ -63,7 +58,7 @@ export default async function CargoPage() {
       commodityKey: getCommodityKey(descVal),
       originPort: cfValue(cargo.originPort) ?? null,
       destinationPort: cfValue(cargo.destinationPort) ?? null,
-      quantity: fmtWeight(weightMt) ?? formatQuantity(cargo.quantity),
+      quantity: formatQuantityCompact(weightMt, cargo.quantity),
       laycan: cargo.laycan ?? null,
       status: hasMatch ? 'match' : 'open',
       sourceTag: email ? 'Email' : 'Manual',

--- a/lib/cargo-render.ts
+++ b/lib/cargo-render.ts
@@ -2,6 +2,39 @@ import { isRange, type Range } from '@/lib/types';
 import { safeRender } from '@/lib/ui-render';
 import { formatNumber } from '@/lib/utils';
 
+function fmtK(mt: number): string {
+  if (mt >= 1000) {
+    const k = Math.round((mt / 1000) * 10) / 10;
+    return `${k}k`;
+  }
+  return String(mt);
+}
+
+/**
+ * Compact k-notation formatter for the cargo list QTY column.
+ * Ranges: "4,300–4,500" → "4.3–4.5k"; singles: 22000 → "22k".
+ * Use formatQuantity for full-number display (cargo detail page).
+ */
+export function formatQuantityCompact(
+  weightMt: number | null,
+  q: Range<number> | number | null | undefined,
+): string | null {
+  if (weightMt !== null) return fmtK(weightMt);
+  if (q == null) return null;
+  if (isRange<number>(q)) {
+    const { min, max } = q;
+    if (min === max) return fmtK(min);
+    if (min >= 1000 && max >= 1000) {
+      const lo = Math.round((min / 1000) * 10) / 10;
+      const hi = Math.round((max / 1000) * 10) / 10;
+      return `${lo}–${hi}k`;
+    }
+    return `${fmtK(min)}–${fmtK(max)}`;
+  }
+  if (typeof q === 'number' && !isNaN(q)) return fmtK(q);
+  return null;
+}
+
 /**
  * Format a quantity value (plain number or Range) into a human-readable string.
  * Returns null when the value is absent or invalid — callers skip rendering.


### PR DESCRIPTION
## Summary

- **Before**: ranges rendered as full numbers ("4,300-4,500", "10,000-10,500") — too wide for the Qty column, visually overlapping the Load port column
- **After**: ranges compact to k-notation ("4.3-4.5k", "10-10.5k", "3-3.5k") matching the style of single quantities ("22k", "55k")

## What changed

**`lib/cargo-render.ts`** — added `formatQuantityCompact(weightMt, q)`:
- Ranges with both ends ≥ 1000 → shared `k` suffix: `"4.3–4.5k"` (not `"4.3k–4.5k"`)
- Singles → same `fmtK` logic: `22000 → "22k"`, `4300 → "4.3k"`
- `formatQuantity` (full-number, used by cargo detail page) **unchanged**

**`app/cargo/page.tsx`** — cargo list QTY build:
- Replace `fmtWeight(weightMt) ?? formatQuantity(cargo.quantity)` → `formatQuantityCompact(weightMt, cargo.quantity)`
- Remove now-unused local `fmtWeight` function

**`__tests__/lib/cargo-render.test.ts`** — 11 new behavioral tests for `formatQuantityCompact` covering all 3 founder examples + edge cases

## Scope

`formatQuantity` is shared (also used in `app/cargo/[id]/page.tsx`). The compact formatter is a **new separate export**, scoped only to the cargo list column. Detail page rendering unchanged.

## Before / After — QTY column ranges

| Before | After |
|--------|-------|
| `4,300-4,500` | `4.3-4.5k` |
| `10,000-10,500` | `10-10.5k` |
| `3,000-3,500` | `3-3.5k` |
| `22k` _(unchanged)_ | `22k` |
| `55k` _(unchanged)_ | `55k` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)