### PR TITLE
fix(demo-seed): preserve existing vessel speed/consumption values

### DIFF
--- a/__tests__/patch-vessel-speed.test.ts
+++ b/__tests__/patch-vessel-speed.test.ts
@@ -3,6 +3,9 @@ import {
   extractDwt,
   asItems,
   patchVesselItem,
+  extractNumericValue,
+  normalizeSpeedField,
+  normalizeConsumptionField,
 } from '../scripts/demo-seed/patch-vessel-speed-consumption';
 
 // ── defaultSpeedConsumption ───────────────────────────────────────────────────
@@ -111,6 +114,100 @@ describe('asItems', () => {
     const items = asItems('{"vesselName":"mv Legacy"}');
     expect(items).toHaveLength(1);
     expect(items[0].vesselName).toBe('mv Legacy');
+  });
+});
+
+// ── extractNumericValue ───────────────────────────────────────────────────────
+
+describe('extractNumericValue', () => {
+  it('extracts plain integer', () => {
+    expect(extractNumericValue(13)).toBe(13);
+  });
+
+  it('extracts plain decimal', () => {
+    expect(extractNumericValue(12.5)).toBe(12.5);
+  });
+
+  it('extracts from ConfidenceField with numeric value', () => {
+    expect(extractNumericValue({ value: 13, confidence: 'confirmed', source_text: '13 knts' })).toBe(13);
+  });
+
+  it('extracts from ConfidenceField with string value', () => {
+    expect(extractNumericValue({ value: '13 knts', confidence: 'confirmed' })).toBe(13);
+  });
+
+  it('extracts from normalized string "13 kts"', () => {
+    expect(extractNumericValue('13 kts')).toBe(13);
+  });
+
+  it('extracts from non-normalized string "13 knts"', () => {
+    expect(extractNumericValue('13 knts')).toBe(13);
+  });
+
+  it('extracts from string "12.5 kts"', () => {
+    expect(extractNumericValue('12.5 kts')).toBe(12.5);
+  });
+
+  it('extracts from string "22 mt/day"', () => {
+    expect(extractNumericValue('22 mt/day')).toBe(22);
+  });
+
+  it('returns null for null', () => {
+    expect(extractNumericValue(null)).toBeNull();
+  });
+
+  it('returns null for zero', () => {
+    expect(extractNumericValue(0)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractNumericValue('')).toBeNull();
+  });
+
+  it('returns null for ConfidenceField with zero value', () => {
+    expect(extractNumericValue({ value: 0, confidence: 'estimated' })).toBeNull();
+  });
+});
+
+// ── normalizeSpeedField / normalizeConsumptionField ───────────────────────────
+
+describe('normalizeSpeedField', () => {
+  it('normalizes ConfidenceField to "N kts"', () => {
+    expect(normalizeSpeedField({ value: 13, confidence: 'confirmed' })).toBe('13 kts');
+  });
+
+  it('normalizes plain number to "N kts"', () => {
+    expect(normalizeSpeedField(14)).toBe('14 kts');
+  });
+
+  it('normalizes non-standard string "13 knts" to "13 kts"', () => {
+    expect(normalizeSpeedField('13 knts')).toBe('13 kts');
+  });
+
+  it('round-trips already-normalized "13 kts" unchanged', () => {
+    expect(normalizeSpeedField('13 kts')).toBe('13 kts');
+  });
+
+  it('returns null for null', () => {
+    expect(normalizeSpeedField(null)).toBeNull();
+  });
+});
+
+describe('normalizeConsumptionField', () => {
+  it('normalizes ConfidenceField to "N mt/day"', () => {
+    expect(normalizeConsumptionField({ value: 22, confidence: 'confirmed' })).toBe('22 mt/day');
+  });
+
+  it('normalizes plain number to "N mt/day"', () => {
+    expect(normalizeConsumptionField(28)).toBe('28 mt/day');
+  });
+
+  it('round-trips already-normalized "22 mt/day" unchanged', () => {
+    expect(normalizeConsumptionField('22 mt/day')).toBe('22 mt/day');
+  });
+
+  it('returns null for null', () => {
+    expect(normalizeConsumptionField(null)).toBeNull();
   });
 });
 
