### PR TITLE
feat(demo-seed): backfill 30-day drewry-bb history into market_indices

### DIFF
--- a/__tests__/scripts/seed-market-history.test.ts
+++ b/__tests__/scripts/seed-market-history.test.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import migration019 from '@/lib/migrations/019-port-master-baltic-indices';
 import migration023 from '@/lib/migrations/023-bunker-prices-rewrite';
 import migration024 from '@/lib/migrations/024-eua-prices-rewrite';
+import migration027 from '@/lib/migrations/027-market-indices';
 import {
   generateDates,
   generateSeries,
@@ -110,6 +111,7 @@ describe('seedMarketHistory', () => {
     migration019.up(db);
     migration023.up(db);
     migration024.up(db);
+    migration027.up(db);
   });
 
   afterEach(() => db.close());
@@ -198,5 +200,57 @@ describe('seedMarketHistory', () => {
       .prepare(`SELECT COUNT(*) as n FROM eua_prices WHERE source = 'demo-seed'`)
       .get() as { n: number };
     expect(m.n).toBe(0);
+  });
+
+  it('inserts 30 drewry-bb rows into market_indices', () => {
+    seedMarketHistory(db, false);
+
+    const row = db
+      .prepare(`SELECT COUNT(*) as n FROM market_indices WHERE index_name = 'drewry-bb' AND source = 'demo-seed'`)
+      .get() as { n: number };
+    expect(row.n).toBe(DAYS);
+  });
+
+  it('drewry-bb last value on frozen_date equals 2800', () => {
+    seedMarketHistory(db, false);
+
+    const row = db
+      .prepare(`SELECT value FROM market_indices WHERE index_name = 'drewry-bb' AND index_date = '2026-05-28' AND source = 'demo-seed'`)
+      .get() as { value: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.value).toBe(2800);
+  });
+
+  it('drewry-bb all dates are <= frozen_date 2026-05-28', () => {
+    seedMarketHistory(db, false);
+
+    const bad = db
+      .prepare(`SELECT COUNT(*) as n FROM market_indices WHERE index_name = 'drewry-bb' AND source = 'demo-seed' AND index_date > '2026-05-28'`)
+      .get() as { n: number };
+    expect(bad.n).toBe(0);
+  });
+
+  it('drewry-bb is idempotent — re-running produces same 30 rows', () => {
+    seedMarketHistory(db, false);
+    seedMarketHistory(db, false);
+
+    const row = db
+      .prepare(`SELECT COUNT(*) as n FROM market_indices WHERE index_name = 'drewry-bb' AND source = 'demo-seed'`)
+      .get() as { n: number };
+    expect(row.n).toBe(DAYS);
+  });
+
+  it('dry mode writes nothing to market_indices', () => {
+    seedMarketHistory(db, true);
+
+    const row = db
+      .prepare(`SELECT COUNT(*) as n FROM market_indices WHERE source = 'demo-seed'`)
+      .get() as { n: number };
+    expect(row.n).toBe(0);
+  });
+
+  it('seedMarketHistory returns marketIndexRows = 30', () => {
+    const result = seedMarketHistory(db, false);
+    expect(result.marketIndexRows).toBe(DAYS);
   });
 });

--- a/scripts/seed-market-history.ts
+++ b/scripts/seed-market-history.ts
@@ -114,6 +114,14 @@ interface EuaSpec {
   noiseAbs: number;
 }
 
+interface IndexSpec {
+  indexName: string;
+  unit: string;
+  startValue: number;
+  endValue: number;
+  noiseAbs: number;
+}
+
 // Current demo values from frozen_date 2026-05-28.
 // Trend direction matches sparklineDir in app/market/page.tsx:
 //   BDI up, BCI up, BSI up, BHSI down, VLSFO up, MGO down, EUA up.
