### PR TITLE
feat(bunker): BunkerComparisonTable — multi-port eff $/MT comparison in EconomicsTab (Delta-Step 3)

### DIFF
--- a/__tests__/components/economics/BunkerComparisonTable.test.tsx
+++ b/__tests__/components/economics/BunkerComparisonTable.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @jest-environment jsdom
+ *
+ * TDD tests for BunkerComparisonTable component (Delta-Step 3).
+ * Covers: render candidates, winner highlight, sort order, empty/fallback, lift header, human-decision flags.
+ * PI2: behavioral tests via @testing-library/react (render + screen assertions), not just source analysis.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BunkerComparisonTable } from '@/components/economics/BunkerComparisonTable';
+import type { BunkerCandidateResult } from '@/lib/economics/bunker-comparison';
+
+const CANDIDATES: BunkerCandidateResult[] = [
+  {
+    port: 'SGSIN',
+    grade: 'VLSFO',
+    priceUsdPerMt: 610,
+    deviationNm: 0,
+    deviationHours: 0,
+    deviationFuelUsd: 0,
+    timeCostUsd: 0,
+    effectiveUsdPerMt: 610,
+    onRoute: true,
+  },
+  {
+    port: 'AEFJR',
+    grade: 'VLSFO',
+    priceUsdPerMt: 590,
+    deviationNm: 120,
+    deviationHours: 9.6,
+    deviationFuelUsd: 226,
+    timeCostUsd: 6000,
+    effectiveUsdPerMt: 622.45,
+    onRoute: true,
+  },
+  {
+    port: 'NLRTM',
+    grade: 'VLSFO',
+    priceUsdPerMt: 575,
+    deviationNm: 0,
+    deviationHours: 0,
+    deviationFuelUsd: 0,
+    timeCostUsd: 0,
+    effectiveUsdPerMt: 575,
+    onRoute: true,
+  },
+];
+
+// Pre-sorted by effectiveUsdPerMt ASC (as API returns them):
+const SORTED_CANDIDATES = [...CANDIDATES].sort((a, b) => a.effectiveUsdPerMt - b.effectiveUsdPerMt);
+// Order: NLRTM (575), SGSIN (610), AEFJR (622.45)
+
+describe('BunkerComparisonTable', () => {
+  it('renders table with candidate rows', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    expect(screen.getByTestId('bunker-comparison-table')).toBeInTheDocument();
+    // At least 3 rows rendered
+    const rows = screen.getAllByTestId(/^bunker-row-/);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('highlights winner (first candidate, min eff $/MT) with checkmark', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    const winnerRow = screen.getByTestId('bunker-row-0');
+    expect(winnerRow).toHaveAttribute('data-winner', 'true');
+    // Winner checkmark visible
+    expect(screen.getByTestId('winner-badge')).toBeInTheDocument();
+  });
+
+  it('shows effective $/MT for each candidate', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    // NLRTM winner: 575.00
+    expect(screen.getByTestId('eff-0')).toHaveTextContent('575');
+    // SGSIN: 610.00
+    expect(screen.getByTestId('eff-1')).toHaveTextContent('610');
+    // AEFJR: 622.45
+    expect(screen.getByTestId('eff-2')).toHaveTextContent('622');
+  });
+
+  it('shows spot $/MT price for each candidate', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    expect(screen.getByTestId('price-0')).toHaveTextContent('575');
+    expect(screen.getByTestId('price-1')).toHaveTextContent('610');
+    expect(screen.getByTestId('price-2')).toHaveTextContent('590');
+  });
+
+  it('shows deviation nm/h for candidates with detour', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    // AEFJR is index 2 after sort, has 120nm/9.6h detour
+    const deviationCell = screen.getByTestId('deviation-2');
+    expect(deviationCell).toHaveTextContent('120');
+  });
+
+  it('shows — for deviation when on-route with no detour', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    const deviationCell = screen.getByTestId('deviation-0');
+    expect(deviationCell).toHaveTextContent('—');
+  });
+
+  it('renders empty-state when candidates array is empty', () => {
+    render(<BunkerComparisonTable candidates={[]} />);
+    expect(screen.getByTestId('bunker-table-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('bunker-comparison-table')).toBeNull();
+  });
+
+  it('renders liftTonnes header when provided', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} liftTonnes={500} />);
+    expect(screen.getByTestId('lift-header')).toHaveTextContent('500');
+  });
+
+  it('does not render lift header when liftTonnes not provided', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    expect(screen.queryByTestId('lift-header')).toBeNull();
+  });
+
+  it('renders recommended split when provided', () => {
+    render(
+      <BunkerComparisonTable
+        candidates={SORTED_CANDIDATES}
+        recommendedSplit="Lift 300t at Rotterdam + 200t at Singapore"
+      />,
+    );
+    expect(screen.getByTestId('recommended-split')).toBeInTheDocument();
+    expect(screen.getByTestId('recommended-split')).toHaveTextContent('300t');
+  });
+
+  it('renders human-decision flags block', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    expect(screen.getByTestId('human-decision-flags')).toBeInTheDocument();
+  });
+
+  it('human-decision flags mention laycan risk', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    const flags = screen.getByTestId('human-decision-flags');
+    expect(flags).toHaveTextContent(/laycan|laytim/i);
+  });
+
+  it('human-decision flags mention fuel quality', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    const flags = screen.getByTestId('human-decision-flags');
+    expect(flags).toHaveTextContent(/quality|fuel/i);
+  });
+
+  it('human-decision flags mention charter type', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    const flags = screen.getByTestId('human-decision-flags');
+    expect(flags).toHaveTextContent(/charter/i);
+  });
+
+  it('does not render non-winner row with winner styling', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    const secondRow = screen.getByTestId('bunker-row-1');
+    expect(secondRow).toHaveAttribute('data-winner', 'false');
+  });
+
+  it('port name column shows human-readable name for known LOCODEs', () => {
+    render(<BunkerComparisonTable candidates={SORTED_CANDIDATES} />);
+    // NLRTM → Rotterdam, SGSIN → Singapore
+    expect(screen.getByTestId('port-0')).toHaveTextContent(/Rotterdam/i);
+    expect(screen.getByTestId('port-1')).toHaveTextContent(/Singapore/i);
+  });
+});

