### PR TITLE
fix(match): worksheet readiness wins laycanDisplay — CARGO card aligns with Time row

### DIFF
--- a/__tests__/match-laycan-unify.test.ts
+++ b/__tests__/match-laycan-unify.test.ts
@@ -1,13 +1,14 @@
 /**
  * Regression tests — laycan-unify: all renders on /match/[id] derive from ONE unified value.
  *
- * Bug: storedMatch.laycan_start/end == null → laycanDisplay was null →
+ * Original bug (#745): storedMatch.laycan_start/end == null → laycanDisplay was null →
  *   header/cargo-card showed nothing while Source Attribution fell back to raw
  *   cargo.preferredDates ("Jan 19-Apr 7"), mismatching the worksheet Time row
  *   which showed the computed window ("2026-06-03 – 2026-06-06").
  *
- * Fix: laycanDisplay falls back to worksheet.readiness.laycanStart/End (parsed via
- *   fmtLaycan), then to cargo.preferredDates.value. All renders use laycanDisplay.
+ * Second fix: even when storedMatch.laycan_start/end is SET (stale original), CARGO card
+ *   showed the stale date while worksheet Time row showed the rebased readiness window.
+ *   Fix: worksheet readiness wins — precedence order now readiness > storedMatch > preferredDates.
  */
 
 import * as fs from 'fs';
@@ -48,19 +49,28 @@ describe('app/match/[id]/page.tsx — laycan unified fallback chain (#laycan-uni
     expect(src).toMatch(/laycanDisplay\s*=\s*\(\s*\(\s*\)\s*=>/);
   });
 