@@ -230,5 +327,76 @@ describe('patchVesselItem', () => {
     expect(second).toBe(false);   // already populated → no-op
     expect(vessel.speedLaden).toBe('13 kts');
     expect(vessel.consumption).toBe('26 mt/day');
+  });
+
+  // ── Adversarial: existing-value preservation across all shapes ────────────
+  // These are the cases the original impl missed — real values were overwritten.
+
+  it('ConfidenceField speedLaden preserved — NOT overwritten with DWT default', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV CONFIRMED',
+      dwtSummer: { value: 28_000, confidence: 'confirmed' }, // small → default 12.5 kts
+      speedLaden: { value: 13, confidence: 'confirmed', source_text: '13 knts' }, // real = 13
+      consumption: null,
+    };
+    const modified = patchVesselItem(vessel);
+    expect(modified).toBe(true);
+    expect(vessel.speedLaden).toBe('13 kts');     // preserved, NOT '12.5 kts'
+    expect(vessel.consumption).toBe('22 mt/day'); // defaulted (was null)
+  });
+
+  it('non-normalized string "13 knts" normalized to "13 kts" — NOT overwritten with default', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV TYPO',
+      dwtSummer: { value: 28_000, confidence: 'confirmed' }, // small → default 12.5 kts
+      speedLaden: '13 knts', // non-standard string, real value 13
+      consumption: null,
+    };
+    const modified = patchVesselItem(vessel);
+    expect(modified).toBe(true);
+    expect(vessel.speedLaden).toBe('13 kts'); // normalized from '13 knts', NOT '12.5 kts'
+  });
+
+  it('plain number speedLaden preserved — NOT overwritten with DWT default', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV NUMBER',
+      dwtSummer: { value: 28_000, confidence: 'confirmed' }, // small → default 12.5 kts
+      speedLaden: 13,  // plain number
+      consumption: 22, // plain number
+    };
+    const modified = patchVesselItem(vessel);
+    expect(modified).toBe(true);
+    expect(vessel.speedLaden).toBe('13 kts');     // NOT '12.5 kts' default
+    expect(vessel.consumption).toBe('22 mt/day');
+  });
+
+  it('idempotent after normalizing ConfidenceField — second run is no-op', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV IDEMPOTENT',
+      dwtSummer: { value: 28_000, confidence: 'confirmed' },
+      speedLaden: { value: 13, confidence: 'confirmed' },
+      consumption: { value: 22, confidence: 'confirmed' },
+    };
+    const first = patchVesselItem(vessel);
+    expect(first).toBe(true);
+    expect(vessel.speedLaden).toBe('13 kts');
+    expect(vessel.consumption).toBe('22 mt/day');
+
+    const second = patchVesselItem(vessel);
+    expect(second).toBe(false); // already normalized → no-op
+    expect(vessel.speedLaden).toBe('13 kts');     // unchanged
+    expect(vessel.consumption).toBe('22 mt/day'); // unchanged
+  });
+
+  it('both ConfidenceField fields preserved — neither overwritten by DWT defaults', () => {
+    const vessel: Record<string, unknown> = {
+      vesselName: 'MV BOTH',
+      dwtSummer: { value: 56_000, confidence: 'confirmed' }, // handymax → default 13 kts / 26 mt/day
+      speedLaden: { value: 14, confidence: 'confirmed', source_text: '14 knts' },
+      consumption: { value: 28, confidence: 'confirmed', source_text: '28 mt/day' },
+    };
+    patchVesselItem(vessel);
+    expect(vessel.speedLaden).toBe('14 kts');     // NOT '13 kts' default
+    expect(vessel.consumption).toBe('28 mt/day'); // NOT '26 mt/day' default
   });
 });