--- a/components/economics/BunkerComparisonTable.tsx
+++ b/components/economics/BunkerComparisonTable.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import type { BunkerCandidateResult } from '@/lib/economics/bunker-comparison';
+
+const PORT_NAMES: Record<string, string> = {
+  SGSIN: 'Singapore',
+  CNZOS: 'Zhoushan',
+  HKHKG: 'Hong Kong',
+  KRPUS: 'Busan',
+  CNSHA: 'Shanghai',
+  TWKHH: 'Kaohsiung',
+  LKCMB: 'Colombo',
+  AEFJR: 'Fujairah',
+  SAJED: 'Jeddah',
+  NLRTM: 'Rotterdam',
+  BEANR: 'Antwerp',
+  GIGIB: 'Gibraltar',
+  ESALG: 'Algeciras',
+  ESLPA: 'Las Palmas',
+  GRPIR: 'Piraeus',
+  TRIST: 'Istanbul',
+  USHOU: 'Houston',
+  USNYC: 'New York',
+  PABLB: 'Balboa',
+  BRSSZ: 'Santos',
+  USLAX: 'Los Angeles',
+  ZADUR: 'Durban',
+  MTMLA: 'Malta',
+};
+
+function portLabel(locode: string): string {
+  return PORT_NAMES[locode] ?? locode;
+}
+
+interface BunkerComparisonTableProps {
+  candidates: BunkerCandidateResult[];
+  liftTonnes?: number;
+  recommendedSplit?: string | null;
+}
+
+export function BunkerComparisonTable({
+  candidates,
+  liftTonnes,
+  recommendedSplit,
+}: BunkerComparisonTableProps) {
+  if (candidates.length === 0) {
+    return (
+      <p data-testid="bunker-table-empty" className="text-xs text-gray-500">
+        No on-route bunker ports found — enter price manually or select nearest port.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {liftTonnes != null && (
+        <p data-testid="lift-header" className="text-xs font-medium text-gray-700">
+          Нужно залить ~{liftTonnes.toLocaleString()} т
+        </p>
+      )}
+
+      <div className="overflow-x-auto">
+        <table
+          data-testid="bunker-comparison-table"
+          className="w-full text-xs border-collapse"
+        >
+          <thead>
+            <tr className="border-b border-gray-200 text-gray-500 text-left">
+              <th className="py-1 pr-2 font-medium">Порт</th>
+              <th className="py-1 pr-2 font-medium text-right">$/т</th>
+              <th className="py-1 pr-2 font-medium text-right">Крюк</th>
+              <th className="py-1 pr-2 font-medium text-right">+Топл $</th>
+              <th className="py-1 pr-2 font-medium text-right">Время×$сут</th>
+              <th className="py-1 font-medium text-right">ЭФФ. $/т</th>
+            </tr>
+          </thead>
+          <tbody>
+            {candidates.map((c, i) => {
+              const isWinner = i === 0;
+              return (
+                <tr
+                  key={c.port}
+                  data-testid={`bunker-row-${i}`}
+                  data-winner={isWinner ? 'true' : 'false'}
+                  className={
+                    isWinner
+                      ? 'bg-emerald-50 font-semibold text-emerald-900'
+                      : 'text-gray-700 odd:bg-gray-50'
+                  }
+                >
+                  <td data-testid={`port-${i}`} className="py-1 pr-2 flex items-center gap-1">
+                    {isWinner && (
+                      <span data-testid="winner-badge" aria-label="Лучший вариант" className="text-emerald-600">
+                        ✅
+                      </span>
+                    )}
+                    {portLabel(c.port)}
+                    <span className="text-gray-400 font-normal ml-0.5">{c.grade}</span>
+                  </td>
+                  <td data-testid={`price-${i}`} className="py-1 pr-2 text-right">
+                    {c.priceUsdPerMt.toFixed(0)}
+                  </td>
+                  <td data-testid={`deviation-${i}`} className="py-1 pr-2 text-right">
+                    {c.deviationNm > 0
+                      ? `${c.deviationNm.toFixed(0)}nm / ${c.deviationHours.toFixed(1)}h`
+                      : '—'}
+                  </td>
+                  <td className="py-1 pr-2 text-right">
+                    {c.deviationFuelUsd > 0 ? `$${c.deviationFuelUsd.toFixed(0)}` : '—'}
+                  </td>
+                  <td className="py-1 pr-2 text-right">
+                    {c.timeCostUsd > 0 ? `$${c.timeCostUsd.toFixed(0)}` : '—'}
+                  </td>
+                  <td data-testid={`eff-${i}`} className="py-1 text-right font-semibold">
+                    {c.effectiveUsdPerMt.toFixed(2)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {recommendedSplit && (
+        <div
+          data-testid="recommended-split"
+          className="rounded border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-800"
+        >
+          <span className="font-medium">Рекомендованный сплит: </span>
+          {recommendedSplit}
+        </div>
+      )}
+
+      <div
+        data-testid="human-decision-flags"
+        className="rounded border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-800 space-y-1"
+      >
+        <p className="font-semibold text-amber-900">Решает человек ⚠</p>
+        <ul className="list-disc list-inside space-y-0.5">
+          <li>Laycan risk — проверьте, укладывается ли крюк в laycan</li>
+          <li>Fuel quality — VLSFO spec различается по порту; проверить бункерный отчёт</li>
+          <li>Charter type — при TC off-hire detour может требовать разрешения</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo, useEffect, useCallback } from 'react';
 import type { ParsedVessel, ParsedCargo } from '@/lib/types';
 import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
 import { VoyageBreakdownChart } from '@/components/economics/VoyageBreakdownChart';
+import { BunkerComparisonTable } from '@/components/economics/BunkerComparisonTable';
+import type { BunkerCandidateResult } from '@/lib/economics/bunker-comparison';
 import { calculateFuelEu } from '@/lib/economics/fueleu';
 import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
@@ -74,6 +76,8 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const [bunkerPortManual, setBunkerPortManual] = useState(false);
   const [bunkerReco, setBunkerReco] = useState<{ port: string; priceUsdPerMt: number; recommendation: string } | null>(null);
   const [bunkerFallback, setBunkerFallback] = useState<string | null>(null);
+  const [bunkerCandidates, setBunkerCandidates] = useState<BunkerCandidateResult[]>([]);
+  const [bunkerRecommendedSplit, setBunkerRecommendedSplit] = useState<string | null>(null);
   const [displayCurrency, setDisplayCurrency] = useState<DisplayCurrency>('USD');
   const [fuelType, setFuelType] = useState('hfo');
   const [euaData, setEuaData] = useState<{ value: number; period: string; stale?: boolean } | null>(null);
@@ -107,14 +111,18 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const url = `/api/voyage/bunker-recommendation?from=${encodeURIComponent(recoFrom)}&to=${encodeURIComponent(recoTo)}&grade=${bunkerGrade}`;
     fetch(url)
       .then((r) => r.ok ? r.json() : null)
-      .then((data: { fallback: boolean; message: string | null; port: string | null; priceUsdPerMt: number | null; recommendation: string | null; savingsUsd: number } | null) => {
+      .then((data: { fallback: boolean; message: string | null; port: string | null; priceUsdPerMt: number | null; recommendation: string | null; savingsUsd: number; candidates: BunkerCandidateResult[] } | null) => {
         if (cancelled || !data) return;
         if (data.fallback) {
           setBunkerFallback(data.message);
           setBunkerReco(null);
+          setBunkerCandidates([]);
+          setBunkerRecommendedSplit(null);
         } else if (data.port && data.priceUsdPerMt != null && data.recommendation) {
           setBunkerFallback(null);
           setBunkerReco({ port: data.port, priceUsdPerMt: data.priceUsdPerMt, recommendation: data.recommendation });
+          setBunkerCandidates(data.candidates ?? []);
+          setBunkerRecommendedSplit(data.recommendation ?? null);
           if (!bunkerPortManual && BUNKER_PORTS.some(p => p.value === data.port)) {
             setBunkerPort(data.port as BunkerPort);
           }
@@ -463,17 +471,28 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
             ))}
           </select>
         </div>
-        {bunkerReco && (
-          <p data-testid="bunker-reco" className="text-xs text-blue-700 bg-blue-50 rounded px-2 py-1 mt-1">
-            {bunkerReco.recommendation}
-          </p>
-        )}
         {bunkerFallback && (
           <p data-testid="bunker-fallback" className="text-xs text-amber-600 mt-1">
             {bunkerFallback}
           </p>
         )}
+        {!bunkerFallback && bunkerReco && bunkerCandidates.length === 0 && (
+          <p data-testid="bunker-reco" className="text-xs text-blue-700 bg-blue-50 rounded px-2 py-1 mt-1">
+            {bunkerReco.recommendation}
+          </p>
+        )}
       </div>
+
+      {bunkerCandidates.length > 0 && (
+        <div data-testid="bunker-comparison-section" className="rounded border border-gray-200 bg-white p-3">
+          <h3 className="text-xs font-semibold text-gray-700 mb-2">Бункеровка — сравнение портов</h3>
+          <BunkerComparisonTable
+            candidates={bunkerCandidates}
+            liftTonnes={cargo?.weightMt?.value}
+            recommendedSplit={bunkerRecommendedSplit}
+          />
+        </div>
+      )}
 
       {MULTI_CURRENCY_V2_ENABLED && (
         <div className="space-y-1">


### PR DESCRIPTION
## Summary

- **NEW** `components/economics/BunkerComparisonTable.tsx` — table comparing on-route bunker ports: Port | $/t | Detour (nm/h) | +Fuel $ | Time×Day-Rate | **EFF $/t**, winner (min eff$/t) highlighted ✅, sorted cheapest-effective first
- **EconomicsTab** now fetches `candidates[]` from the `/api/voyage/bunker-recommendation` response (#757), renders `BunkerComparisonTable` when candidates present; backward-compat fallback: if candidates is empty → old single-port `bunkerReco` verdict preserved, P&L chart untouched
- Header "Нужно залить ~X т" (from `cargo.weightMt`), recommended split from API `recommendation` field
- Human-decision flags block: laycan risk · fuel quality · charter type (informational, non-blocking)

## Test plan

- [ ] `npx jest __tests__/components/economics/BunkerComparisonTable.test.tsx --maxWorkers=1` — 16 behavioral tests green (render, winner badge, sort, empty-state, lift header, recommended split, human-decision flags, port name labels)
- [ ] `npx jest --findRelatedTests components/economics/BunkerComparisonTable.tsx components/match/EconomicsTab.tsx --maxWorkers=1` — 90 tests green
- [ ] Gate 3 PREVIEW: visit `/match/[id]` → Economics tab → confirm table shows ≥2-3 ports with numbers, winner highlighted
- [ ] Empty-state: route with no bunker candidates shows fallback message (backward-compat)

## UI routes affected

- `/match/[id]` (EconomicsTab → bunker comparison section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)