@@ -131,10 +139,17 @@ const BUNKER_SPECS: BunkerSpec[] = [
 
 const EUA_SPEC: EuaSpec = { startValue: 68.0, endValue: 78.2, noiseAbs: 1.2 };
 
+// Drewry World Container Index — breakbulk variant used in /market freight chart.
+// endValue 2800 = current demo value (2026-05-28 seed row); gentle uptrend.
+const INDEX_SPECS: IndexSpec[] = [
+  { indexName: 'drewry-bb', unit: 'USD/FEU', startValue: 2720, endValue: 2800, noiseAbs: 25 },
+];
+
 export interface SeedResult {
   balticRows: number;
   bunkerRows: number;
   euaRows: number;
+  marketIndexRows: number;
 }
 
 export function seedMarketHistory(db: Database.Database, dry: boolean): SeedResult {
@@ -142,6 +157,7 @@ export function seedMarketHistory(db: Database.Database, dry: boolean): SeedResu
   let balticRows = 0;
   let bunkerRows = 0;
   let euaRows = 0;
+  let marketIndexRows = 0;
   const now = new Date().toISOString();
 
   // ── Baltic indices ──────────────────────────────────────────────────────────
@@ -214,7 +230,32 @@ export function seedMarketHistory(db: Database.Database, dry: boolean): SeedResu
     euaRows++;
   }
 
-  return { balticRows, bunkerRows, euaRows };
+  // ── Market indices (drewry-bb) ──────────────────────────────────────────────
+  const marketStmt = dry ? null : db.prepare(`
+    INSERT INTO market_indices (id, index_name, index_date, value, unit, source, fetched_at)
+    VALUES (?, ?, ?, ?, ?, 'demo-seed', ?)
+    ON CONFLICT(index_name, index_date) DO UPDATE SET
+      value = excluded.value,
+      source = excluded.source,
+      fetched_at = excluded.fetched_at
+  `);
+
+  for (const spec of INDEX_SPECS) {
+    const values = generateSeries(spec.startValue, spec.endValue, DAYS, spec.noiseAbs, spec.indexName);
+    for (let i = 0; i < dates.length; i++) {
+      const date = dates[i]!;
+      const val = values[i]!;
+      if (dry) {
+        console.log(`[DRY] market_indices ${spec.indexName} ${date} = ${val} ${spec.unit}`);
+      } else {
+        const id = `${spec.indexName}-${date}`;
+        marketStmt!.run(id, spec.indexName, date, val, spec.unit, now);
+      }
+      marketIndexRows++;
+    }
+  }
+
+  return { balticRows, bunkerRows, euaRows, marketIndexRows };
 }
 
 if (require.main === module) {
@@ -232,9 +273,9 @@ if (require.main === module) {
     const result = seedMarketHistory(db, isDry);
 
     if (isDry) {
-      console.log(`\nWould write: ${result.balticRows} baltic + ${result.bunkerRows} bunker + ${result.euaRows} eua rows`);
+      console.log(`\nWould write: ${result.balticRows} baltic + ${result.bunkerRows} bunker + ${result.euaRows} eua + ${result.marketIndexRows} drewry rows`);
     } else {
-      console.log(`\n✓ Seeded ${result.balticRows} baltic + ${result.bunkerRows} bunker + ${result.euaRows} eua rows`);
+      console.log(`\n✓ Seeded ${result.balticRows} baltic + ${result.bunkerRows} bunker + ${result.euaRows} eua + ${result.marketIndexRows} drewry rows`);
       console.log('  Idempotent — safe to re-run.');
     }
   } finally {


### PR DESCRIPTION
## Summary
- Adds `INDEX_SPECS` array + `IndexSpec` interface to `seed-market-history.ts`
- Upserts 30 daily rows for `drewry-bb` into `market_indices` (2026-04-29 → 2026-05-28, last value = 2800 USD/FEU)
- `ON CONFLICT(index_name, index_date) DO UPDATE` — fully idempotent
- Extends `SeedResult` with `marketIndexRows`; summary line updated to show `+ 30 drewry`

## Test plan
- [ ] `npx tsx scripts/seed-market-history.ts --dry` prints 30 drewry-bb rows ending 2026-05-28 = 2800
- [ ] `npx jest --findRelatedTests scripts/seed-market-history.ts` → 25 tests pass
- [ ] Re-run produces same row count (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)