-  it('first tier: storedMatch.laycan_start / laycan_end via fmtLaycan', () => {
-    const src = detailSrc();
-    expect(src).toMatch(/storedMatch\.laycan_start.*storedMatch\.laycan_end|storedMatch\.laycan_end.*storedMatch\.laycan_start/);
-    expect(src).toMatch(/fmtLaycan\(storedMatch\.laycan_start,\s*storedMatch\.laycan_end\)/);
-  });
-
-  it('second tier: worksheet readiness laycanStart/End via fmtLaycan', () => {
+  it('first/wins tier: worksheet readiness laycanStart/End via fmtLaycan', () => {
     const src = detailSrc();
     expect(src).toMatch(/worksheet\?\.readiness\?\.laycanStart/);
     expect(src).toMatch(/worksheet\?\.readiness\?\.laycanEnd/);
     // must convert ISO to timestamp and call fmtLaycan
     expect(src).toMatch(/toTs\s*=.*new Date\(iso/);
     expect(src).toMatch(/fmtLaycan\(rs\s*\?.*toTs/);
+  });
+
+  it('second/fallback tier: storedMatch.laycan_start / laycan_end via fmtLaycan', () => {
+    const src = detailSrc();
+    expect(src).toMatch(/storedMatch\.laycan_start.*storedMatch\.laycan_end|storedMatch\.laycan_end.*storedMatch\.laycan_start/);
+    expect(src).toMatch(/fmtLaycan\(storedMatch\.laycan_start,\s*storedMatch\.laycan_end\)/);
+  });
+
+  it('worksheet readiness check appears BEFORE storedMatch check in source (precedence)', () => {
+    const src = detailSrc();
+    const readinessIdx = src.indexOf('worksheet?.readiness?.laycanStart');
+    const storedMatchIdx = src.indexOf('fmtLaycan(storedMatch.laycan_start');
+    expect(readinessIdx).toBeGreaterThan(0);
+    expect(storedMatchIdx).toBeGreaterThan(0);
+    expect(readinessIdx).toBeLessThan(storedMatchIdx);
   });
 
   it('third tier: cargo.preferredDates.value', () => {
@@ -81,5 +91,80 @@ describe('app/match/[id]/page.tsx — laycan unified fallback chain (#laycan-uni
     const src = detailSrc();
     const count = (src.match(/worksheet = JSON\.parse\(storedMatch\.worksheet_json\)/g) ?? []).length;
     expect(count).toBe(1);
+  });
+});
+
+// ── Behavioral: laycanDisplay precedence (#laycan-precedence) ────────────────
+// Mirrors the laycanDisplay IIFE logic to verify precedence without hitting Next.js server infra.
+
+describe('laycanDisplay precedence — behavioral (#laycan-precedence)', () => {
+  const toTs = (iso: string) => Math.floor(new Date(iso + 'T00:00:00Z').getTime() / 1000);
+
+  function computeLaycanDisplay(
+    storedMatch: { laycan_start: number | null; laycan_end: number | null },
+    worksheet: { readiness?: { laycanStart?: string; laycanEnd?: string } } | null,
+    cargo: { preferredDates?: { value?: string } } | undefined,
+  ): string | null {
+    const rs = worksheet?.readiness?.laycanStart;
+    const re = worksheet?.readiness?.laycanEnd;
+    if (rs || re) {
+      return fmtLaycan(rs ? toTs(rs) : null, re ? toTs(re) : null);
+    }
+    if (storedMatch.laycan_start || storedMatch.laycan_end) {
+      return fmtLaycan(storedMatch.laycan_start, storedMatch.laycan_end);
+    }
+    if (cargo?.preferredDates?.value) {
+      return cargo.preferredDates.value;
+    }
+    return null;
+  }
+
+  it('worksheet readiness wins over storedMatch when both present with different dates', () => {
+    const result = computeLaycanDisplay(
+      { laycan_start: toTs('2026-01-19'), laycan_end: toTs('2026-04-07') }, // stale original
+      { readiness: { laycanStart: '2026-06-03', laycanEnd: '2026-06-06' } }, // rebased window
+      undefined,
+    );
+    expect(result).toMatch(/Jun 3/);
+    expect(result).toMatch(/Jun 6/);
+    expect(result).not.toMatch(/Jan 19/);
+    expect(result).not.toMatch(/Apr 7/);
+  });
+
+  it('falls back to storedMatch when worksheet has no readiness', () => {
+    const result = computeLaycanDisplay(
+      { laycan_start: toTs('2026-01-19'), laycan_end: toTs('2026-04-07') },
+      null,
+      undefined,
+    );
+    expect(result).toMatch(/Jan 19/);
+    expect(result).toMatch(/Apr 7/);
+  });
+
+  it('falls back to storedMatch when worksheet.readiness exists but has no dates', () => {
+    const result = computeLaycanDisplay(
+      { laycan_start: toTs('2026-01-19'), laycan_end: toTs('2026-04-07') },
+      { readiness: {} },
+      undefined,
+    );
+    expect(result).toMatch(/Jan 19/);
+  });
+
+  it('falls back to cargo.preferredDates when neither worksheet readiness nor storedMatch', () => {
+    const result = computeLaycanDisplay(
+      { laycan_start: null, laycan_end: null },
+      { readiness: {} },
+      { preferredDates: { value: 'early July' } },
+    );
+    expect(result).toBe('early July');
+  });
+
+  it('returns null when nothing available', () => {
+    const result = computeLaycanDisplay(
+      { laycan_start: null, laycan_end: null },
+      null,
+      undefined,
+    );
+    expect(result).toBeNull();
   });
 });

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -80,16 +80,17 @@ export default async function MatchDetailPage({ params }: Props) {
     }
   }
 
-  // Unified laycan: storedMatch timestamps → worksheet computed window → raw cargo string → null
+  // Unified laycan: worksheet readiness window (rebased) → storedMatch timestamps → raw cargo string → null
+  // Readiness wins so CARGO card aligns with the Time row in MatchWorksheet (both show rebased window).
   const laycanDisplay = (() => {
-    if (storedMatch.laycan_start || storedMatch.laycan_end) {
-      return fmtLaycan(storedMatch.laycan_start, storedMatch.laycan_end);
-    }
     const rs = worksheet?.readiness?.laycanStart;
     const re = worksheet?.readiness?.laycanEnd;
     if (rs || re) {
       const toTs = (iso: string) => Math.floor(new Date(iso + 'T00:00:00Z').getTime() / 1000);
       return fmtLaycan(rs ? toTs(rs) : null, re ? toTs(re) : null);
+    }
+    if (storedMatch.laycan_start || storedMatch.laycan_end) {
+      return fmtLaycan(storedMatch.laycan_start, storedMatch.laycan_end);
     }
     if (cargo?.preferredDates?.value) {
       return cargo.preferredDates.value;


### PR DESCRIPTION
## Summary

- **Root cause**: `laycanDisplay` IIFE in `app/match/[id]/page.tsx` checked `storedMatch.laycan_start/end` first — the stale original cargo laycan from the matches-table columns. The rebased readiness window was only a fallback.
- **Fix**: Swap precedence — `worksheet.readiness.laycanStart/End` (rebased window) wins first; `storedMatch.laycan_start/end` becomes the fallback when no readiness exists. CARGO card now shows the same date as the MatchWorksheet Time row.
- **Tests**: Added behavioral precedence tests (readiness beats storedMatch when both present with different dates), fallback scenarios (storedMatch when no readiness, preferredDates, null), and source ordering test (readiness check appears before storedMatch in IIFE).

## Test plan

- [ ] `npx jest __tests__/match-laycan-unify.test.ts --maxWorkers=1 --no-coverage` — 15/15 green
- [ ] `tsc --noEmit` — clean
- [ ] On `/match/[id]` with a match that has `worksheet.readiness.laycanStart/End`: CARGO card and Time row show the same rebased date
- [ ] On `/match/[id]` with no worksheet: CARGO card falls back to `storedMatch` laycan columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)