--- a/scripts/demo-seed/patch-vessel-speed-consumption.ts
+++ b/scripts/demo-seed/patch-vessel-speed-consumption.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env -S npx tsx
 /**
- * patch-vessel-speed-consumption.ts — add speedLaden + consumption defaults to
- * existing demo-seed vessel rows that were parsed before #736.
+ * patch-vessel-speed-consumption.ts — normalize + default speedLaden + consumption
+ * for existing demo-seed vessel rows that were parsed before #736.
  *
- * The prod demo-seed.db is frozen from before #736 (commit c396093b), which
- * added realistic speed/consumption defaults in build.ts. This script applies
- * the same logic in-place, idempotently.
+ * Normalization rules (EconomicsTab reads via parseLeadingNumber):
+ *  - ConfidenceField {value, confidence, ...} → extract numeric → "N kts" / "N mt/day"
+ *  - Plain number 13 → "13 kts" / "13 mt/day"
+ *  - Non-standard string "13 knts" → "13 kts"
+ *  - Already-normalized string "13 kts" / "22 mt/day" → no-op (idempotent)
+ *  - Null / absent → apply DWT-based default from build.ts #736
  *
  * Usage:
  *   npx tsx scripts/demo-seed/patch-vessel-speed-consumption.ts [--db <path>] [--dry]
@@ -49,19 +52,85 @@ export function asItems(json: string): Record<string, unknown>[] {
   return Array.isArray(parsed) ? (parsed as Record<string, unknown>[]) : [parsed as Record<string, unknown>];
 }
 
+// Extract leading decimal from a string (e.g. "13 knts" → 13, "12.5 kts" → 12.5).
+function parseLeadingNumber(s: string): number | null {
+  const m = s.match(/(\d+(?:\.\d+)?)/);
+  return m ? parseFloat(m[1]) : null;
+}
+
+// Extract numeric value from any shape: plain number, ConfidenceField{value}, or string.
+export function extractNumericValue(field: unknown): number | null {
+  if (typeof field === 'number') return field > 0 ? field : null;
+  if (field && typeof field === 'object' && 'value' in (field as object)) {
+    const v = (field as { value: unknown }).value;
+    if (typeof v === 'number') return v > 0 ? v : null;
+    if (typeof v === 'string' && v.trim() !== '') {
+      const n = parseLeadingNumber(v);
+      return n !== null && n > 0 ? n : null;
+    }
+  }
+  if (typeof field === 'string' && field.trim() !== '') {
+    const n = parseLeadingNumber(field);
+    return n !== null && n > 0 ? n : null;
+  }
+  return null;
+}
+
+// Normalize any speedLaden shape to "N kts" readable string, or null if no value.
+export function normalizeSpeedField(field: unknown): string | null {
+  const n = extractNumericValue(field);
+  return n !== null ? `${n} kts` : null;
+}
+
+// Normalize any consumption shape to "N mt/day" readable string, or null if no value.
+export function normalizeConsumptionField(field: unknown): string | null {
+  const n = extractNumericValue(field);
+  return n !== null ? `${n} mt/day` : null;
+}
+
 // Patch a single vessel item in-place. Returns true if modified.
+//
+// Preservation rule: if speedLaden/consumption exists in ANY shape (ConfidenceField,
+// number, or non-normalized string) extract the numeric value and write the readable
+// string form. Only apply DWT defaults when the value is genuinely absent (null).
+// Re-running on already-normalized data is a no-op (idempotent).
 export function patchVesselItem(vessel: Record<string, unknown>): boolean {
-  const hasSpeed = typeof vessel.speedLaden === 'string' && vessel.speedLaden.trim() !== '';
-  const hasConsumption = typeof vessel.consumption === 'string' && vessel.consumption.trim() !== '';
-  if (hasSpeed && hasConsumption) return false;
+  const normalizedSpeed = normalizeSpeedField(vessel.speedLaden);
+  const normalizedConsumption = normalizeConsumptionField(vessel.consumption);
+
+  // Already in correct normalized string form — nothing to do.
+  const alreadySpeed = normalizedSpeed !== null && vessel.speedLaden === normalizedSpeed;
+  const alreadyConsumption = normalizedConsumption !== null && vessel.consumption === normalizedConsumption;
+  if (alreadySpeed && alreadyConsumption) return false;
 
   const dwt = extractDwt(vessel.dwtSummer) ?? extractDwt(vessel.dwcc) ?? null;
   const defaults = defaultSpeedConsumption(dwt);
-  if (!defaults) return false;
 
-  if (!hasSpeed) vessel.speedLaden = defaults.speedLaden;
-  if (!hasConsumption) vessel.consumption = defaults.consumption;
-  return true;
+  let modified = false;
+
+  if (!alreadySpeed) {
+    if (normalizedSpeed !== null) {
+      // Preserve: existing value in non-normalized shape → normalize it.
+      vessel.speedLaden = normalizedSpeed;
+      modified = true;
+    } else if (defaults) {
+      // Default: no existing value → apply DWT-based default.
+      vessel.speedLaden = defaults.speedLaden;
+      modified = true;
+    }
+  }
+
+  if (!alreadyConsumption) {
+    if (normalizedConsumption !== null) {
+      vessel.consumption = normalizedConsumption;
+      modified = true;
+    } else if (defaults) {
+      vessel.consumption = defaults.consumption;
+      modified = true;
+    }
+  }
+
+  return modified;
 }
 
 // ── CLI entry-point ───────────────────────────────────────────────────────────
@@ -86,8 +155,9 @@ function main() {
     .all() as Array<{ rowid: number; gmail_message_id: string; result_json: string }>;
 
   let totalVessels = 0;
-  let patched = 0;
-  let skipped = 0;
+  let defaulted = 0;    // was null/absent, applied DWT-based default
+  let preserved = 0;    // had existing value in non-normalized shape, normalized it
+  let already = 0;      // already in normalized string form, no-op
   const samples: Array<{ id: string; before: Record<string, unknown>; after: Record<string, unknown> }> = [];
 
   const update = dry
@@ -101,10 +171,23 @@ function main() {
     for (const vessel of items) {
       totalVessels++;
       const before = { speedLaden: vessel.speedLaden, consumption: vessel.consumption };
+
+      // Determine whether vessel had ANY existing value before patching.
+      const hadExisting =
+        extractNumericValue(vessel.speedLaden) !== null ||
+        extractNumericValue(vessel.consumption) !== null;
+
       const modified = patchVesselItem(vessel);
-      if (modified) {
+
+      if (!modified) {
+        already++;
+      } else {
         rowModified = true;
-        patched++;
+        if (hadExisting) {
+          preserved++;
+        } else {
+          defaulted++;
+        }
         if (samples.length < 3) {
           samples.push({
             id: row.gmail_message_id,
@@ -112,8 +195,6 @@ function main() {
             after: { speedLaden: vessel.speedLaden, consumption: vessel.consumption },
           });
         }
-      } else {
-        skipped++;
       }
     }
 
@@ -122,10 +203,12 @@ function main() {
     }
   }
 
+  const dryNote = dry ? ' (dry — no write)' : '';
   console.log(`\nVessel rows read: ${rows.length}`);
   console.log(`Total vessel items: ${totalVessels}`);
-  console.log(`  Would patch: ${patched}` + (dry ? ' (dry — no write)' : ''));
-  console.log(`  Already had speed+consumption: ${skipped}`);
+  console.log(`  Preserved (existing value normalized): ${preserved}${dryNote}`);
+  console.log(`  Defaulted (was missing → DWT default): ${defaulted}${dryNote}`);
+  console.log(`  Already normalized (no-op): ${already}`);
 
   if (samples.length > 0) {
     console.log('\nSamples (before → after):');
@@ -138,7 +221,7 @@ function main() {
   }
 
   if (!dry) {
-    console.log(`\nDone. Patched ${patched} vessel items in ${rows.length} rows.`);
+    console.log(`\nDone. Patched ${preserved + defaulted} vessel items in ${rows.length} rows.`);
   }
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: `patch-vessel-speed-consumption.ts` clobbered existing `speedLaden`/`consumption` with DWT-tier defaults — ConfidenceField objects (`{value:13,confidence:'confirmed',...}`), plain numbers, and non-normalized strings (`'13 knts'`) were not recognized as existing values
- **Fix**: Extract numeric value from any shape, write normalized readable string (`"13 kts"`, `"22 mt/day"`). DWT defaults only for genuinely null/absent fields.
- **Idempotent**: re-running on already-normalized seed = no-op
- **Stats**: `--dry` now reports `preserved` / `defaulted` / `already-normalized` counts separately (was always showing `Already had: 0`)

## Changed files
- `scripts/demo-seed/patch-vessel-speed-consumption.ts` — core fix + stats
- `__tests__/patch-vessel-speed.test.ts` — 13 new adversarial tests covering all shapes

## Test plan
- [x] 52/52 tests pass (`npx jest --findRelatedTests`)
- [x] `tsc --noEmit --skipLibCheck` clean
- [x] ConfidenceField `{value:13,...}` → preserved as `"13 kts"` (not overwritten with `"12.5 kts"`)
- [x] String `"13 knts"` → normalized to `"13 kts"`
- [x] Plain number `13` → normalized to `"13 kts"`
- [x] Null → DWT default applied
- [x] Re-run on normalized seed = no-op (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)