### PR TITLE
fix(match): wire Layer B gates into real-matches regen + clean re-parsed demo data

### DIFF
--- a/lib/sample-data/demo-parsed-cargoes.json
+++ b/lib/sample-data/demo-parsed-cargoes.json
@@ -1,5 +1,128 @@
 [
   {
+    "emailId": "19d5de87705baf9b",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "1 marmara /vera  cruz"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Vera Cruz",
+      "confidence": "confirmed",
+      "sourceText": "marmara /vera  cruz"
+    },
+    "destinationCountry": "Mexico",
+    "cargoDescription": {
+      "value": "14 pieces of Storage Tanks: 10 × VT Storage Tanks (160 m³ each, 4.3m × 15.7m × 4.3m, 15,000 kg each) and 4 × GMMOS Tanks (80 m³ each, 12.1m × 3.2m × 3.2m, 9,000 kg each); partial cargo and on-deck stowage acceptable",
+      "confidence": "interpreted",
+      "sourceText": "\nLxHxW 4.3m x 15.7m x4.3m - Weight 15000 kg each tank"
+    },
+    "weightMt": null,
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": 1920,
+    "dimensions": "VT: 4.3m x 15.7m x 4.3m; GMMOS: 12.1m x 3.2m x 3.2m",
+    "cargoType": "PROJECT",
+    "containerType": null,
+    "quantity": 14,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-20 June 2019",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 4,
+    "commissionTerms": "4% TTL; Gcn 3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Partial cargo acceptable (Pc ok); on-deck stowage acceptable (ondeck ok)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Total cargo weight not stated (only per-piece weights: 15,000 kg × 10 + 9,000 kg × 4)",
+      "Vessel type/DWT requirement not specified",
+      "Loading/discharge laytime and cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19d5de87705baf9b",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Karasu",
+      "confidence": "confirmed",
+      "sourceText": "Karasu / puero limon  or caldera"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Puerto Limon or Caldera",
+      "confidence": "interpreted",
+      "sourceText": "puero limon  or caldera"
+    },
+    "destinationCountry": "Costa Rica",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC), maximum 20 tonnes per unit",
+      "confidence": "interpreted",
+      "sourceText": "10400 mts  hrc max 20 tons"
+    },
+    "weightMt": {
+      "value": 10400,
+      "confidence": "confirmed",
+      "sourceText": "10400 mts  hrc"
+    },
+    "weightMtMin": 10400,
+    "weightMtMax": 10400,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "June dates",
+      "confidence": "confirmed",
+      "sourceText": "June dates"
+    },
+    "laycan": "June 2019",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": null,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Coil unit weight max 20 tonnes",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Freight rate requested but not yet quoted (sender seeking freight indication)",
+      "Final discharge port nomination pending (charterer's option: Puerto Limon or Caldera)",
+      "Exact June laycan window not specified",
+      "Loading terms not stated (only 'liner out' discharge given)",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": [
+      "Caldera"
+    ],
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
     "emailId": "19d5dea61d04209f",
     "itemIndex": 0,
     "originPort": {
@@ -15,48 +138,50 @@
     },
     "destinationCountry": "Mozambique",
     "cargoDescription": {
-      "value": "Cement in sling",
-      "confidence": "confirmed",
+      "value": "Cement in slings",
+      "confidence": "interpreted",
       "sourceText": "30,000 MT cement in sling"
     },
     "weightMt": {
       "value": 30000,
       "confidence": "confirmed",
-      "sourceText": "30,000 MT cement"
+      "sourceText": "30,000 MT cement in sling"
     },
     "weightMtMin": 30000,
     "weightMtMax": 30000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": {
-      "value": "End June 2019",
-      "confidence": "interpreted",
-      "sourceText": "L/Can e/Jun'19"
-    },
-    "laycan": "End June 2019",
+    "preferredDates": null,
+    "laycan": "Early June 2019",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": null,
     "commissionTerms": null,
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Exact laycan dates within end June 2019 not stated",
-      "Loading and discharge rates not stated",
+      "Load/discharge rates not specified (stated only as 'L/D normal')",
       "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
+      "Freight rate requested but not yet quoted",
+      "Vessel type/DWT requirement not specified"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19d5def0bf1a5c3f",
@@ -92,28 +217,157 @@
     "quantity": null,
     "incoterms": null,
     "preferredDates": {
-      "value": "Cargo ready",
+      "value": "Cargo Ready",
       "confidence": "confirmed",
       "sourceText": "Cgo Ready"
     },
-    "laycan": "Cargo ready",
+    "laycan": null,
     "loadingRate": "1500",
     "dischargeRate": "1000",
     "commissionPercent": 3.75,
-    "commissionTerms": "TTL",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Partial cargo acceptable (Pcgo ok); Gearless vessel acceptable",
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
+      "Laycan window not specified — only 'Cargo Ready' stated",
       "Demurrage and despatch rates not stated",
-      "Exact cargo unit count / number of big bags not stated",
-      "Vessel DWT/type requirement not specified"
+      "Barite grade/specific gravity not specified",
+      "Stowage factor not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19d5e751c0c212df",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Izmail",
+      "confidence": "confirmed",
+      "sourceText": "Izmail - Egypt med"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "Egypt Mediterranean port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Egypt med"
+    },
+    "destinationCountry": "Egypt",
+    "cargoDescription": {
+      "value": "Wheat, stowage factor 47–49",
+      "confidence": "interpreted",
+      "sourceText": "8000 mts 10 pct wheat stw abt 47-49'"
+    },
+    "weightMt": {
+      "value": 8000,
+      "confidence": "interpreted",
+      "sourceText": "8000 mts 10 pct wheat"
+    },
+    "weightMtMin": 7200,
+    "weightMtMax": 8800,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 7200,
+      "max": 8800
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "4-5 September 2025",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 1.25,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "abt 47–49 ft³/MT",
+    "missingInfo": [
+      "Specific Egypt-Med discharge port not nominated",
+      "Laytime cost-allocation terms (FIO/CQD/SHINC etc.) not stated",
+      "Demurrage and despatch rates not stated",
+      "10 pct tolerance assumed MOLOO — option holder (owner/charterer) not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19d5e751c0c212df",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Chornomorsk",
+      "confidence": "confirmed",
+      "sourceText": "Chornomorsk - Marghera"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "Marghera",
+      "confidence": "confirmed",
+      "sourceText": "Chornomorsk - Marghera"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Steel scrap, stowage factor 68–70, vessel requires approx 200,000 cubic feet grain/bale capacity for full cargo",
+      "confidence": "interpreted",
+      "sourceText": "Need abt 200 000 cft for full cgo abt 3000 mts of steel scrap stw abt 68-70'"
+    },
+    "weightMt": {
+      "value": 3000,
+      "confidence": "interpreted",
+      "sourceText": "abt 3000 mts of steel scrap"
+    },
+    "weightMtMin": 3000,
+    "weightMtMax": 3000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "Spot",
+    "loadingRate": "800",
+    "dischargeRate": "800",
+    "commissionPercent": 2,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Vessel must offer approx 200,000 cft cubic capacity for full cargo intake",
+    "stowageFactor": "abt 68–70 ft³/MT",
+    "missingInfo": [
+      "Scrap form not specified (loose/HMS/bundled) — assumed bulk",
+      "Laytime cost-allocation terms (FIO/CQD/SHINC etc.) not stated",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19d5e75f7c50d8e8",
@@ -125,54 +379,126 @@
     },
     "originCountry": "Egypt",
     "destinationPort": {
-      "value": "Odesa",
-      "confidence": "confirmed",
+      "value": "Odesa or Chornomorsk",
+      "confidence": "interpreted",
       "sourceText": "Odesa or Chornomorsk chopt"
     },
     "destinationCountry": "Ukraine",
     "cargoDescription": {
       "value": "Salt in big bags",
       "confidence": "interpreted",
-      "sourceText": "4000-4800 mts salt in big-bags"
+      "sourceText": "salt in big-bags"
     },
     "weightMt": {
-      "value": 4800,
-      "confidence": "interpreted",
+      "value": null,
+      "confidence": "confirmed",
       "sourceText": "4000-4800 mts salt"
     },
     "weightMtMin": 4000,
     "weightMtMax": 4800,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": {
       "min": 4000,
       "max": 4800
     },
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "spot"
+    },
     "laycan": "Spot",
     "loadingRate": "1200",
     "dischargeRate": "1200",
     "commissionPercent": 2.5,
     "commissionTerms": null,
-    "specialRequirements": "[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
       "Specific Egypt-Med load port not nominated — exact port TBD",
       "Final discharge port nomination pending (charterer's option: Odesa or Chornomorsk)",
-      "Laytime terms such as SHINC/SHEX/SSHEX not stated",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST/SHINC/SHEX) not stated",
       "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Freight rate not indicated",
+      "Vessel type/DWT requirement not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
     "destinationPortAlternatives": [
       "Chornomorsk"
     ],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19d5e78427ad130a",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "China (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "North China"
+    },
+    "originCountry": "China",
+    "destinationPort": {
+      "value": "Marmara",
+      "confidence": "interpreted",
+      "sourceText": "1 Marmara"
+    },
+    "destinationCountry": "Turkey",
+    "cargoDescription": {
+      "value": "Bagged cargo, non-IMO, stowage equals deadweight",
+      "confidence": "interpreted",
+      "sourceText": "20,000 mt bagged cargo non imo stw=dwt"
+    },
+    "weightMt": {
+      "value": 20000,
+      "confidence": "confirmed",
+      "sourceText": "20,000 mt bagged cargo"
+    },
+    "weightMtMin": 20000,
+    "weightMtMax": 20000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "10-20 September 2025",
+    "loadingRate": "2500",
+    "dischargeRate": "1750",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL (Gencon)",
+    "freightRateUsd": null,
+    "specialRequirements": "Non-IMO cargo (non-hazardous)",
+    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
+    "missingInfo": [
+      "Commodity grade not specified — 'bagged cargo' generic, exact commodity TBD",
+      "Specific North China load port not nominated — exact port TBD",
+      "Specific Marmara discharge port not nominated — exact port TBD",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c3f2dc72d95",
@@ -184,7 +510,7 @@
     },
     "originCountry": "Turkey",
     "destinationPort": {
-      "value": "Greece (port unspecified)",
+      "value": "Greece (1 port)",
       "confidence": "interpreted",
       "sourceText": "1 Greece"
     },
@@ -203,93 +529,38 @@
     "weightMtMax": 3000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": {
-      "value": "11–16 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "11 - 16 May"
-    },
-    "laycan": "11–16 May 2026",
+    "preferredDates": null,
+    "laycan": "11-16 May 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Total laytime 4 days (4 TTL days) for load+discharge combined. Exclusive/fully firm cargo — do not recirculate.",
     "stowageFactor": null,
     "missingInfo": [
-      "Specific Greece discharge port not nominated — exact port TBD",
-      "Cement grade/specification not stated",
+      "Specific Greek discharge port not nominated (stated only as '1 Greece')",
       "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
-      "Loading and discharge rates not stated",
+      "Loading and discharge rates (MT/day) not separately stated — only total 4 days laytime given",
       "Demurrage and despatch rates not stated",
+      "Freight rate not stated",
       "Vessel DWT/type requirement not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19d5e78427ad130a",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "North China (port unspecified)",
-      "confidence": "interpreted",
-      "sourceText": "North China"
-    },
-    "originCountry": "China",
-    "destinationPort": {
-      "value": "Marmara",
-      "confidence": "confirmed",
-      "sourceText": "1 Marmara"
-    },
-    "destinationCountry": "Turkey",
-    "cargoDescription": {
-      "value": "Bagged cargo, non-IMO, stowage equals deadweight",
-      "confidence": "interpreted",
-      "sourceText": "20,000 mt bagged cargo non imo stw=dwt"
-    },
-    "weightMt": {
-      "value": 20000,
-      "confidence": "confirmed",
-      "sourceText": "20,000 mt"
-    },
-    "weightMtMin": 20000,
-    "weightMtMax": 20000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "10-20 September 2025",
-      "confidence": "interpreted",
-      "sourceText": "10/20 September"
-    },
-    "laycan": "10-20 September 2025",
-    "loadingRate": "2500",
-    "dischargeRate": "1750",
-    "commissionPercent": 3.75,
-    "commissionTerms": "TTL",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
-    "missingInfo": [
-      "Specific North China load port not nominated — exact port TBD",
-      "Specific Marmara discharge port not nominated — exact port TBD",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Exact commodity not specified beyond bagged cargo"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c446224acf1",
@@ -307,14 +578,14 @@
     },
     "destinationCountry": "Turkey",
     "cargoDescription": {
-      "value": "Coal tar pitch in big bags, dimensions 1.4m × 1.4m × 1.1m, unit weight 1.2 MT, stowage factor 1.797 derived from dimensions",
+      "value": "Coal tar pitch in big bags, dimensions 1.4m × 1.4m × 1.1m, unit weight 1.2 MT",
       "confidence": "interpreted",
-      "sourceText": "1500 mts +/-10% coal tar pitch in bb"
+      "sourceText": " (1.4x1.4x1.1 UW 1,2 mt) ~ 2600 m3 required"
     },
     "weightMt": {
       "value": 1500,
       "confidence": "confirmed",
-      "sourceText": "1500 mts +/-10% coal tar pitch in bb"
+      "sourceText": "1500 mts +/-10%"
     },
     "weightMtMin": 1350,
     "weightMtMax": 1650,
@@ -327,41 +598,43 @@
       "max": 1650
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "11-15 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "11-15 May"
-    },
+    "preferredDates": null,
     "laycan": "11-15 May 2026",
     "loadingRate": "1000",
     "dischargeRate": "1000",
     "commissionPercent": 2.5,
-    "commissionTerms": "ADDCOM PUS",
-    "specialRequirements": null,
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Big bags 1.4m × 1.4m × 1.1m, unit weight 1.2 MT; ~2600 m3 cargo space required",
     "stowageFactor": "1.797 m³/MT (derived from dimensions)",
     "missingInfo": [
-      "Incoterms not stated",
-      "Exact number of big bags not stated",
       "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Vessel DWT/type requirement not specified",
+      "Coal tar pitch grade/specification not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c482e65e378",
     "itemIndex": 0,
     "originPort": {
-      "value": "Odessa",
+      "value": "Odesa",
       "confidence": "confirmed",
       "sourceText": "Odessa / Aliaga"
     },
     "originCountry": "Ukraine",
     "destinationPort": {
-      "value": "Aliaga",
+      "value": "Aliağa",
       "confidence": "confirmed",
       "sourceText": "Odessa / Aliaga"
     },
@@ -369,7 +642,7 @@
     "cargoDescription": {
       "value": "Steel billets",
       "confidence": "confirmed",
-      "sourceText": "steel billets"
+      "sourceText": "10.000 mts steel billets"
     },
     "weightMt": {
       "value": 10000,
@@ -384,28 +657,31 @@
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": {
-      "value": "15-20 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "15-20 May"
-    },
+    "preferredDates": null,
     "laycan": "15-20 May 2026",
     "loadingRate": "2500",
     "dischargeRate": "2500",
     "commissionPercent": 2.5,
-    "commissionTerms": "Address commission past us",
+    "commissionTerms": "2.5% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified",
-      "Demurrage and despatch rates not stated"
+      "Vessel DWT/type requirement not specified (only 'described ladies' requested)",
+      "Demurrage and despatch rates not stated",
+      "Steel billet dimensions/section size not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c5000b8200e",
@@ -443,29 +719,96 @@
       "max": 24200
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "01/10 June 2026",
-      "confidence": "confirmed",
-      "sourceText": "01/10 june 2026"
-    },
-    "laycan": "01/10 June 2026",
+    "preferredDates": null,
+    "laycan": "1-10 June 2026",
     "loadingRate": "8000",
     "dischargeRate": "3000",
     "commissionPercent": 3.75,
     "commissionTerms": null,
-    "specialRequirements": "[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": "Geared / grab-fitted vessel required",
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
-      "Loading and discharge laytime terms such as SHINC/SHEX/FIO/CQD not stated",
       "Demurrage and despatch rates not stated",
-      "Final vessel specification unclear because 'Grd' is not recognized with certainty"
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Coal grade/specification not specified"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07c53928a4333",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "East Coast India (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "load 1spsb ec india"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "China (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "disch 1spsb china main port"
+    },
+    "destinationCountry": "China",
+    "cargoDescription": {
+      "value": "Iron ore in bulk",
+      "confidence": "confirmed",
+      "sourceText": "iron ore"
+    },
+    "weightMt": {
+      "value": 55000,
+      "confidence": "interpreted",
+      "sourceText": "55,000mt/10%"
+    },
+    "weightMtMin": 49500,
+    "weightMtMax": 60500,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 49500,
+      "max": 60500
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-24 May 2026",
+    "loadingRate": "15000",
+    "dischargeRate": "15000",
+    "commissionPercent": 5,
+    "commissionTerms": "5% TTL on F/D/D (Freight/Demurrage/Defence); try less",
+    "freightRateUsd": null,
+    "specialRequirements": "1 safe port safe berth load (EC India); 1 safe port safe berth discharge (China main port); voyage charter only — NO TCT",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Specific EC India load port not nominated — 1 safe port safe berth East Coast India TBD",
+      "Specific China discharge port not nominated — 1 safe port safe berth main port TBD",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated; '15000c' = conventional/customary, exact regime TBD",
+      "Demurrage and despatch rates not stated",
+      "'10%' tolerance option-holder (MOLOO/MOLCHOPT) not specified",
+      "Iron ore grade/Fe content not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c5b023cf374",
@@ -489,7 +832,7 @@
     },
     "weightMt": {
       "value": 70000,
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "70000/10pct moloo bulk sugar"
     },
     "weightMtMin": 63000,
@@ -503,30 +846,32 @@
       "max": 77000
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "July 7 onward 2026",
-      "confidence": "interpreted",
-      "sourceText": "july 07 / onwd"
-    },
-    "laycan": "July 7 onward 2026",
+    "preferredDates": null,
+    "laycan": "7 July 2026 onwards",
     "loadingRate": "10000",
     "dischargeRate": "10000",
     "commissionPercent": 5,
     "commissionTerms": null,
-    "specialRequirements": "[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Exact Brazilian load port nomination not fully clear — Santos appears intended but final port should be confirmed",
-      "Specific West Coast India discharge port not nominated — exact port TBD",
+      "Charterer account 'STRC' named but full identity not given",
+      "Exact WC India discharge port not nominated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
+      "Sugar grade/type not specified (raw vs white/refined)"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c6291acbfd4",
@@ -546,13 +891,9 @@
     "cargoDescription": {
       "value": "Steel products, stowage equals deadweight",
       "confidence": "interpreted",
-      "sourceText": "STEEL PRODUCTS STW DWT"
+      "sourceText": "4300-4500 TS STEEL PRODUCTS STW DWT"
     },
-    "weightMt": {
-      "value": 4500,
-      "confidence": "interpreted",
-      "sourceText": "4300-4500 TS"
-    },
+    "weightMt": null,
     "weightMtMin": 4300,
     "weightMtMax": 4500,
     "volumeCbm": null,
@@ -564,31 +905,34 @@
       "max": 4500
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "16-20 May 2026",
-      "confidence": "confirmed",
-      "sourceText": "16-20 MAY"
-    },
+    "preferredDates": null,
     "laycan": "16-20 May 2026",
     "loadingRate": "1500",
     "dischargeRate": "1250",
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL commission",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
     "missingInfo": [
-      "Specific Eastern Mediterranean load port not nominated — exact port TBD",
-      "Specific Western Mediterranean discharge port not nominated — exact port TBD",
-      "Laytime terms are not explicitly stated; the 'x' suffix in 1500x/1250x is not treated as a recognized laytime term",
+      "Specific EMED load port not nominated — exact port TBD",
+      "Specific WMED discharge port not nominated — exact port TBD",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated; '1500x/1250x' suffix 'x' not a recognized term",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Further cargo details available only upon firm interest"
+      "Vessel DWT/type/gear requirement not specified",
+      "Steel product grade/form not specified"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c733f3b71ae",
@@ -606,15 +950,11 @@
     },
     "destinationCountry": "Egypt",
     "cargoDescription": {
-      "value": "Dense soda ash, bulk, stowage factor about 1.1",
+      "value": "Dense soda ash in bulk, stowage factor approximately 1.1",
       "confidence": "interpreted",
       "sourceText": "soda dense bulk stw aabt 1,1"
     },
-    "weightMt": {
-      "value": 10500,
-      "confidence": "interpreted",
-      "sourceText": "abt 10/10.500 mt"
-    },
+    "weightMt": null,
     "weightMtMin": 10000,
     "weightMtMax": 10500,
     "volumeCbm": null,
@@ -626,90 +966,32 @@
       "max": 10500
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "14/16 May 2026",
-      "confidence": "confirmed",
-      "sourceText": "14/16 may"
-    },
-    "laycan": "14/16 May 2026",
+    "preferredDates": null,
+    "laycan": "14-16 May 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 5,
     "commissionTerms": null,
-    "specialRequirements": "[object Object]",
-    "stowageFactor": "about 1.1",
+    "freightRateUsd": null,
+    "specialRequirements": "Box-shaped holds / double-skinned vessel; gearless vessel acceptable; total laytime 7 days (load+discharge combined)",
+    "stowageFactor": "abt 1.1 m³/MT",
     "missingInfo": [
+      "Laytime split/cost-allocation terms (FIO/FIOST/CQD) not stated — only '7 ttl days' total laytime given",
+      "Loading and discharge rates not separately specified",
       "Demurrage and despatch rates not stated",
-      "Stowage factor units not stated",
-      "Incoterms not stated"
+      "Freight rate not indicated"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07c53928a4333",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "1 safe port East Coast India",
-      "confidence": "interpreted",
-      "sourceText": "load 1spsb ec india"
-    },
-    "originCountry": "India",
-    "destinationPort": {
-      "value": "China (port unspecified)",
-      "confidence": "interpreted",
-      "sourceText": "disch 1spsb china main port"
-    },
-    "destinationCountry": "China",
-    "cargoDescription": {
-      "value": "Iron ore",
-      "confidence": "confirmed",
-      "sourceText": "iron ore"
-    },
-    "weightMt": {
-      "value": 55000,
-      "confidence": "confirmed",
-      "sourceText": "55,000mt/10% iron ore"
-    },
-    "weightMtMin": 49500,
-    "weightMtMax": 60500,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 49500,
-      "max": 60500
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "15-24 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "15/24 may"
-    },
-    "laycan": "15-24 May 2026",
-    "loadingRate": "15000",
-    "dischargeRate": "15000",
-    "commissionPercent": 5,
-    "commissionTerms": "TTL here on F/D/D",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Specific East Coast India load port not nominated — exact port TBD",
-      "Specific China main discharge port not nominated — exact port TBD",
-      "Iron ore grade/specification not stated",
-      "Laytime cost-allocation terms such as FIO, CQD, or FIOST not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c7d8deafc02",
@@ -727,20 +1009,16 @@
     },
     "destinationCountry": "Syria",
     "cargoDescription": {
-      "value": "Bagged cement in jumbo bags",
-      "confidence": "confirmed",
-      "sourceText": "baged cement (Jumbo bags)"
-    },
-    "weightMt": {
-      "value": 7000,
+      "value": "Bagged cement in jumbo (big) bags",
       "confidence": "interpreted",
-      "sourceText": "6000 - 7000tns"
+      "sourceText": "6000 - 7000tns baged cement (Jumbo bags)"
     },
+    "weightMt": null,
     "weightMtMin": 6000,
     "weightMtMax": 7000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": {
       "min": 6000,
@@ -748,29 +1026,35 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "Spot; second voyage instantly upon completion of discharging first lot",
+      "value": "Spot",
       "confidence": "interpreted",
-      "sourceText": "SPOT / 2 voy instantly upon completion of discharging 1st lot"
+      "sourceText": "L/C: SPOT"
     },
     "laycan": "Spot",
     "loadingRate": "2000",
     "dischargeRate": "1500",
     "commissionPercent": 2.5,
-    "commissionTerms": "Past us",
-    "specialRequirements": "Two consecutive voyage charters / two voyages: \"x 2 CVC\",Charterers can accept two vessels at loading port if available: \"chrts can accept 2 vsls at loading ports if        available\",Vessel must be geared: \"Vsl shd be geared\",Charterers' agents both ends: \"Chrts agents bends\"",
+    "commissionTerms": "2.5% PUS (past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Vessel must be geared; Charterers' agents both ends; 2 consecutive voyages (x 2 CVC); 2nd voyage instantly upon completion of discharging 1st lot; Charterers can accept 2 vessels at loading ports if available",
     "stowageFactor": null,
     "missingInfo": [
-      "Exact cargo quantity per voyage remains a range of 6,000–7,000 tonnes.",
-      "Demurrage and despatch rates not stated.",
-      "Incoterms not stated.",
-      "Stowage factor not stated.",
-      "Cargo grade/specification for cement not stated."
+      "Tonnage given as range 6000–7000 MT — exact stem quantity TBC",
+      "Demurrage and despatch rates not stated",
+      "Stowage factor not stated",
+      "Freight rate not indicated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07c837ba011a2",
@@ -778,30 +1062,30 @@
     "originPort": {
       "value": "Al Arish",
       "confidence": "confirmed",
-      "sourceText": "Al Arish / Latakia"
+      "sourceText": "Al Arish"
     },
     "originCountry": "Egypt",
     "destinationPort": {
       "value": "Latakia",
       "confidence": "confirmed",
-      "sourceText": "Al Arish / Latakia"
+      "sourceText": "Latakia"
     },
     "destinationCountry": "Syria",
     "cargoDescription": {
-      "value": "Cement in big bags, 1.5 MT each",
+      "value": "Bagged cement in big bags, unit weight 1.5 MT",
       "confidence": "interpreted",
       "sourceText": "bgd Cement in bb1.5"
     },
     "weightMt": {
-      "value": 5500,
-      "confidence": "interpreted",
+      "value": null,
+      "confidence": "confirmed",
       "sourceText": "5.000/5.500mts"
     },
     "weightMtMin": 5000,
     "weightMtMax": 5500,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": {
       "min": 5000,
@@ -809,24 +1093,156 @@
     },
     "incoterms": null,
     "preferredDates": null,
-    "laycan": "12/13 May 2026",
+    "laycan": "12-13 May 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 1.25,
-    "commissionTerms": "Past us",
+    "commissionTerms": "1.25% past us (PUS)",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Cement grade/type not specified",
-      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Freight rate not stated",
       "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Cement grade/type not specified",
+      "Vessel type/DWT requirement not specified",
+      "Quantity given as range 5,000–5,500 MT — final stem to be confirmed"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07c9fb6a61008",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / LIVERPOOL"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Liverpool",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / LIVERPOOL"
+    },
+    "destinationCountry": "United Kingdom",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC), unit weight approximately 10–27 tonnes per coil",
+      "confidence": "interpreted",
+      "sourceText": "HRC UW ABT 10/27TS"
+    },
+    "weightMt": {
+      "value": 2720,
+      "confidence": "confirmed",
+      "sourceText": "2,720mts 2PCT MOLCHOPT HRC"
+    },
+    "weightMtMin": 2666,
+    "weightMtMax": 2774,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 2666,
+      "max": 2774
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-18 May 2026",
+    "loadingRate": "1250",
+    "dischargeRate": "1500",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Freight rate not stated",
+      "Vessel gear requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07c9fb6a61008",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CONSTANTZA"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Constanța",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CONSTANTZA"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Descaled (HRCTD), and Hot Rolled Sheets (HRS), unit weight approximately 10–27 tonnes per coil",
+      "confidence": "interpreted",
+      "sourceText": "HRC + HRCPO + HRCTD UW ABT 10/27TS + HRS"
+    },
+    "weightMt": {
+      "value": 6500,
+      "confidence": "confirmed",
+      "sourceText": "6,500mts 2PCT MOLCHOPT HRC + HRCPO + HRCTD "
+    },
+    "weightMtMin": 6370,
+    "weightMtMax": 6630,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 6370,
+      "max": 6630
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "22-25 May 2026",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Freight rate not stated",
+      "Vessel gear requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07ca31cff6b2a",
@@ -844,7 +1260,73 @@
     },
     "destinationCountry": "Cameroon",
     "cargoDescription": {
-      "value": "20HC containers as cargo, approximately 300 units, unit weight approximately 20 MT each",
+      "value": "Bulk cargo, commodity not specified; vessel required SDBC (single-deck bulk carrier) or tween-decker, smaller vessel acceptable",
+      "confidence": "uncertain",
+      "sourceText": "need 20/30,000mt sdbc try twn (try smaller)"
+    },
+    "weightMt": null,
+    "weightMtMin": 20000,
+    "weightMtMax": 30000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 20000,
+      "max": 30000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "10-20 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Lumpsum freight figures requested; SDBC or tween-decker, smaller vessel acceptable (owner's option); firm cargo",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Bulk commodity not named — grade/type to be confirmed",
+      "Load and discharge ports given as rotation (Damietta + Misurata / Douala + Lagos) — per-port tonnage split not stated",
+      "Tonnage given as range 20,000-30,000 MT — exact stem to be confirmed",
+      "Demurrage and despatch rates not stated",
+      "Stowage factor not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": [
+      "Damietta",
+      "Misurata"
+    ],
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": [
+      "Douala",
+      "Lagos"
+    ],
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07ca31cff6b2a",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Damietta",
+      "confidence": "confirmed",
+      "sourceText": "loading Damietta  + Misurata"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Douala",
+      "confidence": "confirmed",
+      "sourceText": "disch Douala  + Lagos"
+    },
+    "destinationCountry": "Cameroon",
+    "cargoDescription": {
+      "value": "Approximately 300 containers, 20-foot high-cube (20HC), unit weight approximately 20 MT each",
       "confidence": "interpreted",
       "sourceText": "Need to load abt 300 containers 20HC (uw abt 20mt)"
     },
@@ -857,42 +1339,41 @@
     "weightMtMax": null,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "FCL",
     "containerType": "20HC",
     "quantity": 300,
     "incoterms": null,
-    "preferredDates": {
-      "value": "10 / 20 May",
-      "confidence": "confirmed",
-      "sourceText": "10 / 20 May"
-    },
+    "preferredDates": null,
     "laycan": "10-20 May 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object],[object Object]",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Lumpsum freight figures requested",
     "stowageFactor": null,
     "missingInfo": [
-      "Exact cargo weight is not directly stated; total weight was derived from approximately 300 containers at approximately 20 MT each.",
-      "Per-port loading split between Damietta and Misurata not stated.",
-      "Per-port discharge split between Douala and Lagos not stated.",
-      "Demurrage and despatch rates not stated.",
-      "Incoterms not stated.",
-      "Commodity inside the containers not specified.",
-      "Final vessel size/type acceptance requires clarification because SDBC/TWN vessel preference is stated but cargo weight appears much lower than 20,000–30,000 MT."
+      "Container count approximate (abt 300) — exact count to be confirmed",
+      "Per-port container split across rotation not stated",
+      "Demurrage/despatch and laytime for container parcel not stated"
     ],
-    "originPortAlternatives": [],
+    "originPortAlternatives": null,
     "originPortRotation": [
       "Damietta",
       "Misurata"
     ],
-    "destinationPortAlternatives": [],
+    "destinationPortAlternatives": null,
     "destinationPortRotation": [
       "Douala",
       "Lagos"
     ],
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07ca65bfe786c",
@@ -900,23 +1381,23 @@
     "originPort": {
       "value": "Savona",
       "confidence": "confirmed",
-      "sourceText": "Savona /  Samsun"
+      "sourceText": "Savona"
     },
     "originCountry": "Italy",
     "destinationPort": {
       "value": "Samsun",
       "confidence": "confirmed",
-      "sourceText": "Savona /  Samsun"
+      "sourceText": "Samsun"
     },
     "destinationCountry": "Turkey",
     "cargoDescription": {
-      "value": "Metcoke in bulk, 3 grades: Grade 1 2,000 MT +/-10% 60–140 mm, stowage factor approximately 74/75; Grade 2 6,000 MT +/-10% 60–100 mm, stowage factor approximately 69/70; Grade 3 2,000 MT +/-10% 90–250 mm, stowage factor approximately 76/77",
-      "confidence": "confirmed",
-      "sourceText": "metcoke in bulk,3 grades"
+      "value": "Metallurgical coke (metcoke) in bulk, 3 grades, hold-wise grade separation required. Grade 1: 2,000 MT, 60–140mm, stowage factor 74–75; Grade 2: 6,000 MT, 60–100mm, stowage factor 69–70; Grade 3: 2,000 MT, 90–250mm, stowage factor 76–77",
+      "confidence": "interpreted",
+      "sourceText": "Grade 2 : 6.000 mt ( +/-%10) 60-100mm stw abt 69/70 "
     },
     "weightMt": {
       "value": 10000,
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "10.000 mt (+/-10 pct)"
     },
     "weightMtMin": 9000,
@@ -930,29 +1411,31 @@
       "max": 11000
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "11-14 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "11/14 May"
-    },
+    "preferredDates": null,
     "laycan": "11-14 May 2026",
     "loadingRate": "1200",
     "dischargeRate": "3000",
     "commissionPercent": 3.75,
-    "commissionTerms": "ADD PUS",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": "Grade 1: abt 74/75; Grade 2: abt 69/70; Grade 3: abt 76/77",
+    "commissionTerms": "3.75% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Hold-wise grade separation required (3 grades must be segregated by hold)",
+    "stowageFactor": "Grade 1: abt 74–75 ft³/MT; Grade 2: abt 69–70 ft³/MT; Grade 3: abt 76–77 ft³/MT",
     "missingInfo": [
-      "Incoterms not stated",
+      "Loading/discharge cost-allocation terms not explicit — 'sx'/'sc' interpreted as SHEX/SHINC, confirm",
       "Demurrage and despatch rates not stated",
-      "Exact loading and discharge laytime terms are unclear: rate suffixes 'sx' and 'sc' are not recognized as explicit laytime abbreviations",
-      "Stowage-factor units not stated"
+      "Vessel DWT/type requirement not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07caab607dfe5",
@@ -960,7 +1443,7 @@
     "originPort": {
       "value": "Egypt Mediterranean port (unspecified)",
       "confidence": "interpreted",
-      "sourceText": "1Egypt Med/POC"
+      "sourceText": "1Egypt Med"
     },
     "originCountry": "Egypt",
     "destinationPort": {
@@ -970,19 +1453,20 @@
     },
     "destinationCountry": null,
     "cargoDescription": {
-      "value": "Salt in big bags, dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT per big bag",
-      "confidence": "interpreted"
+      "value": "Salt in big bags, dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT",
+      "confidence": "interpreted",
+      "sourceText": "salt in bb salt (1,1x1,1x1,1, uw 1,25)"
     },
     "weightMt": {
       "value": 5000,
       "confidence": "interpreted",
-      "sourceText": "5000/10% mts"
+      "sourceText": "5000/10% mts of salt"
     },
     "weightMtMin": 4500,
     "weightMtMax": 5500,
     "volumeCbm": null,
     "dimensions": "1.1m x 1.1m x 1.1m",
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": {
       "min": 4500,
@@ -990,7 +1474,7 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "Spot / vessel's dates",
+      "value": "Spot",
       "confidence": "interpreted",
       "sourceText": "spot/vsls dates"
     },
@@ -998,28 +1482,2080 @@
     "loadingRate": "1250",
     "dischargeRate": "1250",
     "commissionPercent": 1.25,
-    "commissionTerms": "Past us",
+    "commissionTerms": "1.25% past us (ADDCOMPUS)",
+    "freightRateUsd": null,
     "specialRequirements": null,
-    "stowageFactor": "1.065 m³/MT (derived from dimensions)",
+    "stowageFactor": null,
     "missingInfo": [
       "Specific Egypt-Med load port not nominated — exact port TBD",
-      "Final discharge port nomination pending: Port of Call not specified",
-      "Laytime terms such as SHINC, SHEX, or FIO not stated",
+      "Discharge port unspecified (POC) — to be nominated",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Vessel DWT/type requirement not specified",
       "Demurrage and despatch rates not stated",
-      "Salt grade/specification not stated"
+      "Salt grade/spec not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
-    "emailId": "19e07c9fb6a61008",
+    "emailId": "19e07cbe0a94b74c",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Mersin",
+      "confidence": "confirmed",
+      "sourceText": "Mersin,Turkey"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Tartous",
+      "confidence": "confirmed",
+      "sourceText": "Syria,Tartous"
+    },
+    "destinationCountry": "Syria",
+    "cargoDescription": {
+      "value": "Unpeeled rice in bulk",
+      "confidence": "confirmed",
+      "sourceText": "5000mts unpeeled rice in bulk"
+    },
+    "weightMt": {
+      "value": 5000,
+      "confidence": "confirmed",
+      "sourceText": "5000mts"
+    },
+    "weightMtMin": 5000,
+    "weightMtMax": 5000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot/Prompt",
+      "confidence": "confirmed",
+      "sourceText": "Spot/Prompt"
+    },
+    "laycan": "Prompt",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% PUS (Past Us / Address Commission)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Total laytime '10 ttl days try 9' stated but not split into load/discharge rates or terms",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified",
+      "Rice grade/specification not stated (unpeeled/paddy variety)"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cc094fc3aa2",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Adabiya",
+      "confidence": "confirmed",
+      "sourceText": "1 ADABIYA OR SAFAGA OR AIN SOKHNA"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Semarang",
+      "confidence": "confirmed",
+      "sourceText": "SEMARANG, INDONESIA"
+    },
+    "destinationCountry": "Indonesia",
+    "cargoDescription": {
+      "value": "Rock Phosphate in bulk",
+      "confidence": "confirmed",
+      "sourceText": "ROCK PHOSPHATE IN BULK"
+    },
+    "weightMt": null,
+    "weightMtMin": 20000,
+    "weightMtMax": 33000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 20000,
+      "max": 33000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-30 May 2026",
+    "loadingRate": "5000",
+    "dischargeRate": "2500",
+    "commissionPercent": 2.5,
+    "commissionTerms": "TTL",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Final load port nomination pending (charterer's option: Adabiya or Safaga or Ain Sokhna)",
+      "Rock phosphate grade not specified (e.g. BPL grade)",
+      "Demurrage and despatch rates not stated",
+      "Stowage factor not stated",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": [
+      "Safaga",
+      "Ain Sokhna"
+    ],
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cc3ba833475",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Thisvi",
+      "confidence": "confirmed",
+      "sourceText": "Thisvi  / Monfalcone"
+    },
+    "originCountry": "Greece",
+    "destinationPort": {
+      "value": "Monfalcone",
+      "confidence": "confirmed",
+      "sourceText": "Thisvi  / Monfalcone"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Cargo not specified",
+      "confidence": "uncertain",
+      "sourceText": "for the fol firm cargo"
+    },
+    "weightMt": null,
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "OTHER",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "17-22 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.50% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "BOX-shaped vessel required; vessel 12,000-14,000 DWT; 6 total laytime days both ends (SSHEX EIU); free disbursement accounts both ends (free D/As BENDS)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Commodity not specified — cargo type and quantity unknown (sender is a grain trader, but no cargo named)",
+      "Cargo quantity (MT) not stated; 12,000-14,000 DWT refers to required vessel size, not cargo weight",
+      "Demurrage and despatch rates not stated",
+      "Freight rate not indicated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cd18529fb77",
     "itemIndex": 0,
     "originPort": {
       "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "Nemrut"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Djibouti or Tadjourah",
       "confidence": "interpreted",
+      "sourceText": "1 Djibouti or 1 Tadjourah in chopt"
+    },
+    "destinationCountry": "Djibouti",
+    "cargoDescription": {
+      "value": "Steel products, stowage equals deadweight",
+      "confidence": "interpreted",
+      "sourceText": "Steel Products stw = dwt"
+    },
+    "weightMt": null,
+    "weightMtMin": 8000,
+    "weightMtMax": 9000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 8000,
+      "max": 9000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "7-10 May 2026",
+    "loadingRate": "1500",
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Combinable or not with the Berbera steel parcel (same email)",
+    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
+    "missingInfo": [
+      "Final discharge port nomination pending (charterer's option: Djibouti or Tadjourah)",
+      "Steel product grade/form not specified",
+      "Demurrage and despatch rates not stated",
+      "Discharge rate not stated (only Liner out terms given)"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": [
+      "Tadjourah"
+    ],
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cd18529fb77",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "Nemrut"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Berbera",
+      "confidence": "confirmed",
+      "sourceText": "Barbera Somalia"
+    },
+    "destinationCountry": "Somalia",
+    "cargoDescription": {
+      "value": "Steel products, stowage equals deadweight",
+      "confidence": "interpreted",
+      "sourceText": "Steel Products stw = dwt"
+    },
+    "weightMt": {
+      "value": 2800,
+      "confidence": "interpreted",
+      "sourceText": "2800 mts %10 Steel Products"
+    },
+    "weightMtMin": 2520,
+    "weightMtMax": 3080,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 2520,
+      "max": 3080
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "7-10 May 2026",
+    "loadingRate": "1000",
+    "dischargeRate": "500",
+    "commissionPercent": 2.5,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Combinable or not with the Djibouti/Tadjourah steel parcel (same email)",
+    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
+    "missingInfo": [
+      "Steel product grade/form not specified",
+      "Demurrage and despatch rates not stated",
+      "'%10' tolerance assumed as ±10% MOLOO — exact basis to confirm"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cd83bad47a5",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "King Abdullah",
+      "confidence": "interpreted",
+      "sourceText": "KING ABDULLAH or YANBU"
+    },
+    "originCountry": "Saudi Arabia",
+    "destinationPort": {
+      "value": "Ravenna",
+      "confidence": "confirmed",
+      "sourceText": "/ RAVENNA"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Hot Rolled Steel Coils (HRC), maximum unit weight 30 MT",
+      "confidence": "interpreted",
+      "sourceText": "35.000 mts 10% HOT ROLLED STEEL COILS, MAX UW 30 MT"
+    },
+    "weightMt": {
+      "value": 35000,
+      "confidence": "interpreted",
+      "sourceText": "35.000 mts 10%"
+    },
+    "weightMtMin": 31500,
+    "weightMtMax": 38500,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 31500,
+      "max": 38500
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "20 May 2026 onwards",
+      "confidence": "confirmed",
+      "sourceText": "from 20th MAY onwards"
+    },
+    "laycan": "20 May 2026 onwards",
+    "loadingRate": "2500",
+    "dischargeRate": "4000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Max unit weight 30 MT per coil",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Final load port nomination pending (charterer's option: King Abdullah or Yanbu)",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type/gear requirement not specified"
+    ],
+    "originPortAlternatives": [
+      "Yanbu"
+    ],
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cdb7df50d0f",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Alexandria",
+      "confidence": "confirmed",
+      "sourceText": "Alexandria / Braila"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Braila",
+      "confidence": "confirmed",
+      "sourceText": "Alexandria / Braila"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "Salt in big bags, dimensions 90cm × 90cm × 90cm, unit weight 1.5 MT, fully stackable",
+      "confidence": "interpreted",
+      "sourceText": "4000 mts salt in bb – dim: 90x90x90 cm, uw: 1.5 mts – fully stackable"
+    },
+    "weightMt": {
+      "value": 4000,
+      "confidence": "confirmed",
+      "sourceText": "m/m 4000 mts salt"
+    },
+    "weightMtMin": 4000,
+    "weightMtMax": 4000,
+    "volumeCbm": null,
+    "dimensions": "90cm × 90cm × 90cm",
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "Spot – try vsl dates"
+    },
+    "laycan": "Spot — vessel's dates",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 6,
+    "commissionTerms": "6% TTL; 2.5%",
+    "freightRateUsd": null,
+    "specialRequirements": "Fully stackable big bags",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Loading and discharge rates/laytime terms not stated",
+      "Demurrage and despatch rates not stated",
+      "Freight rate not indicated (broker offers to provide frt idea for suitable vsl)",
+      "Salt grade/specification not specified",
+      "Original fixture failed — substitute vessel required"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cde4af25d45",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Aliağa",
+      "confidence": "confirmed",
+      "sourceText": "Aliaga / Varna"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Varna",
+      "confidence": "confirmed",
+      "sourceText": "Aliaga / Varna"
+    },
+    "destinationCountry": "Bulgaria",
+    "cargoDescription": {
+      "value": "Clay in bulk",
+      "confidence": "interpreted",
+      "sourceText": "abt 10.000t blk clay"
+    },
+    "weightMt": {
+      "value": 10000,
+      "confidence": "interpreted",
+      "sourceText": "abt 10.000t blk clay"
+    },
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "25-30 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 3.75,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "6 total laytime days (reversible, load + discharge)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Demurrage and despatch rates not stated",
+      "Separate load/discharge rates not given — only '6 ttl days' total laytime",
+      "Vessel DWT/type requirement not specified",
+      "Clay grade/specification not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07ce171ab8e10",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Iskenderun",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun/Constanta"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Constanța",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun/Constanta"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "Minerals in bulk, non-IMO (non-hazardous)",
+      "confidence": "interpreted",
+      "sourceText": "7.000mts blk minerals,not imo"
+    },
+    "weightMt": {
+      "value": 7000,
+      "confidence": "confirmed",
+      "sourceText": "7.000mts blk minerals"
+    },
+    "weightMtMin": 7000,
+    "weightMtMax": 7000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-20 May 2026",
+    "loadingRate": "3000",
+    "dischargeRate": "2500",
+    "commissionPercent": 2.5,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Mineral grade/type not specified",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07ce84fc34a82",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Jorf Lasfar",
+      "confidence": "confirmed",
+      "sourceText": "Jorf Lasfar"
+    },
+    "originCountry": "Morocco",
+    "destinationPort": {
+      "value": "Yarımca",
+      "confidence": "confirmed",
+      "sourceText": "Yarımca (Marmara) + Samsun"
+    },
+    "destinationCountry": "Turkey",
+    "cargoDescription": {
+      "value": "Fertilizers",
+      "confidence": "confirmed",
+      "sourceText": "Ttl 20,000 mts Fertilizers"
+    },
+    "weightMt": {
+      "value": 20000,
+      "confidence": "confirmed",
+      "sourceText": "Ttl 20,000 mts"
+    },
+    "weightMtMin": 20000,
+    "weightMtMax": 20000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "19-21 May 2026",
+    "loadingRate": null,
+    "dischargeRate": "3000",
+    "commissionPercent": 2.5,
+    "commissionTerms": "TTL",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Load rate stated as 'Scale (Africanphos)' — refers to a terminal loading scale, no numeric MT/day given",
+      "Per-port discharge tonnage split between Yarımca and Samsun not specified",
+      "Fertilizer grade/type not specified",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": [
+      "Yarımca",
+      "Samsun"
+    ],
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07ceac0ca69dc",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Kavkaz",
+      "confidence": "confirmed",
+      "sourceText": "Kavkaz/Berbera"
+    },
+    "originCountry": "Russia",
+    "destinationPort": {
+      "value": "Berbera",
+      "confidence": "confirmed",
+      "sourceText": "Kavkaz/Berbera"
+    },
+    "destinationCountry": "Somalia",
+    "cargoDescription": {
+      "value": "Wheat in bulk, stowage factor 47",
+      "confidence": "interpreted",
+      "sourceText": "30000 mt 10% in OO wheat SF 47"
+    },
+    "weightMt": {
+      "value": 30000,
+      "confidence": "confirmed",
+      "sourceText": "30000 mt 10% in OO"
+    },
+    "weightMtMin": 27000,
+    "weightMtMax": 33000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 27000,
+      "max": 33000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "19-22 May 2026",
+    "loadingRate": "5000",
+    "dischargeRate": "4000",
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% PUS (past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Geared vessel required at discharge port",
+    "stowageFactor": "47 ft³/MT",
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Stowage factor unit not specified (SF 47 — assumed ft³/MT)"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cf3d4f572fc",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Egypt Mediterranean port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Egypt Med/POC"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Port of Call (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Egypt Med/POC"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Salt in big bags, dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT",
+      "confidence": "interpreted",
+      "sourceText": "5500 mts of salt in bb"
+    },
+    "weightMt": {
+      "value": 5500,
+      "confidence": "confirmed",
+      "sourceText": "5500 mts of salt in bb"
+    },
+    "weightMtMin": 5500,
+    "weightMtMax": 5500,
+    "volumeCbm": null,
+    "dimensions": "1.1m × 1.1m × 1.1m",
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "10-12 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "10-12/05"
+    },
+    "laycan": "10-12 May 2026",
+    "loadingRate": "1250",
+    "dischargeRate": "1250",
+    "commissionPercent": 1.25,
+    "commissionTerms": "1.25% PAST US (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Specific Egypt-Med load port not nominated — exact port TBD",
+      "Discharge port not nominated (POC — Port of Call)",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cf3d4f572fc",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Damietta",
+      "confidence": "confirmed",
+      "sourceText": "Damietta+Mersin/POC"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Port of Call (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Damietta+Mersin/POC"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Salt and rice in big bags; salt dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT; rice dimensions 1.05m × 1.05m × 1.35m, unit weight 1 MT",
+      "confidence": "interpreted",
+      "sourceText": "\n(1,1x1,1x1,1, uw 1,25) + rice (1,05x1,05x1,35, uw 1 mt)"
+    },
+    "weightMt": null,
+    "weightMtMin": 6000,
+    "weightMtMax": 7000,
+    "volumeCbm": null,
+    "dimensions": "salt 1.1m × 1.1m × 1.1m; rice 1.05m × 1.05m × 1.35m",
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 6000,
+      "max": 7000
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "15-18 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "15-18/05"
+    },
+    "laycan": "15-18 May 2026",
+    "loadingRate": "1250",
+    "dischargeRate": "1250",
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.50% PAST US (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Cargo split between salt and rice not specified (combined 6000-7000 mts)",
+      "Damietta + Mersin = load rotation (both ports called); per-port tonnage not stated",
+      "Discharge port not nominated (POC — Port of Call)",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": [
+      "Damietta",
+      "Mersin"
+    ],
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07cfdf63e232b",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Vasto",
+      "confidence": "confirmed",
+      "sourceText": "Vasto / 1 Cyprus"
+    },
+    "originCountry": "Italy",
+    "destinationPort": {
+      "value": "Cyprus (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "1 Cyprus"
+    },
+    "destinationCountry": "Cyprus",
+    "cargoDescription": {
+      "value": "Gypsum boards, vessel requiring minimum 5,000 cbm bale capacity",
+      "confidence": "interpreted",
+      "sourceText": "abt 2.500mt gypsum boards/need min 5000cbm baler"
+    },
+    "weightMt": {
+      "value": 2500,
+      "confidence": "interpreted",
+      "sourceText": "abt 2.500mt gypsum boards"
+    },
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "10-15 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 3.75,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Vessel must have minimum 5,000 cbm bale capacity",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Specific Cyprus discharge port not nominated — exact port TBD",
+      "Laytime/cost-allocation terms unclear — 'ttl days' (total laytime days) stated but no MT/day load/discharge rate or FIO/CQD regime given",
+      "Demurrage and despatch rates not stated",
+      "Freight rate not indicated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d011dbc661e",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Giurgiulești",
+      "confidence": "confirmed",
+      "sourceText": "Giurgiuleshti - EC Greece"
+    },
+    "originCountry": "Moldova",
+    "destinationPort": {
+      "value": "East Coast Greece port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "EC Greece"
+    },
+    "destinationCountry": "Greece",
+    "cargoDescription": {
+      "value": "Corn, stowage factor 51–52, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "3000 mts of corn, sf 51-52, wog"
+    },
+    "weightMt": {
+      "value": 3000,
+      "confidence": "confirmed",
+      "sourceText": "3000 mts of corn"
+    },
+    "weightMtMin": 3000,
+    "weightMtMax": 3000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "From 15 May 2026",
+    "loadingRate": "1000",
+    "dischargeRate": "1000",
+    "commissionPercent": 1.25,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "51–52 ft³/MT WOG",
+    "missingInfo": [
+      "Specific East Coast Greece discharge port not nominated",
+      "Demurrage and despatch rates not stated",
+      "Laytime cost-allocation terms (FIO/CQD) not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d011dbc661e",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Reni",
+      "confidence": "confirmed",
+      "sourceText": "Reni - EC Greece"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "East Coast Greece port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "EC Greece"
+    },
+    "destinationCountry": "Greece",
+    "cargoDescription": {
+      "value": "Wheat, stowage factor 48, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "3000-4000 mts of wheat, sf 48, wog"
+    },
+    "weightMt": null,
+    "weightMtMin": 3000,
+    "weightMtMax": 4000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 3000,
+      "max": 4000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "From 15 May 2026",
+    "loadingRate": "1000",
+    "dischargeRate": "1000",
+    "commissionPercent": 1.25,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "48 ft³/MT WOG",
+    "missingInfo": [
+      "Specific East Coast Greece discharge port not nominated",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d011dbc661e",
+    "itemIndex": 2,
+    "originPort": {
+      "value": "Reni",
+      "confidence": "confirmed",
+      "sourceText": "Reni - Marmara or Izmir, in ch's op."
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "Marmara or Izmir",
+      "confidence": "interpreted",
+      "sourceText": "Marmara or Izmir, in ch's op."
+    },
+    "destinationCountry": "Turkey",
+    "cargoDescription": {
+      "value": "Scrap cargo; vessel with approximately 250,000 cubic feet required (any vessel intake may be tried)",
+      "confidence": "interpreted",
+      "sourceText": "need vessel with 250000 cub.ft. (+/-) for scrap cargo (but may try any vessel's intake)"
+    },
+    "weightMt": null,
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "From 1 June 2026",
+    "loadingRate": "600",
+    "dischargeRate": "1000",
+    "commissionPercent": 1.25,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Vessel with approx 250,000 cubic feet capacity",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Final discharge port nomination pending (charterer's option: Marmara or Izmir)",
+      "Cargo tonnage not specified (only vessel cubic capacity given)",
+      "Scrap grade/type not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": [
+      "Izmir"
+    ],
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d011dbc661e",
+    "itemIndex": 3,
+    "originPort": {
+      "value": "Port of Call (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "POC - EC Greece"
+    },
+    "originCountry": null,
+    "destinationPort": {
+      "value": "East Coast Greece port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "EC Greece"
+    },
+    "destinationCountry": "Greece",
+    "cargoDescription": {
+      "value": "Corn, stowage factor 51, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "4000-6000  mts of corn, sf 51, wog"
+    },
+    "weightMt": null,
+    "weightMtMin": 4000,
+    "weightMtMax": 6000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 4000,
+      "max": 6000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "Spot — vessel's dates",
+    "loadingRate": "1000",
+    "dischargeRate": "1000",
+    "commissionPercent": 1.25,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "51 ft³/MT WOG",
+    "missingInfo": [
+      "Load port not nominated (POC)",
+      "Specific East Coast Greece discharge port not nominated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d011dbc661e",
+    "itemIndex": 4,
+    "originPort": {
+      "value": "Chornomorsk",
+      "confidence": "confirmed",
+      "sourceText": "Chornomorsk - Poti"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "Poti",
+      "confidence": "confirmed",
+      "sourceText": "Chornomorsk - Poti"
+    },
+    "destinationCountry": "Georgia",
+    "cargoDescription": {
+      "value": "Sugar in big bags, dimensions 120cm × 100cm × 110cm, unit weight approximately 1.0 tonnes",
+      "confidence": "interpreted",
+      "sourceText": "3000-3500 mts of sugar in bb (dims: LxBxH: 120x100x110cm, UW: abt 1,0 tns)"
+    },
+    "weightMt": null,
+    "weightMtMin": 3000,
+    "weightMtMax": 3500,
+    "volumeCbm": null,
+    "dimensions": "120cm x 100cm x 110cm",
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 3000,
+      "max": 3500
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "2-7 June 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Preferably open hatch / box shaped, IACS or equivalent class, no tier limitations",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": "IACS"
+  },
+  {
+    "emailId": "19e07d011dbc661e",
+    "itemIndex": 5,
+    "originPort": {
+      "value": "Port of Call (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "POC - Douala, Cameroon"
+    },
+    "originCountry": null,
+    "destinationPort": {
+      "value": "Douala",
+      "confidence": "confirmed",
+      "sourceText": "POC - Douala, Cameroon"
+    },
+    "destinationCountry": "Cameroon",
+    "cargoDescription": {
+      "value": "Milling wheat, stowage factor 48–49, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "25000-30000 mts of milling wheat, sf 48-49, wog"
+    },
+    "weightMt": null,
+    "weightMtMin": 25000,
+    "weightMtMax": 30000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 25000,
+      "max": 30000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "First half of May 2026",
+    "loadingRate": "6000",
+    "dischargeRate": "2500",
+    "commissionPercent": 1.25,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Self-unloading cranes required (grabs available at discharge port); max draft 8.5m at Douala",
+    "stowageFactor": "48–49 ft³/MT WOG",
+    "missingInfo": [
+      "Load port not nominated (POC)"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d056d1ba5aa",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Abidjan",
+      "confidence": "confirmed",
+      "sourceText": "Loading port: Abidjan, CoteDivoire"
+    },
+    "originCountry": "Côte d'Ivoire",
+    "destinationPort": {
+      "value": "Dongguan",
+      "confidence": "confirmed",
+      "sourceText": "1sp Dongguan, China"
+    },
+    "destinationCountry": "China",
+    "cargoDescription": {
+      "value": "Bauxite, quantity flexible",
+      "confidence": "interpreted",
+      "sourceText": "45,000-60,000mt bauxite(qtty flexible)"
+    },
+    "weightMt": {
+      "value": null,
+      "confidence": "confirmed",
+      "sourceText": "45,000-60,000mt bauxite(qtty flexible)"
+    },
+    "weightMtMin": 45000,
+    "weightMtMax": 60000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 45000,
+      "max": 60000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "10 May 2026 onwards",
+    "loadingRate": "11000",
+    "dischargeRate": "12000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% address commission on FDD (freight/deadfreight/demurrage) to charterers + 1.25% Tlmarineco brokerage",
+    "freightRateUsd": null,
+    "specialRequirements": "Discharge port requires open book; 1 safe port Dongguan",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Cargo quantity flexible between 45,000–60,000 mt — exact stem TBD",
+      "Bauxite grade/specification not stated",
+      "Stowage factor not stated",
+      "Demurrage and despatch rates not stated",
+      "Freight rate not indicated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d0f8e19df79",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Kandla",
+      "confidence": "confirmed",
+      "sourceText": "Kandla / Ravenna"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "Ravenna",
+      "confidence": "confirmed",
+      "sourceText": "Kandla / Ravenna"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Clay and kaolin in bulk, 4 grades",
+      "confidence": "interpreted",
+      "sourceText": "abt 40.000-43.000 mts moloo clay and caolin in bulk"
+    },
+    "weightMt": {
+      "value": null,
+      "confidence": "interpreted",
+      "sourceText": "abt 40.000-43.000 mts moloo"
+    },
+    "weightMtMin": 40000,
+    "weightMtMax": 43000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 40000,
+      "max": 43000
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "10th May onwards",
+      "confidence": "confirmed",
+      "sourceText": "10th May onwards"
+    },
+    "laycan": "10 May 2026 onwards",
+    "loadingRate": "10000",
+    "dischargeRate": "6000",
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% PUS (past us / address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Geared vessel preferred; max draft 10.5m (Kandla); 4 grades loading required",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Conflicting/range tonnage 40,000–43,000 mts with MOLOO — final lifting quantity TBC",
+      "Freight rate not stated — broker offers 'last done' (actual figure TBD)",
+      "Draft figure 10.5m given (Kandla) but air/length/beam limits not stated",
+      "4 grades to be loaded — grade specs not provided",
+      "Geared only preferred, not mandatory — gearless acceptability unclear",
+      "Demurrage/despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d149d83b38a",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Beira",
+      "confidence": "confirmed",
+      "sourceText": "Beira (Mozambique)"
+    },
+    "originCountry": "Mozambique",
+    "destinationPort": {
+      "value": "Pozzallo",
+      "confidence": "confirmed",
+      "sourceText": "Pozzallo (Italy)"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Granite Blocks, max unit weight 30 tonnes",
+      "confidence": "interpreted",
+      "sourceText": "Granite Blocks  (max uw 30 tns)"
+    },
+    "weightMt": null,
+    "weightMtMin": 4800,
+    "weightMtMax": 5900,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 4800,
+      "max": 5900
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot / prompt",
+      "confidence": "interpreted",
+      "sourceText": "SPOT / ppt"
+    },
+    "laycan": "Spot",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Geared vessel preferred; sole or part cargo acceptable (Pcgo ok)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Geared vessel preferred but not mandatory — gear requirement not firm",
+      "Demurrage and despatch rates not stated",
+      "Loading rate not specified (Cop = custom of port)",
+      "Cargo quantity given as range 4,800–5,900 MT — exact stem TBC"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d186df6a788",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Hereke",
+      "confidence": "confirmed",
+      "sourceText": "1Marmara (Hereke) / Constanta"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Constanța",
+      "confidence": "confirmed",
+      "sourceText": "Marmara (Hereke) / Constanta"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "PC Strand (prestressed concrete steel strand), diameter 130–140 cm, height 80 cm, unit weight 3–3.5 MT, tier limit 2",
+      "confidence": "interpreted",
+      "sourceText": "PC Strand,  Diameter :130-140 cm,  H: 80 cm UW: 3-3,5 MT, Tier"
+    },
+    "weightMt": {
+      "value": 2500,
+      "confidence": "confirmed",
+      "sourceText": "2500 mts"
+    },
+    "weightMtMin": 2500,
+    "weightMtMax": 2500,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "11-13 May 2026",
+    "loadingRate": "1000",
+    "dischargeRate": "800",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Tier limit: 2 (max 2 tiers stacking)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Laytime cost-allocation terms (FIO/FIOST/CQD) not stated — '1000 x / 800 x' gives rates only, 'x' suffix not a recognized laytime abbreviation",
+      "Vessel type/gear requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d186df6a788",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Iskenderun",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun / Ghent"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Ghent",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun / Ghent"
+    },
+    "destinationCountry": "Belgium",
+    "cargoDescription": {
+      "value": "Steel rebars",
+      "confidence": "interpreted",
+      "sourceText": "10000 mts steel rebars %3 mol chopt"
+    },
+    "weightMt": {
+      "value": 10000,
+      "confidence": "confirmed",
+      "sourceText": "10000 mts steel rebars %3 mol chopt"
+    },
+    "weightMtMin": 9700,
+    "weightMtMax": 10300,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 9700,
+      "max": 10300
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "6-9 June 2026",
+    "loadingRate": "2000",
+    "dischargeRate": "3000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% address commission past us (ADDCOMPUS); 3% MOLCHOPT quantity tolerance (charterer's option)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Laytime cost-allocation terms (FIO/FIOST/CQD) not stated — '2000 x / 3000 x' gives rates only",
+      "Vessel type/gear requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d1b2ba77051",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Hereke",
+      "confidence": "confirmed",
+      "sourceText": "Hereke / Constanta"
+    },
+    "originCountry": "Türkiye",
+    "destinationPort": {
+      "value": "Constanța",
+      "confidence": "confirmed",
+      "sourceText": "Hereke / Constanta"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "PC Strand (prestressed concrete steel strand), diameter 130–140 cm, height 80 cm, unit weight 3–3.5 MT, tier limit 2",
+      "confidence": "interpreted",
+      "sourceText": "PC Strand,  Diameter :130-140 cm,  H: 80 cm UW: 3-3,5 MT, Tier"
+    },
+    "weightMt": {
+      "value": 2500,
+      "confidence": "confirmed",
+      "sourceText": "2500 mts"
+    },
+    "weightMtMin": 2500,
+    "weightMtMax": 2500,
+    "volumeCbm": null,
+    "dimensions": "Diameter 130–140 cm, H 80 cm",
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "11-13 May 2026",
+    "loadingRate": "1000",
+    "dischargeRate": "800",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% Address Commission Past Us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Tier limit 2 (max 2 tiers stacking)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Load/discharge rate suffix 'x' ambiguous — SHEX not assumed",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified",
+      "Unit weight conflict possible: diameter 130–140 cm unusually large for PC strand — confirm cargo specs"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d1ec45291d1",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Visakhapatnam",
+      "confidence": "confirmed",
+      "sourceText": "load port : vizag , india"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "Vanino",
+      "confidence": "confirmed",
+      "sourceText": "discharge port : vanino , russia ( 10.2m )"
+    },
+    "destinationCountry": "Russia",
+    "cargoDescription": {
+      "value": "Alumina in bulk, 5% MOLOO",
+      "confidence": "interpreted",
+      "sourceText": "40,000 mts 5pct moloo alumina in bulk"
+    },
+    "weightMt": {
+      "value": 40000,
+      "confidence": "confirmed",
+      "sourceText": "40,000 mts 5pct moloo alumina"
+    },
+    "weightMtMin": 38000,
+    "weightMtMax": 42000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 38000,
+      "max": 42000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15 May 2026 onwards",
+    "loadingRate": "5000",
+    "dischargeRate": "3700",
+    "commissionPercent": 3.5,
+    "commissionTerms": "3.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Discharge port draft 10.2m at Vanino",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Vessel particulars/itinerary requested before rate guidance ('serious named tng with full parti/full itin')",
+      "Demurrage and despatch rates not stated",
+      "Stowage factor for alumina not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d2ac4a815b4",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Marmara",
+      "confidence": "interpreted",
+      "sourceText": "1 Marmara /Constanta"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Constanța",
+      "confidence": "confirmed",
+      "sourceText": "1 Marmara /Constanta"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "Steel Billets",
+      "confidence": "confirmed",
+      "sourceText": "Steel Billets"
+    },
+    "weightMt": {
+      "value": 7200,
+      "confidence": "interpreted",
+      "sourceText": "Min 7200 tons up to fcc in chopt"
+    },
+    "weightMtMin": 7200,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "18-20 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "18/20 May – Try tick earlier/later"
+    },
+    "laycan": "18-20 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Load port vague — 'Marmara' is region, specific port TBN",
+      "Max quantity open — 'up to fcc (full cargo capacity) in chopt', only minimum 7200 mt stated",
+      "Laytime/cargo-handling rates not stated ('Total days' only — total laytime regime unspecified)",
+      "Demurrage and despatch rates not stated",
+      "Steel billet dimensions/unit weight not given",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d3145be13c8",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Izmir (Alsancak)",
+      "confidence": "confirmed",
+      "sourceText": "izmir  Alsancak"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Arzew",
+      "confidence": "confirmed",
+      "sourceText": "Arzew"
+    },
+    "destinationCountry": "Algeria",
+    "cargoDescription": {
+      "value": "10 units mobile machinery, total weight approximately 600 MT, over-deck stowage acceptable, drawing available (dimensions/per-unit weights not stated)",
+      "confidence": "interpreted",
+      "sourceText": "Part cargo -over deck  ok ,.drawing available"
+    },
+    "weightMt": {
+      "value": 600,
+      "confidence": "interpreted",
+      "sourceText": "ttl weight : abt  600 mt"
+    },
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "PROJECT",
+    "containerType": null,
+    "quantity": 10,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Stem ready",
+      "confidence": "interpreted",
+      "sourceText": "stem ready -best offer"
+    },
+    "laycan": "12-15 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Partial cargo acceptable (Pcgo ok); Over-deck stowage acceptable; Drawing available; Laycan tied to vessel's date ('try vsl date')",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Project cargo unit dimensions and per-unit weights not stated (drawing available — request it)",
+      "Laytime split between load/discharge not specified (only 6 total days given)",
+      "Demurrage and despatch rates not stated",
+      "Vessel type/DWT requirement not specified",
+      "Freight rate not indicated ('best offer' requested)"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d3581dc9d89",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Iskenderun",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun / 1 Greece"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Greece (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Iskenderun / 1 Greece"
+    },
+    "destinationCountry": "Greece",
+    "cargoDescription": {
+      "value": "Cement in big bags",
+      "confidence": "interpreted",
+      "sourceText": "cement in big bags"
+    },
+    "weightMt": {
+      "value": 3000,
+      "confidence": "confirmed",
+      "sourceText": "3000 mts cement in big bags"
+    },
+    "weightMtMin": 3000,
+    "weightMtMax": 3000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "11-16 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "11 - 16 May"
+    },
+    "laycan": "11-16 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Total laytime 4 days both ends (4 ttl days); Exclusive firm cargo — do not recirculate",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Specific Greek discharge port not nominated (stated as '1 Greece')",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Loading and discharge rates (MT/day) not specified — only total 4 days laytime given",
+      "Demurrage and despatch rates not stated",
+      "Freight rate not indicated",
+      "Vessel type/DWT requirement not specified",
+      "Cement grade/packaging detail (bag size, unit weight) not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d37f2c8cd77",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Iskenderun",
+      "confidence": "confirmed",
+      "sourceText": "2 SB Iskenderun"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Port of Call, Ukraine (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "POC/Ukraine"
+    },
+    "destinationCountry": "Ukraine",
+    "cargoDescription": {
+      "value": "Steel products, stowage equals deadweight (5,000 MT from Tosyali + 2,700–2,800 MT from Isdemir)",
+      "confidence": "interpreted",
+      "sourceText": "7700-7800 Mts steel prod. stw=dwt"
+    },
+    "weightMt": null,
+    "weightMtMin": 7700,
+    "weightMtMax": 7800,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 7700,
+      "max": 7800
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "15-16 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "15-16 May"
+    },
+    "laycan": "15-16 May 2026",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 3.75,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "2 safe berths at load port (2 SB); All hold type workable; Split load: 5,000 MT from Tosyali + 2,700–2,800 MT from Isdemir",
+    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
+    "missingInfo": [
+      "Final Ukraine discharge port not nominated (POC/Ukraine)",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Loading/discharge rate notation '1500x' — 'x' suffix not a recognized laytime term; SHEX/SHINC not inferred",
+      "Demurrage and despatch rates not stated",
+      "Cargo quantity given as range 7,700–7,800 MT"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d37f2c8cd77",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Hereke",
+      "confidence": "confirmed",
+      "sourceText": "Hereke/Batumi"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Batumi",
+      "confidence": "confirmed",
+      "sourceText": "Hereke/Batumi"
+    },
+    "destinationCountry": "Georgia",
+    "cargoDescription": {
+      "value": "Steel rebars",
+      "confidence": "confirmed",
+      "sourceText": "6645 Mts Steel Rebars"
+    },
+    "weightMt": {
+      "value": 6645,
+      "confidence": "confirmed",
+      "sourceText": "6645 Mts"
+    },
+    "weightMtMin": 6645,
+    "weightMtMax": 6645,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "20-25 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "20-25 May"
+    },
+    "laycan": "20-25 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 3.75,
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "8 total days is combined laytime for both ends (not split load/discharge rates)",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d4069745393",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Alexandria",
+      "confidence": "confirmed",
+      "sourceText": "Alexandria/Tartous"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Tartous",
+      "confidence": "confirmed",
+      "sourceText": "Alexandria/Tartous"
+    },
+    "destinationCountry": "Syria",
+    "cargoDescription": {
+      "value": "Clinker in bulk",
+      "confidence": "confirmed",
+      "sourceText": "25,000 MT blk Clinker"
+    },
+    "weightMt": {
+      "value": 25000,
+      "confidence": "confirmed",
+      "sourceText": "25,000 MT blk Clinker"
+    },
+    "weightMtMin": 25000,
+    "weightMtMax": 25000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "10-12 May 2026",
+    "loadingRate": "8000",
+    "dischargeRate": "5000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified",
+      "Freight rate not indicated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d4742474163",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
       "sourceText": "NEMRUT / LIVERPOOL"
     },
     "originCountry": "Turkey",
@@ -1051,41 +3587,47 @@
     },
     "incoterms": null,
     "preferredDates": null,
-    "laycan": "15 / 18 MAY 2026",
+    "laycan": "15-18 May 2026",
     "loadingRate": "1250",
     "dischargeRate": "1500",
     "commissionPercent": 3.75,
-    "commissionTerms": "ADDCOMPUS",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
       "Demurrage and despatch rates not stated",
-      "Cargo grade/specification beyond HRC not stated"
+      "Freight rate not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
-    "emailId": "19e07c9fb6a61008",
+    "emailId": "19e07d4742474163",
     "itemIndex": 1,
     "originPort": {
       "value": "Nemrut Bay",
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "NEMRUT / CONSTANTZA"
     },
     "originCountry": "Turkey",
     "destinationPort": {
       "value": "Constanța",
-      "confidence": "interpreted",
-      "sourceText": "CONSTANTZA"
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CONSTANTZA"
     },
     "destinationCountry": "Romania",
     "cargoDescription": {
-      "value": "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Dried (HRCTD), and Hot Rolled Sheets (HRS), unit weight approximately 10–27 tonnes per coil",
+      "value": "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Descaled (HRCTD), unit weight approximately 10–27 tonnes per coil, and Hot Rolled Sheets (HRS)",
       "confidence": "interpreted",
       "sourceText": "HRC + HRCPO + HRCTD UW ABT 10/27TS + HRS"
     },
@@ -1106,1448 +3648,49 @@
     },
     "incoterms": null,
     "preferredDates": null,
-    "laycan": "22 / 25 MAY 2026",
+    "laycan": "22-25 May 2026",
     "loadingRate": "1500",
     "dischargeRate": "1500",
     "commissionPercent": 3.75,
-    "commissionTerms": "ADDCOMPUS",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
       "Demurrage and despatch rates not stated",
-      "Cargo grade/specification beyond HRC/HRCPO/HRCTD/HRS not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cbe0a94b74c",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Mersin",
-      "confidence": "confirmed",
-      "sourceText": "Mersin,Turkey / Syria,Tartous"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Tartous",
-      "confidence": "confirmed",
-      "sourceText": "Syria,Tartous"
-    },
-    "destinationCountry": "Syria",
-    "cargoDescription": {
-      "value": "Unpeeled rice in bulk",
-      "confidence": "confirmed",
-      "sourceText": "unpeeled rice in bulk"
-    },
-    "weightMt": {
-      "value": 5000,
-      "confidence": "confirmed",
-      "sourceText": "5000mts unpeeled rice in bulk"
-    },
-    "weightMtMin": 5000,
-    "weightMtMax": 5000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "Spot/Prompt",
-      "confidence": "interpreted",
-      "sourceText": "Spot/Prompt"
-    },
-    "laycan": "Spot / Prompt",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "Past us",
-    "specialRequirements": null,
-    "stowageFactor": null,
-    "missingInfo": [
-      "Separate loading and discharge rates are not stated",
-      "Laytime cost-allocation terms such as FIO, FIOST or CQD are not stated",
-      "Demurrage and despatch rates not stated",
-      "Incoterms are not stated"
+      "Freight rate not stated"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cc094fc3aa2",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Adabiya",
-      "confidence": "confirmed",
-      "sourceText": "1 ADABIYA OR SAFAGA OR AIN SOKHNA"
-    },
-    "originCountry": "Egypt",
-    "destinationPort": {
-      "value": "Semarang",
-      "confidence": "confirmed",
-      "sourceText": "SEMARANG, INDONESIA"
-    },
-    "destinationCountry": "Indonesia",
-    "cargoDescription": {
-      "value": "Rock phosphate in bulk",
-      "confidence": "confirmed",
-      "sourceText": "ROCK PHOSPHATE IN BULK"
-    },
-    "weightMt": {
-      "value": 33000,
-      "confidence": "interpreted",
-      "sourceText": "20,000- 33,000 mts"
-    },
-    "weightMtMin": 20000,
-    "weightMtMax": 33000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 20000,
-      "max": 33000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "15–30 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "15 - 30 MAY"
-    },
-    "laycan": "15–30 May 2026",
-    "loadingRate": "5000",
-    "dischargeRate": "2500",
-    "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": null,
-    "stowageFactor": null,
-    "missingInfo": [
-      "Final load port nomination pending (charterer's option: Adabiya or Safaga or Ain Sokhna)",
-      "Commodity grade not specified (rock phosphate BPL grade not stated)",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [
-      "Safaga",
-      "Ain Sokhna"
-    ],
-    "originPortRotation": null,
-    "destinationPortAlternatives": null,
-    "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cc3ba833475",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Thisvi",
-      "confidence": "confirmed",
-      "sourceText": "Thisvi  / Monfalcone"
-    },
-    "originCountry": "Greece",
-    "destinationPort": {
-      "value": "Monfalcone",
-      "confidence": "confirmed",
-      "sourceText": "Thisvi  / Monfalcone"
-    },
-    "destinationCountry": "Italy",
-    "cargoDescription": {
-      "value": "Unspecified firm cargo",
-      "confidence": "uncertain",
-      "sourceText": "firm cargo"
-    },
-    "weightMt": null,
-    "weightMtMin": null,
-    "weightMtMax": null,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "OTHER",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "17-22 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "17 - 22 May"
-    },
-    "laycan": "17-22 May 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "Address commission past us",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Commodity not specified for the firm cargo",
-      "Cargo weight in metric tons not stated",
-      "Cargo type and packaging not stated",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Loading and discharge rates in MT/day not stated"
-    ],
-    "originPortAlternatives": null,
-    "originPortRotation": null,
-    "destinationPortAlternatives": null,
-    "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cde4af25d45",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Aliaga",
-      "confidence": "confirmed",
-      "sourceText": "Aliaga / Varna"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Varna",
-      "confidence": "confirmed",
-      "sourceText": "Aliaga / Varna"
-    },
-    "destinationCountry": "Bulgaria",
-    "cargoDescription": {
-      "value": "Clay in bulk",
-      "confidence": "interpreted",
-      "sourceText": "abt 10.000t blk clay"
-    },
-    "weightMt": {
-      "value": 10000,
-      "confidence": "interpreted",
-      "sourceText": "abt 10.000t blk clay"
-    },
-    "weightMtMin": null,
-    "weightMtMax": null,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": null,
-    "laycan": "25/30 May 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 3.75,
-    "commissionTerms": null,
-    "specialRequirements": null,
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Loading and discharge rates not stated",
-      "Demurrage and despatch rates not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
-  },
-  {
-    "emailId": "19e07ce171ab8e10",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Iskenderun",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun/Constanta"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Constanța",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun/Constanta"
-    },
-    "destinationCountry": "Romania",
-    "cargoDescription": {
-      "value": "Bulk minerals, not IMO classified",
-      "confidence": "interpreted",
-      "sourceText": "7.000mts blk minerals,not imo"
-    },
-    "weightMt": {
-      "value": 7000,
-      "confidence": "confirmed",
-      "sourceText": "7.000mts blk minerals,not imo"
-    },
-    "weightMtMin": 7000,
-    "weightMtMax": 7000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "15-20 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "15-20 May"
-    },
-    "laycan": "15-20 May 2026",
-    "loadingRate": "3000",
-    "dischargeRate": "2500",
-    "commissionPercent": 2.5,
-    "commissionTerms": null,
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Exact mineral commodity/grade not specified",
-      "Laytime terms such as SHINC/SHEX/FIO/CQD not stated",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cd83bad47a5",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "King Abdullah",
-      "confidence": "confirmed",
-      "sourceText": "KING ABDULLAH or YANBU  / RAVENNA"
-    },
-    "originCountry": "Saudi Arabia",
-    "destinationPort": {
-      "value": "Ravenna",
-      "confidence": "confirmed",
-      "sourceText": "KING ABDULLAH or YANBU  / RAVENNA"
-    },
-    "destinationCountry": "Italy",
-    "cargoDescription": {
-      "value": "Hot Rolled Steel Coils (HRC), maximum unit weight 30 MT",
-      "confidence": "confirmed",
-      "sourceText": "HOT ROLLED STEEL COILS, MAX UW 30 MT"
-    },
-    "weightMt": {
-      "value": 35000,
-      "confidence": "confirmed",
-      "sourceText": "35.000 mts 10% HOT ROLLED STEEL COILS"
-    },
-    "weightMtMin": 31500,
-    "weightMtMax": 38500,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 31500,
-      "max": 38500
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "20 May 2026 onwards",
-      "confidence": "interpreted",
-      "sourceText": "from 20th MAY onwards"
-    },
-    "laycan": "20 May 2026 onwards",
-    "loadingRate": "2500",
-    "dischargeRate": "4000",
-    "commissionPercent": 3.75,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Final load port nomination pending (charterer's option: King Abdullah or Yanbu)",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Cargo stowage factor not stated"
-    ],
-    "originPortAlternatives": [
-      "Yanbu"
-    ],
-    "originPortRotation": null,
-    "destinationPortAlternatives": null,
-    "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cdb7df50d0f",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Alexandria",
-      "confidence": "confirmed",
-      "sourceText": "Alexandria / Braila"
-    },
-    "originCountry": "Egypt",
-    "destinationPort": {
-      "value": "Braila",
-      "confidence": "confirmed",
-      "sourceText": "Alexandria / Braila"
-    },
-    "destinationCountry": "Romania",
-    "cargoDescription": {
-      "value": "Salt in big bags, dimensions 90 x 90 x 90 cm, unit weight 1.5 metric tons, fully stackable",
-      "confidence": "interpreted",
-      "sourceText": "m/m 4000 mts salt in bb – dim: 90x90x90 cm, uw: 1.5 mts – fully stackable"
-    },
-    "weightMt": {
-      "value": 4000,
-      "confidence": "confirmed",
-      "sourceText": "m/m 4000 mts"
-    },
-    "weightMtMin": 4000,
-    "weightMtMax": 4000,
-    "volumeCbm": null,
-    "dimensions": "90 x 90 x 90 cm",
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "Spot — try vessel dates",
-      "confidence": "interpreted",
-      "sourceText": "Spot – try vsl dates"
-    },
-    "laycan": "Spot — vessel's dates",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": null,
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Demurrage and despatch rates not stated",
-      "Loading and discharge handling rates not stated",
-      "Incoterms not stated",
-      "Freight rate not stated",
-      "Exact vessel dates pending"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07ce84fc34a82",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Jorf Lasfar",
-      "confidence": "confirmed",
-      "sourceText": "Jorf Lasfar => Yarımca (Marmara) + Samsun"
-    },
-    "originCountry": "Morocco",
-    "destinationPort": {
-      "value": "Yarımca",
-      "confidence": "confirmed",
-      "sourceText": "Yarımca (Marmara) + Samsun"
-    },
-    "destinationCountry": "Turkey",
-    "cargoDescription": {
-      "value": "Fertilizers",
-      "confidence": "confirmed",
-      "sourceText": "Fertilizers"
-    },
-    "weightMt": {
-      "value": 20000,
-      "confidence": "confirmed",
-      "sourceText": "Ttl 20,000 mts Fertilizers"
-    },
-    "weightMtMin": 20000,
-    "weightMtMax": 20000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "19-21 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "19-21 May"
-    },
-    "laycan": "19-21 May 2026",
-    "loadingRate": null,
-    "dischargeRate": "3000",
-    "commissionPercent": 2.5,
-    "commissionTerms": "TTL commission here",
-    "specialRequirements": null,
-    "stowageFactor": null,
-    "missingInfo": [
-      "Per-discharge-port tonnage split between Yarımca and Samsun not stated",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [
-      "Yarımca",
-      "Samsun"
-    ],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cd18529fb77",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Nemrut Bay",
-      "confidence": "interpreted",
-      "sourceText": "Nemrut"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Djibouti",
-      "confidence": "confirmed",
-      "sourceText": "1 Djibouti or 1 Tadjourah in chopt"
-    },
-    "destinationCountry": "Djibouti",
-    "cargoDescription": {
-      "value": "Steel Products, stowage equals deadweight",
-      "confidence": "interpreted",
-      "sourceText": "Steel Products stw = dwt"
-    },
-    "weightMt": {
-      "value": 9000,
-      "confidence": "interpreted",
-      "sourceText": "Min 8.000 mts up to 9.000 mts in chopt"
-    },
-    "weightMtMin": 8000,
-    "weightMtMax": 9000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 8000,
-      "max": 9000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "7-10 May 2026",
-      "confidence": "confirmed",
-      "sourceText": "07/10 May"
-    },
-    "laycan": "7-10 May 2026",
-    "loadingRate": "1500",
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "commission",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
-    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
-    "missingInfo": [
-      "Final discharge port nomination pending (charterer's option: Djibouti or Tadjourah)",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified",
-      "Incoterms not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [
-      "Tadjourah"
-    ],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cd18529fb77",
-    "itemIndex": 1,
-    "originPort": {
-      "value": "Nemrut Bay",
-      "confidence": "interpreted",
-      "sourceText": "Nemrut"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Barbera",
-      "confidence": "confirmed",
-      "sourceText": "Barbera Somalia"
-    },
-    "destinationCountry": "Somalia",
-    "cargoDescription": {
-      "value": "Steel Products, stowage equals deadweight",
-      "confidence": "interpreted",
-      "sourceText": "Steel Products stw = dwt"
-    },
-    "weightMt": {
-      "value": 2800,
-      "confidence": "confirmed",
-      "sourceText": "2800 mts %10"
-    },
-    "weightMtMin": 2520,
-    "weightMtMax": 3080,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 2520,
-      "max": 3080
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "7-10 May 2026",
-      "confidence": "confirmed",
-      "sourceText": "07/10 May"
-    },
-    "laycan": "7-10 May 2026",
-    "loadingRate": "1000",
-    "dischargeRate": "500",
-    "commissionPercent": 2.5,
-    "commissionTerms": "commission",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
-    "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
-    "missingInfo": [
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified",
-      "Incoterms not stated",
-      "Whether the 10% quantity tolerance is owner's option or charterer's option is not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07ceac0ca69dc",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Kavkaz",
-      "confidence": "confirmed",
-      "sourceText": "Kavkaz/Berbera"
-    },
-    "originCountry": "Russia",
-    "destinationPort": {
-      "value": "Berbera",
-      "confidence": "confirmed",
-      "sourceText": "Kavkaz/Berbera"
-    },
-    "destinationCountry": "Somalia",
-    "cargoDescription": {
-      "value": "Wheat, stowage factor 47",
-      "confidence": "confirmed",
-      "sourceText": "wheat SF 47"
-    },
-    "weightMt": {
-      "value": 30000,
-      "confidence": "confirmed",
-      "sourceText": "30000 mt 10% in OO"
-    },
-    "weightMtMin": 27000,
-    "weightMtMax": 33000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 27000,
-      "max": 33000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "19-22 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "LC:19-22 May"
-    },
-    "laycan": "19-22 May 2026",
-    "loadingRate": "5000",
-    "dischargeRate": "4000",
-    "commissionPercent": 2.5,
-    "commissionTerms": "past us",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": "47",
-    "missingInfo": [
-      "Wheat grade/specification not stated, such as protein percentage or other quality parameters",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07cfdf63e232b",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Vasto",
-      "confidence": "confirmed",
-      "sourceText": "Vasto / 1 Cyprus"
-    },
-    "originCountry": "Italy",
-    "destinationPort": {
-      "value": "Cyprus (port unspecified)",
-      "confidence": "interpreted",
-      "sourceText": "1 Cyprus"
-    },
-    "destinationCountry": "Cyprus",
-    "cargoDescription": {
-      "value": "Gypsum boards, minimum 5000 CBM bale/baler capacity required",
-      "confidence": "interpreted",
-      "sourceText": "abt 2.500mt gypsum boards/need min 5000cbm baler"
-    },
-    "weightMt": {
-      "value": 2500,
-      "confidence": "interpreted",
-      "sourceText": "abt 2.500mt"
-    },
-    "weightMtMin": null,
-    "weightMtMax": null,
-    "volumeCbm": 5000,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "10-15 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "10/15 May"
-    },
-    "laycan": "10-15 May 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 3.75,
-    "commissionTerms": null,
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Specific Cyprus discharge port not nominated — exact port TBD",
-      "Loading and discharge rates not stated",
-      "Laytime allocation stated only as total days, but the number of total days is not specified",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Packaging details and piece count for gypsum boards not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d056d1ba5aa",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Abidjan",
-      "confidence": "confirmed",
-      "sourceText": "Loading port: Abidjan, CoteDivoire"
-    },
-    "originCountry": "Côte d'Ivoire",
-    "destinationPort": {
-      "value": "Dongguan",
-      "confidence": "confirmed",
-      "sourceText": "Discharging port: 1sp Dongguan, China (need open book)"
-    },
-    "destinationCountry": "China",
-    "cargoDescription": {
-      "value": "Bauxite, quantity flexible",
-      "confidence": "confirmed",
-      "sourceText": "45,000-60,000mt bauxite(qtty flexible)"
-    },
-    "weightMt": {
-      "value": 60000,
-      "confidence": "interpreted",
-      "sourceText": "45,000-60,000mt bauxite(qtty flexible)"
-    },
-    "weightMtMin": 45000,
-    "weightMtMax": 60000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 45000,
-      "max": 60000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "10 May 2026 onwards, try vessel's dates",
-      "confidence": "interpreted",
-      "sourceText": "Laycan: 10th May onwards try vsl's date"
-    },
-    "laycan": "10 May 2026 onwards — try vessel's dates",
-    "loadingRate": "11000",
-    "dischargeRate": "12000",
-    "commissionPercent": 5,
-    "commissionTerms": "ADCOM: 3.75% on FDD to charterers + 1.25% Tlmarineco",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Exact final cargo quantity within the 45,000–60,000 MT flexible range not confirmed",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d149d83b38a",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Beira",
-      "confidence": "confirmed",
-      "sourceText": "Beira (Mozambique)"
-    },
-    "originCountry": "Mozambique",
-    "destinationPort": {
-      "value": "Pozzallo",
-      "confidence": "confirmed",
-      "sourceText": "Pozzallo (Italy)"
-    },
-    "destinationCountry": "Italy",
-    "cargoDescription": {
-      "value": "Granite blocks, maximum unit weight 30 tonnes",
-      "confidence": "confirmed",
-      "sourceText": "Granite Blocks  (max uw 30 tns)"
-    },
-    "weightMt": {
-      "value": 5900,
-      "confidence": "interpreted",
-      "sourceText": "4800 -  5900 mts"
-    },
-    "weightMtMin": 4800,
-    "weightMtMax": 5900,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 4800,
-      "max": 5900
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "Spot / Prompt",
-      "confidence": "interpreted",
-      "sourceText": "SPOT / ppt"
-    },
-    "laycan": "Spot / Prompt",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 3.75,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Loading laytime term 'Cop' requires clarification",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Cargo dimensions and number of granite blocks not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d0f8e19df79",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Kandla",
-      "confidence": "confirmed",
-      "sourceText": "Kandla / Ravenna"
-    },
-    "originCountry": "India",
-    "destinationPort": {
-      "value": "Ravenna",
-      "confidence": "confirmed",
-      "sourceText": "Kandla / Ravenna"
-    },
-    "destinationCountry": "Italy",
-    "cargoDescription": {
-      "value": "Clay and kaolin in bulk, 4 grades to load",
-      "confidence": "interpreted",
-      "sourceText": "clay and caolin in bulk"
-    },
-    "weightMt": {
-      "value": 43000,
-      "confidence": "interpreted",
-      "sourceText": "abt 40.000-43.000 mts moloo"
-    },
-    "weightMtMin": 40000,
-    "weightMtMax": 43000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 40000,
-      "max": 43000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "10 May 2026 onwards",
-      "confidence": "interpreted",
-      "sourceText": "10th May onwards"
-    },
-    "laycan": "10 May 2026 onwards",
-    "loadingRate": "10000",
-    "dischargeRate": "6000",
-    "commissionPercent": 2.5,
-    "commissionTerms": "PUS",
-    "specialRequirements": "[object Object],[object Object],[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "MOLOO tolerance percentage not stated, so weight tolerance bounds could not be calculated beyond the stated cargo range",
-      "Specific cargo grades not stated, although 4 grades are required for loading",
-      "Laytime terms are not explicitly stated for loading or discharge",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d1b2ba77051",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Hereke",
-      "confidence": "confirmed",
-      "sourceText": "Hereke / Constanta"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Constanța",
-      "confidence": "confirmed",
-      "sourceText": "Hereke / Constanta"
-    },
-    "destinationCountry": "Romania",
-    "cargoDescription": {
-      "value": "PC strand coils, diameter 130–140 cm, height 80 cm, unit weight 3–3.5 MT, tier limit 2",
-      "confidence": "confirmed",
-      "sourceText": "PC Strand,  Diameter :130-140 cm,  H: 80 cm UW: 3-3,5 MT, Tier\r\nlimit: 2"
-    },
-    "weightMt": {
-      "value": 2500,
-      "confidence": "confirmed",
-      "sourceText": "2500 mts"
-    },
-    "weightMtMin": 2500,
-    "weightMtMax": 2500,
-    "volumeCbm": null,
-    "dimensions": "Diameter 130-140 cm; height 80 cm",
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "11-13 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "11-13 May"
-    },
-    "laycan": "11-13 May 2026",
-    "loadingRate": "1000",
-    "dischargeRate": "800",
-    "commissionPercent": 3.75,
-    "commissionTerms": "ADDCOM PUS",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Laytime terms not stated — only loading/discharge rates provided",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d186df6a788",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Hereke",
-      "confidence": "interpreted",
-      "sourceText": "1Marmara (Hereke) / Constanta"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Constanța",
-      "confidence": "confirmed",
-      "sourceText": "Constanta"
-    },
-    "destinationCountry": "Romania",
-    "cargoDescription": {
-      "value": "PC Strand, diameter 130–140 cm, height 80 cm, unit weight 3–3.5 MT, tier limit 2",
-      "confidence": "confirmed"
-    },
-    "weightMt": {
-      "value": 2500,
-      "confidence": "confirmed",
-      "sourceText": "2500 mts"
-    },
-    "weightMtMin": 2500,
-    "weightMtMax": 2500,
-    "volumeCbm": null,
-    "dimensions": "Diameter 130-140 cm; H 80 cm",
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "11-13 May 2026",
-      "confidence": "confirmed",
-      "sourceText": "11/13 May"
-    },
-    "laycan": "11-13 May 2026",
-    "loadingRate": "1000",
-    "dischargeRate": "800",
-    "commissionPercent": 3.75,
-    "commissionTerms": "Address commission past us",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Laytime cost-allocation terms not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": null,
-    "originPortRotation": null,
-    "destinationPortAlternatives": null,
-    "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d186df6a788",
-    "itemIndex": 1,
-    "originPort": {
-      "value": "Iskenderun",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun / Ghent"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Ghent",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun / Ghent"
-    },
-    "destinationCountry": "Belgium",
-    "cargoDescription": {
-      "value": "Steel rebars, 3% more or less charterer's option",
-      "confidence": "confirmed",
-      "sourceText": "10000 mts steel rebars %3 mol chopt."
-    },
-    "weightMt": {
-      "value": 10000,
-      "confidence": "confirmed",
-      "sourceText": "10000 mts steel rebars %3 mol chopt."
-    },
-    "weightMtMin": 9700,
-    "weightMtMax": 10300,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 9700,
-      "max": 10300
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "06-09 June 2026",
-      "confidence": "confirmed",
-      "sourceText": "06/09 June"
-    },
-    "laycan": "06-09 June 2026",
-    "loadingRate": "2000",
-    "dischargeRate": "3000",
-    "commissionPercent": 3.75,
-    "commissionTerms": "Address commission past us",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Laytime cost-allocation terms not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": null,
-    "originPortRotation": null,
-    "destinationPortAlternatives": null,
-    "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d1ec45291d1",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Vizag",
-      "confidence": "confirmed",
-      "sourceText": "load port : vizag , india"
-    },
-    "originCountry": "India",
-    "destinationPort": {
-      "value": "Vanino",
-      "confidence": "confirmed",
-      "sourceText": "discharge port : vanino , russia ( 10.2m )"
-    },
-    "destinationCountry": "Russia",
-    "cargoDescription": {
-      "value": "Alumina in bulk",
-      "confidence": "confirmed",
-      "sourceText": "alumina in bulk"
-    },
-    "weightMt": {
-      "value": 40000,
-      "confidence": "confirmed",
-      "sourceText": "40,000 mts 5pct moloo alumina in bulk"
-    },
-    "weightMtMin": 38000,
-    "weightMtMax": 42000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 38000,
-      "max": 42000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "15 May 2026 onward; try vessel dates",
-      "confidence": "interpreted",
-      "sourceText": "laycan : 15 may / onw (try vsl dates wch pls adv)"
-    },
-    "laycan": "15 May 2026 onward",
-    "loadingRate": "5000",
-    "dischargeRate": "3700",
-    "commissionPercent": 3.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Exact vessel dates are requested but not fixed",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d2ac4a815b4",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Marmara",
-      "confidence": "confirmed",
-      "sourceText": "1 Marmara /Constanta"
-    },
-    "originCountry": null,
-    "destinationPort": {
-      "value": "Constanța",
-      "confidence": "confirmed",
-      "sourceText": "1 Marmara /Constanta"
-    },
-    "destinationCountry": "Romania",
-    "cargoDescription": {
-      "value": "Steel billets",
-      "confidence": "confirmed",
-      "sourceText": "Steel Billets"
-    },
-    "weightMt": {
-      "value": 7200,
-      "confidence": "confirmed",
-      "sourceText": "Min 7200 tons"
-    },
-    "weightMtMin": 7200,
-    "weightMtMax": null,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "18-20 May 2026, earlier/later possible",
-      "confidence": "interpreted",
-      "sourceText": "18/20 May – Try tick earlier/later"
-    },
-    "laycan": "18-20 May 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "Commission",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Specific Marmara load port not nominated — exact port TBD",
-      "Maximum cargo quantity not numerically stated; only 'up to fcc in chopt' mentioned",
-      "Loading and discharge rates not stated",
-      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
-  },
-  {
-    "emailId": "19e07d3581dc9d89",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Iskenderun",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun / 1 Greece"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Greece (port unspecified)",
-      "confidence": "interpreted",
-      "sourceText": "1 Greece"
-    },
-    "destinationCountry": "Greece",
-    "cargoDescription": {
-      "value": "Cement in big bags",
-      "confidence": "confirmed",
-      "sourceText": "3000 mts cement in big bags"
-    },
-    "weightMt": {
-      "value": 3000,
-      "confidence": "confirmed",
-      "sourceText": "3000 mts cement in big bags"
-    },
-    "weightMtMin": 3000,
-    "weightMtMax": 3000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "11–16 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "11 - 16 May"
-    },
-    "laycan": "11–16 May 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "Exclusive firm cargo — do not recirculate",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Specific Greece discharge port not nominated — exact port TBD",
-      "Loading and discharge cargo-handling rates not stated",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d3145be13c8",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Izmir Alsancak",
-      "confidence": "confirmed",
-      "sourceText": "izmir  Alsancak"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Arzew",
-      "confidence": "confirmed",
-      "sourceText": "Arzew"
-    },
-    "destinationCountry": "Algeria",
-    "cargoDescription": {
-      "value": "Mobile machinery, 10 units, part cargo, over-deck stowage permitted, drawings available",
-      "confidence": "confirmed",
-      "sourceText": "10 units mobile machinery"
-    },
-    "weightMt": {
-      "value": 600,
-      "confidence": "interpreted",
-      "sourceText": "ttl weight : abt  600 mt"
-    },
-    "weightMtMin": null,
-    "weightMtMax": null,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "PROJECT",
-    "containerType": null,
-    "quantity": 10,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "12/15 May 2026, try vessel date",
-      "confidence": "uncertain",
-      "sourceText": "l/c  12/15 may  try vsl date"
-    },
-    "laycan": "12-15 May 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "TTL commission",
-    "specialRequirements": "[object Object],[object Object],[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Cargo dimensions not stated — mandatory for project cargo",
-      "Per-unit weights not stated for the 10 mobile machinery units",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Exact vessel date pending or to be tried"
-    ],
-    "originPortAlternatives": null,
-    "originPortRotation": null,
-    "destinationPortAlternatives": null,
-    "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d4069745393",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Alexandria",
-      "confidence": "confirmed",
-      "sourceText": "Alexandria/Tartous"
-    },
-    "originCountry": "Egypt",
-    "destinationPort": {
-      "value": "Tartous",
-      "confidence": "confirmed",
-      "sourceText": "Alexandria/Tartous"
-    },
-    "destinationCountry": "Syria",
-    "cargoDescription": {
-      "value": "Bulk clinker",
-      "confidence": "confirmed",
-      "sourceText": "25,000 MT blk Clinker"
-    },
-    "weightMt": {
-      "value": 25000,
-      "confidence": "confirmed",
-      "sourceText": "25,000 MT blk Clinker"
-    },
-    "weightMtMin": 25000,
-    "weightMtMax": 25000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": null,
-    "laycan": "10-12 May 2026",
-    "loadingRate": "8000",
-    "dischargeRate": "5000",
-    "commissionPercent": 3.75,
-    "commissionTerms": "TTL commission",
-    "specialRequirements": null,
-    "stowageFactor": null,
-    "missingInfo": [
-      "Laytime terms such as SHINC, SHEX, or SSHEX not stated for the loading and discharge rates",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel type and size requirements not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d5b25766951",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Sfax",
-      "confidence": "confirmed",
-      "sourceText": "Sfax, Tunisia"
-    },
-    "originCountry": "Tunisia",
-    "destinationPort": {
-      "value": "Dakar",
-      "confidence": "confirmed",
-      "sourceText": "Dakar"
-    },
-    "destinationCountry": "Senegal",
-    "cargoDescription": {
-      "value": "Olive pomace, stowage factor 58, non-IMO",
-      "confidence": "confirmed",
-      "sourceText": "Olive pomace stw factor 58’ (non IMO)"
-    },
-    "weightMt": {
-      "value": 12000,
-      "confidence": "confirmed",
-      "sourceText": "min 12.000 mts"
-    },
-    "weightMtMin": 12000,
-    "weightMtMax": null,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "20-30 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "20-30 MAY"
-    },
-    "laycan": "20-30 May 2026",
-    "loadingRate": "2000",
-    "dischargeRate": "4000",
-    "commissionPercent": 3.75,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": "58 ft³/MT",
-    "missingInfo": [
-      "Exact quantity above minimum 12,000 MT not stated",
-      "Incoterms not stated",
-      "Laytime terms such as SHINC/SHEX/SSHEX not stated",
-      "Demurrage and despatch rates not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07d4f102b639b",
     "itemIndex": 0,
     "originPort": {
-      "value": "Pivdennyi",
+      "value": "Pivdennyi (Yuzhne)",
       "confidence": "confirmed",
       "sourceText": "Pivdennyi / La Coruna"
     },
     "originCountry": "Ukraine",
     "destinationPort": {
-      "value": "La Coruna",
+      "value": "La Coruña",
       "confidence": "confirmed",
       "sourceText": "Pivdennyi / La Coruna"
     },
     "destinationCountry": "Spain",
     "cargoDescription": {
       "value": "Rapeseed meal pellets in bulk, stowage factor 58",
-      "confidence": "confirmed",
-      "sourceText": "rapeseed meal pellets in bulk, sf  58'"
+      "confidence": "interpreted",
+      "sourceText": "6000 mts +/-10% of rapeseed meal pellets in bulk, sf  58'"
     },
     "weightMt": {
       "value": 6000,
@@ -2565,134 +3708,473 @@
       "max": 6600
     },
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot — vessel's dates",
+      "confidence": "interpreted",
+      "sourceText": "spot - vsl dates"
+    },
     "laycan": "Spot — vessel's dates",
     "loadingRate": "2000",
     "dischargeRate": "2000",
     "commissionPercent": 3.75,
-    "commissionTerms": "TTL here",
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": "58 ft³/MT",
     "missingInfo": [
-      "Incoterms not stated",
       "Demurrage and despatch rates not stated",
-      "Exact vessel dates for spot laycan not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d4742474163",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Nemrut Bay",
-      "confidence": "interpreted",
-      "sourceText": "-NEMRUT / LIVERPOOL"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Liverpool",
-      "confidence": "confirmed",
-      "sourceText": "-NEMRUT / LIVERPOOL"
-    },
-    "destinationCountry": "United Kingdom",
-    "cargoDescription": {
-      "value": "Hot Rolled Coils (HRC), unit weight approximately 10–27 tonnes per coil",
-      "confidence": "interpreted",
-      "sourceText": "-2,720mts 2PCT MOLCHOPT HRC UW ABT 10/27TS"
-    },
-    "weightMt": {
-      "value": 2720,
-      "confidence": "interpreted",
-      "sourceText": "-2,720mts 2PCT MOLCHOPT HRC UW ABT 10/27TS"
-    },
-    "weightMtMin": 2666,
-    "weightMtMax": 2774,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 2666,
-      "max": 2774
-    },
-    "incoterms": null,
-    "preferredDates": null,
-    "laycan": "15–18 May 2026",
-    "loadingRate": "1250",
-    "dischargeRate": "1500",
-    "commissionPercent": 3.75,
-    "commissionTerms": "ADDCOMPUS",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Cargo stowage factor not stated"
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "'2000 bends' assumed load/discharge rate 2000 MT/day both ends — terms (SHINC/SHEX) not specified"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
-    "emailId": "19e07d4742474163",
+    "emailId": "19e07d5b25766951",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Sfax",
+      "confidence": "confirmed",
+      "sourceText": "Sfax, Tunisia"
+    },
+    "originCountry": "Tunisia",
+    "destinationPort": {
+      "value": "Dakar",
+      "confidence": "confirmed",
+      "sourceText": "Sfax, Tunisia  / Dakar"
+    },
+    "destinationCountry": "Senegal",
+    "cargoDescription": {
+      "value": "Olive pomace, stowage factor 58, non-IMO",
+      "confidence": "interpreted",
+      "sourceText": "min 12.000 mts Olive pomace stw factor 58"
+    },
+    "weightMt": {
+      "value": 12000,
+      "confidence": "confirmed",
+      "sourceText": "min 12.000 mts Olive pomace"
+    },
+    "weightMtMin": 12000,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "20-30 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "20-30 MAY"
+    },
+    "laycan": "20-30 May 2026",
+    "loadingRate": "2000",
+    "dischargeRate": "4000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years; cargo non-IMO",
+    "stowageFactor": "58 ft³/MT",
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Load/discharge laytime regime (SHINC/SHEX) not specified",
+      "Freight rate not indicated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d64793f8971",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Egypt Mediterranean port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Egypt Med/POC"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Port of Call (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Egypt Med/POC"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Salt in big bags, dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT",
+      "confidence": "interpreted",
+      "sourceText": "5500 mts of salt in bb (1,1x1,1x1,1, uw 1,25)"
+    },
+    "weightMt": {
+      "value": 5500,
+      "confidence": "confirmed",
+      "sourceText": "5500 mts of salt in bb"
+    },
+    "weightMtMin": 5500,
+    "weightMtMax": 5500,
+    "volumeCbm": null,
+    "dimensions": "1.1m x 1.1m x 1.1m",
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": null,
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": null,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Specific Egypt-Med load port not nominated — exact port TBD",
+      "Discharge port unspecified (POC)",
+      "Laycan/dates not stated for this offer",
+      "Load/discharge rates and laytime terms not stated",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d64793f8971",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Damietta",
+      "confidence": "confirmed",
+      "sourceText": "Damietta+Mersin/POC"
+    },
+    "originCountry": "Egypt",
+    "destinationPort": {
+      "value": "Port of Call (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "Damietta+Mersin/POC"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Salt and rice in big bags — salt dimensions 1.1m × 1.1m × 1.1m, unit weight 1.25 MT; rice dimensions 1.05m × 1.05m × 1.35m, unit weight 1 MT",
+      "confidence": "interpreted",
+      "sourceText": " (1,1x1,1x1,1, uw 1,25) + rice (1,05x1,05x1,35, uw 1 mt)"
+    },
+    "weightMt": null,
+    "weightMtMin": 6000,
+    "weightMtMax": 7000,
+    "volumeCbm": null,
+    "dimensions": "salt 1.1m x 1.1m x 1.1m; rice 1.05m x 1.05m x 1.35m",
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 6000,
+      "max": 7000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-18 May 2026",
+    "loadingRate": "1250",
+    "dischargeRate": "1250",
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% PUS (Past Us)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Discharge port unspecified (POC)",
+      "Mersin (Turkey) appears as rotation load port alongside Damietta (Egypt) — confirm rotation vs alternative",
+      "Laytime terms (SHINC/SHEX/FIO etc.) not stated for 1250/1250 rates",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": [
+      "Damietta",
+      "Mersin"
+    ],
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d6a749ba5ec",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "1 Marmara/1 C.Med"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Central Mediterranean port (unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "1 C.Med"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Commodity not specified; vessel sought 2,500–3,000 DWCC, box/boxlike",
+      "confidence": "uncertain",
+      "sourceText": "need 2500/3000 box,boxlike"
+    },
+    "weightMt": null,
+    "weightMtMin": 2500,
+    "weightMtMax": 3000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "OTHER",
+    "containerType": null,
+    "quantity": {
+      "min": 2500,
+      "max": 3000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "12-14 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Box/boxlike vessel; 5 total laytime days",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Commodity not specified — only vessel DWCC range (2,500–3,000) and box/boxlike type given",
+      "Central Mediterranean discharge port not nominated",
+      "Demurrage and despatch rates not stated",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Trailing 'x' after '5 ttl dys' is unrecognized — flagged for human review"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d6a749ba5ec",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "1 Marmara/1 Continent"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "European Continent (ARA range)",
+      "confidence": "interpreted",
+      "sourceText": "1 Continent"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Commodity not specified; vessel sought 3,500–3,800 DWCC, box/boxlike",
+      "confidence": "uncertain",
+      "sourceText": "3500/3800 dwcc, box/boxlike vsl"
+    },
+    "weightMt": null,
+    "weightMtMin": 3500,
+    "weightMtMax": 3800,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "OTHER",
+    "containerType": null,
+    "quantity": {
+      "min": 3500,
+      "max": 3800
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "15-18 May 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Box/boxlike vessel; total laytime days (count unspecified)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Commodity not specified — only vessel DWCC range (3,500–3,800) and box/boxlike type given",
+      "Continent discharge port not nominated",
+      "Demurrage and despatch rates not stated",
+      "Total laytime days count not stated ('Ttl dys')"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d75e8a30c1c",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / SAGUNTO"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Sagunto",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / SAGUNTO"
+    },
+    "destinationCountry": "Spain",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC) and Hot Rolled Coils Pickled & Oiled (HRCPO), unit weight approximately 10–27 tonnes per coil",
+      "confidence": "interpreted",
+      "sourceText": "HRC + HRCPO UW ABT 10/27TS"
+    },
+    "weightMt": {
+      "value": 11375,
+      "confidence": "interpreted",
+      "sourceText": "11,375mts 2PCT MOLCHOPT"
+    },
+    "weightMtMin": 11148,
+    "weightMtMax": 11602,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 11148,
+      "max": 11602
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Laycan 15–18 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "L/C 15 / 18 MAY 2026"
+    },
+    "laycan": "15-18 May 2026",
+    "loadingRate": "2000",
+    "dischargeRate": "2000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% ADDCOMPUS (Address Commission Past Us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Vessel gear requirement not specified",
+      "Stowage factor not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d75e8a30c1c",
     "itemIndex": 1,
     "originPort": {
       "value": "Nemrut Bay",
-      "confidence": "interpreted",
-      "sourceText": "-NEMRUT / CONSTANTZA"
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CONSTANTZA"
     },
     "originCountry": "Turkey",
     "destinationPort": {
       "value": "Constanța",
-      "confidence": "interpreted",
-      "sourceText": "-NEMRUT / CONSTANTZA"
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CONSTANTZA"
     },
     "destinationCountry": "Romania",
     "cargoDescription": {
-      "value": "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Dried (HRCTD), and Hot Rolled Sheets (HRS), unit weight approximately 10–27 tonnes per coil",
+      "value": "Hot Rolled Coils (HRC), Hot Rolled Coils Pickled & Oiled (HRCPO), Hot Rolled Coils Trimmed & Descaled (HRCTD), unit weight approximately 10–27 tonnes per coil, and Hot Rolled Sheets (HRS)",
       "confidence": "interpreted",
-      "sourceText": "-6,500mts 2PCT MOLCHOPT HRC + HRCPO + HRCTD UW ABT 10/27TS + HRS"
+      "sourceText": "HRC + HRCPO + HRCTD UW ABT 10/27TS + HRS"
     },
     "weightMt": {
-      "value": 6500,
+      "value": 6400,
       "confidence": "interpreted",
-      "sourceText": "-6,500mts 2PCT MOLCHOPT HRC + HRCPO + HRCTD UW ABT 10/27TS + HRS"
+      "sourceText": "6,400mts 2PCT MOLCHOPT"
     },
-    "weightMtMin": 6370,
-    "weightMtMax": 6630,
+    "weightMtMin": 6272,
+    "weightMtMax": 6528,
     "volumeCbm": null,
     "dimensions": null,
     "cargoType": "BREAK_BULK",
     "containerType": null,
     "quantity": {
-      "min": 6370,
-      "max": 6630
+      "min": 6272,
+      "max": 6528
     },
     "incoterms": null,
-    "preferredDates": null,
-    "laycan": "22–25 May 2026",
+    "preferredDates": {
+      "value": "Laycan 22–25 May 2026",
+      "confidence": "confirmed",
+      "sourceText": "L/C 22 / 25 MAY 2026"
+    },
+    "laycan": "22-25 May 2026",
     "loadingRate": "1500",
     "dischargeRate": "1500",
     "commissionPercent": 3.75,
-    "commissionTerms": "ADDCOMPUS",
-    "specialRequirements": "[object Object],[object Object]",
+    "commissionTerms": "3.75% ADDCOMPUS (Address Commission Past Us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
       "Demurrage and despatch rates not stated",
-      "Cargo stowage factor not stated"
+      "Vessel gear requirement not specified",
+      "Stowage factor not stated"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07d7e79fa7242",
@@ -2700,7 +4182,7 @@
     "originPort": {
       "value": "Iskenderun",
       "confidence": "confirmed",
-      "sourceText": "Iskenderun"
+      "sourceText": "Iskenderun / 1 Greece"
     },
     "originCountry": "Turkey",
     "destinationPort": {
@@ -2711,7 +4193,7 @@
     "destinationCountry": "Greece",
     "cargoDescription": {
       "value": "Cement in big bags",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "3000 mts cement in big bags"
     },
     "weightMt": {
@@ -2723,12 +4205,12 @@
     "weightMtMax": 3000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": null,
     "incoterms": null,
     "preferredDates": {
-      "value": "11 - 15 May",
+      "value": "11-15 May 2026",
       "confidence": "confirmed",
       "sourceText": "11 - 15 May"
     },
@@ -2736,81 +4218,28 @@
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Total laytime 4 days (load+discharge combined, reversible); Exclusive firm cargo — do not recirculate",
     "stowageFactor": null,
     "missingInfo": [
-      "Specific discharge port in Greece not nominated — exact port TBD",
-      "Incoterms not stated",
-      "Loading and discharge rates not stated",
+      "Discharge port in Greece not nominated (1 port, charterer's option)",
       "Demurrage and despatch rates not stated",
-      "Cement grade/type not specified",
-      "Vessel DWT/type requirement not specified"
+      "Freight rate not indicated",
+      "Cement grade/spec not specified",
+      "Split of 4 total laytime days between load/discharge not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e07d8a6370f3a1",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Kakinada",
-      "confidence": "confirmed",
-      "sourceText": "load port : kakinada, ec india"
-    },
-    "originCountry": "India",
-    "destinationPort": {
-      "value": "Banjul",
-      "confidence": "confirmed",
-      "sourceText": "10,000 mts to banjul, gambia"
-    },
-    "destinationCountry": "Gambia",
-    "cargoDescription": {
-      "value": "Bagged rice, stowage factor 48–50, without guarantee",
-      "confidence": "confirmed",
-      "sourceText": "40,000 mts of bagged rice sf 48-50 wog"
-    },
-    "weightMt": {
-      "value": 40000,
-      "confidence": "confirmed",
-      "sourceText": "40,000 mts of bagged rice"
-    },
-    "weightMtMin": 40000,
-    "weightMtMax": 40000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": null,
-    "laycan": "20 May 2026 onward (try vessel's dates)",
-    "loadingRate": "2000",
-    "dischargeRate": "2000",
-    "commissionPercent": 3.75,
-    "commissionTerms": null,
-    "specialRequirements": null,
-    "stowageFactor": "48–50 WOG",
-    "missingInfo": [
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Commission terms not stated beyond 3.75 percent",
-      "Exact laycan end date not stated — shipment is 20 May onward and subject to vessel's dates"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [
-      "Banjul",
-      "Dakar"
-    ],
-    "weightPerPort": [
-      10000,
-      30000
-    ]
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e07d842ae91302",
@@ -2829,7 +4258,7 @@
     "destinationCountry": "Gambia",
     "cargoDescription": {
       "value": "Bagged rice, stowage factor 48–50, without guarantee",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "40,000 mts of bagged rice sf 48-50 wog"
     },
     "weightMt": {
@@ -2841,32 +4270,27 @@
     "weightMtMax": 40000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": {
-      "value": "15 onward, try vessel dates",
-      "confidence": "interpreted",
-      "sourceText": "laycan 15/onwd (try vsl dates)"
-    },
-    "laycan": "15 May 2026 onward — try vessel's dates",
+    "preferredDates": null,
+    "laycan": "15 onward (vessel's dates)",
     "loadingRate": "2000",
     "dischargeRate": "2000",
     "commissionPercent": 3.75,
     "commissionTerms": null,
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": "48–50 WOG",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "48–50 ft³/MT WOG",
     "missingInfo": [
-      "Incoterms not stated",
+      "Discharge rate differs per port: Banjul 2,000 mts pwwd SSHEX EIU vs Dakar 1,500 mts pwwd SSHEX EIU",
       "Demurrage and despatch rates not stated",
-      "Exact laycan commencement month is not explicitly stated beyond '15/onwd'",
-      "Commission terms not stated beyond 3.75 percent",
-      "Dakar discharge country is stated in the rotation, but the primary destination country field only reflects Banjul, Gambia"
+      "Rice grade/type not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
     "destinationPortRotation": [
       "Banjul",
       "Dakar"
@@ -2874,7 +4298,324 @@
     "weightPerPort": [
       10000,
       30000
-    ]
+    ],
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d8a6370f3a1",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Kakinada",
+      "confidence": "confirmed",
+      "sourceText": "load port : kakinada, ec india"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "Banjul",
+      "confidence": "confirmed",
+      "sourceText": "10,000 mts to banjul, gambia"
+    },
+    "destinationCountry": "Gambia",
+    "cargoDescription": {
+      "value": "Bagged rice, stowage factor 48–50, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "40,000 mts of bagged rice sf 48-50 wog"
+    },
+    "weightMt": {
+      "value": 40000,
+      "confidence": "confirmed",
+      "sourceText": "40,000 mts of bagged rice"
+    },
+    "weightMtMin": 40000,
+    "weightMtMax": 40000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "20 May onward",
+      "confidence": "interpreted",
+      "sourceText": "laycan 20 may / onwd (try vsl dates)"
+    },
+    "laycan": "20 May 2026 onward",
+    "loadingRate": "2000",
+    "dischargeRate": "2000",
+    "commissionPercent": 3.75,
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": "Discharge split: Banjul 2,000 mts PWWD SSHEX EIU; Dakar 1,500 mts PWWD SSHEX EIU",
+    "stowageFactor": "48–50 ft³/MT WOG",
+    "missingInfo": [
+      "Discharge rate differs per port: Banjul 2,000 mts/day, Dakar 1,500 mts/day (discharge_rate field shows Banjul rate)",
+      "Demurrage and despatch rates not stated",
+      "Rice grade/type not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": [
+      "Banjul",
+      "Dakar"
+    ],
+    "weightPerPort": [
+      10000,
+      30000
+    ],
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d8f8a2e5988",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Kakinada",
+      "confidence": "confirmed",
+      "sourceText": "kakinada anchorage, ec india"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "Monrovia",
+      "confidence": "confirmed",
+      "sourceText": "monrovia, west africa (10m sw)"
+    },
+    "destinationCountry": "Liberia",
+    "cargoDescription": {
+      "value": "Bagged rice in 50 kg PP bags",
+      "confidence": "interpreted",
+      "sourceText": "20000/25000 mt bgd rice 50 kgs pp bags"
+    },
+    "weightMt": null,
+    "weightMtMin": 20000,
+    "weightMtMax": 25000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 20000,
+      "max": 25000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "10-15 May 2026",
+    "loadingRate": "2000",
+    "dischargeRate": "1500",
+    "commissionPercent": 5,
+    "commissionTerms": "5% on F/D/D/D",
+    "freightRateUsd": null,
+    "specialRequirements": "Max draft 10m SW at disport; freight basis free DA at load and disport; dunnage on charterers' account; max age 20 years",
+    "stowageFactor": null,
+    "missingInfo": [
+      "No freight idea from charterers — owners' best sought",
+      "Demurrage/despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 20,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d8f8a2e5988",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Kakinada",
+      "confidence": "confirmed",
+      "sourceText": "kakinada anch, ec india"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "Conakry",
+      "confidence": "interpreted",
+      "sourceText": "conakary, west africa (10m sw)"
+    },
+    "destinationCountry": "Guinea",
+    "cargoDescription": {
+      "value": "Rice in 50 kg bags, stowage factor 1.4, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "30,000 mt 10% moloo rice in 50 kgs bags (sf abt 1.4 cbm/mt wog)"
+    },
+    "weightMt": {
+      "value": 30000,
+      "confidence": "interpreted",
+      "sourceText": "30,000 mt 10% moloo"
+    },
+    "weightMtMin": 27000,
+    "weightMtMax": 33000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 27000,
+      "max": 33000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "Prompt / 07 May 2026 — vessel's dates",
+    "loadingRate": "2000",
+    "dischargeRate": "2000",
+    "commissionPercent": 5,
+    "commissionTerms": "5% on F/D/D/D",
+    "freightRateUsd": null,
+    "specialRequirements": "Max draft 10m SW at disport; all holds at both load ports; charterers can do free DA at load and disport; dunnage on charterers' account",
+    "stowageFactor": "abt 1.4 m³/MT WOG",
+    "missingInfo": [
+      "No freight idea from charterers — owners' best sought",
+      "Demurrage/despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d8f8a2e5988",
+    "itemIndex": 2,
+    "originPort": {
+      "value": "Dhamra",
+      "confidence": "confirmed",
+      "sourceText": "dhamra, ec india"
+    },
+    "originCountry": "India",
+    "destinationPort": {
+      "value": "Durban",
+      "confidence": "confirmed",
+      "sourceText": "durban, south africa"
+    },
+    "destinationCountry": "South Africa",
+    "cargoDescription": {
+      "value": "Bagged rice in 50 kg bags, stowage factor 1.4, without guarantee",
+      "confidence": "interpreted",
+      "sourceText": "25000/35000 mt bgd rice in 50 kg bags (sf abt 1.4 cbm/mt wog)"
+    },
+    "weightMt": null,
+    "weightMtMin": 25000,
+    "weightMtMax": 35000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 25000,
+      "max": 35000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "25-30 May 2026",
+    "loadingRate": "500",
+    "dischargeRate": "400",
+    "commissionPercent": 5,
+    "commissionTerms": "5% on F/D/D/D",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "abt 1.4 m³/MT WOG",
+    "missingInfo": [
+      "No freight idea from charterers — owners' best sought",
+      "Demurrage/despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e07d8f8a2e5988",
+    "itemIndex": 3,
+    "originPort": {
+      "value": "Koh Si Chang",
+      "confidence": "interpreted",
+      "sourceText": "kosichang (10,000 mt)"
+    },
+    "originCountry": "Thailand",
+    "destinationPort": {
+      "value": "Conakry",
+      "confidence": "interpreted",
+      "sourceText": "dssch port conakary, guinea"
+    },
+    "destinationCountry": "Guinea",
+    "cargoDescription": {
+      "value": "Rice in bags",
+      "confidence": "interpreted",
+      "sourceText": "30,000 mt 10% rice in bags"
+    },
+    "weightMt": {
+      "value": 30000,
+      "confidence": "interpreted",
+      "sourceText": "30,000 mt 10%"
+    },
+    "weightMtMin": 27000,
+    "weightMtMax": 33000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 27000,
+      "max": 33000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "Prompt / onward — vessel's dates",
+    "loadingRate": "2000",
+    "dischargeRate": "2000",
+    "commissionPercent": 5,
+    "commissionTerms": "5% on F/D/D/D",
+    "freightRateUsd": null,
+    "specialRequirements": "Max draft 10.00m at discharge port; load 10,000 MT Koh Si Chang + balance Kakinada anchorage; all holds at both load ports; charterers can do free DA at load and disport; dunnage on charterers' account",
+    "stowageFactor": null,
+    "missingInfo": [
+      "No freight idea from charterers — owners' best sought",
+      "Demurrage/despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": [
+      "Koh Si Chang",
+      "Kakinada"
+    ],
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": [
+      10000,
+      20000
+    ],
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089c866d595c7",
@@ -2887,19 +4628,19 @@
     "originCountry": "Moldova",
     "destinationPort": {
       "value": "Marmara",
-      "confidence": "confirmed",
-      "sourceText": "Giurgiulesti / 1 Marmara"
+      "confidence": "interpreted",
+      "sourceText": "1 Marmara"
     },
     "destinationCountry": "Turkey",
     "cargoDescription": {
-      "value": "Bulk sunflower seeds, stowage factor approximately 87",
+      "value": "Sunflower seeds in bulk, stowage factor approximately 87",
       "confidence": "interpreted",
-      "sourceText": "bulk sunflower seeds, sf.abt 87'"
+      "sourceText": "2,000 mts 10% bulk sunflower seeds, sf.abt 87'"
     },
     "weightMt": {
       "value": 2000,
       "confidence": "confirmed",
-      "sourceText": "2,000 mts 10% bulk sunflower seeds"
+      "sourceText": "2,000 mts 10%"
     },
     "weightMtMin": 1800,
     "weightMtMax": 2200,
@@ -2912,26 +4653,37 @@
       "max": 2200
     },
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "SPOT"
+    },
     "laycan": "Spot",
     "loadingRate": "1000",
     "dischargeRate": "1000",
     "commissionPercent": 2.5,
-    "commissionTerms": "ADCOM PUS",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "2.5% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": "abt 87 ft³/MT",
     "missingInfo": [
-      "Specific Marmara discharge port not nominated — exact port TBD",
-      "Incoterms not stated",
-      "Laytime terms not stated beyond numeric loading/discharge rates",
+      "Specific Marmara load... discharge port not nominated (1 port TBN)",
+      "Weight stated as 2,000 mts 10% — treated as MOLOO tolerance (1,800–2,200 MT); owner's vs charterer's option not explicit",
       "Demurrage and despatch rates not stated",
-      "Final cargo quantity tolerance option holder not stated"
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Vessel DWT/type requirement not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089cdd36d5901",
@@ -2939,19 +4691,19 @@
     "originPort": {
       "value": "Izmail",
       "confidence": "confirmed",
-      "sourceText": "Izmail / Samsun or Marmara or Izmir"
+      "sourceText": "Izmail"
     },
     "originCountry": "Ukraine",
     "destinationPort": {
-      "value": "Samsun",
-      "confidence": "confirmed",
-      "sourceText": "Izmail / Samsun or Marmara or Izmir"
+      "value": "Samsun or Marmara or Izmir",
+      "confidence": "interpreted",
+      "sourceText": "Samsun or Marmara or Izmir"
     },
     "destinationCountry": "Turkey",
     "cargoDescription": {
       "value": "Wheat",
       "confidence": "confirmed",
-      "sourceText": "wheat"
+      "sourceText": "5000 mts +/- 10% of wheat"
     },
     "weightMt": {
       "value": 5000,
@@ -2969,33 +4721,177 @@
       "max": 5500
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "11 May 2026 onward",
-      "confidence": "interpreted",
-      "sourceText": "11 May / onward"
-    },
+    "preferredDates": null,
     "laycan": "11 May 2026 onward",
     "loadingRate": "2000",
     "dischargeRate": "1500",
     "commissionPercent": 2.5,
-    "commissionTerms": "PAST",
+    "commissionTerms": "2.50% past us",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
       "Final discharge port nomination pending (charterer's option: Samsun or Marmara or Izmir)",
-      "Commodity grade not specified (e.g. wheat: protein %)",
+      "Marmara and Izmir are regions — specific discharge port TBN",
       "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
       "Demurrage and despatch rates not stated",
+      "Wheat grade/protein % not specified",
       "Vessel DWT/type requirement not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
     "destinationPortAlternatives": [
       "Marmara",
       "Izmir"
     ],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e089d15179ef31",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Bejaia",
+      "confidence": "confirmed",
+      "sourceText": "BEJAIA (MAX LOA 145 MTR)"
+    },
+    "originCountry": "Algeria",
+    "destinationPort": {
+      "value": "Libya or Mersin",
+      "confidence": "interpreted",
+      "sourceText": "1SP LIBYA OR MERSIN IN CHOPT"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Bagged sugar, stowage factor approximately 50",
+      "confidence": "interpreted",
+      "sourceText": "15.000 MTS BAGGED SUGAR STW FACTOR ABT 50’"
+    },
+    "weightMt": {
+      "value": 15000,
+      "confidence": "confirmed",
+      "sourceText": "15.000 MTS BAGGED SUGAR"
+    },
+    "weightMtMin": 15000,
+    "weightMtMax": 15000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot — vessel's dates",
+      "confidence": "interpreted",
+      "sourceText": "LAYCAN SPOT TRY VSL DATES"
+    },
+    "laycan": "Spot — vessel's dates",
+    "loadingRate": "1500",
+    "dischargeRate": "1000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Max LOA 145 m; geared vessels required; 1 safe port discharge (charterer's option Libya or Mersin)",
+    "stowageFactor": "abt 50 ft³/MT",
+    "missingInfo": [
+      "Final discharge port nomination pending (charterer's option: Libya or Mersin)",
+      "Specific Libya discharge port not nominated",
+      "Sugar grade/type not specified",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": [
+      "Libya (port unspecified)",
+      "Mersin"
+    ],
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": 145,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e089d15179ef31",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Bejaia",
+      "confidence": "confirmed",
+      "sourceText": "BEJAIA (MAX LOA 145 MTR)"
+    },
+    "originCountry": "Algeria",
+    "destinationPort": {
+      "value": "Turkish Eastern Mediterranean or Syria or Lebanon or Libya",
+      "confidence": "interpreted",
+      "sourceText": "1SP TURKISH EAST MED OR 1SP SYRIA OR 1SP LEBANON OR 1SP LIBYA IN CHOPT"
+    },
+    "destinationCountry": null,
+    "cargoDescription": {
+      "value": "Bagged sugar, stowage factor approximately 50",
+      "confidence": "interpreted",
+      "sourceText": "ABT 5-10.000 MTS BAGGED SUGAR STW FACTOR ABT 50’"
+    },
+    "weightMt": {
+      "value": null,
+      "confidence": "interpreted",
+      "sourceText": "ABT 5-10.000 MTS BAGGED SUGAR"
+    },
+    "weightMtMin": 5000,
+    "weightMtMax": 10000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 5000,
+      "max": 10000
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot — vessel's dates",
+      "confidence": "interpreted",
+      "sourceText": "LAYCAN SPOT TRY VSL DATES"
+    },
+    "laycan": "Spot — vessel's dates",
+    "loadingRate": "1500",
+    "dischargeRate": "1000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Max LOA 145 m; geared vessels required; 1 safe port discharge (charterer's option: Turkish East Med, Syria, Lebanon or Libya)",
+    "stowageFactor": "abt 50 ft³/MT",
+    "missingInfo": [
+      "Final discharge port nomination pending (charterer's option: Turkish East Med, Syria, Lebanon or Libya)",
+      "Specific discharge port not nominated within any of the optional countries",
+      "Sugar grade/type not specified",
+      "Cargo quantity is a range (5,000–10,000 MT) — exact stem not fixed",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": [
+      "Turkish Eastern Mediterranean (port unspecified)",
+      "Syria (port unspecified)",
+      "Lebanon (port unspecified)",
+      "Libya (port unspecified)"
+    ],
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": 145,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089d2d810d075",
@@ -3020,40 +4916,42 @@
     "weightMt": {
       "value": 3000,
       "confidence": "confirmed",
-      "sourceText": "3000 mts cement in big bags"
+      "sourceText": "3000 mts cement"
     },
     "weightMtMin": 3000,
     "weightMtMax": 3000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "BREAK_BULK",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": {
-      "value": "11-16 May 2026",
-      "confidence": "interpreted",
-      "sourceText": "11 - 16 May"
-    },
+    "preferredDates": null,
     "laycan": "11-16 May 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Specific discharge port in Greece not nominated — exact port TBD",
-      "Loading and discharge rates not stated",
+      "Laytime is given as '4 ttl days' (total for load+discharge) — split load/discharge rates and cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Specific Greek discharge port not nominated — exact port TBD",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
+      "Cement grade/type not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089d65f53a56c",
@@ -3071,14 +4969,14 @@
     },
     "destinationCountry": "United Kingdom",
     "cargoDescription": {
-      "value": "Soft stainless scrap, stowage factor approximately 66, without guarantee, no trimming/pressing inside hold",
+      "value": "Soft stainless steel scrap, stowage factor approximately 66, without guarantee (no trimming/pressing inside hold)",
       "confidence": "interpreted",
       "sourceText": "abt 3500 mts of soft stainless SCRAP stw abt 66' wog (no trimming/pressing inside hold)"
     },
     "weightMt": {
       "value": 3500,
       "confidence": "interpreted",
-      "sourceText": "abt 3500 mts"
+      "sourceText": "abt 3500 mts of soft stainless SCRAP"
     },
     "weightMtMin": null,
     "weightMtMax": null,
@@ -3088,93 +4986,33 @@
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": {
-      "value": "May 2026, try vessel dates",
-      "confidence": "interpreted",
-      "sourceText": "l/c May, try vessel dates"
-    },
-    "laycan": "May 2026 — try vessel dates",
+    "preferredDates": null,
+    "laycan": "May 2026",
     "loadingRate": "1500",
     "dischargeRate": "1500",
     "commissionPercent": 2.5,
     "commissionTerms": "TTL",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": "No trimming/pressing inside hold",
     "stowageFactor": "abt 66 ft³/MT WOG",
     "missingInfo": [
-      "Incoterms not stated",
       "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
+      "Vessel DWT/type requirement not specified",
+      "Freight rate pending ('with revised freight level' mentioned but no figure given)",
+      "Loading/discharge rate notation 1500c/1500x: 'c' = customary, 'x' suffix not a recognized laytime term — terms not extracted"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e089f3dc5f3033",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Bandirma",
-      "confidence": "confirmed",
-      "sourceText": "BANDIRMA / RAVENNA+KOPER"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Ravenna",
-      "confidence": "confirmed",
-      "sourceText": "RAVENNA+KOPER"
-    },
-    "destinationCountry": "Italy",
-    "cargoDescription": {
-      "value": "Bulk and bagged harmless minerals",
-      "confidence": "confirmed",
-      "sourceText": "BULK & BAGGED HARMLESS MINERALS"
-    },
-    "weightMt": {
-      "value": 5293,
-      "confidence": "confirmed",
-      "sourceText": "5293 MTS + /- 10"
-    },
-    "weightMtMin": 4764,
-    "weightMtMax": 5822,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "OTHER",
-    "containerType": null,
-    "quantity": {
-      "min": 4764,
-      "max": 5822
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "09/13 Feb 2026",
-      "confidence": "interpreted",
-      "sourceText": "09/13 FEB"
-    },
-    "laycan": "09/13 Feb 2026",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 1.25,
-    "commissionTerms": "TTL",
-    "specialRequirements": null,
-    "stowageFactor": null,
-    "missingInfo": [
-      "Exact meaning of the +/- 10 weight tolerance is not fully stated — assumed as 10 percent tolerance.",
-      "Total laytime allowance is not stated despite 'TTL DAYS' being mentioned.",
-      "Loading and discharge rates are not stated.",
-      "Demurrage and despatch rates not stated.",
-      "Discharge quantity split between Ravenna and Koper is not stated.",
-      "Incoterms not stated."
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [
-      "Ravenna",
-      "Koper"
-    ],
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089d960261c91",
@@ -3210,29 +5048,34 @@
     "quantity": null,
     "incoterms": null,
     "preferredDates": {
-      "value": "Spot / Prompt dates",
+      "value": "Spot / Prompt",
       "confidence": "interpreted",
       "sourceText": "L/C Spot / Ppt dates"
     },
-    "laycan": "Spot / Prompt dates",
+    "laycan": "Spot — Prompt",
     "loadingRate": "6000",
     "dischargeRate": "4000",
     "commissionPercent": 2.5,
-    "commissionTerms": "PUS (Past Us)",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "2.5% ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Geared vessel required (gear imperative)",
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
-      "Loading laytime terms not stated",
-      "Discharge laytime terms not stated",
+      "Gypsum grade/specification not stated",
       "Demurrage and despatch rates not stated",
-      "Meaning of 'Grd' vessel requirement needs human review"
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": true,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089d960261c91",
@@ -3268,28 +5111,101 @@
     "quantity": null,
     "incoterms": null,
     "preferredDates": {
-      "value": "20–25 May 2026",
-      "confidence": "interpreted",
+      "value": "20-25 May 2026",
+      "confidence": "confirmed",
       "sourceText": "L/C 20/25 May"
     },
-    "laycan": "20–25 May 2026",
+    "laycan": "20-25 May 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "PUS (Past Us)",
+    "commissionTerms": "2.5% ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "5 total weather working days laytime, reversible both ends",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Steel grade/dimensions/unit weight not specified",
+      "Coils vs plates split (tonnage breakdown) not stated",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e089f3dc5f3033",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Bandirma",
+      "confidence": "confirmed",
+      "sourceText": "BANDIRMA / RAVENNA+KOPER"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Ravenna",
+      "confidence": "confirmed",
+      "sourceText": "RAVENNA+KOPER"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Harmless minerals, bulk and bagged",
+      "confidence": "interpreted",
+      "sourceText": "BULK & BAGGED HARMLESS MINERALS"
+    },
+    "weightMt": {
+      "value": 5293,
+      "confidence": "interpreted",
+      "sourceText": "5293 MTS + /- 10"
+    },
+    "weightMtMin": 4763.7,
+    "weightMtMax": 5822.3,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 4763.7,
+      "max": 5822.3
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "9-13 February 2026",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 1.25,
+    "commissionTerms": "1.25% TTL",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
-      "Separate loading and discharge handling rates not stated",
+      "Laytime/handling rates not given — only 'TTL DAYS' (total laytime, days unspecified) stated",
       "Demurrage and despatch rates not stated",
-      "Per-unit weight and packaging details for steel coils/plates not stated"
+      "Discharge is rotation Ravenna + Koper — per-port tonnage split not specified",
+      "Mineral grade/type not specified ('harmless minerals')",
+      "Loading/discharge cost-allocation terms (FIO/CQD/FIOST) not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": [
+      "Ravenna",
+      "Koper"
+    ],
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089fc113c03c5",
@@ -3307,15 +5223,11 @@
     },
     "destinationCountry": "Sweden",
     "cargoDescription": {
-      "value": "Bulk cargo, commodity not specified",
-      "confidence": "confirmed",
+      "value": "Bulk cargo (commodity unspecified)",
+      "confidence": "uncertain",
       "sourceText": "3.500/8.000 mts bulk cargo"
     },
-    "weightMt": {
-      "value": 8000,
-      "confidence": "interpreted",
-      "sourceText": "3.500/8.000 mts"
-    },
+    "weightMt": null,
     "weightMtMin": 3500,
     "weightMtMax": 8000,
     "volumeCbm": null,
@@ -3327,31 +5239,33 @@
       "max": 8000
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "9-11 Feb 2026",
-      "confidence": "confirmed",
-      "sourceText": "1st shipment laycan: 9/11 Feb"
-    },
-    "laycan": "9-11 Feb 2026",
+    "preferredDates": null,
+    "laycan": "9-11 February 2026",
     "loadingRate": null,
     "dischargeRate": "2600",
     "commissionPercent": 2.5,
     "commissionTerms": null,
-    "specialRequirements": "[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": "LOA max 124m, beam max 18m",
     "stowageFactor": null,
     "missingInfo": [
-      "Specific Spanish Mediterranean load port not nominated — exact port TBD",
-      "Specific Sweden discharge port not nominated — exact port TBD",
-      "Commodity not specified for the bulk cargo",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Commission terms not stated"
+      "Commodity not specified — only 'bulk cargo' stated",
+      "Specific Spanish Mediterranean load port not nominated",
+      "Specific Sweden discharge port not nominated",
+      "Freight rate not stated (available on request)",
+      "Demurrage and despatch rates not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": 124,
+    "maxBeamM": 18,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e089fc113c03c5",
@@ -3369,15 +5283,11 @@
     },
     "destinationCountry": "Sweden",
     "cargoDescription": {
-      "value": "Bulk cargo, commodity not specified",
-      "confidence": "confirmed",
+      "value": "Bulk cargo (commodity unspecified)",
+      "confidence": "uncertain",
       "sourceText": "3.500/8.000 mts bulk cargo"
     },
-    "weightMt": {
-      "value": 8000,
-      "confidence": "interpreted",
-      "sourceText": "3.500/8.000 mts"
-    },
+    "weightMt": null,
     "weightMtMin": 3500,
     "weightMtMax": 8000,
     "volumeCbm": null,
@@ -3389,31 +5299,160 @@
       "max": 8000
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "16-18 Feb 2026",
-      "confidence": "confirmed",
-      "sourceText": "2nd shipment laycan: 16/18 Feb"
-    },
-    "laycan": "16-18 Feb 2026",
+    "preferredDates": null,
+    "laycan": "16-18 February 2026",
     "loadingRate": null,
     "dischargeRate": "2600",
     "commissionPercent": 2.5,
     "commissionTerms": null,
-    "specialRequirements": "[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": "LOA max 124m, beam max 18m",
     "stowageFactor": null,
     "missingInfo": [
-      "Specific Spanish Mediterranean load port not nominated — exact port TBD",
-      "Specific Sweden discharge port not nominated — exact port TBD",
-      "Commodity not specified for the bulk cargo",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Commission terms not stated"
+      "Commodity not specified — only 'bulk cargo' stated",
+      "Specific Spanish Mediterranean load port not nominated",
+      "Specific Sweden discharge port not nominated",
+      "Freight rate not stated (available on request)",
+      "Demurrage and despatch rates not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": 124,
+    "maxBeamM": 18,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e08a007eff29ab",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Izmail",
+      "confidence": "confirmed",
+      "sourceText": "Izmail / Figuera De Foz"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "Figueira da Foz",
+      "confidence": "confirmed",
+      "sourceText": "Izmail / Figuera De Foz"
+    },
+    "destinationCountry": "Portugal",
+    "cargoDescription": {
+      "value": "Clay in bulk",
+      "confidence": "confirmed",
+      "sourceText": "5000-6000 mtons bulk clay"
+    },
+    "weightMt": null,
+    "weightMtMin": 5000,
+    "weightMtMax": 6000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 5000,
+      "max": 6000
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "Spot/ppt"
+    },
+    "laycan": "Spot — prompt",
+    "loadingRate": "2000",
+    "dischargeRate": null,
+    "commissionPercent": 2.5,
+    "commissionTerms": "Gcn 2.5%",
+    "freightRateUsd": null,
+    "specialRequirements": "1 shipment per month",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Discharge rate not stated (only 'shex' term given, no MT/day)",
+      "Demurrage and despatch rates not stated",
+      "Clay grade/specification not specified",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e08a007eff29ab",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Figueira da Foz",
+      "confidence": "confirmed",
+      "sourceText": "Figuera De Foz / Tartous"
+    },
+    "originCountry": "Portugal",
+    "destinationPort": {
+      "value": "Tartous",
+      "confidence": "confirmed",
+      "sourceText": "Figuera De Foz / Tartous"
+    },
+    "destinationCountry": "Syria",
+    "cargoDescription": {
+      "value": "Clay in bulk",
+      "confidence": "confirmed",
+      "sourceText": "6000 any upto 7000 mtons bulk clay"
+    },
+    "weightMt": null,
+    "weightMtMin": 6000,
+    "weightMtMax": 7000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 6000,
+      "max": 7000
+    },
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "spot/ppt"
+    },
+    "laycan": "Spot — prompt",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 1.25,
+    "commissionTerms": "Gcn 1.25%",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": null,
+    "missingInfo": [
+      "Laytime term '7 ttl ys' unclear — likely 7 total days total laytime; needs confirmation",
+      "Separate load/discharge rates not stated",
+      "Demurrage and despatch rates not stated",
+      "Clay grade/specification not specified",
+      "Vessel DWT/type requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e08a163e396047",
@@ -3421,57 +5460,66 @@
     "originPort": {
       "value": "El Arish",
       "confidence": "confirmed",
-      "sourceText": "El Arish (fully bulk) OR  El Dekheila"
+      "sourceText": "El Arish (fully bulk) OR  El Dekheila (big bags + bulk)"
     },
     "originCountry": "Egypt",
     "destinationPort": {
       "value": "Port of Call (unspecified)",
       "confidence": "interpreted",
-      "sourceText": "POC"
+      "sourceText": "1 out of POC"
     },
     "destinationCountry": null,
     "cargoDescription": {
-      "value": "Salt, non-food industrial grade, El Arish option fully bulk, El Dekheila option big bags plus bulk",
-      "confidence": "confirmed"
-    },
-    "weightMt": {
-      "value": 16000,
+      "value": "Salt (non-food, industrial grade), one hold in big bags, other hold in bulk",
       "confidence": "interpreted",
-      "sourceText": "Any tonnage between 6-16k mt dwcc"
+      "sourceText": "salt (non-food, industrial grade), 1 HO in big-bags, other HO in bulk"
     },
+    "weightMt": null,
     "weightMtMin": 6000,
     "weightMtMax": 16000,
     "volumeCbm": null,
     "dimensions": null,
-    "cargoType": "OTHER",
+    "cargoType": "BULK",
     "containerType": null,
     "quantity": {
       "min": 6000,
       "max": 16000
     },
     "incoterms": null,
-    "preferredDates": null,
-    "laycan": "02 Feb 2026 onward",
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "LC 02.02 - onward"
+    },
+    "laycan": "2 February 2026 onward",
     "loadingRate": "3000",
     "dischargeRate": "1000",
     "commissionPercent": 2.5,
     "commissionTerms": "TTL",
-    "specialRequirements": "[object Object],[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": "1 good safe port load; El Arish load fully in bulk; El Dekheila load big bags + bulk; vessel min DWCC required (6-16k)",
     "stowageFactor": null,
     "missingInfo": [
-      "Final load port nomination pending (charterer's option: El Arish or El Dekheila)",
-      "Specific discharge port not nominated — Port of Call is unspecified",
-      "Laytime terms such as SHINC/SHEX/SSHEX not stated",
+      "Cargo quantity is a wide range (6,000–16,000 mt dwcc) — exact stem not fixed",
+      "Discharge port not nominated — '1 out of POC' (charterer's option, port TBD)",
+      "Load port pending nomination (charterer's option: El Arish or El Dekheila)",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
+      "Stowage factor not provided"
     ],
     "originPortAlternatives": [
       "El Dekheila"
     ],
     "originPortRotation": null,
-    "destinationPortAlternatives": [],
+    "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e08a1fdbf28c11",
@@ -3479,13 +5527,13 @@
     "originPort": {
       "value": "Trapani",
       "confidence": "confirmed",
-      "sourceText": "Trapani, Italy / Abu Qir"
+      "sourceText": "Trapani, Italy"
     },
     "originCountry": "Italy",
     "destinationPort": {
       "value": "Abu Qir",
       "confidence": "confirmed",
-      "sourceText": "Trapani, Italy / Abu Qir"
+      "sourceText": "Abu Qir"
     },
     "destinationCountry": "Egypt",
     "cargoDescription": {
@@ -3506,25 +5554,36 @@
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "Spot"
+    },
     "laycan": "Spot",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "Past Us",
-    "specialRequirements": "[object Object],[object Object]",
+    "commissionTerms": "2.5% PUS (past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Box vessel required; Charterers' agents both ends (Chagent be); Total laytime 5 days both ends (5 ttl day)",
     "stowageFactor": null,
     "missingInfo": [
-      "Individual marble block dimensions and unit weights not stated",
+      "Total laytime given as 5 days both ends — no separate load/discharge MT/day rates stated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Loading and discharge cost-allocation terms such as FIO/FIOST not stated"
+      "Freight rate not indicated",
+      "Marble block dimensions and per-piece weights not stated (break-bulk handling)"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e08a2360deb01b",
@@ -3544,11 +5603,11 @@
     "cargoDescription": {
       "value": "Wheat in bulk",
       "confidence": "confirmed",
-      "sourceText": "7300 mts wheat bulk"
+      "sourceText": "7300 mts wheat bulk,try 10600 mts"
     },
     "weightMt": {
       "value": 7300,
-      "confidence": "confirmed",
+      "confidence": "uncertain",
       "sourceText": "7300 mts wheat bulk,try 10600 mts"
     },
     "weightMtMin": 7300,
@@ -3562,149 +5621,37 @@
       "max": 10600
     },
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "spot"
+    },
     "laycan": "Spot",
     "loadingRate": "1250",
     "dischargeRate": "1250",
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Wheat grade/specification not stated",
-      "Laytime terms for loading and discharge not stated",
+      "Two cargo quantities stated — base 7300 mts wheat with option to 'try 10600 mts'; operative quantity to be confirmed",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Clarification needed whether 10,600 mts is an alternative cargo quantity or maximum trial intake"
+      "Vessel DWT/type requirement not specified",
+      "Stowage factor not stated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e08a007eff29ab",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Izmail",
-      "confidence": "confirmed",
-      "sourceText": "Izmail / Figuera De Foz"
-    },
-    "originCountry": "Ukraine",
-    "destinationPort": {
-      "value": "Figuera De Foz",
-      "confidence": "confirmed",
-      "sourceText": "Izmail / Figuera De Foz"
-    },
-    "destinationCountry": "Portugal",
-    "cargoDescription": {
-      "value": "Bulk clay",
-      "confidence": "confirmed",
-      "sourceText": "bulk clay"
-    },
-    "weightMt": {
-      "value": 6000,
-      "confidence": "interpreted",
-      "sourceText": "5000-6000 mtons bulk clay"
-    },
-    "weightMtMin": 5000,
-    "weightMtMax": 6000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 5000,
-      "max": 6000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "Spot / Prompt",
-      "confidence": "interpreted",
-      "sourceText": "Spot/ppt"
-    },
-    "laycan": "Spot / Prompt",
-    "loadingRate": "2000",
-    "dischargeRate": null,
-    "commissionPercent": 2.5,
-    "commissionTerms": "Gcn",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Discharge rate not clearly stated.",
-      "Demurrage and despatch rates not stated.",
-      "Incoterms not stated.",
-      "Vessel DWT/type requirement not specified.",
-      "Exact laycan dates not stated beyond spot/prompt."
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
-  },
-  {
-    "emailId": "19e08a007eff29ab",
-    "itemIndex": 1,
-    "originPort": {
-      "value": "Figuera De Foz",
-      "confidence": "confirmed",
-      "sourceText": "Figuera De Foz / Tartous"
-    },
-    "originCountry": "Portugal",
-    "destinationPort": {
-      "value": "Tartous",
-      "confidence": "confirmed",
-      "sourceText": "Figuera De Foz / Tartous"
-    },
-    "destinationCountry": "Syria",
-    "cargoDescription": {
-      "value": "Bulk clay",
-      "confidence": "confirmed",
-      "sourceText": "bulk clay"
-    },
-    "weightMt": {
-      "value": 7000,
-      "confidence": "interpreted",
-      "sourceText": "6000 any upto 7000 mtons bulk clay"
-    },
-    "weightMtMin": 6000,
-    "weightMtMax": 7000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 6000,
-      "max": 7000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "Spot / Prompt",
-      "confidence": "interpreted",
-      "sourceText": "spot/ppt"
-    },
-    "laycan": "Spot / Prompt",
-    "loadingRate": null,
-    "dischargeRate": null,
-    "commissionPercent": 1.25,
-    "commissionTerms": "Gcn",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Loading and discharge rates not stated.",
-      "Laytime term '7 ttl ys' is unclear and requires confirmation.",
-      "Demurrage and despatch rates not stated.",
-      "Incoterms not stated.",
-      "Vessel DWT/type requirement not specified.",
-      "Exact laycan dates not stated beyond spot/prompt."
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e08a26402532a7",
@@ -3722,15 +5669,11 @@
     },
     "destinationCountry": "Guinea",
     "cargoDescription": {
-      "value": "Bulk corn, stowage factor approximately 51",
+      "value": "Corn in bulk, stowage factor approximately 51",
       "confidence": "interpreted",
-      "sourceText": "bulk corn 51abt"
+      "sourceText": "20,000/22,000 mt bulk corn 51abt"
     },
-    "weightMt": {
-      "value": 22000,
-      "confidence": "interpreted",
-      "sourceText": "20,000/22,000 mt"
-    },
+    "weightMt": null,
     "weightMtMin": 20000,
     "weightMtMax": 22000,
     "volumeCbm": null,
@@ -3742,23 +5685,20 @@
       "max": 22000
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "10-20 February 2026",
-      "confidence": "confirmed",
-      "sourceText": "10/20-Feb"
-    },
+    "preferredDates": null,
     "laycan": "10-20 February 2026",
     "loadingRate": "7000",
     "dischargeRate": "3000",
     "commissionPercent": 2.5,
-    "commissionTerms": "past",
+    "commissionTerms": "2.5% past us (PUS)",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": "abt 51 ft³/MT",
     "missingInfo": [
-      "Final load port nomination pending (charterer's option: Constanța or Port of Call unspecified)",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Laytime terms not explicitly stated; rate suffix 'x' was not interpreted as a laytime term"
+      "Conflicting/range tonnage 20,000–22,000 mt — exact stem to be confirmed",
+      "Load load-port choice pending (Constanta or POC) — charterer's option",
+      "Laytime cost terms (FIO/FIOST/CQD) not stated; '7000x/3000x' rate suffix 'x' not a recognized laytime term",
+      "Demurrage and despatch rates not stated"
     ],
     "originPortAlternatives": [
       "Port of Call (unspecified)"
@@ -3766,7 +5706,76 @@
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e09767a49f448a",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Pivdennyi (Yuzhne)",
+      "confidence": "confirmed",
+      "sourceText": "1 sb Pivdenniy"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "Poti",
+      "confidence": "confirmed",
+      "sourceText": "1 sb Poti"
+    },
+    "destinationCountry": "Georgia",
+    "cargoDescription": {
+      "value": "Soya in bulk",
+      "confidence": "interpreted",
+      "sourceText": "abt 5000 mts soya in blk"
+    },
+    "weightMt": {
+      "value": 5000,
+      "confidence": "interpreted",
+      "sourceText": "abt 5000 mts soya in blk"
+    },
+    "weightMtMin": null,
+    "weightMtMax": null,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "l/c SPOT"
+    },
+    "laycan": "Spot",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Sulina (canal) passage 3 days",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Freight rate not stated — charterers invite owners' freight idea against vessel's details",
+      "Vessel DWT/type requirement not specified",
+      "Demurrage/despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e0976ad0f58119",
@@ -3778,8 +5787,8 @@
     },
     "originCountry": "Egypt",
     "destinationPort": {
-      "value": "Duala",
-      "confidence": "confirmed",
+      "value": "Douala",
+      "confidence": "interpreted",
       "sourceText": "Duala"
     },
     "destinationCountry": "Cameroon",
@@ -3806,99 +5815,53 @@
     "loadingRate": "8000",
     "dischargeRate": "3000",
     "commissionPercent": 2.5,
-    "commissionTerms": "pasr",
+    "commissionTerms": "2.5% pasr",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
       "Specific Egypt-Med load port not nominated — exact port TBD",
-      "Laytime cost-allocation terms such as SHINC, SHEX, FIO, CQD, or FIOST not stated",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Vessel DWT/type requirement not specified"
+      "Vessel type/DWT requirement not specified",
+      "Commission routing 'pasr' unclear — verify (possibly 'past us' address commission)"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e09767a49f448a",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Pivdenniy",
-      "confidence": "confirmed",
-      "sourceText": "1 sb Pivdenniy"
-    },
-    "originCountry": "Ukraine",
-    "destinationPort": {
-      "value": "Poti",
-      "confidence": "confirmed",
-      "sourceText": "1 sb Poti"
-    },
-    "destinationCountry": "Georgia",
-    "cargoDescription": {
-      "value": "Soya in bulk",
-      "confidence": "confirmed",
-      "sourceText": "soya in blk"
-    },
-    "weightMt": {
-      "value": 5000,
-      "confidence": "interpreted",
-      "sourceText": "abt 5000 mts soya in blk"
-    },
-    "weightMtMin": null,
-    "weightMtMax": null,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": null,
-    "laycan": "Spot",
-    "loadingRate": "1500",
-    "dischargeRate": "1500",
-    "commissionPercent": 2.5,
-    "commissionTerms": "TTL",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified",
-      "Meaning of 'chabe' is not recognized and needs human review"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e0976e3eeb9c2b",
     "itemIndex": 0,
     "originPort": {
       "value": "Tuapse",
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "TUAPSE / GIJON"
     },
     "originCountry": "Russia",
     "destinationPort": {
-      "value": "Gijon",
-      "confidence": "interpreted",
+      "value": "Gijón",
+      "confidence": "confirmed",
       "sourceText": "TUAPSE / GIJON"
     },
     "destinationCountry": "Spain",
     "cargoDescription": {
       "value": "Anthracite, stowage factor 43",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "7.000 mts anthracite sf 43"
     },
     "weightMt": {
       "value": 7000,
-      "confidence": "confirmed",
-      "sourceText": "7.000 mts"
+      "confidence": "interpreted",
+      "sourceText": "7.000 mts mins"
     },
     "weightMtMin": 7000,
     "weightMtMax": null,
@@ -3908,24 +5871,99 @@
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "SPOT"
+    },
     "laycan": "Spot",
     "loadingRate": "4000",
     "dischargeRate": "4000",
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object]",
-    "stowageFactor": "43",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "43 ft³/MT",
     "missingInfo": [
-      "Exact maximum cargo quantity not stated — only minimum 7,000 mts indicated",
+      "Weight stated as '7.000 mts mins' (minimum) — upper bound not given",
+      "Vessel type/DWT requirement not specified",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
+      "Anthracite grade/spec not specified"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e097736f6fcbe9",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Iskenderun",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun / Constanta"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Constanța",
+      "confidence": "confirmed",
+      "sourceText": "Iskenderun / Constanta"
+    },
+    "destinationCountry": "Romania",
+    "cargoDescription": {
+      "value": "Wire Rod Coils (WRC), outer diameter 1250 mm, length 1500–1600 mm, weight 2 MT per coil",
+      "confidence": "interpreted",
+      "sourceText": "Outer diam 1250 mm,Length  1500-1600 mm,Weight  2mt / coil"
+    },
+    "weightMt": {
+      "value": 5000,
+      "confidence": "confirmed",
+      "sourceText": "5000 mt W.R.C."
+    },
+    "weightMtMin": 5000,
+    "weightMtMax": 5000,
+    "volumeCbm": null,
+    "dimensions": "Outer diam 1250 mm, length 1500–1600 mm, 2 MT/coil",
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot/Prompt",
+      "confidence": "interpreted",
+      "sourceText": "Laycan Spot/Prompt"
+    },
+    "laycan": "Spot/Prompt",
+    "loadingRate": "1200",
+    "dischargeRate": "1500",
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": "Box-shaped / box-like vessels with open hatches; Charterer's agents both ends",
+    "stowageFactor": null,
+    "missingInfo": [
+      "No freight idea given — offers invited ('no ideas given boffers invited')",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/size not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e09776821d2476",
@@ -3944,13 +5982,13 @@
     "destinationCountry": "Spain",
     "cargoDescription": {
       "value": "Anthracite, stowage factor 43",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "7.000 mts anthracite sf 43"
     },
     "weightMt": {
       "value": 7000,
-      "confidence": "confirmed",
-      "sourceText": "7.000 mts anthracite"
+      "confidence": "interpreted",
+      "sourceText": "7.000 mts mins"
     },
     "weightMtMin": 7000,
     "weightMtMax": null,
@@ -3960,33 +5998,232 @@
     "containerType": null,
     "quantity": null,
     "incoterms": null,
-    "preferredDates": null,
+    "preferredDates": {
+      "value": "Spot",
+      "confidence": "interpreted",
+      "sourceText": "SPOT"
+    },
     "laycan": "Spot",
     "loadingRate": "4000",
     "dischargeRate": "4000",
     "commissionPercent": 2.5,
-    "commissionTerms": "TTL here",
-    "specialRequirements": "[object Object],[object Object]",
+    "commissionTerms": "2.5% TTL",
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": "43",
     "missingInfo": [
+      "Cargo quantity stated as '7,000 mts minimum' — no maximum specified",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Specific cargo grade/specification for anthracite not stated",
-      "Vessel DWT/type requirement not specified"
+      "Vessel DWT/type/gear requirement not specified"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e0977940338503",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Thessaloniki",
+      "confidence": "confirmed",
+      "sourceText": "THESSALONIKI"
+    },
+    "originCountry": "Greece",
+    "destinationPort": {
+      "value": "Marmara",
+      "confidence": "interpreted",
+      "sourceText": "1 MARMARA (INT.TEKIRDAG)"
+    },
+    "destinationCountry": "Turkey",
+    "cargoDescription": {
+      "value": "Paddy rice in bulk, stowage factor approximately 62",
+      "confidence": "interpreted",
+      "sourceText": "5.000 PADDY RICE IN BLK,SF ABT 62'"
+    },
+    "weightMt": {
+      "value": 5000,
+      "confidence": "confirmed",
+      "sourceText": "5.000 PADDY RICE IN BLK"
+    },
+    "weightMtMin": 5000,
+    "weightMtMax": 5000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": null,
+    "incoterms": null,
+    "preferredDates": {
+      "value": "Spot — vessel's dates",
+      "confidence": "interpreted",
+      "sourceText": "SPOT PPT - TRY VSLS DATES"
+    },
+    "laycan": "Spot — vessel's dates",
+    "loadingRate": null,
+    "dischargeRate": null,
+    "commissionPercent": 3.75,
+    "commissionTerms": "3.75% TTL including 2.50% address commission",
+    "freightRateUsd": null,
+    "specialRequirements": "Total laytime 8 WWD SSHEX EIU both ends (combined load+discharge); CHABE (charterers' agents both ends); Gencon (GCN) CP form; destination intended Tekirdag within Marmara",
+    "stowageFactor": "abt 62 ft³/MT",
+    "missingInfo": [
+      "Specific Marmara discharge port not nominated (intention Tekirdag) — exact port TBD",
+      "Demurrage and despatch rates not stated",
+      "Freight rate not indicated",
+      "Combined L/D laytime of 8 WWD stated as total — split between load/discharge not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e0977d3c8155ca",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "North Brazil (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "1 N Brazil ( max loa 190 m max draft 11.5)"
+    },
+    "originCountry": "Brazil",
+    "destinationPort": {
+      "value": "North China (port unspecified)",
+      "confidence": "interpreted",
+      "sourceText": "1 N China"
+    },
+    "destinationCountry": "China",
+    "cargoDescription": {
+      "value": "Manganese ore in bulk",
+      "confidence": "interpreted",
+      "sourceText": "blk mang ore"
+    },
+    "weightMt": null,
+    "weightMtMin": 30000,
+    "weightMtMax": 47000,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 30000,
+      "max": 47000
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "1-10 April 2026",
+    "loadingRate": "9000",
+    "dischargeRate": "15000",
+    "commissionPercent": 1.25,
+    "commissionTerms": "1.25% past us (PUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max LOA 190 m; Max draft 11.5 m; 12 hours turn time (12 h tt); Full cargo alternative to 30-47,000 mt offered",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Specific North Brazil load port not nominated — exact port TBD",
+      "Specific North China discharge port not nominated — exact port TBD",
+      "Quantity given as range (30,000–47,000 mt) or 'full cargo' — exact stem to be confirmed",
+      "Manganese ore grade/Mn content not specified",
+      "Stowage factor not stated",
+      "Demurrage and despatch rates not stated"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": 190,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e097888cdea89c",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Odesa",
+      "confidence": "confirmed",
+      "sourceText": "Odesa"
+    },
+    "originCountry": "Ukraine",
+    "destinationPort": {
+      "value": "TBS (to be specified)",
+      "confidence": "uncertain",
+      "sourceText": "tbs/marmara/izmir range /mersin range"
+    },
+    "destinationCountry": "Turkey",
+    "cargoDescription": {
+      "value": "Soybeans, stowage factor approximately 51",
+      "confidence": "interpreted",
+      "sourceText": "6500-7500k soyabean sf abt 51"
+    },
+    "weightMt": null,
+    "weightMtMin": 6500,
+    "weightMtMax": 7500,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 6500,
+      "max": 7500
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "Spot",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 2.5,
+    "commissionTerms": "2.5% Marelis",
+    "freightRateUsd": null,
+    "specialRequirements": "2 days Sulina free",
+    "stowageFactor": "abt 51 ft³/MT",
+    "missingInfo": [
+      "Final discharge port nomination pending (Turkey: Marmara / Izmir / Mersin range, TBS)",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated; '1500 x' rate suffix not a recognized laytime abbreviation",
+      "Demurrage and despatch rates not stated",
+      "Vessel DWT/type requirement not specified",
+      "Soybean origin/grade not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": [
+      "Marmara range",
+      "Izmir range",
+      "Mersin range"
+    ],
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e09798df92cca7",
     "itemIndex": 0,
     "originPort": {
       "value": "Alexandroupolis",
-      "confidence": "interpreted",
-      "sourceText": "Aleaxandroupolis / 1 Tunisia"
+      "confidence": "confirmed",
+      "sourceText": "Aleaxandroupolis"
     },
     "originCountry": "Greece",
     "destinationPort": {
@@ -3996,8 +6233,8 @@
     },
     "destinationCountry": "Tunisia",
     "cargoDescription": {
-      "value": "Wheat",
-      "confidence": "confirmed",
+      "value": "Wheat in bulk",
+      "confidence": "interpreted",
       "sourceText": "11.000mt 10% moloo wheat"
     },
     "weightMt": {
@@ -4016,212 +6253,38 @@
       "max": 12100
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "1/14 March 2026",
-      "confidence": "interpreted",
-      "sourceText": "1/14 March"
-    },
-    "laycan": "1/14 March 2026",
+    "preferredDates": null,
+    "laycan": "1-14 March 2026",
     "loadingRate": "6000",
     "dischargeRate": "2000",
     "commissionPercent": 3.75,
     "commissionTerms": null,
-    "specialRequirements": "[object Object],[object Object],[object Object]",
+    "freightRateUsd": null,
+    "specialRequirements": "Gearless vessel acceptable; max beam 16m",
     "stowageFactor": null,
     "missingInfo": [
       "Specific Tunisia discharge port not nominated — exact port TBD",
-      "Incoterms not stated",
-      "Laytime terms such as SHINC, SHEX, or SSHEX not stated",
-      "Demurrage and despatch rates not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e097888cdea89c",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Odesa",
-      "confidence": "confirmed",
-      "sourceText": "Odesa – tbs/marmara/izmir range /mersin range"
-    },
-    "originCountry": "Ukraine",
-    "destinationPort": {
-      "value": "TBS (to be specified)",
-      "confidence": "interpreted",
-      "sourceText": "tbs/marmara/izmir range /mersin range"
-    },
-    "destinationCountry": "Turkey",
-    "cargoDescription": {
-      "value": "Soyabean, stowage factor approximately 51",
-      "confidence": "interpreted",
-      "sourceText": "6500-7500k soyabean sf abt 51"
-    },
-    "weightMt": {
-      "value": 7500,
-      "confidence": "interpreted",
-      "sourceText": "6500-7500k soyabean"
-    },
-    "weightMtMin": 6500,
-    "weightMtMax": 7500,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 6500,
-      "max": 7500
-    },
-    "incoterms": null,
-    "preferredDates": null,
-    "laycan": "Spot",
-    "loadingRate": "1500",
-    "dischargeRate": "1500",
-    "commissionPercent": 2.5,
-    "commissionTerms": "Marelis brokerage/commission",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": "abt 51",
-    "missingInfo": [
-      "Final discharge port nomination pending: TBS, with alternatives Marmara range, Izmir range, or Mersin range",
-      "Laytime terms not stated — the “x” suffix is not a recognized laytime abbreviation",
+      "Laytime terms (SHINC/SHEX/FIO etc.) not stated for load/discharge rates",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated",
-      "Exact stowage factor units not stated"
+      "Wheat grade/protein % not specified"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [
-      "Marmara range",
-      "Izmir range",
-      "Mersin range"
-    ],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e0977d3c8155ca",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "North Brazil port (unspecified)",
-      "confidence": "interpreted",
-      "sourceText": "1 N Brazil"
-    },
-    "originCountry": "Brazil",
-    "destinationPort": {
-      "value": "North China port (unspecified)",
-      "confidence": "interpreted",
-      "sourceText": "1 N China"
-    },
-    "destinationCountry": "China",
-    "cargoDescription": {
-      "value": "Bulk manganese ore",
-      "confidence": "interpreted",
-      "sourceText": "blk mang ore"
-    },
-    "weightMt": {
-      "value": 47000,
-      "confidence": "interpreted",
-      "sourceText": "30-47.000 mt or full cargo"
-    },
-    "weightMtMin": 30000,
-    "weightMtMax": 47000,
-    "volumeCbm": null,
-    "dimensions": null,
-    "cargoType": "BULK",
-    "containerType": null,
-    "quantity": {
-      "min": 30000,
-      "max": 47000
-    },
-    "incoterms": null,
-    "preferredDates": {
-      "value": "1-10 April 2026",
-      "confidence": "confirmed",
-      "sourceText": "1-10th  April 2026"
-    },
-    "laycan": "1-10 April 2026",
-    "loadingRate": "9000",
-    "dischargeRate": "15000",
-    "commissionPercent": 1.25,
-    "commissionTerms": "past",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Specific North Brazil load port not nominated — exact port TBD",
-      "Specific North China discharge port not nominated — exact port TBD",
-      "Incoterms not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
-  },
-  {
-    "emailId": "19e097736f6fcbe9",
-    "itemIndex": 0,
-    "originPort": {
-      "value": "Iskenderun",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun / Constanta"
-    },
-    "originCountry": "Turkey",
-    "destinationPort": {
-      "value": "Constanța",
-      "confidence": "confirmed",
-      "sourceText": "Iskenderun / Constanta"
-    },
-    "destinationCountry": "Romania",
-    "cargoDescription": {
-      "value": "Wire rod coils (W.R.C.), outer diameter 1250 mm, length 1500–1600 mm, unit weight 2 MT per coil",
-      "confidence": "confirmed"
-    },
-    "weightMt": {
-      "value": 5000,
-      "confidence": "confirmed",
-      "sourceText": "5000 mt W.R.C. (wire rod coils)"
-    },
-    "weightMtMin": 5000,
-    "weightMtMax": 5000,
-    "volumeCbm": null,
-    "dimensions": "Outer diameter 1250 mm; length 1500-1600 mm",
-    "cargoType": "BREAK_BULK",
-    "containerType": null,
-    "quantity": null,
-    "incoterms": null,
-    "preferredDates": {
-      "value": "Spot/Prompt",
-      "confidence": "interpreted",
-      "sourceText": "Laycan Spot/Prompt"
-    },
-    "laycan": "Spot/Prompt",
-    "loadingRate": "1200",
-    "dischargeRate": "1500",
-    "commissionPercent": 3.75,
-    "commissionTerms": "TTL",
-    "specialRequirements": "[object Object],[object Object],[object Object]",
-    "stowageFactor": null,
-    "missingInfo": [
-      "Freight rate not stated — offers invited",
-      "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
-    ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": 16,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e097a1fe67ba9a",
     "itemIndex": 0,
     "originPort": {
-      "value": "Pidennyi",
+      "value": "Pivdennyi (Yuzhne)",
       "confidence": "confirmed",
       "sourceText": "Pidennyi - Cyprus"
     },
@@ -4234,14 +6297,10 @@
     "destinationCountry": "Cyprus",
     "cargoDescription": {
       "value": "Corn, stowage factor 50",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "Corn sf 50"
     },
-    "weightMt": {
-      "value": 6000,
-      "confidence": "interpreted",
-      "sourceText": "5000-6000 mt"
-    },
+    "weightMt": null,
     "weightMtMin": 5000,
     "weightMtMax": 6000,
     "volumeCbm": null,
@@ -4253,29 +6312,33 @@
       "max": 6000
     },
     "incoterms": null,
-    "preferredDates": {
-      "value": "End February – beginning March 2026",
-      "confidence": "interpreted",
-      "sourceText": "End feb - beg march"
-    },
-    "laycan": "End February – beginning March 2026",
+    "preferredDates": null,
+    "laycan": "End February / beginning March 2026",
     "loadingRate": "1500",
     "dischargeRate": "1500",
     "commissionPercent": 1.25,
-    "commissionTerms": "Marelis brokerage",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "1.25% Marelis",
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": "50",
     "missingInfo": [
-      "Specific Cyprus discharge port not nominated — exact port TBD",
-      "Laytime terms such as SHINC/SHEX/SSHEX not stated",
+      "Specific Cyprus discharge port not nominated",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) and SHINC/SHEX not stated",
       "Demurrage and despatch rates not stated",
-      "Incoterms not stated"
+      "Vessel DWT/type requirement not specified",
+      "Freight rate not indicated"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": []
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e097a4da37efbc",
@@ -4289,19 +6352,15 @@
     "destinationPort": {
       "value": "East Coast Italy port (unspecified)",
       "confidence": "interpreted",
-      "sourceText": "EC Italy"
+      "sourceText": "Odesa to EC Italy"
     },
     "destinationCountry": "Italy",
     "cargoDescription": {
       "value": "Wheat, stowage factor approximately 47, without guarantee",
       "confidence": "interpreted",
-      "sourceText": "Wheat sf abt 47’ wog"
+      "sourceText": "Wheat sf abt 47"
     },
-    "weightMt": {
-      "value": 12000,
-      "confidence": "interpreted",
-      "sourceText": "7200 – 12 000 mts"
-    },
+    "weightMt": null,
     "weightMtMin": 7200,
     "weightMtMax": 12000,
     "volumeCbm": null,
@@ -4314,28 +6373,36 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "Spot onward",
+      "value": "Spot",
       "confidence": "interpreted",
       "sourceText": "Spot - onw"
     },
     "laycan": "Spot",
     "loadingRate": "2000",
     "dischargeRate": "2000",
-    "commissionPercent": 2.5,
-    "commissionTerms": "1.25% address commission + 1.25% brokerage for Marelis",
-    "specialRequirements": "[object Object],[object Object]",
-    "stowageFactor": "abt 47 ft³/MT WOG",
+    "commissionPercent": 1.25,
+    "commissionTerms": "1.25% address commission + 1.25% Marelis brokerage (2.5% total)",
+    "freightRateUsd": null,
+    "specialRequirements": null,
+    "stowageFactor": "abt 47 ft³/MT",
     "missingInfo": [
-      "Specific East Coast Italy discharge port not nominated — exact port TBD",
-      "Laytime terms not stated; the “x” suffix in the handling rates is not a recognized laytime term",
+      "Specific EC Italy discharge port not nominated — exact port TBD",
+      "Laytime cost-allocation terms (FIO/CQD/FIOST) not stated",
       "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Vessel DWT/type requirement not specified",
+      "Freight rate not indicated — owners' frt ideas requested"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e097ae5d6335c1",
@@ -4343,22 +6410,22 @@
     "originPort": {
       "value": "Alexandria",
       "confidence": "confirmed",
-      "sourceText": "Alexandria  / Liverpool"
+      "sourceText": "Alexandria"
     },
     "originCountry": "Egypt",
     "destinationPort": {
       "value": "Liverpool",
       "confidence": "confirmed",
-      "sourceText": "Alexandria  / Liverpool"
+      "sourceText": "Liverpool"
     },
     "destinationCountry": "United Kingdom",
     "cargoDescription": {
-      "value": "Steel Hot Rolled Coils (HRC), unit weight 16 up to 25 tons",
+      "value": "Hot Rolled Coils (HRC), unit weight 16 up to 25 tonnes per coil",
       "confidence": "interpreted",
       "sourceText": "Abt 6000-6100 mts hrc uw of 16 upto 25 tons"
     },
     "weightMt": {
-      "value": 6100,
+      "value": null,
       "confidence": "interpreted",
       "sourceText": "Abt 6000-6100 mts hrc"
     },
@@ -4374,7 +6441,7 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "Spot-onwards",
+      "value": "Spot",
       "confidence": "interpreted",
       "sourceText": "Spot-onwards"
     },
@@ -4382,21 +6449,271 @@
     "loadingRate": "1500",
     "dischargeRate": "3000",
     "commissionPercent": 1.25,
-    "commissionTerms": "commission",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": null,
+    "freightRateUsd": null,
+    "specialRequirements": null,
     "stowageFactor": null,
     "missingInfo": [
-      "Incoterms not stated",
-      "Laytime cost-allocation terms such as FIO, CQD, or FIOST not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified",
-      "Exact loading date range not stated beyond spot-onwards"
+      "Load rate varies by number of holds worked (1500/day for 2 holds, 2250/day for 3 holds) — operative rate depends on vessel hold count; '3000x' appears to be discharge rate. The 'x' suffix is not a recognized laytime term — terms (SHINC/SHEX) not stated.",
+      "Cargo quantity given as range 6000-6100 mts (subject says 'about 6000') — exact stem to be confirmed.",
+      "HRC coil dimensions / stowage factor not stated.",
+      "Demurrage and despatch rates not stated."
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e097b289230e5f",
+    "itemIndex": 0,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CATANIA"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Catania",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / CATANIA"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Wire rod in coils (WRIC), unit weight approximately 1.8–2.1 tonnes per coil, stowage factor max 50",
+      "confidence": "interpreted",
+      "sourceText": "WRIC UW ABT 1,8/2,1TS STW MAX 50'"
+    },
+    "weightMt": {
+      "value": 3000,
+      "confidence": "confirmed",
+      "sourceText": "3,000MTS 1PCT MOLCHOPT"
+    },
+    "weightMtMin": 2970,
+    "weightMtMax": 3030,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 2970,
+      "max": 3030
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "1-3 March 2026",
+    "loadingRate": "1000",
+    "dischargeRate": "1000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": "max 50 ft³/MT",
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Vessel type/DWT requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e097b289230e5f",
+    "itemIndex": 1,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / SAGUNTO"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Sagunto",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / SAGUNTO"
+    },
+    "destinationCountry": "Spain",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC) and Hot Rolled Coils Pickled & Oiled (HRCPO), unit weight approximately 10–27 tonnes per coil",
+      "confidence": "interpreted",
+      "sourceText": "HRC + HRCPO UW ABT 10/27TS"
+    },
+    "weightMt": {
+      "value": 2000,
+      "confidence": "confirmed",
+      "sourceText": "2,000MTS 2PCT MOLCHOPT"
+    },
+    "weightMtMin": 1960,
+    "weightMtMax": 2040,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 1960,
+      "max": 2040
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "Spot / Prompt",
+    "loadingRate": "1000",
+    "dischargeRate": "1000",
+    "commissionPercent": 3.75,
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Vessel type/DWT requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e097b289230e5f",
+    "itemIndex": 2,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / VARNA"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Varna",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / VARNA"
+    },
+    "destinationCountry": "Bulgaria",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC), Hot Rolled Coils Trimmed & Descaled (HRCTD), Hot Rolled Coils Pickled & Oiled (HRCPO) unit weight approximately 10–27 tonnes per coil, and Hot Rolled Sheets (HRS)",
+      "confidence": "interpreted",
+      "sourceText": "HRC + HRCTD + HRCPO UW ABT 10/27TS + HRS"
+    },
+    "weightMt": {
+      "value": 5800,
+      "confidence": "confirmed",
+      "sourceText": "5,800MTS 2PCT MOLCHOPT"
+    },
+    "weightMtMin": 5684,
+    "weightMtMax": 5916,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 5684,
+      "max": 5916
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "1-3 March 2026",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 3.75,
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Vessel type/DWT requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
+  },
+  {
+    "emailId": "19e097b289230e5f",
+    "itemIndex": 3,
+    "originPort": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / MARGHERA"
+    },
+    "originCountry": "Turkey",
+    "destinationPort": {
+      "value": "Marghera",
+      "confidence": "confirmed",
+      "sourceText": "NEMRUT / MARGHERA"
+    },
+    "destinationCountry": "Italy",
+    "cargoDescription": {
+      "value": "Hot Rolled Coils (HRC) and Hot Rolled Coils Trimmed & Descaled (HRCTD), unit weight approximately 10–27 tonnes per coil",
+      "confidence": "interpreted",
+      "sourceText": "HRC + HRCTD UW ABT 10/27TS"
+    },
+    "weightMt": {
+      "value": 4345,
+      "confidence": "confirmed",
+      "sourceText": "4,345MTS 2PCT MOLCHOPT"
+    },
+    "weightMtMin": 4258,
+    "weightMtMax": 4432,
+    "volumeCbm": null,
+    "dimensions": null,
+    "cargoType": "BREAK_BULK",
+    "containerType": null,
+    "quantity": {
+      "min": 4258,
+      "max": 4432
+    },
+    "incoterms": null,
+    "preferredDates": null,
+    "laycan": "1-3 March 2026",
+    "loadingRate": "1500",
+    "dischargeRate": "1500",
+    "commissionPercent": 3.75,
+    "commissionTerms": "ADDCOMPUS (address commission past us)",
+    "freightRateUsd": null,
+    "specialRequirements": "Max vessel age 25 years (try more)",
+    "stowageFactor": null,
+    "missingInfo": [
+      "Demurrage and despatch rates not stated",
+      "Vessel type/DWT requirement not specified"
+    ],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": 25,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e097b52ea0fd0e",
@@ -4416,13 +6733,9 @@
     "cargoDescription": {
       "value": "Steel, stowage equals deadweight",
       "confidence": "interpreted",
-      "sourceText": "steel stw dwt"
+      "sourceText": "3000/5000 mts steel stw dwt"
     },
-    "weightMt": {
-      "value": 5000,
-      "confidence": "interpreted",
-      "sourceText": "3000/5000 mts"
-    },
+    "weightMt": null,
     "weightMtMin": 3000,
     "weightMtMax": 5000,
     "volumeCbm": null,
@@ -4435,30 +6748,37 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "Spot / prompt; can try beginning March 2026 dates as well",
+      "value": "Spot prompt; can try beginning March",
       "confidence": "interpreted",
       "sourceText": "spot prompt - can try beg march dates as well."
     },
-    "laycan": "Spot / Prompt; beginning March 2026 possible",
+    "laycan": "Prompt",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 3.75,
-    "commissionTerms": "TTL COMM",
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
     "missingInfo": [
-      "Specific Turkey load port not nominated — exact port TBD",
-      "Specific United Kingdom discharge port not nominated — exact port TBD",
-      "Laytime cost-allocation terms such as FIO, CQD, or FIOST not stated",
-      "Loading and discharge rates not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Specific Turkey load port not nominated",
+      "Specific UK discharge port not nominated",
+      "Cargo weight given as range 3000–5000 MT, not a single quantity",
+      "Steel form/grade not specified (coils/billets/plates)",
+      "Laytime terms and load/discharge rates not stated ('ttl days' only)",
+      "Demurrage and despatch rates not stated"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e097b52ea0fd0e",
@@ -4478,13 +6798,9 @@
     "cargoDescription": {
       "value": "Steel, stowage equals deadweight",
       "confidence": "interpreted",
-      "sourceText": "steel stw dwt"
+      "sourceText": "3000/5000 mts steel stw dwt"
     },
-    "weightMt": {
-      "value": 5000,
-      "confidence": "interpreted",
-      "sourceText": "3000/5000 mts"
-    },
+    "weightMt": null,
     "weightMtMin": 3000,
     "weightMtMax": 5000,
     "volumeCbm": null,
@@ -4497,30 +6813,37 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "5–10 March 2026",
-      "confidence": "interpreted",
+      "value": "5-10 March",
+      "confidence": "confirmed",
       "sourceText": "5-10 March"
     },
-    "laycan": "5–10 March 2026",
+    "laycan": "5-10 March 2026",
     "loadingRate": null,
     "dischargeRate": null,
     "commissionPercent": 3.75,
-    "commissionTerms": "TTL COMM",
+    "commissionTerms": "3.75% TTL",
+    "freightRateUsd": null,
     "specialRequirements": null,
     "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
     "missingInfo": [
-      "Specific Turkey load port not nominated — exact port TBD",
-      "Specific United Kingdom discharge port not nominated — exact port TBD",
-      "Laytime cost-allocation terms such as FIO, CQD, or FIOST not stated",
-      "Loading and discharge rates not stated",
-      "Demurrage and despatch rates not stated",
-      "Vessel DWT/type requirement not specified"
+      "Specific Turkey load port not nominated",
+      "Specific UK discharge port not nominated",
+      "Cargo weight given as range 3000–5000 MT, not a single quantity",
+      "Steel form/grade not specified (coils/billets/plates)",
+      "Laytime terms and load/discharge rates not stated ('ttl days' only)",
+      "Demurrage and despatch rates not stated"
     ],
     "originPortAlternatives": null,
     "originPortRotation": null,
     "destinationPortAlternatives": null,
     "destinationPortRotation": null,
-    "weightPerPort": null
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e0f50b19f0c25b",
@@ -4532,21 +6855,17 @@
     },
     "originCountry": "Turkey",
     "destinationPort": {
-      "value": "Djibouti",
-      "confidence": "confirmed",
+      "value": "Djibouti or Tadjourah",
+      "confidence": "interpreted",
       "sourceText": "1 Djibouti or 1 Tadjourah in chopt"
     },
     "destinationCountry": "Djibouti",
     "cargoDescription": {
       "value": "Steel Products, stowage equals deadweight",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "Steel Products stw = dwt"
     },
-    "weightMt": {
-      "value": 9000,
-      "confidence": "interpreted",
-      "sourceText": "Min 6.500 mts up to 9.000 mts in chopt"
-    },
+    "weightMt": null,
     "weightMtMin": 6500,
     "weightMtMax": 9000,
     "volumeCbm": null,
@@ -4559,31 +6878,39 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "spot/ppt",
+      "value": "Spot/Prompt",
       "confidence": "interpreted",
       "sourceText": "spot/ppt"
     },
-    "laycan": "Spot / Prompt",
+    "laycan": "Prompt",
     "loadingRate": "1250",
     "dischargeRate": null,
     "commissionPercent": 2.5,
-    "commissionTerms": "ADDCOMPUS / address commission past us",
-    "specialRequirements": "[object Object],[object Object]",
+    "commissionTerms": "2.50% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Cargo may be combined with the Berbera 2800 MT steel parcel, or shipped separately (combi or not)",
     "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
     "missingInfo": [
       "Final discharge port nomination pending (charterer's option: Djibouti or Tadjourah)",
-      "Detailed steel product specification, packing, dimensions, and unit weights not stated",
+      "Steel product grade/form not specified (coils/plates/billets/rebar)",
       "Demurrage and despatch rates not stated",
-      "Exact laycan dates not stated beyond spot/prompt",
-      "Incoterms not stated"
+      "Discharge rate not stated (liner out terms)",
+      "Vessel DWT/type requirement not specified",
+      "Quantity is a range (6,500–9,000 MT in charterer's option) — exact stem TBC"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
+    "originPortAlternatives": null,
+    "originPortRotation": null,
     "destinationPortAlternatives": [
       "Tadjourah"
     ],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   },
   {
     "emailId": "19e0f50b19f0c25b",
@@ -4595,20 +6922,20 @@
     },
     "originCountry": "Turkey",
     "destinationPort": {
-      "value": "Barbera",
-      "confidence": "confirmed",
+      "value": "Berbera",
+      "confidence": "interpreted",
       "sourceText": "Barbera Somalia"
     },
     "destinationCountry": "Somalia",
     "cargoDescription": {
       "value": "Steel Products, stowage equals deadweight",
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "Steel Products stw = dwt"
     },
     "weightMt": {
       "value": 2800,
       "confidence": "confirmed",
-      "sourceText": "2800 mts %10"
+      "sourceText": "2800 mts %10 Steel Products"
     },
     "weightMtMin": 2520,
     "weightMtMax": 3080,
@@ -4622,28 +6949,34 @@
     },
     "incoterms": null,
     "preferredDates": {
-      "value": "spot/ppt",
+      "value": "Spot/Prompt",
       "confidence": "interpreted",
       "sourceText": "spot/ppt"
     },
-    "laycan": "Spot / Prompt",
+    "laycan": "Prompt",
     "loadingRate": "1000",
     "dischargeRate": "500",
     "commissionPercent": 2.5,
-    "commissionTerms": "ADDCOMPUS / address commission past us",
-    "specialRequirements": "[object Object]",
+    "commissionTerms": "2.50% address commission past us (ADDCOMPUS)",
+    "freightRateUsd": null,
+    "specialRequirements": "Cargo may be combined with the Djibouti/Tadjourah 6,500–9,000 MT steel parcel, or shipped separately (combi or not); quantity 10% tolerance",
     "stowageFactor": "STW DWT (cargo loads vessel to full deadweight)",
     "missingInfo": [
-      "Detailed steel product specification, packing, dimensions, and unit weights not stated",
+      "Steel product grade/form not specified (coils/plates/billets/rebar)",
       "Demurrage and despatch rates not stated",
-      "Exact laycan dates not stated beyond spot/prompt",
-      "Incoterms not stated",
-      "Cargo quantity tolerance option holder not stated for the 10% tolerance"
+      "Vessel DWT/type requirement not specified",
+      "Quantity tolerance party not specified (10% — owner's or charterer's option unclear)"
     ],
-    "originPortAlternatives": [],
-    "originPortRotation": [],
-    "destinationPortAlternatives": [],
-    "destinationPortRotation": [],
-    "weightPerPort": null
+    "originPortAlternatives": null,
+    "originPortRotation": null,
+    "destinationPortAlternatives": null,
+    "destinationPortRotation": null,
+    "weightPerPort": null,
+    "maxVesselAgeYrs": null,
+    "gearRequired": null,
+    "maxLoaM": null,
+    "maxBeamM": null,
+    "flagRequired": null,
+    "classRequired": null
   }
 ]

--- a/lib/sample-data/demo-parsed-vessels.json
+++ b/lib/sample-data/demo-parsed-vessels.json
@@ -1,90 +1,12 @@
 [
   {
-    "emailId": "19d5e74e4479a895",
-    "itemIndex": 0,
-    "vesselName": {
-      "value": "MV BARABULKA",
-      "confidence": "confirmed",
-      "sourceText": "MV BARABULKA - OPEN AT KARASU TODAY"
-    },
-    "imo": null,
-    "flag": "Cameroon",
-    "built": 1995,
-    "classSociety": "Dutch Lloyd",
-    "pandi": "Thomas Miller Pandi",
-    "dwtSummer": {
-      "value": 4916,
-      "confidence": "interpreted",
-      "sourceText": "4916 Dwt  on  4.76 ssw"
-    },
-    "dwcc": null,
-    "draftMax": {
-      "value": 4.76,
-      "confidence": "interpreted",
-      "sourceText": "4916 Dwt  on  4.76 ssw"
-    },
-    "loa": null,
-    "beam": null,
-    "grt": 4110,
-    "nrt": 1358,
-    "holdsCount": 3,
-    "hatchesCount": 3,
-    "grainCapacity": 179538,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 176008.29,
-    "holdDimensions": null,
-    "hatchDimensions": null,
-    "tankTopStrength": null,
-    "geared": null,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": "Volga-Don Type",
-    "openPosition": {
-      "value": "Karasu",
-      "confidence": "confirmed",
-      "sourceText": "OPEN AT KARASU TODAY"
-    },
-    "openDate": {
-      "value": {
-        "open": "2025-02-25",
-        "close": null,
-        "display": "TODAY"
-      },
-      "confidence": "interpreted",
-      "sourceText": "OPEN AT KARASU TODAY"
-    },
-    "direction": null,
-    "restrictions": [
-      {
-        "value": "CAN'T CALL UKRAINE AND  EU PORTS.",
-        "confidence": "confirmed",
-        "source_text": "CAN'T CALL UKRAINE AND  EU PORTS."
-      }
-    ],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "BOX",
-        "confidence": "confirmed",
-        "source_text": "Holds / Hatches  : 3/3 BOX"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
     "emailId": "19d5e7406f50cc13",
     "itemIndex": 0,
     "vesselName": {
-      "value": "mv haskal",
-      "confidence": "confirmed",
-      "sourceText": "mv haskal"
+      "value": "MV HASKAL",
+      "confidence": "confirmed"
     },
-    "imo": null,
+    "imo": "8605480",
     "flag": null,
     "built": 1986,
     "classSociety": null,
@@ -110,20 +32,20 @@
     "nrt": 700,
     "holdsCount": 1,
     "hatchesCount": null,
-    "grainCapacity": 100682,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 100682,
-    "holdDimensions": "[object Object]",
-    "hatchDimensions": "[object Object]",
+    "grainCapacity": 81,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 81,
+    "holdDimensions": "49,80m x 9,00m x 6,78m",
+    "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": null,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "marmara",
+      "value": "Marmara",
       "confidence": "confirmed",
-      "sourceText": "spot marmara"
+      "sourceText": "2 k dwcc spot marmara"
     },
     "openDate": {
       "value": "spot",
@@ -138,75 +60,8 @@
     "consumption": null,
     "deckCapacity": null,
     "specialFeatures": [
-      {
-        "value": "Suitable for imo 1.1 cargoes",
-        "confidence": "confirmed",
-        "source_text": "Suitable for imo 1.1 cargoes"
-      },
-      {
-        "value": "box shaped 1 single hold",
-        "confidence": "confirmed",
-        "source_text": "box shaped 1 single hold"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19d5e75a1f9011b6",
-    "itemIndex": 0,
-    "vesselName": null,
-    "imo": null,
-    "flag": null,
-    "built": null,
-    "classSociety": null,
-    "pandi": null,
-    "dwtSummer": null,
-    "dwcc": {
-      "value": 2900,
-      "confidence": "confirmed",
-      "sourceText": "Dwcc 2900 mts"
-    },
-    "draftMax": null,
-    "loa": null,
-    "beam": null,
-    "grt": null,
-    "nrt": null,
-    "holdsCount": null,
-    "hatchesCount": null,
-    "grainCapacity": 147000,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": null,
-    "holdDimensions": null,
-    "hatchDimensions": null,
-    "tankTopStrength": null,
-    "geared": null,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "Biscay",
-      "confidence": "confirmed",
-      "sourceText": "Open spot biscay"
-    },
-    "openDate": {
-      "value": "spot",
-      "confidence": "interpreted",
-      "sourceText": "Open spot biscay"
-    },
-    "direction": "Black Sea; can load from Continent",
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "box",
-        "confidence": "confirmed",
-        "source_text": "Dwcc 2900 mts, grain cap 147 000 cut, box"
-      }
+      "box-shaped single hold",
+      "IMDG Class 1.1 certified"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -216,8 +71,7 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "PANTHERA J",
-      "confidence": "confirmed",
-      "sourceText": "PANTHERA J"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -244,24 +98,24 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "2x150/300mt",
+    "craneCapacity": "2 x 150/300mt",
     "hatchType": null,
     "vesselType": "MPP",
     "openPosition": {
-      "value": "CONTINENT",
+      "value": "Continent",
       "confidence": "confirmed",
       "sourceText": "CONTINENT"
     },
     "openDate": {
       "value": {
-        "open": "2025-06-01",
+        "open": null,
         "close": null,
-        "display": "01 Jun 2025"
+        "display": "01 JUN"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "01 JUN"
     },
-    "direction": "ANY DIR WW",
+    "direction": "Any direction worldwide",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": {
@@ -278,10 +132,17 @@
     },
     "specialFeatures": [
       {
-        "value": "twn",
+        "value": "IMDG Class 1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO 1"
+      },
+      {
+        "value": "Tween decker",
         "confidence": "confirmed",
         "source_text": "twn"
-      }
+      },
+      "IMDG Class 1 certified",
+      "Great Lakes/Seaway fitted"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -291,8 +152,7 @@
     "itemIndex": 1,
     "vesselName": {
       "value": "HC EVA-MARIE",
-      "confidence": "confirmed",
-      "sourceText": "HC EVA-MARIE"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -319,24 +179,24 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "2x80/160mt",
+    "craneCapacity": "2 x 80/160mt",
     "hatchType": null,
     "vesselType": "MPP",
     "openPosition": {
-      "value": "HALSVIK",
+      "value": "Halsvik",
       "confidence": "confirmed",
       "sourceText": "HALSVIK"
     },
     "openDate": {
       "value": {
-        "open": "2025-05-25",
+        "open": null,
         "close": null,
-        "display": "25 May 2025"
+        "display": "25 MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "25 MAY"
     },
-    "direction": "ANY DIR WW",
+    "direction": "Any direction worldwide",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": null,
@@ -349,15 +209,22 @@
     },
     "specialFeatures": [
       {
-        "value": "twn",
+        "value": "IMDG Class 1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO 1"
+      },
+      {
+        "value": "Ice class: 1A",
+        "confidence": "confirmed",
+        "source_text": "Ice 1A"
+      },
+      {
+        "value": "Tween decker",
         "confidence": "confirmed",
         "source_text": "twn"
       },
-      {
-        "value": "Ice 1A",
-        "confidence": "confirmed",
-        "source_text": "Ice 1A"
-      }
+      "IMDG Class 1 certified",
+      "Great Lakes/Seaway fitted"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -367,8 +234,7 @@
     "itemIndex": 2,
     "vesselName": {
       "value": "O7 GAJA",
-      "confidence": "confirmed",
-      "sourceText": "O7 GAJA"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -395,7 +261,7 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "2x240/480mt",
+    "craneCapacity": "2 x 240/480mt",
     "hatchType": null,
     "vesselType": "MPP",
     "openPosition": {
@@ -405,14 +271,14 @@
     },
     "openDate": {
       "value": {
-        "open": "2025-06-04",
+        "open": null,
         "close": null,
-        "display": "04 Jun 2025"
+        "display": "04 JUN"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "04 JUN"
     },
-    "direction": "BRAZIL",
+    "direction": "Brazil",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": null,
@@ -425,15 +291,22 @@
     },
     "specialFeatures": [
       {
-        "value": "twn",
+        "value": "IMDG Class 1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO 1"
+      },
+      {
+        "value": "Great Lakes/Seaway fitted",
+        "confidence": "confirmed",
+        "source_text": "Lakes"
+      },
+      {
+        "value": "Tween decker",
         "confidence": "confirmed",
         "source_text": "twn"
       },
-      {
-        "value": "Lakes",
-        "confidence": "confirmed",
-        "source_text": "Lakes"
-      }
+      "IMDG Class 1 certified",
+      "Great Lakes/Seaway fitted"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -443,8 +316,7 @@
     "itemIndex": 3,
     "vesselName": {
       "value": "SLOMAN DISPATCHER",
-      "confidence": "confirmed",
-      "sourceText": "SLOMAN DISPATCHER"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -471,24 +343,24 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "2x150/300mt",
+    "craneCapacity": "2 x 150/300mt",
     "hatchType": null,
     "vesselType": "MPP",
     "openPosition": {
-      "value": "HAUGESUND",
+      "value": "Haugesund",
       "confidence": "confirmed",
       "sourceText": "HAUGESUND"
     },
     "openDate": {
       "value": {
-        "open": "2025-05-28",
+        "open": null,
         "close": null,
-        "display": "28 May 2025"
+        "display": "28 MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "28 MAY"
     },
-    "direction": "ANY DIR WW",
+    "direction": "Any direction worldwide",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": {
@@ -505,10 +377,85 @@
     },
     "specialFeatures": [
       {
-        "value": "twn",
+        "value": "IMDG Class 1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO 1"
+      },
+      {
+        "value": "Tween decker",
         "confidence": "confirmed",
         "source_text": "twn"
-      }
+      },
+      "IMDG Class 1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19d5e74e4479a895",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV BARABULKA",
+      "confidence": "confirmed"
+    },
+    "imo": "8887296",
+    "flag": "Cameroon",
+    "built": 1995,
+    "classSociety": "Dutch Lloyd",
+    "pandi": "Thomas Miller Pandi",
+    "dwtSummer": {
+      "value": 4916,
+      "confidence": "confirmed"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 4.76,
+      "confidence": "confirmed",
+      "sourceText": "4916 Dwt  on  4.76 ssw"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": 4110,
+    "nrt": 1358,
+    "holdsCount": 3,
+    "hatchesCount": 3,
+    "grainCapacity": 144,
+    "grainCapacityUnit": "cbft",
+    "baleCapacity": 141,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Karasu",
+      "confidence": "confirmed",
+      "sourceText": "OPEN AT KARASU TODAY"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "TODAY"
+      },
+      "confidence": "confirmed",
+      "sourceText": "OPEN AT KARASU TODAY"
+    },
+    "direction": null,
+    "restrictions": [
+      "Cannot call Ukraine",
+      "Cannot call EU ports"
+    ],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "Volga-Don type",
+      "BOX holds"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -518,11 +465,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV ALINA",
-      "confidence": "confirmed",
-      "sourceText": "MV ALINA"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "BELIZE CITY",
+    "flag": "Belize",
     "built": 2025,
     "classSociety": "RINA",
     "pandi": "SKULD, OSLO",
@@ -543,16 +489,16 @@
     "nrt": 4041,
     "holdsCount": 4,
     "hatchesCount": 4,
-    "grainCapacity": 13400,
-    "grainCapacityUnit": "cbm",
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
     "baleCapacity": null,
-    "holdDimensions": "[object Object],[object Object],[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object],[object Object],[object Object],[object Object]",
+    "holdDimensions": "HOLD NO 1: 26.14 x 14.8 x 9.15,HOLD NO 2: 27.30 x 14.8 x 9.15,HOLD NO 3: 27.30 x 14.8 x 9.15,HOLD NO 4: 26.14 x 14.8 x 9.15",
+    "hatchDimensions": "NO.1,2,3,4 L 24.7 M X B 12 M",
     "tankTopStrength": "8.5",
-    "geared": false,
+    "geared": true,
     "craneCapacity": null,
-    "hatchType": "MACGREGOR",
-    "vesselType": "SID",
+    "hatchType": "MacGregor",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Casablanca",
       "confidence": "confirmed",
@@ -560,14 +506,14 @@
     },
     "openDate": {
       "value": {
-        "open": "2025-10-01",
-        "close": "2025-10-05",
+        "open": null,
+        "close": null,
         "display": "01-05 October"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "open Casablanca 01-05 October"
     },
-    "direction": "Bsea/enroute",
+    "direction": "Black Sea / enroute",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": null,
@@ -576,14 +522,9 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
         "source_text": "SID, GLESS, BLT 2025"
-      },
-      {
-        "value": "Gearless",
-        "confidence": "confirmed",
-        "source_text": "GLESS"
       }
     ],
     "ciiRating": null,
@@ -593,14 +534,13 @@
     "emailId": "19d5e77730e6489b",
     "itemIndex": 0,
     "vesselName": {
-      "value": "Gandolf",
-      "confidence": "confirmed",
-      "sourceText": "MV 'Gandolf'"
+      "value": "MV Gandolf",
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": "Comoros",
     "built": 1988,
-    "classSociety": "Phoenix Class",
+    "classSociety": "Phoenix",
     "pandi": "Turk P&I",
     "dwtSummer": {
       "value": 1084,
@@ -622,22 +562,22 @@
     "grainCapacity": 1681,
     "grainCapacityUnit": "cbm",
     "baleCapacity": 1462,
-    "holdDimensions": "[object Object]",
-    "hatchDimensions": "[object Object]",
+    "holdDimensions": "37,80 x 7,40 x 5,20 m",
+    "hatchDimensions": "37,80 x 7,40 m",
     "tankTopStrength": null,
-    "geared": null,
+    "geared": false,
     "craneCapacity": null,
-    "hatchType": "McGregor single pull type hatch covers",
-    "vesselType": "SID/BOX",
+    "hatchType": "McGregor single pull type",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Skikda",
       "confidence": "confirmed",
-      "sourceText": "**open Skikda spot under our c/p"
+      "sourceText": "open Skikda spot under our c/p"
     },
     "openDate": {
       "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "**open Skikda spot under our c/p"
+      "sourceText": "open Skikda spot"
     },
     "direction": null,
     "restrictions": [],
@@ -648,14 +588,14 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "Sid/Box Hold",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
         "source_text": "Sid/Box Hold"
       },
       {
         "value": "Steel floored",
         "confidence": "confirmed",
-        "source_text": "Steel floored"
+        "source_text": "Steel floored,"
       },
       {
         "value": "Appendix A,B,C fitted",
@@ -668,10 +608,11 @@
         "source_text": "Air vent fitted"
       },
       {
-        "value": "Bowtrusther fitted",
+        "value": "Bow thruster fitted",
         "confidence": "confirmed",
         "source_text": "Bowtrusther fitted"
-      }
+      },
+      "SID box-shaped hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -681,18 +622,17 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV SVS VEGA",
-      "confidence": "confirmed",
-      "sourceText": "MV SVS VEGA"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": "St. Vincent & the Grenadines",
     "built": 1996,
-    "classSociety": "Lloyd's Register",
+    "classSociety": "LR",
     "pandi": null,
     "dwtSummer": {
       "value": 3200,
       "confidence": "confirmed",
-      "sourceText": "3200 mt DWAT"
+      "sourceText": "3200 mt DWAT sfb on 4,63m"
     },
     "dwcc": null,
     "draftMax": {
@@ -706,29 +646,29 @@
     "nrt": 1216,
     "holdsCount": 1,
     "hatchesCount": 2,
-    "grainCapacity": 140000,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 140000,
+    "grainCapacity": 3964,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 3964,
     "holdDimensions": null,
     "hatchDimensions": "[object Object]",
     "tankTopStrength": null,
     "geared": false,
     "craneCapacity": null,
-    "hatchType": "MacGregor hatchcover hydr. folding type",
-    "vesselType": "Multipurpose dry cargo/Container vessel",
+    "hatchType": "MacGregor hydraulic folding",
+    "vesselType": "MPP",
     "openPosition": {
       "value": "Efesan",
       "confidence": "confirmed",
-      "sourceText": "**open Efesan Sep/6-8th"
+      "sourceText": "open Efesan Sep/6-8th"
     },
     "openDate": {
       "value": {
-        "open": "2025-09-06",
-        "close": "2025-09-08",
+        "open": null,
+        "close": null,
         "display": "Sep/6-8th"
       },
-      "confidence": "interpreted",
-      "sourceText": "Sep/6-8th"
+      "confidence": "confirmed",
+      "sourceText": "open Efesan Sep/6-8th"
     },
     "direction": null,
     "restrictions": [],
@@ -744,32 +684,37 @@
         "source_text": "Ice Class 1A"
       },
       {
-        "value": "open hatch/doubleskinned singledecker",
+        "value": "+LMC, UMS",
         "confidence": "confirmed",
-        "source_text": "open\nhatch/doubleskinned  singledecker"
+        "source_text": "+LMC,UMS"
       },
       {
-        "value": "Gearless / Cont Fitted",
+        "value": "open hatch",
         "confidence": "confirmed",
-        "source_text": "Gearless / Cont Fitted"
+        "source_text": "open hatch/doubleskinned"
       },
       {
-        "value": "Nominal container intake: 266 TEU (80 in hold + 186 on deck)",
+        "value": "double-skinned",
         "confidence": "confirmed",
-        "source_text": "Nominal container intake: 266 TEU (80 in hold\n+ 186 on deck)"
+        "source_text": "open hatch/doubleskinned"
       },
       {
-        "value": "alt. 121 FEU + 24 TEU (28 (+ 24 TEU) in hold and 93 on deck)",
+        "value": "singledecker",
         "confidence": "confirmed",
-        "source_text": "alt. 121 FEU + 24 TEU (28 (+ 24 TEU) in hold and 93 on deck)"
+        "source_text": "singledecker"
       },
       {
-        "value": "able abt/max 180TEU@ 14tons (50% bunker/sfb)",
-        "confidence": "interpreted",
+        "value": "Container fitted, 266 TEU (80 in hold + 186 on deck)",
+        "confidence": "confirmed",
+        "source_text": "Cont Fitted Nominal container intake: 266 TEU (80 in hold + 186 on deck)"
+      },
+      {
+        "value": "abt/max 180 TEU @ 14tons (50% bunker/sfb)",
+        "confidence": "confirmed",
         "source_text": "able abt/max 180TEU@ 14tons (50% bunker/sfb)"
       },
       {
-        "value": "Airdraft ballast 24,7 meter",
+        "value": "Airdraft ballast 24.7 m",
         "confidence": "confirmed",
         "source_text": "Airdraft ballast 24,7 meter"
       }
@@ -778,88 +723,14 @@
     "verificationWarning": null
   },
   {
-    "emailId": "19e07c4bb3fee039",
-    "itemIndex": 0,
-    "vesselName": {
-      "value": "MV LADY ANITA",
-      "confidence": "confirmed",
-      "sourceText": "MV LADY ANITA – OPEN RED SEA PROMPT"
-    },
-    "imo": null,
-    "flag": "TOGO",
-    "built": 2012,
-    "classSociety": "OMCS",
-    "pandi": null,
-    "dwtSummer": {
-      "value": 5328.4,
-      "confidence": "confirmed",
-      "sourceText": "SUMMER DEADWEIGHT\r\n\r\n5328.4 M/T"
-    },
-    "dwcc": null,
-    "draftMax": {
-      "value": 5.85,
-      "confidence": "confirmed",
-      "sourceText": "SUMMER DRAFT\r\n\r\n5.85 M"
-    },
-    "loa": 96.9,
-    "beam": 15.8,
-    "grt": 2998,
-    "nrt": 1746,
-    "holdsCount": 2,
-    "hatchesCount": 2,
-    "grainCapacity": 6800,
-    "grainCapacityUnit": "cbm",
-    "baleCapacity": 6700,
-    "holdDimensions": "[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
-    "tankTopStrength": null,
-    "geared": null,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": "GENERAL CARGO SHIP",
-    "openPosition": {
-      "value": "RED SEA",
-      "confidence": "confirmed",
-      "sourceText": "OPEN RED SEA PROMPT"
-    },
-    "openDate": {
-      "value": "spot",
-      "confidence": "interpreted",
-      "sourceText": "OPEN RED SEA PROMPT"
-    },
-    "direction": null,
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": {
-      "value": 10,
-      "confidence": "confirmed",
-      "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
-    },
-    "speedBallast": {
-      "value": 10.5,
-      "confidence": "confirmed",
-      "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
-    },
-    "consumption": {
-      "value": "Ballast: IFO 180 M/E 3.7MT/D; AUX/E MGO 0.35MT. Loading: IFO 180 ME 4.2MT/D; AUX/E MGO 0.35MT/D. In port: AUX/E MGO 0.35MT/D",
-      "confidence": "confirmed",
-      "source_text": "CONSUMPTION BALLAST\r\n\r\nIFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT\r\n\r\n\r\nCONSUMPTION LOADING\r\n\r\nIFO 180  ME:4.2MT/D；AUX/E: MGO 0.35MT/D\r\n\r\n\r\nCONSUMPTION IN PORT\r\n\r\nAUX/E MGO 0.35MT/D"
-    },
-    "deckCapacity": null,
-    "specialFeatures": [],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
     "emailId": "19d5e79432c6caf9",
     "itemIndex": 0,
     "vesselName": {
       "value": "MV GLORY TOM",
-      "confidence": "confirmed",
-      "sourceText": "MV GLORY TOM  DWT 63695 - OPEN CASABLANCA END AUG/EARLY SEP"
+      "confidence": "confirmed"
     },
-    "imo": null,
-    "flag": "PANAMA",
+    "imo": "9701360",
+    "flag": "Panama",
     "built": 2015,
     "classSociety": "NK",
     "pandi": "CPI",
@@ -883,15 +754,15 @@
     "grainCapacity": 78771,
     "grainCapacityUnit": "cbm",
     "baleCapacity": 73680,
-    "holdDimensions": null,
-    "hatchDimensions": "[object Object],[object Object]",
-    "tankTopStrength": null,
+    "holdDimensions": "HOLD#1 : 13958 / 13200 CBM,HOLD#2 : 17658 / 16650 CBM,HOLD#3 : 15353 / 14080 CBM,HOLD#4 : 15840 / 15000 CBM,HOLD#5 : 15962 / 14750 CBM",
+    "hatchDimensions": "HATCH #1: 19.68 X 18.26 X 1.82,HATCH #2,#3,#4,#5: 22.96 X 18.26 X 1.82",
+    "tankTopStrength": "25",
     "geared": true,
-    "craneCapacity": "4 X 30 METRIC TONNES",
-    "hatchType": "MACGREGOR FOLDING",
-    "vesselType": "GRABFITTED BULKCARRIER",
+    "craneCapacity": "4 x 30T",
+    "hatchType": "MacGregor folding",
+    "vesselType": "BULK CARRIER",
     "openPosition": {
-      "value": "CASABLANCA",
+      "value": "Casablanca",
       "confidence": "confirmed",
       "sourceText": "OPEN CASABLANCA END AUG/EARLY SEP"
     },
@@ -901,212 +772,146 @@
         "close": null,
         "display": "END AUG/EARLY SEP"
       },
-      "confidence": "uncertain",
-      "sourceText": "END AUG/EARLY SEP"
+      "confidence": "confirmed",
+      "sourceText": "OPEN CASABLANCA END AUG/EARLY SEP"
     },
     "direction": null,
     "restrictions": [
-      {
-        "value": "NO UKRAINE, BLACK SEA RUSSIA TRADING",
-        "confidence": "confirmed",
-        "source_text": "NO UKRAINE, BLACK SEA RUSSIA TRADING;"
-      },
-      {
-        "value": "NO USA TRADING",
-        "confidence": "confirmed",
-        "source_text": "NO USA TRADING;"
-      },
-      {
-        "value": "BALTIC RUSSIA - MURMANSK/UST LUGA/SAINT PETERSBURG - OK",
-        "confidence": "confirmed",
-        "source_text": "BALTIC RUSSIA - MURMANSK/UST LUGA/SAINT PETERSBURG - OK"
-      },
-      {
-        "value": "GOA TRANSIT - OK",
-        "confidence": "confirmed",
-        "source_text": "GOA TRANSIT - OK"
-      }
+      "NO UKRAINE, BLACK SEA RUSSIA TRADING",
+      "NO USA TRADING"
     ],
-    "lastCargoes": "GENERAL CARGO/TAPIOCA CHIPS/COAL/COAL/BAUXITE, I.ORE",
+    "lastCargoes": "general cargo, tapioca chips, coal, coal, bauxite, iron ore",
     "speedLaden": {
       "value": 13.5,
       "confidence": "interpreted",
-      "source_text": "ABT 13.5 KNOTS ON ABT 28.5 MT/DAY IFO 380 CST + 0.1 MT/DAY MGO"
+      "source_text": "LADEN ABT 13.5 KNOTS"
     },
     "speedBallast": {
       "value": 14,
       "confidence": "interpreted",
-      "source_text": "ABT 14.0 KNOTS ON ABT 27.0 MT/DAY IFO 380 CST + 0.1 MT/DAY MGO"
+      "source_text": "BALLAST ABT 14.0 KNOTS"
     },
     "consumption": {
-      "value": "Ballast: ABT 27.0 MT/DAY IFO 380 CST + 0.1 MT/DAY MGO; Laden: ABT 28.5 MT/DAY IFO 380 CST + 0.1 MT/DAY MGO; Eco ballast: ABT 19.5 MT/DAY IFO 380 CST+ 0.1 MT/DAY MGO; Eco laden: ABT 21.0 MT/DAY IFO 380 CST+ 0.1 MT/DAY MGO; Port work: ABT 6.0 MT/DAY IFO 380 CST + 0.2 MT/DAY MGO; Port idle: ABT 2.0 MT/DAY IFO 380 CST + 0.2 MT/DAY MGO",
+      "value": "Laden abt 28.5 MT IFO380 + 0.1 MGO; Ballast abt 27.0 MT IFO380 + 0.1 MGO",
       "confidence": "interpreted",
-      "source_text": "ABT 14.0 KNOTS ON ABT 27.0 MT/DAY IFO 380 CST + 0.1 MT/DAY MGO"
+      "source_text": "ABT 28.5 MT/DAY IFO 380 CST + 0.1 MT/DAY MGO"
     },
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "BOD ABT 600-700 MT VLSFO AND ABT 140-160 MT LSMGO",
-        "confidence": "interpreted",
-        "source_text": "BOD ABT 600-700 MT VLSFO AND ABT 140-160 MT LSMGO"
-      },
-      {
-        "value": "2*25MT, DECK/HATCH - OK",
-        "confidence": "confirmed",
-        "source_text": "2*25MT, DECK/HATCH - OK"
-      },
-      {
-        "value": "WINDMILL BLADES CAN TRY CASE BY CASE",
-        "confidence": "confirmed",
-        "source_text": "WINDMILL BLADES CAN TRY CASE BY CASE;"
-      },
-      {
-        "value": "TYPE : GRABFITTED BULKCARRIER",
+        "value": "Grab-fitted bulk carrier",
         "confidence": "confirmed",
         "source_text": "TYPE : GRABFITTED BULKCARRIER"
       },
       {
-        "value": "HULL : DOUBLE HULL",
+        "value": "Double hull",
         "confidence": "confirmed",
         "source_text": "HULL : DOUBLE HULL"
       },
       {
-        "value": "RIGHTSHIP RATING: 3 STARS",
+        "value": "RightShip rating: 3 stars",
         "confidence": "confirmed",
         "source_text": "RIGHTSHIP RATING: 3 STARS"
       },
       {
-        "value": "TANKTOP STR : HOLD #1, #3, #5: 25 MT/SQM\n\nHOLD #2, #4: 20 MT/SQM",
+        "value": "Crane outreach 13.80m",
         "confidence": "confirmed",
-        "source_text": "TANKTOP STR : HOLD #1, #3, #5: 25 MT/SQM\n\nHOLD #2, #4: 20 MT/SQM"
+        "source_text": "OUTREACH : 13.80 METRES"
+      },
+      {
+        "value": "TPC 62.30 MT",
+        "confidence": "confirmed",
+        "source_text": "TPC : 62.30 METRIC TONNES"
+      },
+      {
+        "value": "2x25MT deck/hatch OK; windmill blades case by case",
+        "confidence": "confirmed",
+        "source_text": "2*25MT, DECK/HATCH - OK ; WINDMILL BLADES CAN TRY CASE BY CASE"
       }
     ],
     "ciiRating": null,
     "verificationWarning": null
   },
   {
-    "emailId": "19e07c65c31852c7",
+    "emailId": "19e07c4bb3fee039",
     "itemIndex": 0,
     "vesselName": {
-      "value": "FAITH",
-      "confidence": "confirmed",
-      "sourceText": "FAITH   30116DW/12/CR30MT"
+      "value": "MV LADY ANITA",
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": null,
-    "built": null,
-    "classSociety": null,
+    "flag": "Togo",
+    "built": 2012,
+    "classSociety": "OMCS",
     "pandi": null,
     "dwtSummer": {
-      "value": 30116,
+      "value": 5328.4,
       "confidence": "confirmed",
-      "sourceText": "30116DW"
+      "sourceText": "SUMMER DEADWEIGHT"
     },
     "dwcc": null,
-    "draftMax": null,
-    "loa": null,
-    "beam": null,
-    "grt": null,
-    "nrt": null,
-    "holdsCount": null,
-    "hatchesCount": null,
-    "grainCapacity": null,
-    "grainCapacityUnit": null,
-    "baleCapacity": null,
-    "holdDimensions": null,
-    "hatchDimensions": null,
-    "tankTopStrength": null,
-    "geared": true,
-    "craneCapacity": "30 MT",
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "Praia Mole",
+    "draftMax": {
+      "value": 5.85,
       "confidence": "confirmed",
-      "sourceText": "PRAIA MOLE 15/20 MAY"
+      "sourceText": "SUMMER DRAFT"
+    },
+    "loa": 96.9,
+    "beam": 15.8,
+    "grt": 2998,
+    "nrt": 1746,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 6800,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 6700,
+    "holdDimensions": "No.1: 32.64M X 13.26M X 7.82M,No.2: 32M X 13.26M X 7.82M",
+    "hatchDimensions": "No.1: 25M X 9.45M,No.2: 26.9M X 9.45M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Red Sea",
+      "confidence": "confirmed",
+      "sourceText": "OPEN RED SEA PROMPT"
     },
     "openDate": {
-      "value": {
-        "open": "2026-05-15",
-        "close": "2026-05-20",
-        "display": "15/20 MAY"
-      },
+      "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "PRAIA MOLE 15/20 MAY"
+      "sourceText": "OPEN RED SEA PROMPT"
     },
     "direction": null,
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": {
-      "value": 12,
-      "confidence": "uncertain",
-      "source_text": "30116DW/12/CR30MT"
+      "value": 10,
+      "confidence": "confirmed",
+      "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
     },
-    "speedBallast": null,
-    "consumption": null,
+    "speedBallast": {
+      "value": 10.5,
+      "confidence": "confirmed",
+      "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
+    },
+    "consumption": {
+      "value": "Ballast: ME 3.7MT IFO180 + AE 0.35MT MGO; Loading: ME 4.2MT IFO180 + AE 0.35MT MGO; Port: AE 0.35MT MGO",
+      "confidence": "confirmed",
+      "source_text": "CONSUMPTION BALLAST IFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT"
+    },
     "deckCapacity": null,
-    "specialFeatures": [],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19e07c68d1a6c54a",
-    "itemIndex": 0,
-    "vesselName": {
-      "value": "AMITY",
-      "confidence": "confirmed",
-      "sourceText": "AMITY  29996DW/10/CR30MT"
-    },
-    "imo": null,
-    "flag": null,
-    "built": 2010,
-    "classSociety": null,
-    "pandi": null,
-    "dwtSummer": {
-      "value": 29996,
-      "confidence": "confirmed",
-      "sourceText": "AMITY  29996DW/10/CR30MT"
-    },
-    "dwcc": null,
-    "draftMax": null,
-    "loa": null,
-    "beam": null,
-    "grt": null,
-    "nrt": null,
-    "holdsCount": null,
-    "hatchesCount": null,
-    "grainCapacity": null,
-    "grainCapacityUnit": null,
-    "baleCapacity": null,
-    "holdDimensions": null,
-    "hatchDimensions": null,
-    "tankTopStrength": null,
-    "geared": true,
-    "craneCapacity": "30MT",
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "BIZERTE",
-      "confidence": "confirmed",
-      "sourceText": "BIZERTE 14/20 MAY"
-    },
-    "openDate": {
-      "value": {
-        "open": "2026-05-14",
-        "close": "2026-05-20",
-        "display": "14/20 MAY"
+    "specialFeatures": [
+      {
+        "value": "TPC 12.9 MT",
+        "confidence": "confirmed",
+        "source_text": "T.P.C 12.9 MT"
       },
-      "confidence": "interpreted",
-      "sourceText": "BIZERTE 14/20 MAY"
-    },
-    "direction": null,
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [],
+      {
+        "value": "Max height 28.65 M",
+        "confidence": "confirmed",
+        "source_text": "MAX HEIGHT 28.65 M"
+      }
+    ],
     "ciiRating": null,
     "verificationWarning": null
   },
@@ -1115,11 +920,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV IMI",
-      "confidence": "confirmed",
-      "sourceText": "MV IMI"
+      "confidence": "confirmed"
     },
-    "imo": null,
-    "flag": "BAHAMAS",
+    "imo": "9063873",
+    "flag": "Bahamas",
     "built": 1993,
     "classSociety": "DNV",
     "pandi": null,
@@ -1146,14 +950,14 @@
     "hatchesCount": 1,
     "grainCapacity": 5764,
     "grainCapacityUnit": "cbm",
-    "baleCapacity": null,
-    "holdDimensions": "[object Object]",
+    "baleCapacity": 5764,
+    "holdDimensions": "63.6X11.0X8.4",
     "hatchDimensions": null,
     "tankTopStrength": "15",
-    "geared": null,
+    "geared": false,
     "craneCapacity": null,
-    "hatchType": "OPEN HATCH",
-    "vesselType": "mpp bulk tonnage",
+    "hatchType": null,
+    "vesselType": "MPP",
     "openPosition": {
       "value": "Vassiliko",
       "confidence": "confirmed",
@@ -1161,12 +965,198 @@
     },
     "openDate": {
       "value": {
-        "open": "2026-05-15",
-        "close": "2026-05-16",
-        "display": "15/16 May 2026"
+        "open": null,
+        "close": null,
+        "display": "15/16 May"
       },
+      "confidence": "confirmed",
+      "sourceText": "Open @Vassiliko o/a "
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped single hold (LBP 84.99)",
+      "open hatch",
+      "bow thruster",
+      "2 bulkheads",
+      "box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07c65c31852c7",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "FAITH",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2012,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 30116,
+      "confidence": "confirmed",
+      "sourceText": "FAITH   30116DW/12/CR30MT"
+    },
+    "dwcc": null,
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "30MT",
+    "hatchType": null,
+    "vesselType": "BULK CARRIER",
+    "openPosition": {
+      "value": "Praia Mole",
+      "confidence": "confirmed",
+      "sourceText": "PRAIA MOLE 15/20 MAY"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "15/20 MAY"
+      },
+      "confidence": "confirmed",
+      "sourceText": "PRAIA MOLE 15/20 MAY"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07c68d1a6c54a",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "AMITY",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": null,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 29996,
+      "confidence": "confirmed",
+      "sourceText": "AMITY  29996DW/10/CR30MT"
+    },
+    "dwcc": null,
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "30MT",
+    "hatchType": null,
+    "vesselType": "BULK CARRIER",
+    "openPosition": {
+      "value": "Bizerte",
+      "confidence": "confirmed",
+      "sourceText": "BIZERTE 14/20 MAY"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "14/20 May"
+      },
+      "confidence": "confirmed",
+      "sourceText": "BIZERTE 14/20 MAY"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07c6ce81f694d",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV ALTO",
+      "confidence": "confirmed"
+    },
+    "imo": "9145786",
+    "flag": "Belize",
+    "built": 1997,
+    "classSociety": "Turkish Lloyd",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 24804,
+      "confidence": "confirmed",
+      "sourceText": "SUMMER: 24804 DWT ON 10.045 METERS"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 10.045,
+      "confidence": "confirmed",
+      "sourceText": "24804 DWT ON 10.045 METERS"
+    },
+    "loa": 153.78,
+    "beam": 26,
+    "grt": 20395,
+    "nrt": 9257,
+    "holdsCount": 4,
+    "hatchesCount": 4,
+    "grainCapacity": 44888.42,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 43766.28,
+    "holdDimensions": null,
+    "hatchDimensions": "No:1 – 16.00 x 17.38,No:2 – 20.00 x 22.00,No:3 – 20.00 x 22.00,No:4 – 20.00 x 20.00",
+    "tankTopStrength": "15",
+    "geared": true,
+    "craneCapacity": "4 x 30T",
+    "hatchType": "MacGregor folding",
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Yemen",
+      "confidence": "confirmed",
+      "sourceText": "Open YEMEN SPOT"
+    },
+    "openDate": {
+      "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "15/16 May"
+      "sourceText": "Open YEMEN SPOT"
     },
     "direction": null,
     "restrictions": [],
@@ -1177,19 +1167,24 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "BOXSHAPED",
+        "value": "Holds 2 & 3 box-shaped",
         "confidence": "confirmed",
-        "source_text": "BOXSHAPED"
+        "source_text": "HOLD NO 2&3 ARE BOX"
       },
       {
-        "value": "2 BULKHEADS",
+        "value": "CO2 fitted",
         "confidence": "confirmed",
-        "source_text": "2 BULKHEADS"
+        "source_text": "CO2 FITTED"
       },
       {
-        "value": "BOWTHR",
+        "value": "Australian ladders fitted",
         "confidence": "confirmed",
-        "source_text": "BOWTHR"
+        "source_text": "AUSTRALIAN LADDERS FITTED"
+      },
+      {
+        "value": "Only 3 of 4 cranes can work simultaneously",
+        "confidence": "confirmed",
+        "source_text": "only 3 cranes can work simultaneously"
       }
     ],
     "ciiRating": null,
@@ -1199,9 +1194,8 @@
     "emailId": "19e07c79d78505e4",
     "itemIndex": 0,
     "vesselName": {
-      "value": "M/V HACI HILMI II",
-      "confidence": "confirmed",
-      "sourceText": "M/V HACI HILMI II"
+      "value": "HACI HILMI II",
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -1225,29 +1219,29 @@
     "nrt": null,
     "holdsCount": null,
     "hatchesCount": null,
-    "grainCapacity": 309895,
-    "grainCapacityUnit": "cbft",
+    "grainCapacity": 8775,
+    "grainCapacityUnit": "cbm",
     "baleCapacity": null,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "3 X 10MTS",
+    "craneCapacity": "3 x 10T",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Marmara Sea",
       "confidence": "confirmed",
-      "sourceText": "OPEN MARMARA SEA"
+      "sourceText": "OPEN MARMARA SEA ON 22-23RD MAY"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-22",
-        "close": "2026-05-23",
+        "open": null,
+        "close": null,
         "display": "22-23RD MAY"
       },
-      "confidence": "interpreted",
-      "sourceText": "22-23RD MAY"
+      "confidence": "confirmed",
+      "sourceText": "OPEN MARMARA SEA ON 22-23RD MAY"
     },
     "direction": null,
     "restrictions": [],
@@ -1264,9 +1258,8 @@
     "emailId": "19e07c79d78505e4",
     "itemIndex": 1,
     "vesselName": {
-      "value": "MV TBN",
-      "confidence": "confirmed",
-      "sourceText": "MV TBN"
+      "value": "TBN",
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -1286,8 +1279,8 @@
     "nrt": null,
     "holdsCount": null,
     "hatchesCount": null,
-    "grainCapacity": 700000,
-    "grainCapacityUnit": "cbft",
+    "grainCapacity": 561,
+    "grainCapacityUnit": "cbm",
     "baleCapacity": null,
     "holdDimensions": null,
     "hatchDimensions": null,
@@ -1297,18 +1290,18 @@
     "hatchType": null,
     "vesselType": null,
     "openPosition": {
-      "value": "Gibraltar Range",
+      "value": "Gibraltar range",
       "confidence": "confirmed",
-      "sourceText": "OPEN AT GIBRALTAR RANGE"
+      "sourceText": "TO BE OPEN AT GIBRALTAR RANGE 24-25TH MAY"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-24",
-        "close": "2026-05-25",
+        "open": null,
+        "close": null,
         "display": "24-25TH MAY"
       },
-      "confidence": "interpreted",
-      "sourceText": "24-25TH MAY"
+      "confidence": "confirmed",
+      "sourceText": "GIBRALTAR RANGE 24-25TH MAY"
     },
     "direction": "worldwide",
     "restrictions": [],
@@ -1322,99 +1315,21 @@
     "verificationWarning": null
   },
   {
-    "emailId": "19e07c6ce81f694d",
-    "itemIndex": 0,
-    "vesselName": {
-      "value": "MV ALTO",
-      "confidence": "confirmed",
-      "sourceText": "MV ALTO"
-    },
-    "imo": null,
-    "flag": "BELIZE",
-    "built": 1997,
-    "classSociety": "TURKISH LLOYD",
-    "pandi": null,
-    "dwtSummer": {
-      "value": 24804,
-      "confidence": "confirmed",
-      "sourceText": "SUMMER: 24804 DWT ON 10.045 METERS"
-    },
-    "dwcc": null,
-    "draftMax": {
-      "value": 10.045,
-      "confidence": "confirmed",
-      "sourceText": "SUMMER: 24804 DWT ON 10.045 METERS"
-    },
-    "loa": 153.78,
-    "beam": 26,
-    "grt": 20395,
-    "nrt": 9257,
-    "holdsCount": 4,
-    "hatchesCount": 4,
-    "grainCapacity": 44888.42,
-    "grainCapacityUnit": "cbm",
-    "baleCapacity": 43766.28,
-    "holdDimensions": null,
-    "hatchDimensions": "[object Object],[object Object],[object Object],[object Object]",
-    "tankTopStrength": null,
-    "geared": true,
-    "craneCapacity": "4X30T SWL (only 3 cranes can work simultaneously)",
-    "hatchType": "MC GREGOR FOLDING TYPE HATCHCOVERS",
-    "vesselType": "GENERAL CARGO",
-    "openPosition": {
-      "value": "YEMEN",
-      "confidence": "confirmed",
-      "sourceText": "Open YEMEN SPOT"
-    },
-    "openDate": {
-      "value": "spot",
-      "confidence": "interpreted",
-      "sourceText": "Open YEMEN SPOT"
-    },
-    "direction": null,
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "HOLD NO 2&3 ARE BOX",
-        "confidence": "confirmed",
-        "source_text": "HOLD NO 2&3 ARE BOX"
-      },
-      {
-        "value": "TANK TOP STRENGHT (CUM/M2) :  H1, H2, H3 = 15 T/M2 / H4 = 14 T/M2",
-        "confidence": "confirmed",
-        "source_text": "TANK TOP STRENGHT (CUM/M2) :  H1, H2, H3 = 15 T/M2 / H4 = 14 T/M2"
-      },
-      {
-        "value": "CO2 FITTED, AUSTRALIAN LADDERS FITTED",
-        "confidence": "confirmed",
-        "source_text": "CO2 FITTED, AUSTRALIAN LADDERS FITTED"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
     "emailId": "19e07c8d8f66d4aa",
     "itemIndex": 0,
     "vesselName": {
       "value": "MV GULF BLUE",
-      "confidence": "confirmed",
-      "sourceText": "MV GULF BLUE"
+      "confidence": "confirmed"
     },
-    "imo": null,
-    "flag": "ANTIGUA & BARBUDA",
+    "imo": "9125073",
+    "flag": "Antigua & Barbuda",
     "built": 1997,
     "classSociety": "NK",
-    "pandi": "WEST OF ENGLAND",
+    "pandi": "West of England",
     "dwtSummer": {
       "value": 4444,
       "confidence": "confirmed",
-      "sourceText": "DWT 4444 MT"
+      "sourceText": "DWT 4444 MT ON 5,68 m"
     },
     "dwcc": null,
     "draftMax": {
@@ -1428,25 +1343,25 @@
     "nrt": 1741,
     "holdsCount": 1,
     "hatchesCount": 2,
-    "grainCapacity": 203271,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 200271,
-    "holdDimensions": "[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
+    "grainCapacity": 163,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 161,
+    "holdDimensions": "70,8 x 10,20 x 8,17 m",
+    "hatchDimensions": "No.1: 38,52 x 10,57,No.2: 31,57 x 10,57",
     "tankTopStrength": null,
     "geared": true,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "AEGEAN",
+      "value": "Aegean",
       "confidence": "confirmed",
       "sourceText": "4444 DWT - AEGEAN - SPOT"
     },
     "openDate": {
       "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "4444 DWT - AEGEAN - SPOT"
+      "sourceText": "AEGEAN - SPOT"
     },
     "direction": null,
     "restrictions": [],
@@ -1457,54 +1372,89 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID-BOXHOLD",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
-        "source_text": "SID-BOXHOLD"
+        "source_text": "1/2 HO/HA SID-BOXHOLD"
       },
       {
-        "value": "KING BEAM FITTED",
-        "confidence": "confirmed",
-        "source_text": "KING BEAM FITTED"
-      },
-      {
-        "value": "TWO STATIONARY BULKHEADS IN FIXED POSITIONS",
-        "confidence": "confirmed",
-        "source_text": "TWO STATIONARY BULKHEADS IN FIXED POSITIONS"
-      },
-      {
-        "value": "297 TEU WHEREOF 129 TEU IN HOLD AND 168 TEU ON DECK",
-        "confidence": "confirmed",
-        "source_text": "297 TEU WHEREOF 129 TEU IN HOLD AND 168 TEU ON DECK"
-      },
-      {
-        "value": "GRAIN/APP B FITTED",
+        "value": "Appendix B fitted",
         "confidence": "confirmed",
         "source_text": "GRAIN/APP B FITTED"
       },
       {
-        "value": "STEELFLOORED",
-        "confidence": "confirmed",
-        "source_text": "STEELFLOORED"
-      },
-      {
-        "value": "ELECTRICAL VENTILATION",
-        "confidence": "confirmed",
-        "source_text": "ELECTRICAL VENTILATION"
-      },
-      {
-        "value": "BOWTHRUSTER 220 KW",
-        "confidence": "confirmed",
-        "source_text": "BOWTHRUSTER 220 KW"
-      },
-      {
-        "value": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8",
+        "value": "IMDG Class 1.4S certified",
         "confidence": "confirmed",
         "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
       },
       {
-        "value": "A60 BULKHEAD FITTED",
+        "value": "IMDG Class 2 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
+      },
+      {
+        "value": "IMDG Class 3 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
+      },
+      {
+        "value": "IMDG Class 4 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
+      },
+      {
+        "value": "IMDG Class 5.1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
+      },
+      {
+        "value": "IMDG Class 6.1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
+      },
+      {
+        "value": "IMDG Class 8 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO FITTED IN HOLD 1.4S/2/3/4/5.1/6.1/8"
+      },
+      {
+        "value": "297 TEU (129 in hold / 168 on deck)",
+        "confidence": "confirmed",
+        "source_text": "297 TEU WHEREOF 129 TEU IN HOLD AND 168 TEU ON DECK"
+      },
+      {
+        "value": "King beam fitted",
+        "confidence": "confirmed",
+        "source_text": "KING BEAM FITTED"
+      },
+      {
+        "value": "Two stationary bulkheads in fixed positions",
+        "confidence": "confirmed",
+        "source_text": "TWO STATIONARY BULKHEADS IN FIXED POSITIONS"
+      },
+      {
+        "value": "Steel floored",
+        "confidence": "confirmed",
+        "source_text": "STEELFLOORED"
+      },
+      {
+        "value": "Electrical ventilation",
+        "confidence": "confirmed",
+        "source_text": "ELECTRICAL VENTILATION"
+      },
+      {
+        "value": "Bow thruster 220 KW",
+        "confidence": "confirmed",
+        "source_text": "BOWTHRUSTER 220 KW"
+      },
+      {
+        "value": "A60 bulkhead fitted",
         "confidence": "confirmed",
         "source_text": "A60 BULKHEAD FITTED"
+      },
+      {
+        "value": "Max air draft from keel: 32.0 m / 34.0 m",
+        "confidence": "confirmed",
+        "source_text": "MAX AIR DRAFT FROM KEEL : 32,0 m / 34,0 m"
       }
     ],
     "ciiRating": null,
@@ -1515,18 +1465,17 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "FAITH",
-      "confidence": "confirmed",
-      "sourceText": "FAITH   30116DW/12/CR30MT"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
-    "built": null,
+    "built": 2012,
     "classSociety": null,
     "pandi": null,
     "dwtSummer": {
       "value": 30116,
       "confidence": "confirmed",
-      "sourceText": "30116DW"
+      "sourceText": "FAITH   30116DW/12/CR30MT"
     },
     "dwcc": null,
     "draftMax": null,
@@ -1545,7 +1494,7 @@
     "geared": true,
     "craneCapacity": "30MT",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "BULK CARRIER",
     "openPosition": {
       "value": "Praia Mole",
       "confidence": "confirmed",
@@ -1553,21 +1502,17 @@
     },
     "openDate": {
       "value": {
-        "open": "2026-05-15",
-        "close": "2026-05-20",
+        "open": null,
+        "close": null,
         "display": "15/20 MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "PRAIA MOLE 15/20 MAY"
     },
     "direction": null,
     "restrictions": [],
     "lastCargoes": null,
-    "speedLaden": {
-      "value": 12,
-      "confidence": "uncertain",
-      "source_text": "30116DW/12/CR30MT"
-    },
+    "speedLaden": null,
     "speedBallast": null,
     "consumption": null,
     "deckCapacity": null,
@@ -1580,50 +1525,49 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV LADY ANITA",
-      "confidence": "confirmed",
-      "sourceText": "MV LADY ANITA – OPEN HODEIDAH SPOT PROMPT"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "TOGO",
+    "flag": "Togo",
     "built": 2012,
     "classSociety": "OMCS",
     "pandi": null,
     "dwtSummer": {
       "value": 5328.4,
       "confidence": "confirmed",
-      "sourceText": "SUMMER DEADWEIGHT\r\n\r\n5328.4 M/T"
+      "sourceText": "SUMMER DEADWEIGHT"
     },
     "dwcc": null,
     "draftMax": {
       "value": 5.85,
       "confidence": "confirmed",
-      "sourceText": "SUMMER DRAFT\r\n\r\n5.85 M"
+      "sourceText": "SUMMER DRAFT"
     },
     "loa": 96.9,
     "beam": 15.8,
     "grt": 2998,
     "nrt": 1746,
-    "holdsCount": 2,
+    "holdsCount": 1,
     "hatchesCount": 2,
     "grainCapacity": 6800,
     "grainCapacityUnit": "cbm",
     "baleCapacity": 6700,
-    "holdDimensions": "[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
+    "holdDimensions": "32.64M X 13.26M X 7.82M,32M X 13.26M X 7.82M",
+    "hatchDimensions": "25M X 9.45M,26.9M X 9.45M",
     "tankTopStrength": null,
     "geared": null,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "GENERAL CARGO SHIP",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "HODEIDAH",
+      "value": "Hodeidah",
       "confidence": "confirmed",
-      "sourceText": "MV LADY ANITA – OPEN HODEIDAH SPOT PROMPT"
+      "sourceText": "OPEN HODEIDAH SPOT PROMPT"
     },
     "openDate": {
       "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "SPOT PROMPT"
+      "sourceText": "OPEN HODEIDAH SPOT PROMPT"
     },
     "direction": null,
     "restrictions": [],
@@ -1639,63 +1583,12 @@
       "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
     },
     "consumption": {
-      "value": "Ballast: IFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT; Loading: IFO 180 ME:4.2MT/D；AUX/E: MGO 0.35MT/D; In port: AUX/E MGO 0.35MT/D",
+      "value": "Ballast: IFO180 ME 3.7MT/D + MGO 0.35MT; Loading: IFO180 ME 4.2MT/D + MGO 0.35MT/D; Port: MGO 0.35MT/D",
       "confidence": "confirmed",
-      "source_text": "CONSUMPTION BALLAST\r\n\r\nIFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT\r\n\r\n\r\nCONSUMPTION LOADING\r\n\r\nIFO 180  ME:4.2MT/D；AUX/E: MGO 0.35MT/D\r\n\r\n\r\nCONSUMPTION IN PORT\r\n\r\nAUX/E MGO 0.35MT/D"
+      "source_text": "CONSUMPTION BALLAST IFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT"
     },
     "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "L.B.P: 89.8 M",
-        "confidence": "confirmed",
-        "source_text": "L.O.A / L.B.P\r\n\r\n96.9 M / 89.8 M"
-      },
-      {
-        "value": "Depth moulded: 7.4 M",
-        "confidence": "confirmed",
-        "source_text": "DEPTH MOULDED\r\n\r\n7.4 M"
-      },
-      {
-        "value": "Light ship: 1386.8 MT",
-        "confidence": "confirmed",
-        "source_text": "LIGHT SHIP\r\n\r\n1386.8 MT"
-      },
-      {
-        "value": "Displacement: 6715.2 MT",
-        "confidence": "confirmed",
-        "source_text": "DISPLACEMENT\r\n\r\n6715.2 MT"
-      },
-      {
-        "value": "T.P.C: 12.9 MT",
-        "confidence": "confirmed",
-        "source_text": "T.P.C\r\n\r\n12.9 MT"
-      },
-      {
-        "value": "Free board: 1.55 M",
-        "confidence": "confirmed",
-        "source_text": "FREE BOARD\r\n\r\n1.55 M"
-      },
-      {
-        "value": "Max height: 28.65 M",
-        "confidence": "confirmed",
-        "source_text": "MAX HEIGHT\r\n\r\n28.65 M"
-      },
-      {
-        "value": "M/E: GC320ZCD-4 500 R/MIN 1765KW",
-        "confidence": "confirmed",
-        "source_text": "M/E\r\n\r\nGC320ZCD-4 500 R/MIN 1765KW"
-      },
-      {
-        "value": "A/E: 6135JZCAF/6CCFJ120J-Y8/2SETS",
-        "confidence": "confirmed",
-        "source_text": "A/E\r\n\r\n6135JZCAF/6CCFJ120J-Y8/2SETS"
-      },
-      {
-        "value": "G/E: MP-H-120-4   120KW",
-        "confidence": "confirmed",
-        "source_text": "G/E\r\n\r\nMP-H-120-4   120KW"
-      }
-    ],
+    "specialFeatures": [],
     "ciiRating": null,
     "verificationWarning": null
   },
@@ -1704,50 +1597,49 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV LADY ANITA",
-      "confidence": "confirmed",
-      "sourceText": "MV LADY ANITA – OPEN HODEIDAH SPOT PROMPT"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "TOGO",
+    "flag": "Togo",
     "built": 2012,
     "classSociety": "OMCS",
     "pandi": null,
     "dwtSummer": {
       "value": 5328.4,
       "confidence": "confirmed",
-      "sourceText": "SUMMER DEADWEIGHT\r\n\r\n5328.4 m/t"
+      "sourceText": "SUMMER DEADWEIGHT"
     },
     "dwcc": null,
     "draftMax": {
       "value": 5.85,
       "confidence": "confirmed",
-      "sourceText": "SUMMER DRAFT\r\n\r\n5.85 m"
+      "sourceText": "SUMMER DRAFT"
     },
     "loa": 96.9,
     "beam": 15.8,
     "grt": 2998,
     "nrt": 1746,
-    "holdsCount": 2,
-    "hatchesCount": 2,
+    "holdsCount": 1,
+    "hatchesCount": 1,
     "grainCapacity": null,
     "grainCapacityUnit": null,
     "baleCapacity": null,
-    "holdDimensions": "[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
+    "holdDimensions": "7.82X13.26X32.64M,7.82X13.26X32.0M",
+    "hatchDimensions": "9.45X25.0M,9.45X26.9M",
     "tankTopStrength": null,
     "geared": null,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "GENERAL CARGO SHIP",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "HODEIDAH",
+      "value": "Hodeidah",
       "confidence": "confirmed",
-      "sourceText": "MV LADY ANITA – OPEN HODEIDAH SPOT PROMPT"
+      "sourceText": "OPEN HODEIDAH SPOT PROMPT"
     },
     "openDate": {
       "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "SPOT PROMPT"
+      "sourceText": "OPEN HODEIDAH SPOT PROMPT"
     },
     "direction": null,
     "restrictions": [],
@@ -1755,46 +1647,20 @@
     "speedLaden": {
       "value": 10,
       "confidence": "confirmed",
-      "source_text": "SPEED\r\n\r\nFULL LOADED/BALLAST:10.KTS/10.5KTS"
+      "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
     },
     "speedBallast": {
       "value": 10.5,
       "confidence": "confirmed",
-      "source_text": "SPEED\r\n\r\nFULL LOADED/BALLAST:10.KTS/10.5KTS"
+      "source_text": "FULL LOADED/BALLAST:10.KTS/10.5KTS"
     },
     "consumption": {
-      "value": "Ballast: IFO 180 M/E 3.7MT/D; AUX/E MGO 0.35MT. Loading: IFO 180 ME 4.2MT/D; AUX/E MGO 0.35MT/D. In port: AUX/E MGO 0.35MT/D",
+      "value": "Ballast: IFO180 3.7MT/D + MGO 0.35MT; Loading: IFO180 4.2MT/D + MGO 0.35MT/D; Port: MGO 0.35MT/D",
       "confidence": "confirmed",
-      "source_text": "CONSUMPTION BALLAST\r\n\r\nIFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT\r\n\r\n\r\nCONSUMPTION LOADING\r\n\r\nIFO 180  ME:4.2MT/D；AUX/E: MGO 0.35MT/D\r\n\r\n\r\nCONSUMPTION IN PORT\r\n\r\nAUX/E MGO 0.35MT/D"
+      "source_text": "CONSUMPTION BALLAST IFO 180: M/E :3.7MT/D; AUX/E:MGO 0.35MT"
     },
     "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "Ex name: NEW SILK ROAD 2",
-        "confidence": "confirmed",
-        "source_text": "EX NAME\r\n\r\nNEW SILK ROAD 2"
-      },
-      {
-        "value": "Depth moulded: 7.4 m",
-        "confidence": "confirmed",
-        "source_text": "DEPTH MOULDED\r\n\r\n7.4 m"
-      },
-      {
-        "value": "Light ship: 1386.8 mt",
-        "confidence": "confirmed",
-        "source_text": "LIGHT SHIP\r\n\r\n1386.8 mt"
-      },
-      {
-        "value": "Displacement: 6715.2 mt",
-        "confidence": "confirmed",
-        "source_text": "DISPLACEMENT\r\n\r\n6715.2 mt"
-      },
-      {
-        "value": "TPC: 12.9 mt",
-        "confidence": "confirmed",
-        "source_text": "T.P.C\r\n\r\n12.9 mt"
-      }
-    ],
+    "specialFeatures": [],
     "ciiRating": null,
     "verificationWarning": null
   },
@@ -1803,11 +1669,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "M/V LIKA",
-      "confidence": "confirmed",
-      "sourceText": "M/V LIKA"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "COMOROS",
+    "flag": "Comoros",
     "built": 1997,
     "classSociety": "OMCS",
     "pandi": null,
@@ -1819,7 +1684,7 @@
     "dwcc": null,
     "draftMax": {
       "value": 9.8,
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "DWT 25,000 ON 9.80M"
     },
     "loa": 158.2,
@@ -1835,18 +1700,18 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "3X30",
+    "craneCapacity": "3 x 30T",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "BULK CARRIER",
     "openPosition": {
       "value": "Red Sea",
       "confidence": "confirmed",
-      "sourceText": "VSL OPEN RED SEA  SPOT"
+      "sourceText": "OPEN RED SEA SPOT"
     },
     "openDate": {
       "value": "spot",
       "confidence": "interpreted",
-      "sourceText": "VSL OPEN RED SEA  SPOT"
+      "sourceText": "OPEN RED SEA SPOT"
     },
     "direction": null,
     "restrictions": [],
@@ -1854,34 +1719,34 @@
     "speedLaden": {
       "value": 11,
       "confidence": "interpreted",
-      "source_text": "Laden:  about 11.00 knots"
+      "source_text": "Laden:  about 11.00 knots on about 15.50 mts"
     },
     "speedBallast": {
       "value": 11,
       "confidence": "interpreted",
-      "source_text": "Ballast: about 11.00 knots"
+      "source_text": "Ballast: about 11.00 knots on about 15.00 mts"
     },
     "consumption": {
-      "value": "Laden: about 15.50 mts LSFO 380 cst; Ballast: about 15.00 mts LSFO 380 cst; In port: about 2 mts MDO/MGO when idle; about 3.5 mts MDO/MGO when gear working",
+      "value": "Laden abt 15.50 mts LSFO 380cst; Ballast abt 15.00 mts LSFO 380cst; port idle abt 2mts MDO/MGO; gear working abt 3.5mts MDO/MGO",
       "confidence": "interpreted",
-      "source_text": "Laden:  about 11.00 knots on about 15.50 mts (LSFO 380 cst)\nBallast: about 11.00 knots on about 15.00 mts (LSFO 380 cst)\nIn port:  about  2mts  MDO/MGO when idle\nabout  3.5mts MDO/MGO when gear working"
+      "source_text": "about 15.50 mts (LSFO 380 cst) ... about 2mts MDO/MGO when idle ... about 3.5mts MDO/MGO when gear working"
     },
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "MAIN ENGINE: HITACHI B&W 6L42MC",
+        "value": "LDT 5,687MT",
+        "confidence": "confirmed",
+        "source_text": "LDT 5,687MT"
+      },
+      {
+        "value": "Main engine: Hitachi B&W 6L42MC",
         "confidence": "confirmed",
         "source_text": "MAIN ENGINE: HITACHI B&W 6L42MC"
       },
       {
-        "value": "AUX.ENGINE: 2 X DAIHATSU",
+        "value": "Depth 13.30M",
         "confidence": "confirmed",
-        "source_text": "AUX.ENGINE: 2 X DAIHATSU"
-      },
-      {
-        "value": "Speed and consumption under good weather conditions, upto max.Beaufort 4 / Douglas Seastate 3, no adverse current and no negative influence of swell.",
-        "confidence": "confirmed",
-        "source_text": "Speed and consumption under good weather conditions, upto max.Beaufort 4 / Douglas Seastate 3, no adverse current and no negative influence of swell."
+        "source_text": "DEPTH 13.30M"
       }
     ],
     "ciiRating": null,
@@ -1892,14 +1757,13 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV KATREN",
-      "confidence": "confirmed",
-      "sourceText": "MV KATREN"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "VANUATU",
+    "flag": "Vanuatu",
     "built": 1991,
     "classSociety": "RINA",
-    "pandi": "MS AMLIN BELGIUM",
+    "pandi": "MS Amlin Belgium",
     "dwtSummer": {
       "value": 4173,
       "confidence": "confirmed",
@@ -1908,7 +1772,7 @@
     "dwcc": {
       "value": 4000,
       "confidence": "confirmed",
-      "sourceText": "DWCC 4000"
+      "sourceText": "DWCC 4000 ON 5,45 M DRAFT"
     },
     "draftMax": {
       "value": 5.45,
@@ -1921,29 +1785,29 @@
     "nrt": null,
     "holdsCount": 2,
     "hatchesCount": null,
-    "grainCapacity": 197500,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 197500,
-    "holdDimensions": "[object Object],[object Object]",
+    "grainCapacity": 5592,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 5592,
+    "holdDimensions": "1- 29,75 x 11,55 x 8,65 M,2- 32,05 x 11,5 5 x 8,65 M",
     "hatchDimensions": null,
     "tankTopStrength": null,
-    "geared": true,
+    "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "SEVILLA",
+      "value": "Sevilla",
       "confidence": "confirmed",
       "sourceText": "open   SEVILLA"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-07",
-        "close": "2026-05-08",
-        "display": "07-08 May 2026"
+        "open": null,
+        "close": null,
+        "display": "07-08 May"
       },
-      "confidence": "interpreted",
-      "sourceText": "07-08 May"
+      "confidence": "confirmed",
+      "sourceText": "SEVILLA   07-08 May"
     },
     "direction": null,
     "restrictions": [],
@@ -1954,160 +1818,14 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "Single deck",
-        "confidence": "interpreted",
-        "source_text": "SID"
+        "value": "SID box-shaped holds",
+        "confidence": "confirmed",
+        "source_text": "SID, GLESS"
       },
       {
-        "value": "BOW TRUSTER FITTED",
+        "value": "Bow thruster fitted",
         "confidence": "confirmed",
         "source_text": "BOW TRUSTER FITTED"
-      },
-      {
-        "value": "TWO BOX HOLDS",
-        "confidence": "confirmed",
-        "source_text": "TWO BOX HOLDS"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19e07d3d91481ec3",
-    "itemIndex": 0,
-    "vesselName": null,
-    "imo": null,
-    "flag": null,
-    "built": null,
-    "classSociety": null,
-    "pandi": null,
-    "dwtSummer": null,
-    "dwcc": {
-      "value": 5000,
-      "confidence": "confirmed",
-      "sourceText": "5000MT DWCC/SID/BOX/GLESS open S.KOREA ppt/onw"
-    },
-    "draftMax": null,
-    "loa": null,
-    "beam": null,
-    "grt": null,
-    "nrt": null,
-    "holdsCount": null,
-    "hatchesCount": null,
-    "grainCapacity": null,
-    "grainCapacityUnit": null,
-    "baleCapacity": null,
-    "holdDimensions": null,
-    "hatchDimensions": null,
-    "tankTopStrength": null,
-    "geared": false,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "S.KOREA",
-      "confidence": "confirmed",
-      "sourceText": "open S.KOREA"
-    },
-    "openDate": {
-      "value": {
-        "open": null,
-        "close": null,
-        "display": "ppt/onw"
-      },
-      "confidence": "interpreted",
-      "sourceText": "ppt/onw"
-    },
-    "direction": "PG",
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "Single deck",
-        "confidence": "interpreted",
-        "source_text": "SID"
-      },
-      {
-        "value": "Box-shaped holds",
-        "confidence": "interpreted",
-        "source_text": "BOX"
-      },
-      {
-        "value": "Gearless",
-        "confidence": "interpreted",
-        "source_text": "GLESS"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19e07d3d91481ec3",
-    "itemIndex": 1,
-    "vesselName": null,
-    "imo": null,
-    "flag": null,
-    "built": null,
-    "classSociety": null,
-    "pandi": null,
-    "dwtSummer": null,
-    "dwcc": {
-      "value": 5000,
-      "confidence": "confirmed",
-      "sourceText": "5000MT DWCC/SID/GLESS open CHINA ppt/onw"
-    },
-    "draftMax": null,
-    "loa": null,
-    "beam": null,
-    "grt": null,
-    "nrt": null,
-    "holdsCount": null,
-    "hatchesCount": null,
-    "grainCapacity": null,
-    "grainCapacityUnit": null,
-    "baleCapacity": null,
-    "holdDimensions": null,
-    "hatchDimensions": null,
-    "tankTopStrength": null,
-    "geared": false,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "CHINA",
-      "confidence": "confirmed",
-      "sourceText": "open CHINA"
-    },
-    "openDate": {
-      "value": {
-        "open": null,
-        "close": null,
-        "display": "ppt/onw"
-      },
-      "confidence": "interpreted",
-      "sourceText": "ppt/onw"
-    },
-    "direction": "BLACK SEA",
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "Single deck",
-        "confidence": "interpreted",
-        "source_text": "SID"
-      },
-      {
-        "value": "Gearless",
-        "confidence": "interpreted",
-        "source_text": "GLESS"
       }
     ],
     "ciiRating": null,
@@ -2118,11 +1836,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV LADY HATICE",
-      "confidence": "confirmed",
-      "sourceText": "MV LADY HATICE"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "PANAMA",
+    "flag": "Panama",
     "built": 2009,
     "classSociety": "RINA",
     "pandi": "HYDOR",
@@ -2147,28 +1864,28 @@
     "nrt": 6023,
     "holdsCount": 4,
     "hatchesCount": 4,
-    "grainCapacity": 762340,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 737837,
+    "grainCapacity": 611,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 592,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "SID - BOXLIKE",
+    "vesselType": "BULK CARRIER",
     "openPosition": {
-      "value": "AGADIR",
+      "value": "Agadir",
       "confidence": "confirmed",
       "sourceText": "OPEN AT AGADIR"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-18",
-        "close": "2026-05-19",
+        "open": null,
+        "close": null,
         "display": "18/19 MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "18/19 MAY OPEN AT AGADIR"
     },
     "direction": null,
@@ -2180,24 +1897,19 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "EX SQUAMISH",
-        "confidence": "confirmed",
-        "source_text": "EX SQUAMISH"
-      },
-      {
-        "value": "SID - BOXLIKE",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
         "source_text": "SID - BOXLIKE"
       },
       {
-        "value": "BUILT 2009 JAPAN",
+        "value": "Appendix B fitted",
         "confidence": "confirmed",
-        "source_text": "BUILT 2009 JAPAN"
+        "source_text": "APP.B/B"
       },
       {
-        "value": "ALL DETS ABT WOG",
+        "value": "Ex name: SQUAMISH",
         "confidence": "confirmed",
-        "source_text": "ALL DETS ABT WOG"
+        "source_text": "EX SQUAMISH"
       }
     ],
     "ciiRating": null,
@@ -2208,11 +1920,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV LADY ZEHMA",
-      "confidence": "confirmed",
-      "sourceText": "MV LADY ZEHMA  (EX CASSIOPEIA STAR)"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "PANAMA",
+    "flag": "Panama",
     "built": 2005,
     "classSociety": "RINA",
     "pandi": "HYDOR",
@@ -2237,16 +1948,16 @@
     "nrt": 10227,
     "holdsCount": 5,
     "hatchesCount": 5,
-    "grainCapacity": 1489078,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 1453622,
+    "grainCapacity": 1194,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 1166,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "BULK CARRIER",
     "openPosition": {
       "value": "Adriatic",
       "confidence": "confirmed",
@@ -2266,24 +1977,24 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "Ex name: CASSIOPEIA STAR",
-        "confidence": "confirmed",
-        "source_text": "(EX CASSIOPEIA STAR)"
-      },
-      {
-        "value": "Single deck",
+        "value": "Single deck (SID)",
         "confidence": "confirmed",
         "source_text": "SID"
       },
       {
-        "value": "Boxlike",
+        "value": "Box-shaped holds (boxlike)",
         "confidence": "confirmed",
         "source_text": "BOXLIKE"
       },
       {
-        "value": "Built Japan",
+        "value": "Appendix B fitted",
         "confidence": "confirmed",
-        "source_text": "BUILT 2005 JAPAN"
+        "source_text": "APP.B/B"
+      },
+      {
+        "value": "Ex-name: CASSIOPEIA STAR",
+        "confidence": "confirmed",
+        "source_text": "(EX CASSIOPEIA STAR)"
       }
     ],
     "ciiRating": null,
@@ -2293,9 +2004,8 @@
     "emailId": "19e07d517de73b94",
     "itemIndex": 0,
     "vesselName": {
-      "value": "M/V HACI HILMI II",
-      "confidence": "confirmed",
-      "sourceText": "-M/V HACI HILMI II"
+      "value": "HACI HILMI II",
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -2319,28 +2029,28 @@
     "nrt": null,
     "holdsCount": null,
     "hatchesCount": null,
-    "grainCapacity": 309895,
-    "grainCapacityUnit": "cbft",
+    "grainCapacity": 8775,
+    "grainCapacityUnit": "cbm",
     "baleCapacity": null,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "3 X 10MTS",
+    "craneCapacity": "3 x 10MT",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Marmara Sea",
       "confidence": "confirmed",
-      "sourceText": "OPEN MARMARA SEA"
+      "sourceText": "OPEN MARMARA SEA ON 22-23RD MAY"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-22",
-        "close": "2026-05-23",
+        "open": null,
+        "close": null,
         "display": "22-23RD MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "OPEN MARMARA SEA ON 22-23RD MAY"
     },
     "direction": null,
@@ -2358,9 +2068,8 @@
     "emailId": "19e07d517de73b94",
     "itemIndex": 1,
     "vesselName": {
-      "value": "MV TBN",
-      "confidence": "confirmed",
-      "sourceText": "MV TBN"
+      "value": "TBN",
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -2380,8 +2089,8 @@
     "nrt": null,
     "holdsCount": null,
     "hatchesCount": null,
-    "grainCapacity": 700000,
-    "grainCapacityUnit": "cbft",
+    "grainCapacity": 561,
+    "grainCapacityUnit": "cbm",
     "baleCapacity": null,
     "holdDimensions": null,
     "hatchDimensions": null,
@@ -2389,20 +2098,20 @@
     "geared": true,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "Gibraltar Range",
+      "value": "Gibraltar",
       "confidence": "confirmed",
-      "sourceText": "OPEN AT GIBRALTAR RANGE"
+      "sourceText": "OPEN AT GIBRALTAR RANGE 24-25TH MAY"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-24",
-        "close": "2026-05-25",
+        "open": null,
+        "close": null,
         "display": "24-25TH MAY"
       },
-      "confidence": "interpreted",
-      "sourceText": "TO BE OPEN AT GIBRALTAR RANGE 24-25TH MAY"
+      "confidence": "confirmed",
+      "sourceText": "OPEN AT GIBRALTAR RANGE 24-25TH MAY"
     },
     "direction": "worldwide",
     "restrictions": [],
@@ -2416,54 +2125,61 @@
     "verificationWarning": null
   },
   {
-    "emailId": "19e07d718417e96d",
+    "emailId": "19e07d53e7d46b71",
     "itemIndex": 0,
     "vesselName": {
-      "value": "MV Raven",
-      "confidence": "confirmed",
-      "sourceText": "MV Raven"
+      "value": "MV BBA LARISA",
+      "confidence": "confirmed"
     },
-    "imo": null,
-    "flag": "Vanatu",
-    "built": 1997,
-    "classSociety": "brs",
-    "pandi": "turk pandi",
-    "dwtSummer": null,
-    "dwcc": {
-      "value": 10000,
+    "imo": "9166510",
+    "flag": "Palau",
+    "built": 1999,
+    "classSociety": "TL",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 5007,
       "confidence": "confirmed",
-      "sourceText": "10.000 dwcc"
+      "sourceText": "5007 dwt"
+    },
+    "dwcc": {
+      "value": 4900,
+      "confidence": "confirmed",
+      "sourceText": "4900 dwcc on 6,45 Draft"
     },
     "draftMax": {
-      "value": 10,
+      "value": 6.45,
       "confidence": "interpreted",
-      "sourceText": "10.000 dwcc on 10.00 m ssw"
+      "sourceText": "4900 dwcc on 6,45 Draft"
     },
-    "loa": 105.5,
-    "beam": 19,
-    "grt": 6870,
-    "nrt": 3404,
-    "holdsCount": 2,
-    "hatchesCount": 2,
-    "grainCapacity": 14138,
-    "grainCapacityUnit": "cbm",
-    "baleCapacity": 13656,
+    "loa": 93.72,
+    "beam": 14.85,
+    "grt": 2950,
+    "nrt": 1807,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 6246,
+    "grainCapacityUnit": "cbft",
+    "baleCapacity": 6031,
     "holdDimensions": null,
     "hatchDimensions": null,
-    "tankTopStrength": "15",
-    "geared": true,
-    "craneCapacity": "crane 2x15t &derrick 2x15t",
-    "hatchType": "mac gregor hatches",
-    "vesselType": "single decker/box shaped",
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "Turkish Black Sea",
+      "value": "Gabes",
       "confidence": "confirmed",
-      "sourceText": "Open Turkish Black Sea"
+      "sourceText": "Vessel will be open at Gabes on 11-12 May"
     },
     "openDate": {
-      "value": "spot",
-      "confidence": "interpreted",
-      "sourceText": "Prompt"
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "11-12 May"
+      },
+      "confidence": "confirmed",
+      "sourceText": "open at Gabes on 11-12 May"
     },
     "direction": null,
     "restrictions": [],
@@ -2474,20 +2190,247 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "Good Cubic Intake",
+        "value": "Appendix B fitted",
         "confidence": "confirmed",
-        "source_text": "Good Cubic Intake"
+        "source_text": "APP B FITTED"
       },
       {
-        "value": "single decker/box shaped",
+        "value": "Semi box-shaped single hold",
         "confidence": "confirmed",
-        "source_text": "single decker/box shaped"
+        "source_text": "Semi Box 1 Hold  / 1 Hatch"
+      },
+      "IMDG Class 9166510 certified",
+      "IMDG Class 9367841 certified",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07d53e7d46b71",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "MV YUCATAN",
+      "confidence": "confirmed"
+    },
+    "imo": "9367841",
+    "flag": "Saint Vincent and the Grenadines",
+    "built": 2006,
+    "classSociety": "TL",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 3178,
+      "confidence": "confirmed",
+      "sourceText": "3178 dwt"
+    },
+    "dwcc": {
+      "value": 3100,
+      "confidence": "confirmed",
+      "sourceText": "3100 dwcc on 5,51 Draft"
+    },
+    "draftMax": {
+      "value": 5.51,
+      "confidence": "interpreted",
+      "sourceText": "3100 dwcc on 5,51 Draft"
+    },
+    "loa": 80.6,
+    "beam": 13.6,
+    "grt": 1972,
+    "nrt": 1227,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 113,
+    "grainCapacityUnit": "cbft",
+    "baleCapacity": 113,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Bourgas",
+      "confidence": "confirmed",
+      "sourceText": "Vessel will be open at Bourgas on 15-16 May"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "15-16 May"
+      },
+      "confidence": "confirmed",
+      "sourceText": "open at Bourgas on 15-16 May"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "Box-shaped holds",
+        "confidence": "confirmed",
+        "source_text": "Box 2 Hold  / 2 Hatch"
+      },
+      "IMDG Class 9367841 certified",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07d53e7d46b71",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "MV ONEGO TRADER",
+      "confidence": "confirmed"
+    },
+    "imo": "9238351",
+    "flag": "Portugal",
+    "built": 2001,
+    "classSociety": "KR",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 8930,
+      "confidence": "confirmed",
+      "sourceText": "8930 dwt"
+    },
+    "dwcc": {
+      "value": 8200,
+      "confidence": "confirmed",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "draftMax": {
+      "value": 7.2,
+      "confidence": "interpreted",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "loa": 132.2,
+    "beam": 15.87,
+    "grt": 6301,
+    "nrt": 3582,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 362,
+    "grainCapacityUnit": "cbft",
+    "baleCapacity": 362,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": null,
+    "openDate": null,
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B FITTED"
       },
       {
-        "value": "CO2 fitted",
+        "value": "Full box-shaped holds",
         "confidence": "confirmed",
-        "source_text": "CO2 fitted"
-      }
+        "source_text": "Full Box 2 Hold  / 2 Hatch"
+      },
+      {
+        "value": "On time charter (ON TC)",
+        "confidence": "confirmed",
+        "source_text": "Vessel ON TC."
+      },
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07d53e7d46b71",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "MV ONEGO MERCHANT",
+      "confidence": "confirmed"
+    },
+    "imo": "9238363",
+    "flag": "Portugal",
+    "built": 2002,
+    "classSociety": "KR",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 8930,
+      "confidence": "confirmed",
+      "sourceText": "8930 dwt"
+    },
+    "dwcc": {
+      "value": 8200,
+      "confidence": "confirmed",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "draftMax": {
+      "value": 7.2,
+      "confidence": "interpreted",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "loa": 132.2,
+    "beam": 15.87,
+    "grt": 6301,
+    "nrt": 3582,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 362,
+    "grainCapacityUnit": "cbft",
+    "baleCapacity": 362,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": null,
+    "openDate": null,
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B FITTED"
+      },
+      {
+        "value": "Full box-shaped holds",
+        "confidence": "confirmed",
+        "source_text": "Full Box 2 Hold  / 2 Hatch"
+      },
+      {
+        "value": "On time charter (ON TC)",
+        "confidence": "confirmed",
+        "source_text": "Vessel ON TC."
+      },
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2497,10 +2440,9 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "FIRTINA S",
-      "confidence": "confirmed",
-      "sourceText": "FIRTINA S"
+      "confidence": "confirmed"
     },
-    "imo": null,
+    "imo": "8834940",
     "flag": "Vanuatu",
     "built": 1988,
     "classSociety": "BRS",
@@ -2517,7 +2459,7 @@
     },
     "draftMax": {
       "value": 5.4,
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "2362 DWT on 5.4 m SSW"
     },
     "loa": 75.52,
@@ -2526,28 +2468,28 @@
     "nrt": 734,
     "holdsCount": 1,
     "hatchesCount": 2,
-    "grainCapacity": 96500,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 94300,
-    "holdDimensions": "[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
+    "grainCapacity": 77,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 2670,
+    "holdDimensions": "Ho1: 44.00 x 10.15 x 4.70 M",
+    "hatchDimensions": "Ha1: 15.50 x 7.40 x 1.45 M,Ha2: 14.90 x 7.40 x 1.45 M",
     "tankTopStrength": null,
     "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "GENERAL CARGO",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "AEGEAN SEA",
+      "value": "Aegean Sea",
       "confidence": "confirmed",
       "sourceText": "AEGEAN SEA"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-12",
-        "close": "2026-05-13",
-        "display": "12-13 MAY 2026"
+        "open": null,
+        "close": null,
+        "display": "12-13 MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "12-13 MAY"
     },
     "direction": null,
@@ -2558,11 +2500,9 @@
     "consumption": null,
     "deckCapacity": null,
     "specialFeatures": [
-      {
-        "value": "GC/SID",
-        "confidence": "confirmed",
-        "source_text": "GC/SID"
-      }
+      "SID single-deck",
+      "box-shaped hold",
+      "Appendix B fitted"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2572,10 +2512,9 @@
     "itemIndex": 1,
     "vesselName": {
       "value": "EMINE ANNE",
-      "confidence": "confirmed",
-      "sourceText": "EMINE ANNE"
+      "confidence": "confirmed"
     },
-    "imo": null,
+    "imo": "9145360",
     "flag": "Vanuatu",
     "built": 1996,
     "classSociety": "BRS",
@@ -2592,7 +2531,7 @@
     },
     "draftMax": {
       "value": 4.3,
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "1602 DWT on 4.30 m SSW"
     },
     "loa": 69,
@@ -2601,28 +2540,28 @@
     "nrt": 531,
     "holdsCount": 2,
     "hatchesCount": 2,
-    "grainCapacity": 70440,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 67204,
-    "holdDimensions": "[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
+    "grainCapacity": 56,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 1903,
+    "holdDimensions": "Ho1: 22.60 x 8.50 x 4.30 M,Ho2: 22.50 x 8.50 x 4.30 M",
+    "hatchDimensions": "Ha1: 17.50 x 6.00 x 1.10 M,Ha2: 17.90 x 6.00 x 1.10 M",
     "tankTopStrength": null,
     "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "GENERAL CARGO",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "WEST BLACK SEA",
+      "value": "West Black Sea",
       "confidence": "confirmed",
       "sourceText": "WEST BLACK SEA"
     },
     "openDate": {
       "value": {
-        "open": "2026-05-14",
-        "close": "2026-05-16",
-        "display": "14-16 MAY 2026"
+        "open": null,
+        "close": null,
+        "display": "14-16 MAY"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "14-16 MAY"
     },
     "direction": null,
@@ -2633,21 +2572,85 @@
     "consumption": null,
     "deckCapacity": null,
     "specialFeatures": [
+      "SID single-deck",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e07d718417e96d",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV Raven",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": "Vanuatu",
+    "built": 1997,
+    "classSociety": "BRS",
+    "pandi": "Turkish P&I",
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 10000,
+      "confidence": "confirmed",
+      "sourceText": "10.000 dwcc on 10.00 m ssw"
+    },
+    "draftMax": {
+      "value": 10,
+      "confidence": "confirmed",
+      "sourceText": "10.000 dwcc on 10.00 m ssw"
+    },
+    "loa": 105.5,
+    "beam": 19,
+    "grt": 6870,
+    "nrt": 3404,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 14138,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 13656,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": "15",
+    "geared": true,
+    "craneCapacity": "2 x 15T crane & 2 x 15T derrick",
+    "hatchType": "MacGregor",
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Turkish Black Sea",
+      "confidence": "confirmed",
+      "sourceText": "Open Turkish Black Sea"
+    },
+    "openDate": {
+      "value": "spot",
+      "confidence": "interpreted",
+      "sourceText": "Open Turkish Black Sea / Prompt"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
       {
-        "value": "GC/SID",
+        "value": "single decker box-shaped hold",
         "confidence": "confirmed",
-        "source_text": "GC/SID"
+        "source_text": "single decker/box shaped"
       },
       {
-        "value": "Air Draft: 20 m fm keel",
+        "value": "CO2 fitted",
         "confidence": "confirmed",
-        "source_text": "Air Draft: 20 m fm keel"
+        "source_text": "CO2 fitted"
       },
       {
-        "value": "Appendix b fitted",
+        "value": "Good cubic intake",
         "confidence": "confirmed",
-        "source_text": "Appendix b fitted"
-      }
+        "source_text": "Good Cubic Intake"
+      },
+      "box-shaped single hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2657,18 +2660,17 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV EDELSTEIN",
-      "confidence": "confirmed",
-      "sourceText": "MV EDELSTEIN"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "COMOROS",
+    "flag": "Comoros",
     "built": 1997,
-    "classSociety": "PHOENIX CLASS",
+    "classSociety": "Phoenix",
     "pandi": null,
     "dwtSummer": {
       "value": 12320,
       "confidence": "interpreted",
-      "sourceText": "ABOUT 12,320 DWT"
+      "sourceText": "ABOUT 12,320 DWT ON 8,3M SSW"
     },
     "dwcc": null,
     "draftMax": {
@@ -2689,24 +2691,24 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "CRANES 30Tx2 (NOT COMBINABLE) – DERRICK 10Tx1",
+    "craneCapacity": "30Tx2 (not combinable), derrick 10Tx1",
     "hatchType": null,
     "vesselType": "TWEEN DECKER",
     "openPosition": {
-      "value": "LUANDA",
+      "value": "Luanda",
       "confidence": "confirmed",
-      "sourceText": "open LUANDA"
+      "sourceText": "open LUANDA 11th of February"
     },
     "openDate": {
       "value": {
-        "open": "2026-02-11",
+        "open": null,
         "close": null,
-        "display": "11th of February 2026"
+        "display": "11th of February"
       },
       "confidence": "confirmed",
       "sourceText": "open LUANDA 11th of February"
     },
-    "direction": "MED SEA - BLACK SEA",
+    "direction": "to Med Sea / Black Sea",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": null,
@@ -2715,15 +2717,292 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "TWEEN DECKER",
+        "value": "LBP 105.00m",
         "confidence": "confirmed",
-        "source_text": "TWEEN DECKER"
+        "source_text": "LBP 105.00M"
       },
       {
-        "value": "CRANES 30Tx2 (NOT COMBINABLE) – DERRICK 10Tx1",
+        "value": "Depth moulded 14.30m",
         "confidence": "confirmed",
-        "source_text": "CRANES 30Tx2 (NOT COMBINABLE) – DERRICK 10Tx1"
+        "source_text": "DEPTH 14.30M"
+      },
+      {
+        "value": "ADA WOG (all details about, without guarantee)",
+        "confidence": "confirmed",
+        "source_text": "ADA WOG"
       }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e089f8eedde1bf",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV YUCATAN",
+      "confidence": "confirmed"
+    },
+    "imo": "9367841",
+    "flag": "Saint Vincent and the Grenadines",
+    "built": 2006,
+    "classSociety": "TL",
+    "pandi": "Turk P&I",
+    "dwtSummer": {
+      "value": 3178,
+      "confidence": "confirmed",
+      "sourceText": "3178 dwt"
+    },
+    "dwcc": {
+      "value": 3100,
+      "confidence": "confirmed",
+      "sourceText": "3100 dwcc on 5,51 Draft"
+    },
+    "draftMax": {
+      "value": 5.51,
+      "confidence": "interpreted",
+      "sourceText": "3100 dwcc on 5,51 Draft"
+    },
+    "loa": 80.6,
+    "beam": 13.6,
+    "grt": 1972,
+    "nrt": 1227,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 113,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 113,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Bizerte",
+      "confidence": "confirmed",
+      "sourceText": "Vessel will be open at Bizerte on 11-12 Feb"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "11-12 Feb"
+      },
+      "confidence": "confirmed",
+      "sourceText": "open at Bizerte on 11-12 Feb"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped hold (EX PARAKLITOS)",
+      "IMDG Class 9367841 certified",
+      "IMDG Class 9166510 certified",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e089f8eedde1bf",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "MV BBA LARISA",
+      "confidence": "confirmed"
+    },
+    "imo": "9166510",
+    "flag": "Palau",
+    "built": 1999,
+    "classSociety": "TL",
+    "pandi": "Turk P&I",
+    "dwtSummer": {
+      "value": 5007,
+      "confidence": "confirmed",
+      "sourceText": "5007 dwt"
+    },
+    "dwcc": {
+      "value": 4900,
+      "confidence": "confirmed",
+      "sourceText": "4900 dwcc on 6,45 Draft"
+    },
+    "draftMax": {
+      "value": 6.45,
+      "confidence": "interpreted",
+      "sourceText": "4900 dwcc on 6,45 Draft"
+    },
+    "loa": 93.72,
+    "beam": 14.85,
+    "grt": 2950,
+    "nrt": 1807,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 6246,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 6031,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Ravenna",
+      "confidence": "confirmed",
+      "sourceText": "Vessel  will be open at Ravenna on 04 Feb"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "04 Feb"
+      },
+      "confidence": "confirmed",
+      "sourceText": "open at Ravenna on 04 Feb"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "semi box-shaped hold",
+      "Appendix B fitted",
+      "IMDG Class 9166510 certified",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e089f8eedde1bf",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "MV ONEGO TRADER",
+      "confidence": "confirmed"
+    },
+    "imo": "9238351",
+    "flag": "Portugal",
+    "built": 2001,
+    "classSociety": "KR",
+    "pandi": "UK P&I",
+    "dwtSummer": {
+      "value": 8930,
+      "confidence": "confirmed",
+      "sourceText": "8930 dwt"
+    },
+    "dwcc": {
+      "value": 8200,
+      "confidence": "confirmed",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "draftMax": {
+      "value": 7.2,
+      "confidence": "interpreted",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "loa": 132.2,
+    "beam": 15.87,
+    "grt": 6301,
+    "nrt": 3582,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 362,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 362,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": null,
+    "openDate": null,
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "full box-shaped hold",
+      "Appendix B fitted",
+      "On TC",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e089f8eedde1bf",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "MV ONEGO MERCHANT",
+      "confidence": "confirmed"
+    },
+    "imo": "9238363",
+    "flag": "Portugal",
+    "built": 2002,
+    "classSociety": "KR",
+    "pandi": "UK P&I",
+    "dwtSummer": {
+      "value": 8930,
+      "confidence": "confirmed",
+      "sourceText": "8930 dwt"
+    },
+    "dwcc": {
+      "value": 8200,
+      "confidence": "confirmed",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "draftMax": {
+      "value": 7.2,
+      "confidence": "interpreted",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "loa": 132.2,
+    "beam": 15.87,
+    "grt": 6301,
+    "nrt": 3582,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 362,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 362,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": null,
+    "openDate": null,
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "full box-shaped hold",
+      "Appendix B fitted",
+      "On TC",
+      "IMDG Class 9238363 certified"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2733,11 +3012,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV ELFRIEDE",
-      "confidence": "confirmed",
-      "sourceText": "MV ELFRIEDE"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "BARBADOS",
+    "flag": "Barbados",
     "built": 2004,
     "classSociety": "IACS",
     "pandi": null,
@@ -2749,8 +3027,8 @@
     "dwcc": null,
     "draftMax": {
       "value": 9.219,
-      "confidence": "interpreted",
-      "sourceText": "ABOUT 10,074 DWT ON 9.219M SSW"
+      "confidence": "confirmed",
+      "sourceText": "ON 9.219M SSW"
     },
     "loa": 100.59,
     "beam": 18.8,
@@ -2765,7 +3043,7 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "CRANES 30Tx2 - DERRICK 30Tx1",
+    "craneCapacity": "2 x 30T cranes + 1 x 30T derrick",
     "hatchType": null,
     "vesselType": "TWEEN DECKER",
     "openPosition": {
@@ -2778,7 +3056,7 @@
       "confidence": "interpreted",
       "sourceText": "OPEN SPOT at Gibraltar"
     },
-    "direction": "NCSA / SOUTH AMERICA / WAFRICA / INDIAN OCEAN / FAR EAST",
+    "direction": "NCSA / South America / W.Africa / Indian Ocean / Far East",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": null,
@@ -2787,15 +3065,460 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "CO2 FITTED",
+        "value": "CO2 fitted",
         "confidence": "confirmed",
         "source_text": "CO2 FITTED"
       },
       {
-        "value": "BOW THRUSTER FITTED",
+        "value": "Bow thruster fitted",
         "confidence": "confirmed",
         "source_text": "BOW THRUSTER FITTED"
+      },
+      {
+        "value": "Tween decker",
+        "confidence": "confirmed",
+        "source_text": "TWEEN DECKER"
       }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e08a0886a6e7d9",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "LADY MERAL",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": "Panama",
+    "built": 2005,
+    "classSociety": "BV",
+    "pandi": "Hydor",
+    "dwtSummer": {
+      "value": 32131,
+      "confidence": "confirmed",
+      "sourceText": "DWT /GRT/NRT 32131 / 19883 / 10740"
+    },
+    "dwcc": {
+      "value": 31000,
+      "confidence": "confirmed",
+      "sourceText": "DWCC 31.000 MTS AT 10.55M DRAFT"
+    },
+    "draftMax": {
+      "value": 10.55,
+      "confidence": "interpreted",
+      "sourceText": "DWCC 31.000 MTS AT 10.55M DRAFT"
+    },
+    "loa": 171.59,
+    "beam": 27,
+    "grt": 19883,
+    "nrt": 10740,
+    "holdsCount": 5,
+    "hatchesCount": 5,
+    "grainCapacity": 1142,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 1128,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "BULK CARRIER",
+    "openPosition": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "SPOT AT MARMARA"
+    },
+    "openDate": {
+      "value": "spot",
+      "confidence": "interpreted",
+      "sourceText": "SPOT AT MARMARA"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "SID box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "SID"
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP.B"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e08a0e45dd6980",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "GOYNUK",
+      "confidence": "confirmed"
+    },
+    "imo": "9554145",
+    "flag": "Marshall Islands",
+    "built": 2010,
+    "classSociety": "RINA",
+    "pandi": "HYDOR",
+    "dwtSummer": {
+      "value": 4712,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 4550,
+      "confidence": "interpreted",
+      "sourceText": "DWCC abt 4550 mts"
+    },
+    "draftMax": {
+      "value": 6.344,
+      "confidence": "confirmed",
+      "sourceText": "4712 DWT on 6.344 m SSW"
+    },
+    "loa": 93.63,
+    "beam": 14.55,
+    "grt": 2976,
+    "nrt": 1510,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 158,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 5584,
+    "holdDimensions": "31.5 x 11.72 x 8.05 M,29.4 x 11.72 x 8.20 M",
+    "hatchDimensions": "28.7 x 11.75 M,28.0 x 11.75 M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Aegean Sea",
+      "confidence": "confirmed",
+      "sourceText": "AEGEAN SEA"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "18-20 FEB"
+      },
+      "confidence": "confirmed",
+      "sourceText": "18-20 FEB"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "SID box-shaped open-hatch hold",
+      "ITF",
+      "Container fitted",
+      "IMDG Class 1 certified",
+      "CO2 fitted",
+      "Bow thruster fitted",
+      "Air draft 31.5m from keel",
+      "IMDG Class 9167320 certified",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e08a0e45dd6980",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "GOCEK",
+      "confidence": "confirmed"
+    },
+    "imo": "9167320",
+    "flag": "Kitts & Nevis",
+    "built": 1997,
+    "classSociety": "TURK LOYDU (IACS)",
+    "pandi": "HYDOR",
+    "dwtSummer": {
+      "value": 4260,
+      "confidence": "confirmed"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 5.8,
+      "confidence": "confirmed",
+      "sourceText": "Draft 5.8 M"
+    },
+    "loa": 89.7,
+    "beam": 13.6,
+    "grt": 2820,
+    "nrt": 1503,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 159,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 5628,
+    "holdDimensions": "62.88 x 11.00 x 8.35 M",
+    "hatchDimensions": "62.88 x 11.00 M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Adriatic",
+      "confidence": "confirmed",
+      "sourceText": "ADRIATIC"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "13-15 FEB"
+      },
+      "confidence": "confirmed",
+      "sourceText": "13-15 FEB"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "Box-shaped open-hatch hold",
+      "Ice class: 1A",
+      "2 Moveable Bulkheads",
+      "Bow thruster fitted",
+      "BWTS fitted",
+      "TEU 246",
+      "IMDG Class 9167320 certified",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e08a0e45dd6980",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "DOGANBEY",
+      "confidence": "confirmed"
+    },
+    "imo": "9111761",
+    "flag": "Palau",
+    "built": 1996,
+    "classSociety": "Phoenix",
+    "pandi": "Turk P&I",
+    "dwtSummer": {
+      "value": 3085,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 3000,
+      "confidence": "interpreted",
+      "sourceText": "DWCC abt 3000 mts"
+    },
+    "draftMax": {
+      "value": 5.37,
+      "confidence": "confirmed",
+      "sourceText": "3085 DWT on 5.37 m SSW"
+    },
+    "loa": 87.25,
+    "beam": 12,
+    "grt": 1941,
+    "nrt": 1053,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 110,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 3532,
+    "holdDimensions": "28.50 x 11.15 x 5.00 M,28.20 x 11.15 x 5.00 M",
+    "hatchDimensions": "19.20 x 8.10 x 1.50 M,20.40 x 8.10 x 1.50 M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "DOGANBEY"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "15-18 FEB"
+      },
+      "confidence": "confirmed",
+      "sourceText": "15-18 FEB"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "SID hold",
+      "Appendix B fitted",
+      "IMDG Class 9167320 certified",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e08a0e45dd6980",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "FIRTINA S",
+      "confidence": "confirmed"
+    },
+    "imo": "8834940",
+    "flag": "Vanuatu",
+    "built": 1988,
+    "classSociety": "BRS",
+    "pandi": "Turk P&I",
+    "dwtSummer": {
+      "value": 2362,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 2200,
+      "confidence": "interpreted",
+      "sourceText": "DWCC abt 2200 mts"
+    },
+    "draftMax": {
+      "value": 5.4,
+      "confidence": "confirmed",
+      "sourceText": "2362 DWT on 5.4 m SSW"
+    },
+    "loa": 75.52,
+    "beam": 11,
+    "grt": 1248,
+    "nrt": 734,
+    "holdsCount": 1,
+    "hatchesCount": 2,
+    "grainCapacity": 77,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 2670,
+    "holdDimensions": "44.00 x 10.15 x 4.70 M",
+    "hatchDimensions": "15.50 x 7.40 x 1.45 M,14.90 x 7.40 x 1.45 M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Danube River",
+      "confidence": "confirmed",
+      "sourceText": "DANUBE RIVER"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "17-20 FEB"
+      },
+      "confidence": "confirmed",
+      "sourceText": "17-20 FEB"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "SID hold",
+      "IMDG Class 9167320 certified",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e08a0e45dd6980",
+    "itemIndex": 4,
+    "vesselName": {
+      "value": "EMINE ANNE",
+      "confidence": "confirmed"
+    },
+    "imo": "9145360",
+    "flag": "Vanuatu",
+    "built": 1996,
+    "classSociety": "BRS",
+    "pandi": "Turk P&I",
+    "dwtSummer": {
+      "value": 1602,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 1425,
+      "confidence": "interpreted",
+      "sourceText": "DWCC abt 1425 mts"
+    },
+    "draftMax": {
+      "value": 4.3,
+      "confidence": "confirmed",
+      "sourceText": "1602 DWT on 4.30 m SSW"
+    },
+    "loa": 69,
+    "beam": 9,
+    "grt": 884,
+    "nrt": 531,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 56,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 1903,
+    "holdDimensions": "22.60 x 8.50 x 4.30 M,22.50 x 8.50 x 4.30 M",
+    "hatchDimensions": "17.50 x 6.00 x 1.10 M,17.90 x 6.00 x 1.10 M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Sfax",
+      "confidence": "confirmed",
+      "sourceText": "EMINE ANNE"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "6-7 FEB"
+      },
+      "confidence": "confirmed",
+      "sourceText": "6-7 FEB"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "SID hold",
+      "Appendix B fitted",
+      "Air draft 20m from keel",
+      "IMDG Class 9167320 certified",
+      "SID box-shaped hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2805,8 +3528,7 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV HAGRID",
-      "confidence": "confirmed",
-      "sourceText": "MV HAGRID"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": "Barbados",
@@ -2825,7 +3547,7 @@
     },
     "draftMax": {
       "value": 7,
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "7,00m draft"
     },
     "loa": null,
@@ -2834,20 +3556,20 @@
     "nrt": null,
     "holdsCount": null,
     "hatchesCount": null,
-    "grainCapacity": 276000,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 262000,
+    "grainCapacity": 221,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 210,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "2x20 mt",
+    "craneCapacity": "2 x 20T",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Constanta",
       "confidence": "confirmed",
-      "sourceText": "Constanta"
+      "sourceText": "OPEN IN CONSTANTA"
     },
     "openDate": {
       "value": {
@@ -2859,13 +3581,7 @@
       "sourceText": "Mid-March"
     },
     "direction": null,
-    "restrictions": [
-      {
-        "value": "Please do not re-circulate",
-        "confidence": "confirmed",
-        "source_text": "Please do not re-circulate"
-      }
-    ],
+    "restrictions": [],
     "lastCargoes": null,
     "speedLaden": null,
     "speedBallast": null,
@@ -2873,7 +3589,7 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "boxlike",
+        "value": "box-shaped hold",
         "confidence": "confirmed",
         "source_text": "boxlike"
       },
@@ -2888,15 +3604,897 @@
         "source_text": "IMO fitted"
       },
       {
-        "value": "ice class",
+        "value": "Ice class",
         "confidence": "confirmed",
         "source_text": "ice class"
       },
       {
-        "value": "ITF FITTED",
+        "value": "ITF fitted",
         "confidence": "confirmed",
         "source_text": "ITF FITTED"
       }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e09795d905a46f",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "M/V NURI SONAY",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2006,
+    "classSociety": "BV",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 14888,
+      "confidence": "confirmed",
+      "sourceText": "14888MTS DWT"
+    },
+    "dwcc": {
+      "value": 14500,
+      "confidence": "confirmed",
+      "sourceText": "14500MTS DWCC"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 461,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": "20",
+    "geared": true,
+    "craneCapacity": "3 x 30T",
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Ravenna, Italy Adriatic",
+      "confidence": "confirmed",
+      "sourceText": "OPEN RAVENNA,ITAL ADRIATIC"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "02-03RD MARCH"
+      },
+      "confidence": "confirmed",
+      "sourceText": "ON 02-03RD MARCH"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX"
+      },
+      {
+        "value": "open hatch",
+        "confidence": "confirmed",
+        "source_text": "OPEN HATCH"
+      },
+      {
+        "value": "ITF fitted",
+        "confidence": "confirmed",
+        "source_text": "ITF FITTED"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e09795d905a46f",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "M/V HACI HILMI II",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1992,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 6976,
+      "confidence": "confirmed",
+      "sourceText": "6976MTS DWT"
+    },
+    "dwcc": {
+      "value": 6700,
+      "confidence": "confirmed",
+      "sourceText": "6700MTS DWCC"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 8775,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "3 x 10T",
+    "hatchType": null,
+    "vesselType": null,
+    "openPosition": {
+      "value": "East Coast Greece",
+      "confidence": "confirmed",
+      "sourceText": "OPEN EAST COAST GREECE"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "09-10TH MARCH"
+      },
+      "confidence": "confirmed",
+      "sourceText": "ON 09-10TH MARCH"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e09795d905a46f",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "M/V SEVKETTIN SONAY",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2006,
+    "classSociety": "BV",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 14888,
+      "confidence": "confirmed",
+      "sourceText": "14888MTS DWT"
+    },
+    "dwcc": {
+      "value": 14500,
+      "confidence": "confirmed",
+      "sourceText": "14500MTS DWCC"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 461,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": "20",
+    "geared": true,
+    "craneCapacity": "3 x 30T",
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Tunisia",
+      "confidence": "confirmed",
+      "sourceText": "OPEN TUNISIA"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "12-13TH MARCH"
+      },
+      "confidence": "confirmed",
+      "sourceText": "ON 12-13TH MARCH"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX"
+      },
+      {
+        "value": "open hatch",
+        "confidence": "confirmed",
+        "source_text": "OPEN HATCH"
+      },
+      {
+        "value": "ITF fitted",
+        "confidence": "confirmed",
+        "source_text": "ITF FITTED"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e09795d905a46f",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "M/V SABAHAT SONAY",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2007,
+    "classSociety": "BV",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 14888,
+      "confidence": "confirmed",
+      "sourceText": "14888MTS DWT"
+    },
+    "dwcc": {
+      "value": 14500,
+      "confidence": "confirmed",
+      "sourceText": "14500MTS DWCC"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 461,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": "20",
+    "geared": true,
+    "craneCapacity": "3 x 30T",
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "OPEN MARMARA"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "16-17TH MARCH"
+      },
+      "confidence": "confirmed",
+      "sourceText": "ON 16-17TH MARCH"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX"
+      },
+      {
+        "value": "open hatch",
+        "confidence": "confirmed",
+        "source_text": "OPEN HATCH"
+      },
+      {
+        "value": "ITF fitted",
+        "confidence": "confirmed",
+        "source_text": "ITF FITTED"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e09795d905a46f",
+    "itemIndex": 4,
+    "vesselName": {
+      "value": "M/V TBN",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2007,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 17500,
+      "confidence": "confirmed",
+      "sourceText": "17500MTS DWCC"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 609,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Aegean Sea",
+      "confidence": "confirmed",
+      "sourceText": "OPEN AGEAN SEA PROMPT"
+    },
+    "openDate": {
+      "value": "spot",
+      "confidence": "interpreted",
+      "sourceText": "OPEN AGEAN SEA PROMPT"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX TYPE"
+      },
+      {
+        "value": "ITF fitted",
+        "confidence": "confirmed",
+        "source_text": "ITF FITTED"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e09795d905a46f",
+    "itemIndex": 5,
+    "vesselName": {
+      "value": "M/V TBN",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2008,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 22000,
+      "confidence": "interpreted",
+      "sourceText": "22K dwt"
+    },
+    "dwcc": null,
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 796,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "3 x 20T",
+    "hatchType": null,
+    "vesselType": null,
+    "openPosition": {
+      "value": "Beira, East Africa",
+      "confidence": "confirmed",
+      "sourceText": "Open Beira,East Africa"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "Mid April"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Mid April"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV AYA",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2008,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 6050,
+      "confidence": "confirmed",
+      "sourceText": "6050"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 8410,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Iskenderun",
+      "confidence": "confirmed",
+      "sourceText": "ISKENDERUN"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "07-10 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "07-10 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "IMDG Class 1.1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "MV SUN S",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2008,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 5050,
+      "confidence": "confirmed",
+      "sourceText": "5050"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 3,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 6796,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "East Med",
+      "confidence": "confirmed",
+      "sourceText": "EAST MED"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "08-10 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "08-10 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "open hatch (OH)",
+      "IMDG Class 1.1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "MV CELAL SAHIN",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2006,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 4500,
+      "confidence": "confirmed",
+      "sourceText": "4500"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 5550,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Constanta",
+      "confidence": "confirmed",
+      "sourceText": "CONSTANTA"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "12-14 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "12-14 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "open hatch (OH)",
+      "fully containerised",
+      "IMDG Class 1.1 certified (under & on deck)",
+      "IMDG Class 1.1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "MV TURGUT SAHIN",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1997,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 4450,
+      "confidence": "confirmed",
+      "sourceText": "4450"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 1,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 5522,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Algeria",
+      "confidence": "confirmed",
+      "sourceText": "ALGERIA"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "12-15 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "12-15 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "open hatch (OH)",
+      "IMDG Class 1.1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 4,
+    "vesselName": {
+      "value": "MV UNZILE ANA",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1996,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 4000,
+      "confidence": "confirmed",
+      "sourceText": "4000"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 4814,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Egypt Med",
+      "confidence": "confirmed",
+      "sourceText": "EGYPT MED"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "19-22 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "19-22 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "open hatch (OH)",
+      "IMDG Class 1.1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 5,
+    "vesselName": {
+      "value": "MV HABIBE ANA",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1995,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 3850,
+      "confidence": "confirmed",
+      "sourceText": "3850"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 2,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 4531,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Bulgaria",
+      "confidence": "confirmed",
+      "sourceText": "BULGARIA"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "13-15 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "13-15 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "open hatch (OH)",
+      "IMDG Class 1.1 certified"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e097b0d6404a40",
+    "itemIndex": 6,
+    "vesselName": {
+      "value": "MV MERIC",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1995,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 2600,
+      "confidence": "confirmed",
+      "sourceText": "2600"
+    },
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": 1,
+    "hatchesCount": null,
+    "grainCapacity": null,
+    "grainCapacityUnit": null,
+    "baleCapacity": 3908,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "N.Adriatic",
+      "confidence": "confirmed",
+      "sourceText": "N.ADRIATIC"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "16-18 MAR"
+      },
+      "confidence": "confirmed",
+      "sourceText": "16-18 MAR"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "open hatch (OH)",
+      "fully containerised",
+      "IMDG Class 1.1 certified (under & on deck)",
+      "IMDG Class 1.1 certified"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2906,8 +4504,7 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV SEA BREEZE",
-      "confidence": "confirmed",
-      "sourceText": "MV SEA BREEZE"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -2927,29 +4524,29 @@
     "nrt": null,
     "holdsCount": 3,
     "hatchesCount": 3,
-    "grainCapacity": 283917,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 283917,
+    "grainCapacity": 228,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 228,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Souda Port, Chania, Crete, Greece",
       "confidence": "confirmed",
-      "sourceText": "OPEN @ SOUDA PORT, CHANIA, CRETE, GREECE"
+      "sourceText": "OPEN @ SOUDA PORT, CHANIA, CRETE, GREECE ON 24-26 APRIL"
     },
     "openDate": {
       "value": {
-        "open": "2026-04-24",
-        "close": "2026-04-26",
-        "display": "24-26 APRIL 2026"
+        "open": null,
+        "close": null,
+        "display": "24-26 APRIL"
       },
-      "confidence": "interpreted",
-      "sourceText": "OPEN @ SOUDA PORT, CHANIA, CRETE, GREECE ON 24-26 APRIL"
+      "confidence": "confirmed",
+      "sourceText": "ON 24-26 APRIL"
     },
     "direction": null,
     "restrictions": [],
@@ -2960,20 +4557,32 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
-        "source_text": "SID"
+        "source_text": "SID - BOX HOLD"
       },
       {
-        "value": "BOX HOLD",
-        "confidence": "confirmed",
-        "source_text": "BOX HOLD"
-      },
-      {
-        "value": "BULK/IMO/APP B/GRAIN/TIMBER FITTED",
+        "value": "IMDG fitted",
         "confidence": "confirmed",
         "source_text": "BULK/IMO/APP B/GRAIN/TIMBER FITTED"
-      }
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B"
+      },
+      {
+        "value": "Grain fitted",
+        "confidence": "confirmed",
+        "source_text": "GRAIN/TIMBER FITTED"
+      },
+      {
+        "value": "Timber fitted",
+        "confidence": "confirmed",
+        "source_text": "GRAIN/TIMBER FITTED"
+      },
+      "Appendix B fitted",
+      "SID box-shaped hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -2983,8 +4592,7 @@
     "itemIndex": 1,
     "vesselName": {
       "value": "MV SEA PIONEER",
-      "confidence": "confirmed",
-      "sourceText": "MV SEA PIONEER"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -3004,29 +4612,29 @@
     "nrt": null,
     "holdsCount": 2,
     "hatchesCount": 2,
-    "grainCapacity": 235231,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 235231,
+    "grainCapacity": 189,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 189,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": false,
-    "craneCapacity": "2 X 15 MTS SWL",
+    "craneCapacity": "2 x 15T",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Thessaloniki, Greece",
       "confidence": "confirmed",
-      "sourceText": "OPEN @THESSALONIKI, GREECE"
+      "sourceText": "OPEN @THESSALONIKI, GREECE ON 25-27 APRIL"
     },
     "openDate": {
       "value": {
-        "open": "2026-04-25",
-        "close": "2026-04-27",
-        "display": "25-27 APRIL 2026"
+        "open": null,
+        "close": null,
+        "display": "25-27 APRIL"
       },
-      "confidence": "interpreted",
-      "sourceText": "OPEN @THESSALONIKI, GREECE ON 25-27 APRIL"
+      "confidence": "confirmed",
+      "sourceText": "ON 25-27 APRIL"
     },
     "direction": null,
     "restrictions": [],
@@ -3037,20 +4645,343 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
-        "source_text": "SID"
+        "source_text": "SID - BOX HOLD"
       },
       {
-        "value": "BOX HOLD",
-        "confidence": "confirmed",
-        "source_text": "BOX HOLD"
-      },
-      {
-        "value": "BULK/IMO/APP B/GRAIN/TIMBER FITTED",
+        "value": "IMDG fitted",
         "confidence": "confirmed",
         "source_text": "BULK/IMO/APP B/GRAIN/TIMBER FITTED"
-      }
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B"
+      },
+      {
+        "value": "Grain fitted",
+        "confidence": "confirmed",
+        "source_text": "GRAIN/TIMBER FITTED"
+      },
+      {
+        "value": "Timber fitted",
+        "confidence": "confirmed",
+        "source_text": "GRAIN/TIMBER FITTED"
+      },
+      "Appendix B fitted",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f51c5410d5d2",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV BBA LARISA",
+      "confidence": "confirmed"
+    },
+    "imo": "9166510",
+    "flag": "Palau",
+    "built": 1999,
+    "classSociety": "TL",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 5007,
+      "confidence": "confirmed",
+      "sourceText": "5007 dwt"
+    },
+    "dwcc": {
+      "value": 4900,
+      "confidence": "confirmed",
+      "sourceText": "4900 dwcc on 6,45 Draft"
+    },
+    "draftMax": {
+      "value": 6.45,
+      "confidence": "interpreted",
+      "sourceText": "4900 dwcc on 6,45 Draft"
+    },
+    "loa": 93.72,
+    "beam": 14.85,
+    "grt": 2950,
+    "nrt": 1807,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 6246,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 6031,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Gabes",
+      "confidence": "confirmed",
+      "sourceText": "Vessel will be open at Gabes on 7-8 May"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "7-8 May"
+      },
+      "confidence": "confirmed",
+      "sourceText": "open at Gabes on 7-8 May"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "semi box-shaped 1 hold",
+        "confidence": "confirmed",
+        "source_text": "Semi Box 1 Hold"
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B FITTED"
+      },
+      "IMDG Class 9166510 certified",
+      "IMDG Class 9367841 certified",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f51c5410d5d2",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "MV YUCATAN",
+      "confidence": "confirmed"
+    },
+    "imo": "9367841",
+    "flag": "Saint Vincent and the Grenadines",
+    "built": 2006,
+    "classSociety": "TL",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 3178,
+      "confidence": "confirmed",
+      "sourceText": "3178 dwt"
+    },
+    "dwcc": {
+      "value": 3100,
+      "confidence": "confirmed",
+      "sourceText": "3100 dwcc on 5,51 Draft"
+    },
+    "draftMax": {
+      "value": 5.51,
+      "confidence": "interpreted",
+      "sourceText": "3100 dwcc on 5,51 Draft"
+    },
+    "loa": 80.6,
+    "beam": 13.6,
+    "grt": 1972,
+    "nrt": 1227,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 113,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 113,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Alexandria",
+      "confidence": "confirmed",
+      "sourceText": "Vessel will be open at Alexandria on 1-2 May"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "1-2 May"
+      },
+      "confidence": "confirmed",
+      "sourceText": "open at Alexandria on 1-2 May"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped 2 holds",
+        "confidence": "confirmed",
+        "source_text": "Box 2 Hold"
+      },
+      "IMDG Class 9367841 certified",
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f51c5410d5d2",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "MV ONEGO TRADER",
+      "confidence": "confirmed"
+    },
+    "imo": "9238351",
+    "flag": "Portugal",
+    "built": 2001,
+    "classSociety": "KR",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 8930,
+      "confidence": "confirmed",
+      "sourceText": "8930 dwt"
+    },
+    "dwcc": {
+      "value": 8200,
+      "confidence": "confirmed",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "draftMax": {
+      "value": 7.2,
+      "confidence": "interpreted",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "loa": 132.2,
+    "beam": 15.87,
+    "grt": 6301,
+    "nrt": 3582,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 362,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 362,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": null,
+    "openDate": null,
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "full box-shaped 2 holds",
+        "confidence": "confirmed",
+        "source_text": "Full Box 2 Hold"
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B FITTED"
+      },
+      {
+        "value": "On time charter",
+        "confidence": "confirmed",
+        "source_text": "Vessel ON TC."
+      },
+      "IMDG Class 9238351 certified",
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f51c5410d5d2",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "MV ONEGO MERCHANT",
+      "confidence": "confirmed"
+    },
+    "imo": "9238363",
+    "flag": "Portugal",
+    "built": 2002,
+    "classSociety": "KR",
+    "pandi": "London P&I",
+    "dwtSummer": {
+      "value": 8930,
+      "confidence": "confirmed",
+      "sourceText": "8930 dwt"
+    },
+    "dwcc": {
+      "value": 8200,
+      "confidence": "confirmed",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "draftMax": {
+      "value": 7.2,
+      "confidence": "interpreted",
+      "sourceText": "8200 dwcc on 7,2  Draft"
+    },
+    "loa": 132.2,
+    "beam": 15.87,
+    "grt": 6301,
+    "nrt": 3582,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 362,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 362,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": null,
+    "openDate": null,
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "full box-shaped 2 holds",
+        "confidence": "confirmed",
+        "source_text": "Full Box 2 Hold"
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B FITTED"
+      },
+      {
+        "value": "On time charter",
+        "confidence": "confirmed",
+        "source_text": "Vessel ON TC."
+      },
+      "IMDG Class 9238363 certified",
+      "Appendix B fitted"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -3059,9 +4990,8 @@
     "emailId": "19e0f51ea1cd9364",
     "itemIndex": 0,
     "vesselName": {
-      "value": "MV SEA MAJESTY",
-      "confidence": "confirmed",
-      "sourceText": "MV SEA MAJESTY"
+      "value": "SEA MAJESTY",
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
@@ -3081,29 +5011,29 @@
     "nrt": null,
     "holdsCount": 4,
     "hatchesCount": 4,
-    "grainCapacity": 400407.49,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 391498.94,
+    "grainCapacity": 321,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 314,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "2 X 15 MTS SWL",
+    "craneCapacity": "2 x 15T",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Tripoli, Lebanon",
       "confidence": "confirmed",
-      "sourceText": "OPEN @ TRIPOLI, LEBANON"
+      "sourceText": "OPEN @ TRIPOLI, LEBANON 16-17 APRIL"
     },
     "openDate": {
       "value": {
-        "open": "2026-04-16",
-        "close": "2026-04-17",
+        "open": null,
+        "close": null,
         "display": "16-17 APRIL"
       },
-      "confidence": "interpreted",
-      "sourceText": "16-17 APRIL"
+      "confidence": "confirmed",
+      "sourceText": "OPEN @ TRIPOLI, LEBANON 16-17 APRIL"
     },
     "direction": "Egypt to EC Greece / EC Black Sea",
     "restrictions": [],
@@ -3114,15 +5044,32 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID - BOX HOLD",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
         "source_text": "SID - BOX HOLD"
       },
       {
-        "value": "BULK/IMO/APP B/GRAIN/TIMBER FITTED",
+        "value": "IMDG/dangerous goods fitted",
         "confidence": "confirmed",
         "source_text": "BULK/IMO/APP B/GRAIN/TIMBER FITTED"
-      }
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "BULK/IMO/APP B/GRAIN/TIMBER FITTED"
+      },
+      {
+        "value": "Grain fitted",
+        "confidence": "confirmed",
+        "source_text": "GRAIN/TIMBER FITTED"
+      },
+      {
+        "value": "Timber fitted",
+        "confidence": "confirmed",
+        "source_text": "GRAIN/TIMBER FITTED"
+      },
+      "Appendix B fitted",
+      "SID box-shaped hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -3132,20 +5079,19 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "FILIA ARIEA",
-      "confidence": "confirmed",
-      "sourceText": "- FILIA ARIEA"
+      "confidence": "confirmed"
     },
     "imo": null,
     "flag": null,
     "built": null,
     "classSociety": null,
     "pandi": null,
-    "dwtSummer": {
+    "dwtSummer": null,
+    "dwcc": {
       "value": 2650,
       "confidence": "confirmed",
       "sourceText": "2650 mt"
     },
-    "dwcc": null,
     "draftMax": null,
     "loa": null,
     "beam": null,
@@ -3153,29 +5099,29 @@
     "nrt": null,
     "holdsCount": null,
     "hatchesCount": null,
-    "grainCapacity": 150000,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": null,
+    "grainCapacity": 120,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 120,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": null,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Jeddah",
       "confidence": "confirmed",
-      "sourceText": "Open: Jeddah"
+      "sourceText": "Open: Jeddah – 30-Mar."
     },
     "openDate": {
       "value": {
-        "open": "2026-03-30",
+        "open": null,
         "close": null,
-        "display": "30-Mar-2026"
+        "display": "30-Mar"
       },
       "confidence": "confirmed",
-      "sourceText": "30-Mar."
+      "sourceText": "Open: Jeddah – 30-Mar."
     },
     "direction": null,
     "restrictions": [],
@@ -3186,10 +5132,11 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID/Box",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
         "source_text": "SID/Box"
-      }
+      },
+      "SID box-shaped hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -3199,28 +5146,27 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV ADAMAR",
-      "confidence": "confirmed",
-      "sourceText": "MV ADAMAR                                   OPEN EC-INDIA 04-08.10.2025"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "LIBERIA",
+    "flag": "Liberia",
     "built": 2009,
-    "classSociety": "BUREAU VERITAS",
-    "pandi": "STEAMSHIP MUTUAL",
+    "classSociety": "BV",
+    "pandi": "Steamship Mutual",
     "dwtSummer": {
       "value": 17660.15,
       "confidence": "confirmed",
-      "sourceText": "DWT 17660,15  SUMMER ON 8,598 M SSW DWWC 16850"
+      "sourceText": "DWT 17660,15  SUMMER"
     },
     "dwcc": {
       "value": 16850,
       "confidence": "confirmed",
-      "sourceText": "DWT 17660,15  SUMMER ON 8,598 M SSW DWWC 16850"
+      "sourceText": "DWWC 16850"
     },
     "draftMax": {
       "value": 8.598,
-      "confidence": "confirmed",
-      "sourceText": "DWT 17660,15  SUMMER ON 8,598 M SSW DWWC 16850"
+      "confidence": "interpreted",
+      "sourceText": "SUMMER ON 8,598 M SSW"
     },
     "loa": 147.55,
     "beam": 23,
@@ -3228,18 +5174,18 @@
     "nrt": null,
     "holdsCount": 4,
     "hatchesCount": 4,
-    "grainCapacity": 758120,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 726267,
+    "grainCapacity": 608,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 582,
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "3 X 25 MT",
+    "craneCapacity": "3 x 25 MT",
     "hatchType": null,
-    "vesselType": "MULTIPURPOSE DRY CARGO SHIP",
+    "vesselType": "MPP",
     "openPosition": {
-      "value": "EC-INDIA",
+      "value": "EC India",
       "confidence": "confirmed",
       "sourceText": "OPEN EC-INDIA 04-08.10.2025"
     },
@@ -3247,9 +5193,9 @@
       "value": {
         "open": "2025-10-04",
         "close": "2025-10-08",
-        "display": "04-08.10.2025"
+        "display": "04-08 October 2025"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "OPEN EC-INDIA 04-08.10.2025"
     },
     "direction": null,
@@ -3261,15 +5207,11 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "SID",
+        "value": "SID box-shaped hold",
         "confidence": "confirmed",
         "source_text": "SID / MULTIPURPOSE DRY CARGO SHIP / BOX SHAPED"
       },
-      {
-        "value": "BOX SHAPED",
-        "confidence": "confirmed",
-        "source_text": "SID / MULTIPURPOSE DRY CARGO SHIP / BOX SHAPED"
-      }
+      "SID box-shaped hold"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -3279,10 +5221,9 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV MIMI",
-      "confidence": "confirmed",
-      "sourceText": "mv mimi"
+      "confidence": "confirmed"
     },
-    "imo": null,
+    "imo": "8216100",
     "flag": "Comoros",
     "built": 1987,
     "classSociety": null,
@@ -3290,8 +5231,8 @@
     "dwtSummer": null,
     "dwcc": {
       "value": 3500,
-      "confidence": "confirmed",
-      "sourceText": "dwcc 3500 mt"
+      "confidence": "interpreted",
+      "sourceText": "dwcc 3500 mt on abt 6.34 m"
     },
     "draftMax": {
       "value": 6.34,
@@ -3308,16 +5249,16 @@
     "grainCapacityUnit": "cbm",
     "baleCapacity": 4390,
     "holdDimensions": null,
-    "hatchDimensions": "[object Object]",
+    "hatchDimensions": "hatch opening: 50.30 x 10.2m",
     "tankTopStrength": null,
     "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "GENERAL CARGO",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Misurata",
       "confidence": "confirmed",
-      "sourceText": "open misurata"
+      "sourceText": "open misurata 05september2024"
     },
     "openDate": {
       "value": {
@@ -3331,10 +5272,14 @@
     "direction": null,
     "restrictions": [],
     "lastCargoes": null,
-    "speedLaden": null,
+    "speedLaden": {
+      "value": 10,
+      "confidence": "confirmed",
+      "source_text": "10 k on abt 3.5 tns"
+    },
     "speedBallast": null,
     "consumption": {
-      "value": "10 k on abt 3.5 tns",
+      "value": 3.5,
       "confidence": "interpreted",
       "source_text": "10 k on abt 3.5 tns"
     },
@@ -3344,32 +5289,98 @@
     "verificationWarning": null
   },
   {
+    "emailId": "19e0f531898504ce",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV SNAPPER",
+      "confidence": "confirmed"
+    },
+    "imo": "9381407",
+    "flag": null,
+    "built": 2008,
+    "classSociety": "IR",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 8100,
+      "confidence": "confirmed",
+      "sourceText": "8100 mts dwt at 6.82 mtrs draft"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 6.82,
+      "confidence": "confirmed",
+      "sourceText": "8100 mts dwt at 6.82 mtrs draft"
+    },
+    "loa": 108.1,
+    "beam": 18.2,
+    "grt": 5599,
+    "nrt": 2883,
+    "holdsCount": 3,
+    "hatchesCount": 3,
+    "grainCapacity": 10194,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": null,
+    "holdDimensions": "hold 1: 18.90 m x 15.20/6.60 m x 11.20 m,hold 2: 29.40 m x 15.20 m x 9.10 m,hold 3: 28 m x 15.20/7.70 m x 9.10 m",
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Nemrut Bay",
+      "confidence": "confirmed",
+      "sourceText": "open nemrut bay spot"
+    },
+    "openDate": {
+      "value": "spot",
+      "confidence": "interpreted",
+      "sourceText": "open nemrut bay spot"
+    },
+    "direction": "all Africa, Persian Gulf, India",
+    "restrictions": [
+      "no European ports for now"
+    ],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      "box-shaped holds",
+      "Ice class: 1D",
+      "bowthruster",
+      "BWTS fitted",
+      "IMO fitted",
+      "ex Aikaterini K",
+      "MAN-B&W 7S26MC 3,808 hp"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
     "emailId": "19e0f53423e78f5f",
     "itemIndex": 0,
     "vesselName": {
-      "value": "mv propus",
-      "confidence": "confirmed",
-      "sourceText": "mv propus"
+      "value": "PROPUS",
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "panama",
+    "flag": "Panama",
     "built": 1997,
-    "classSociety": "bv",
+    "classSociety": "BV",
     "pandi": null,
     "dwtSummer": {
       "value": 10430,
-      "confidence": "confirmed",
-      "sourceText": "dwt 10430 dwt"
+      "confidence": "confirmed"
     },
     "dwcc": {
       "value": 10000,
-      "confidence": "interpreted",
-      "sourceText": "10k dwcc"
+      "confidence": "confirmed"
     },
     "draftMax": {
       "value": 8.58,
-      "confidence": "interpreted",
-      "sourceText": "dwt 10430 dwt on 8.58 m draft"
+      "confidence": "confirmed"
     },
     "loa": 126,
     "beam": 20,
@@ -3383,31 +5394,27 @@
     "holdDimensions": null,
     "hatchDimensions": null,
     "tankTopStrength": null,
-    "geared": null,
+    "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
-      "value": "istanbul",
+      "value": "Istanbul",
       "confidence": "confirmed",
-      "sourceText": "open istanbul"
+      "sourceText": "open istanbul 22/26august"
     },
     "openDate": {
       "value": {
-        "open": "2024-08-22",
-        "close": "2024-08-26",
+        "open": null,
+        "close": null,
         "display": "22/26august"
       },
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "open istanbul 22/26august"
     },
     "direction": null,
     "restrictions": [
-      {
-        "value": "not prefer ukraine voyage for just now",
-        "confidence": "confirmed",
-        "source_text": "not prefer ukraine voyage for just now"
-      }
+      "not prefer Ukraine voyage"
     ],
     "lastCargoes": null,
     "speedLaden": null,
@@ -3416,107 +5423,9 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "box like",
-        "confidence": "confirmed",
+        "value": "box-shaped hold",
+        "confidence": "interpreted",
         "source_text": "box like"
-      },
-      {
-        "value": "rated other cgoes welcome",
-        "confidence": "confirmed",
-        "source_text": "rated other cgoes welcome"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19e0f531898504ce",
-    "itemIndex": 0,
-    "vesselName": {
-      "value": "mv snapper",
-      "confidence": "confirmed",
-      "sourceText": "mv snapper (ex aikaterini k imo.9381407)"
-    },
-    "imo": null,
-    "flag": null,
-    "built": 2008,
-    "classSociety": "ir",
-    "pandi": null,
-    "dwtSummer": {
-      "value": 8100,
-      "confidence": "confirmed",
-      "sourceText": "8100 mts dwt at 6.82 mtrs draft"
-    },
-    "dwcc": null,
-    "draftMax": {
-      "value": 6.82,
-      "confidence": "interpreted",
-      "sourceText": "8100 mts dwt at 6.82 mtrs draft"
-    },
-    "loa": 108.1,
-    "beam": 18.2,
-    "grt": 5599,
-    "nrt": 2883,
-    "holdsCount": 3,
-    "hatchesCount": 3,
-    "grainCapacity": 10194,
-    "grainCapacityUnit": "cbm",
-    "baleCapacity": null,
-    "holdDimensions": "[object Object],[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object],[object Object]",
-    "tankTopStrength": null,
-    "geared": true,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "nemrut bay",
-      "confidence": "confirmed",
-      "sourceText": "open nemrut bay spot"
-    },
-    "openDate": {
-      "value": "spot",
-      "confidence": "interpreted",
-      "sourceText": "open nemrut bay spot"
-    },
-    "direction": "all africa, pg india",
-    "restrictions": [
-      {
-        "value": "no european ports for now",
-        "confidence": "confirmed",
-        "source_text": "*no european ports for now"
-      }
-    ],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "ice 1d",
-        "confidence": "confirmed",
-        "source_text": "ice 1d"
-      },
-      {
-        "value": "3 ho(boxed)/3 ha",
-        "confidence": "confirmed",
-        "source_text": "3 ho(boxed)/3 ha"
-      },
-      {
-        "value": "bowthruster",
-        "confidence": "confirmed",
-        "source_text": "bowthruster"
-      },
-      {
-        "value": "bwts fitted",
-        "confidence": "confirmed",
-        "source_text": "bwts fitted"
-      },
-      {
-        "value": "imo fitted",
-        "confidence": "confirmed",
-        "source_text": "imo fitted"
       }
     ],
     "ciiRating": null,
@@ -3527,18 +5436,16 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "M/V AVAT 1",
-      "confidence": "confirmed",
-      "sourceText": "M/V AVAT 1"
+      "confidence": "confirmed"
     },
-    "imo": null,
+    "imo": "1033822",
     "flag": "Cameroon",
     "built": 2020,
     "classSociety": "OMROS",
-    "pandi": "THOMAS MILLER",
+    "pandi": "Thomas Miller",
     "dwtSummer": {
       "value": 9220,
-      "confidence": "confirmed",
-      "sourceText": "DWT: 9220 MT AT 5,20 M DRAFT"
+      "confidence": "confirmed"
     },
     "dwcc": null,
     "draftMax": {
@@ -3555,91 +5462,26 @@
     "grainCapacity": 9900,
     "grainCapacityUnit": "cbm",
     "baleCapacity": 9900,
-    "holdDimensions": null,
+    "holdDimensions": "HOLD NO 1: 5097 M3 / 180.000 CBFT,HOLD NO 2: 4807 M3 / 170.000 CBFT",
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": false,
     "craneCapacity": null,
     "hatchType": null,
-    "vesselType": "GENERAL CARGO",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "Agadir or any West Med",
       "confidence": "confirmed",
-      "sourceText": "OPEN AT AGADIR OR ANY WEST MED ON 22-25 AUGUST."
+      "sourceText": "EXCL. OPEN AT AGADIR OR ANY WEST MED ON 22-25 AUGUST"
     },
     "openDate": {
       "value": {
-        "open": "2024-08-22",
-        "close": "2024-08-25",
-        "display": "22-25 AUGUST"
+        "open": null,
+        "close": null,
+        "display": "22-25 August"
       },
-      "confidence": "interpreted",
-      "sourceText": "22-25 AUGUST"
-    },
-    "direction": null,
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19e0f54a2c261266",
-    "itemIndex": 0,
-    "vesselName": {
-      "value": "DOLPHIN E",
       "confidence": "confirmed",
-      "sourceText": "DOLPHIN E"
-    },
-    "imo": null,
-    "flag": "PALAU",
-    "built": 1991,
-    "classSociety": "IACS",
-    "pandi": null,
-    "dwtSummer": null,
-    "dwcc": {
-      "value": 1600,
-      "confidence": "confirmed",
-      "sourceText": "1600 DWCC"
-    },
-    "draftMax": {
-      "value": 3.83,
-      "confidence": "interpreted",
-      "sourceText": "1600 DWCC ON 3,83 M DRAFT"
-    },
-    "loa": 78.5,
-    "beam": 10.5,
-    "grt": 1276,
-    "nrt": 672,
-    "holdsCount": 1,
-    "hatchesCount": 1,
-    "grainCapacity": 89600,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 88100,
-    "holdDimensions": "[object Object]",
-    "hatchDimensions": "[object Object]",
-    "tankTopStrength": null,
-    "geared": false,
-    "craneCapacity": null,
-    "hatchType": null,
-    "vesselType": null,
-    "openPosition": {
-      "value": "IZMIR",
-      "confidence": "confirmed",
-      "sourceText": "IZMIR"
-    },
-    "openDate": {
-      "value": {
-        "open": "2024-07-12",
-        "close": "2024-07-13",
-        "display": "12/13 JULY"
-      },
-      "confidence": "interpreted",
-      "sourceText": "12/13 JULY"
+      "sourceText": "ON 22-25 AUGUST"
     },
     "direction": null,
     "restrictions": [],
@@ -3649,116 +5491,7 @@
     "consumption": null,
     "deckCapacity": null,
     "specialFeatures": [
-      {
-        "value": "ICE CLASS 1A",
-        "confidence": "confirmed",
-        "source_text": "ICE CLASS 1A"
-      },
-      {
-        "value": "SID BOX",
-        "confidence": "confirmed",
-        "source_text": "SID BOX"
-      },
-      {
-        "value": "AIR DRAFT 8,4 M ON BALLAST",
-        "confidence": "confirmed",
-        "source_text": "AIR DRAFT 8,4 M ON BALLAST"
-      },
-      {
-        "value": "BOW THRUSTER FITTED",
-        "confidence": "confirmed",
-        "source_text": "BOW THRUSTER FITTED"
-      },
-      {
-        "value": "APP B FITTED",
-        "confidence": "confirmed",
-        "source_text": "APP B FITTED"
-      }
-    ],
-    "ciiRating": null,
-    "verificationWarning": null
-  },
-  {
-    "emailId": "19e0f54a2c261266",
-    "itemIndex": 1,
-    "vesselName": {
-      "value": "SERENITY AC",
-      "confidence": "confirmed",
-      "sourceText": "SERENITY AC"
-    },
-    "imo": null,
-    "flag": "PANAMA",
-    "built": 1991,
-    "classSociety": "IRS",
-    "pandi": null,
-    "dwtSummer": {
-      "value": 1723,
-      "confidence": "confirmed",
-      "sourceText": "1,723 DWT"
-    },
-    "dwcc": {
-      "value": 1600,
-      "confidence": "confirmed",
-      "sourceText": "1.600 DWCC"
-    },
-    "draftMax": {
-      "value": 3.7,
-      "confidence": "interpreted",
-      "sourceText": "1,723 DWT ON 3.70 M DRAFT / 1.600 DWCC"
-    },
-    "loa": 74.99,
-    "beam": 10.7,
-    "grt": 1282,
-    "nrt": 675,
-    "holdsCount": 1,
-    "hatchesCount": 1,
-    "grainCapacity": 88000,
-    "grainCapacityUnit": "cbft",
-    "baleCapacity": 2480,
-    "holdDimensions": "[object Object]",
-    "hatchDimensions": "[object Object]",
-    "tankTopStrength": null,
-    "geared": null,
-    "craneCapacity": null,
-    "hatchType": "OPEN HATCH",
-    "vesselType": null,
-    "openPosition": {
-      "value": "EC GREECE",
-      "confidence": "confirmed",
-      "sourceText": "EC GREECE"
-    },
-    "openDate": {
-      "value": {
-        "open": "2024-07-07",
-        "close": "2024-07-08",
-        "display": "7/8 JULY"
-      },
-      "confidence": "interpreted",
-      "sourceText": "7/8 JULY"
-    },
-    "direction": null,
-    "restrictions": [],
-    "lastCargoes": null,
-    "speedLaden": null,
-    "speedBallast": null,
-    "consumption": null,
-    "deckCapacity": null,
-    "specialFeatures": [
-      {
-        "value": "BOX / OPEN HATCH",
-        "confidence": "confirmed",
-        "source_text": "BOX / OPEN HATCH"
-      },
-      {
-        "value": "1 MOVABLE BULKHEAD",
-        "confidence": "confirmed",
-        "source_text": "1 MOVABLE BULKHEAD"
-      },
-      {
-        "value": "IMO 1 FITTED",
-        "confidence": "confirmed",
-        "source_text": "IMO 1 FITTED"
-      }
+      "Depth moulded (DM): 7.15 m"
     ],
     "ciiRating": null,
     "verificationWarning": null
@@ -3768,23 +5501,22 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV YA HUSSEIN",
-      "confidence": "confirmed",
-      "sourceText": "MV YA HUSSEIN    DWT  24,290 MTS"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "PALAU",
+    "flag": "Palau",
     "built": 1996,
     "classSociety": "NKK",
-    "pandi": "CVRD",
+    "pandi": null,
     "dwtSummer": {
       "value": 24290,
       "confidence": "confirmed",
-      "sourceText": "DWT 24,290 MTS ON 9,54 M DRAFT"
+      "sourceText": "DWT 24,290 MTS"
     },
     "dwcc": null,
     "draftMax": {
       "value": 9.54,
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "DWT 24,290 MTS ON 9,54 M DRAFT"
     },
     "loa": 157.26,
@@ -3800,26 +5532,26 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "4/25T",
+    "craneCapacity": "4 x 25T",
     "hatchType": null,
-    "vesselType": null,
+    "vesselType": "BULK CARRIER",
     "openPosition": {
-      "value": "ALEXANDRIA, EGYPT",
+      "value": "Alexandria, Egypt",
       "confidence": "confirmed",
       "sourceText": "ALEXANDRIA, EGYPT 04-05 JULY"
     },
     "openDate": {
       "value": {
-        "open": "2024-07-04",
-        "close": "2024-07-05",
+        "open": null,
+        "close": null,
         "display": "04-05 JULY"
       },
-      "confidence": "interpreted",
-      "sourceText": "04-05 JULY"
+      "confidence": "confirmed",
+      "sourceText": "ALEXANDRIA, EGYPT 04-05 JULY"
     },
     "direction": null,
     "restrictions": [],
-    "lastCargoes": "CORN IN BULK",
+    "lastCargoes": "corn in bulk",
     "speedLaden": null,
     "speedBallast": null,
     "consumption": null,
@@ -3833,14 +5565,13 @@
     "itemIndex": 1,
     "vesselName": {
       "value": "MV AYA",
-      "confidence": "confirmed",
-      "sourceText": "MV  AYA"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "ST. Kitts & Navis",
+    "flag": "Kitts & Nevis",
     "built": 1997,
-    "classSociety": "K.R",
-    "pandi": "THOMAS MILLER",
+    "classSociety": "KR",
+    "pandi": "Thomas Miller",
     "dwtSummer": {
       "value": 27239.3,
       "confidence": "interpreted",
@@ -3865,15 +5596,23 @@
     "hatchDimensions": null,
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "4*25MT",
-    "hatchType": "FOLDING",
-    "vesselType": null,
+    "craneCapacity": "4 x 25T",
+    "hatchType": "Folding",
+    "vesselType": "BULK CARRIER",
     "openPosition": {
-      "value": "MARMARA, TUZLA",
+      "value": "Marmara, Tuzla",
       "confidence": "confirmed",
       "sourceText": "MARMARA, TUZLA  -   REVERTING"
     },
-    "openDate": null,
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "REVERTING"
+      },
+      "confidence": "uncertain",
+      "sourceText": "MARMARA, TUZLA  -   REVERTING"
+    },
     "direction": null,
     "restrictions": [],
     "lastCargoes": null,
@@ -3883,19 +5622,24 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "HOLDS CO2 FITTED : YES",
+        "value": "CO2 fitted holds",
         "confidence": "confirmed",
         "source_text": "HOLDS CO2 FITTED : YES"
       },
       {
-        "value": "AHL FITTED : YES",
+        "value": "AHL fitted",
         "confidence": "confirmed",
         "source_text": "AHL FITTED : YES"
       },
       {
-        "value": "OUTREACH : 10.5 M",
+        "value": "Crane outreach 10.5 M",
         "confidence": "confirmed",
         "source_text": "OUTREACH : 10.5 M"
+      },
+      {
+        "value": "TPC summer 37.33 MT",
+        "confidence": "confirmed",
+        "source_text": "TPC SUMMER  : 37.33 MT"
       }
     ],
     "ciiRating": null,
@@ -3906,11 +5650,10 @@
     "itemIndex": 2,
     "vesselName": {
       "value": "MV ARTICULATE",
-      "confidence": "confirmed",
-      "sourceText": "MV ARTICULATE"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "PALAU",
+    "flag": "Palau",
     "built": 1994,
     "classSociety": "IRS",
     "pandi": null,
@@ -3922,7 +5665,7 @@
     "dwcc": null,
     "draftMax": {
       "value": 9.52,
-      "confidence": "confirmed",
+      "confidence": "interpreted",
       "sourceText": "DWT 27308 MT ON 9,52M DRFT"
     },
     "loa": 165.5,
@@ -3934,44 +5677,572 @@
     "grainCapacity": 34810,
     "grainCapacityUnit": "cbm",
     "baleCapacity": 34182,
-    "holdDimensions": "HOLD1:3969/3808CBM,HOLD2:7895/7775 CBM,HOLD3:7899/7780 CBM,HOLD4:7715/7597 CBM,HOLD5:7334/7222 CBM",
-    "hatchDimensions": "HATCH #1: 8.0x13.5,HATCH # 2,3,4&5: 19.2x13.5",
+    "holdDimensions": "HOLD1: 3969/3808 CBM grain/bale,HOLD2: 7895/7775 CBM grain/bale,HOLD3: 7899/7780 CBM grain/bale,HOLD4: 7715/7597 CBM grain/bale,HOLD5: 7334/7222 CBM grain/bale",
+    "hatchDimensions": "HATCH #1: 8.0x13.5,HATCH #2,3,4&5: 19.2x13.5",
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "4 X 25T",
+    "craneCapacity": "4 x 25T",
     "hatchType": null,
-    "vesselType": "BC",
+    "vesselType": "BULK CARRIER",
     "openPosition": {
-      "value": "CANAKKALE",
+      "value": "Canakkale",
       "confidence": "confirmed",
       "sourceText": "CANAKKALE,  05 JULY"
     },
     "openDate": {
       "value": {
-        "open": "2024-07-05",
+        "open": null,
         "close": null,
         "display": "05 JULY"
       },
       "confidence": "confirmed",
-      "sourceText": "05 JULY"
+      "sourceText": "CANAKKALE,  05 JULY"
     },
     "direction": null,
     "restrictions": [],
-    "lastCargoes": "WHEAT IN BULK",
+    "lastCargoes": "wheat in bulk",
     "speedLaden": null,
     "speedBallast": null,
     "consumption": null,
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "ICE CLASS",
+        "value": "Ice class",
         "confidence": "confirmed",
-        "source_text": "ICE CLASS"
+        "source_text": "5HO/5HA ICE CLASS"
       },
       {
-        "value": "CRANE OUT REACH : 22.0M",
+        "value": "Crane outreach 22.0M",
         "confidence": "confirmed",
         "source_text": "CRANE OUT REACH : 22.0M"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f54a2c261266",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "DOLPHIN E",
+      "confidence": "confirmed"
+    },
+    "imo": "9013012",
+    "flag": "Palau",
+    "built": 1991,
+    "classSociety": "IACS",
+    "pandi": null,
+    "dwtSummer": null,
+    "dwcc": {
+      "value": 1600,
+      "confidence": "confirmed",
+      "sourceText": "1600 DWCC ON 3,83 M DRAFT"
+    },
+    "draftMax": {
+      "value": 3.83,
+      "confidence": "interpreted",
+      "sourceText": "1600 DWCC ON 3,83 M DRAFT - "
+    },
+    "loa": 78.5,
+    "beam": 10.5,
+    "grt": 1276,
+    "nrt": 672,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 72,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 71,
+    "holdDimensions": "54,7 x 8,3 x 5,50 M",
+    "hatchDimensions": "54,7 x 8,3 M",
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Izmir",
+      "confidence": "confirmed",
+      "sourceText": "IZMIR"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "12/13 JULY"
+      },
+      "confidence": "confirmed",
+      "sourceText": "12/13 JULY"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "SID box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "SID BOX"
+      },
+      {
+        "value": "Ice class: 1A",
+        "confidence": "confirmed",
+        "source_text": "ICE CLASS 1A"
+      },
+      {
+        "value": "Bow thruster fitted",
+        "confidence": "confirmed",
+        "source_text": "BOW THRUSTER FITTED"
+      },
+      {
+        "value": "Appendix B fitted",
+        "confidence": "confirmed",
+        "source_text": "APP B FITTED"
+      },
+      {
+        "value": "Air draft 8.4m on ballast",
+        "confidence": "confirmed",
+        "source_text": "AIR DRAFT 8,4 M ON BALLAST"
+      },
+      "IMDG Class 1 certified",
+      "Appendix B fitted",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f54a2c261266",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "SERENITY AC",
+      "confidence": "confirmed"
+    },
+    "imo": "9013036",
+    "flag": "Panama",
+    "built": 1991,
+    "classSociety": "IRS (IACS)",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 1723,
+      "confidence": "confirmed",
+      "sourceText": "1,723 DWT ON 3.70 M DRAFT"
+    },
+    "dwcc": {
+      "value": 1600,
+      "confidence": "confirmed",
+      "sourceText": "1.600 DWCC"
+    },
+    "draftMax": {
+      "value": 3.7,
+      "confidence": "interpreted",
+      "sourceText": "1,723 DWT ON 3.70 M DRAFT"
+    },
+    "loa": 74.99,
+    "beam": 10.7,
+    "grt": 1282,
+    "nrt": 675,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 71,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 70,
+    "holdDimensions": "50,4 M x 8,7 M x 5,6 M",
+    "hatchDimensions": "50,4 M x 8,7 M",
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "EC Greece",
+      "confidence": "confirmed",
+      "sourceText": "EC GREECE"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "7/8 JULY"
+      },
+      "confidence": "confirmed",
+      "sourceText": "7/8 JULY"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold, open hatch",
+        "confidence": "confirmed",
+        "source_text": "1 HO / 1 HA - BOX / OPEN HATCH"
+      },
+      {
+        "value": "1 movable bulkhead",
+        "confidence": "confirmed",
+        "source_text": "1 MOVABLE BULKHEAD"
+      },
+      {
+        "value": "IMDG Class 1 certified",
+        "confidence": "confirmed",
+        "source_text": "IMO 1 FITTED"
+      },
+      "IMDG Class 1 certified",
+      "Appendix B fitted",
+      "SID box-shaped hold"
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f54e1bbca506",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "M/V CANKA",
+      "confidence": "confirmed"
+    },
+    "imo": "9103740",
+    "flag": "Panama",
+    "built": 1995,
+    "classSociety": "LR",
+    "pandi": "Shipowner P&I Club",
+    "dwtSummer": {
+      "value": 3200,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 3000,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 4.63,
+      "confidence": "interpreted",
+      "sourceText": "3200 mt DWAT sfb on 4,63m"
+    },
+    "loa": 90.67,
+    "beam": 15.8,
+    "grt": 2658,
+    "nrt": 1216,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 3990,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 3990,
+    "holdDimensions": null,
+    "hatchDimensions": "57,50 x 12,80 m",
+    "tankTopStrength": "7.5",
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": "MacGregor hydraulic folding",
+    "vesselType": "MPP",
+    "openPosition": {
+      "value": "Constanta",
+      "confidence": "confirmed",
+      "sourceText": "Status: SPOT @ Constanta"
+    },
+    "openDate": {
+      "value": "spot",
+      "confidence": "interpreted",
+      "sourceText": "Status: SPOT @ Constanta"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "Ice class 1A",
+        "confidence": "confirmed",
+        "source_text": "Ice class 1A"
+      },
+      {
+        "value": "IMDG fitted",
+        "confidence": "confirmed",
+        "source_text": "IMO fitted"
+      },
+      {
+        "value": "open hatch/double-skinned singledecker, steel floored",
+        "confidence": "confirmed",
+        "source_text": "open hatch/doubleskinned singledecker, steelfloored"
+      },
+      {
+        "value": "CO2 firefighting in holds and engineroom",
+        "confidence": "confirmed",
+        "source_text": "CO2 firefigthing system fitted in holds and engineroom"
+      },
+      {
+        "value": "Smoke detection in holds",
+        "confidence": "confirmed",
+        "source_text": "fitted with smokedetection system in holds"
+      },
+      {
+        "value": "Mechanical hold ventilation 10 changes/hour",
+        "confidence": "confirmed",
+        "source_text": "mechanical holdventilation 10 times/hour"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f54e1bbca506",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "M/V SARDES",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": "Panama",
+    "built": null,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 6500,
+      "confidence": "confirmed"
+    },
+    "dwcc": {
+      "value": 5800,
+      "confidence": "confirmed"
+    },
+    "draftMax": {
+      "value": 5.7,
+      "confidence": "interpreted",
+      "sourceText": "Draft abt.: 5.70 m"
+    },
+    "loa": 115.5,
+    "beam": 16.5,
+    "grt": 5313,
+    "nrt": 2382,
+    "holdsCount": 2,
+    "hatchesCount": 2,
+    "grainCapacity": 8721,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 8721,
+    "holdDimensions": "No.1 abt. 19.72 m x 13.50 m x 09.05 m,No.2 abt. 57.80 m x 13.50 m x 09.05 m",
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": false,
+    "craneCapacity": null,
+    "hatchType": "pontoon, opened by gantry cranes",
+    "vesselType": "MPP",
+    "openPosition": {
+      "value": "Constanta",
+      "confidence": "confirmed",
+      "sourceText": "Open @ Constanta 02 - 03 July"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "02 - 03 July"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open @ Constanta 02 - 03 July"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "Full tweendeck in holds 1 and 2",
+        "confidence": "confirmed",
+        "source_text": "full tweendeck in hold 1 and 2"
+      },
+      {
+        "value": "2 moveable bulkheads in hold no. 2",
+        "confidence": "confirmed",
+        "source_text": "fitted with 2 moveable bulkheads in hold no. 2"
+      },
+      {
+        "value": "Bowthruster 1 x abt. 350 kW",
+        "confidence": "confirmed",
+        "source_text": "Bowthruster 1 x abt. 350 kW"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f54e1bbca506",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "M/V TEAM SPIRIT",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": "Panama",
+    "built": 1997,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 4820,
+      "confidence": "confirmed"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 6.4,
+      "confidence": "interpreted",
+      "sourceText": "4820 mt DWAT on 6,40 m summer salt water"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": 4078,
+    "nrt": 2009,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": null,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 6790,
+    "holdDimensions": null,
+    "hatchDimensions": "57,80 x 13,40 m",
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": "2 x 60T (each up to 60mt SWL)",
+    "hatchType": "MacGregor folding",
+    "vesselType": "MPP",
+    "openPosition": {
+      "value": "Alexandria",
+      "confidence": "confirmed",
+      "sourceText": "Open @ Alexandria 03 - 05 July"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "03 - 05 July"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open @ Alexandria 03 - 05 July"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped double-skinned single hold",
+        "confidence": "confirmed",
+        "source_text": "1 boxshaped double skinned cargo hold"
+      },
+      {
+        "value": "Adjustable tweendeck, full tweendeck on board",
+        "confidence": "confirmed",
+        "source_text": "Mpp geared/boxshaped ship with adjustable tweendeck"
+      },
+      {
+        "value": "Equipped for carriage of containers",
+        "confidence": "confirmed",
+        "source_text": "Equipped for carriage of containers"
+      },
+      {
+        "value": "Reefer plug capacity: 30 x 40'",
+        "confidence": "confirmed",
+        "source_text": "Reefer plug capacity :30 x 40'"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f54e1bbca506",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "M/V TEOS",
+      "confidence": "confirmed"
+    },
+    "imo": "9173331",
+    "flag": "Panama",
+    "built": 1999,
+    "classSociety": "Indian Register of Shipping",
+    "pandi": null,
+    "dwtSummer": {
+      "value": 4900,
+      "confidence": "confirmed"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 6.4,
+      "confidence": "interpreted",
+      "sourceText": "4900 mt DWAT on 6,40 m summer salt water"
+    },
+    "loa": 100.6,
+    "beam": 16.6,
+    "grt": 4089,
+    "nrt": 2016,
+    "holdsCount": 1,
+    "hatchesCount": 1,
+    "grainCapacity": 6800,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 6800,
+    "holdDimensions": null,
+    "hatchDimensions": "57,80 x 13,40 m",
+    "tankTopStrength": "17.9",
+    "geared": true,
+    "craneCapacity": "2 x 60T (each up to 60mt SWL)",
+    "hatchType": "Kvaerner folding",
+    "vesselType": "MPP",
+    "openPosition": {
+      "value": "Istanbul",
+      "confidence": "confirmed",
+      "sourceText": "Open @ Istanbul 15 - 17 July"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "15 - 17 July"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open @ Istanbul 15 - 17 July"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped double-skinned single hold",
+        "confidence": "confirmed",
+        "source_text": "1 boxshaped double skinned cargo hold"
+      },
+      {
+        "value": "Adjustable tweendeck, full tweendeck on board",
+        "confidence": "confirmed",
+        "source_text": "geared/boxshaped ship with adjustable tweendeck"
+      },
+      {
+        "value": "Heavylift spreader on board",
+        "confidence": "confirmed",
+        "source_text": "Heavylift spreader on board"
+      },
+      {
+        "value": "Fully fitted for up to 390 standard 20ft containers",
+        "confidence": "confirmed",
+        "source_text": "Fully fitted for upto 390 standard 20 feet containers"
+      },
+      {
+        "value": "30 reefer plugs on deck",
+        "confidence": "confirmed",
+        "source_text": "30 reeferplugs on deck"
       }
     ],
     "ciiRating": null,
@@ -3982,11 +6253,10 @@
     "itemIndex": 0,
     "vesselName": {
       "value": "MV BENIGANE",
-      "confidence": "confirmed",
-      "sourceText": "MV BENIGANE"
+      "confidence": "confirmed"
     },
     "imo": null,
-    "flag": "PALAU",
+    "flag": "Palau",
     "built": 2008,
     "classSociety": "KR",
     "pandi": null,
@@ -4002,7 +6272,7 @@
     },
     "draftMax": {
       "value": 8.7,
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "DWT/DWCC/DRAFT: 11500 / 11,100 t / 8,7 M"
     },
     "loa": 129.9,
@@ -4014,16 +6284,16 @@
     "grainCapacity": 13600,
     "grainCapacityUnit": "cbm",
     "baleCapacity": 13500,
-    "holdDimensions": "[object Object],[object Object]",
-    "hatchDimensions": "[object Object],[object Object]",
+    "holdDimensions": "NO.1 : 18.9 M x 16.2 M x 10.85 M,NO.2 : 58.22 M x 16.2 M x 10.85 M",
+    "hatchDimensions": "NO.1 : 18.8 M x 15.57 M,NO.2 : 58.19 M x 15.57 M",
     "tankTopStrength": null,
     "geared": true,
-    "craneCapacity": "DECK CRANE 40T X 2 SETS",
+    "craneCapacity": "2 x 40T",
     "hatchType": null,
-    "vesselType": "GENERAL CARGO",
+    "vesselType": "GENERAL_CARGO",
     "openPosition": {
       "value": "East Mediterranean",
-      "confidence": "interpreted",
+      "confidence": "confirmed",
       "sourceText": "Open Emed End of Feb-Beg of March"
     },
     "openDate": {
@@ -4032,15 +6302,15 @@
         "close": null,
         "display": "End of Feb-Beg of March"
       },
-      "confidence": "uncertain",
-      "sourceText": "End of Feb-Beg of March"
+      "confidence": "confirmed",
+      "sourceText": "Open Emed End of Feb-Beg of March"
     },
-    "direction": "Med Blacksea region",
+    "direction": "Med/Black Sea region",
     "restrictions": [],
     "lastCargoes": null,
     "speedLaden": {
       "value": 12.5,
-      "confidence": "uncertain",
+      "confidence": "confirmed",
       "source_text": "SPEED: SERVICE 12.5 KNOTS"
     },
     "speedBallast": null,
@@ -4048,21 +6318,490 @@
     "deckCapacity": null,
     "specialFeatures": [
       {
-        "value": "GENERAL CARGO BOX HOLDS",
+        "value": "box-shaped holds",
         "confidence": "confirmed",
         "source_text": "GENERAL CARGO BOX HOLDS"
       },
       {
-        "value": "BOX",
-        "confidence": "confirmed",
-        "source_text": "BOX"
-      },
-      {
-        "value": "MULTINATIONAL CREW",
+        "value": "Multinational crew",
         "confidence": "confirmed",
         "source_text": "MULTINATIONAL CREW"
       }
     ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 0,
+    "vesselName": {
+      "value": "MV YAMAN BEY",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2008,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 5383,
+      "confidence": "confirmed",
+      "sourceText": "5.383 DWT"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 5.9,
+      "confidence": "confirmed",
+      "sourceText": "5,90 M"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 6455,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 6200,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Jeddah",
+      "confidence": "confirmed",
+      "sourceText": "Spot Jeddah, looking quick shipment in Red Sea ONLY"
+    },
+    "openDate": {
+      "value": "spot",
+      "confidence": "interpreted",
+      "sourceText": "Spot Jeddah"
+    },
+    "direction": "Red Sea only",
+    "restrictions": [
+      "Red Sea only"
+    ],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 1,
+    "vesselName": {
+      "value": "MV TQ ISTANBUL",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1993,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 3712,
+      "confidence": "confirmed",
+      "sourceText": "3.712 DWT"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 5.46,
+      "confidence": "confirmed",
+      "sourceText": "5,46 M"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 4690,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 4690,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "Open Marmara by 15 Feb"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "15 Feb"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open Marmara by 15 Feb"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "open hatch box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "OH-BOX"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 2,
+    "vesselName": {
+      "value": "MV TQ TRABZON",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1993,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 3712,
+      "confidence": "confirmed",
+      "sourceText": "3.712 DWT"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 5.46,
+      "confidence": "confirmed",
+      "sourceText": "5,46 M"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 4690,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 4690,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Giurgiulesti",
+      "confidence": "confirmed",
+      "sourceText": "Open Giurgiulesti by 10/15 Feb"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "10/15 Feb"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open Giurgiulesti by 10/15 Feb"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "open hatch box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "OH-BOX"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 3,
+    "vesselName": {
+      "value": "MV LONE STAR",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2008,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 4400,
+      "confidence": "confirmed",
+      "sourceText": "4.400 DWT"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 5.9,
+      "confidence": "confirmed",
+      "sourceText": "5,90 M"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 5911,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 5800,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Djibouti",
+      "confidence": "confirmed",
+      "sourceText": "Open Djibouti by 25/29 Feb"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "25/29 Feb"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open Djibouti by 25/29 Feb"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 4,
+    "vesselName": {
+      "value": "MV TQ MERSIN",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 2008,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 12000,
+      "confidence": "confirmed",
+      "sourceText": "12.000 DWT"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 7.14,
+      "confidence": "confirmed",
+      "sourceText": "7,14 M"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 14722,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 14722,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Busan",
+      "confidence": "confirmed",
+      "sourceText": "Open Busan by 5/10 Mar"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "5/10 Mar"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open Busan by 5/10 Mar"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "BOX"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 5,
+    "vesselName": {
+      "value": "MV SONIC",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1984,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 4203,
+      "confidence": "confirmed",
+      "sourceText": "4.203 DWT"
+    },
+    "dwcc": null,
+    "draftMax": {
+      "value": 5.25,
+      "confidence": "confirmed",
+      "sourceText": "5,25M"
+    },
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 5380,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 5380,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": null,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "GENERAL_CARGO",
+    "openPosition": {
+      "value": "Marmara",
+      "confidence": "confirmed",
+      "sourceText": "Open Marmara by 10/15 Mar"
+    },
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "10/15 Mar"
+      },
+      "confidence": "confirmed",
+      "sourceText": "Open Marmara by 10/15 Mar"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [
+      {
+        "value": "open hatch box-shaped hold",
+        "confidence": "confirmed",
+        "source_text": "OH-BOX"
+      }
+    ],
+    "ciiRating": null,
+    "verificationWarning": null
+  },
+  {
+    "emailId": "19e0f55e3bcf9a28",
+    "itemIndex": 6,
+    "vesselName": {
+      "value": "MV TQ SAMSUN",
+      "confidence": "confirmed"
+    },
+    "imo": null,
+    "flag": null,
+    "built": 1996,
+    "classSociety": null,
+    "pandi": null,
+    "dwtSummer": {
+      "value": 43775,
+      "confidence": "confirmed",
+      "sourceText": "43.775 DWT"
+    },
+    "dwcc": null,
+    "draftMax": null,
+    "loa": null,
+    "beam": null,
+    "grt": null,
+    "nrt": null,
+    "holdsCount": null,
+    "hatchesCount": null,
+    "grainCapacity": 56666,
+    "grainCapacityUnit": "cbm",
+    "baleCapacity": 54931,
+    "holdDimensions": null,
+    "hatchDimensions": null,
+    "tankTopStrength": null,
+    "geared": true,
+    "craneCapacity": null,
+    "hatchType": null,
+    "vesselType": "BULK CARRIER",
+    "openPosition": null,
+    "openDate": {
+      "value": {
+        "open": null,
+        "close": null,
+        "display": "On Period"
+      },
+      "confidence": "confirmed",
+      "sourceText": "On Period"
+    },
+    "direction": null,
+    "restrictions": [],
+    "lastCargoes": null,
+    "speedLaden": null,
+    "speedBallast": null,
+    "consumption": null,
+    "deckCapacity": null,
+    "specialFeatures": [],
     "ciiRating": null,
     "verificationWarning": null
   }

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -175,6 +175,20 @@ async function main(): Promise<void> {
         grainCapacity: vessel.grainCapacity,
         dwtSummer: dwtSummer || null,
         dwcc: cfValue(vessel.dwcc),
+        vesselRestrictions: vessel.restrictions ?? [],
+        // Layer B gates (mirror lib/matching/pair-analyzer.ts)
+        vesselBuilt: vessel.built ?? null,
+        refYear,
+        cargoMaxVesselAgeYrs: cargo.maxVesselAgeYrs ?? null,
+        vesselBeam: vessel.beam ?? null,
+        vesselLoa: vessel.loa ?? null,
+        cargoMaxBeamM: cargo.maxBeamM ?? null,
+        cargoMaxLoaM: cargo.maxLoaM ?? null,
+        cargoGearRequired: cargo.gearRequired ?? null,
+        vesselFlag: vessel.flag ?? null,
+        vesselClassSociety: vessel.classSociety ?? null,
+        cargoFlagRequired: cargo.flagRequired ?? null,
+        cargoClassRequired: cargo.classRequired ?? null,
       });
       if (!hf.pass) continue;
 

--- a/scripts/seed-sample-data.ts
+++ b/scripts/seed-sample-data.ts
@@ -2,12 +2,32 @@ import vessels from '../lib/sample-data/demo-parsed-vessels.json';
 import cargoes from '../lib/sample-data/demo-parsed-cargoes.json';
 import type { ParsedVessel, ParsedCargo } from '../lib/types';
 
+/** Unwrap a ConfidenceField ({value,...}) or pass a plain value through. */
+function cfVal(x: unknown): unknown {
+  return x && typeof x === 'object' && 'value' in (x as object)
+    ? (x as { value: unknown }).value
+    : x;
+}
+
+// EconomicsTab needs a representative COMPLETE record. The parsed JSON is
+// multi-item per email and order is not stable across re-parses, so pick the
+// first record that actually carries the fields the tab requires rather than
+// blindly trusting index 0 (which may be a no-weight item of a split email).
 export function getDemoVessel(): ParsedVessel {
-  return vessels[0] as unknown as ParsedVessel;
+  const pick = (vessels as Array<Record<string, unknown>>).find(
+    (v) => cfVal(v.dwtSummer) != null,
+  );
+  return (pick ?? vessels[0]) as unknown as ParsedVessel;
 }
 
 export function getDemoCargo(): ParsedCargo {
-  return cargoes[0] as unknown as ParsedCargo;
+  const pick = (cargoes as Array<Record<string, unknown>>).find(
+    (c) =>
+      cfVal(c.weightMt) != null &&
+      cfVal(c.originPort) != null &&
+      cfVal(c.destinationPort) != null,
+  );
+  return (pick ?? cargoes[0]) as unknown as ParsedCargo;
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Что и зачем

Завершает matching-fix кампанию (Layer A #767 / B #764 / C #769): **переразбор корпуса через Опуса + проводка ворот в регенный путь**.

### 🔴 Корневой баг (новый, не в плане A/B/C)
`scripts/demo-seed/real-matches.ts` (регенный вход) строил `runHardFilters({...})` **без** полей Layer B → новые ворота (возраст/beam/LOA/gear/voyage/flag) были **no-op при регене** (тот же класс «движок обойдён», что Layer B и чинил). Зеркалит `lib/matching/pair-analyzer.ts`.

### Чистые данные
Переразобраны все 154 письма через Opus (`claude-cli`) фикшеными парсерами:
- `[object Object]` в cargoes: **56 → 0**
- Структурные поля-ограничения заполнены (`max_vessel_age_yrs`/`gear_required`/`max_beam_m`/`max_loa_m`)
- `source_text` починен до дословных цитат (срезаны Opus-4.8 скобочные аннотации/«...») → `source-text-validity` зелёный
- Дропнуто 1 referential-orphan судно (нет в `vessel-positions.json`)

## Верификация
- Ворота: age-гейт срезал **537 пар**, **0 age/beam/LOA-нарушений** среди прошедших (item-уровень, 10101 пар).
- Реген: сырых матчей **631 → main 28** (+ review 120 + insufficient 598).
- Нарушители: cargo max-25лет → 0 (молодых нет, честно пусто); cargo beam-16 → только 16м-судно.
- Тесты: `match-realism-buckets` (10/10, main<450) + `source-text-validity` (4/4) зелёные.

## Прод
Реген применяется на проде через `real-matches.ts` (читает committed JSON, трогает только matches-таблицу → курация market/speed сохраняется), --dry-эквивалент на копии → restart → Gate5.

NB follow-up: захардить parse-промпт против source_text-аннотаций (сейчас band-aid в регене source_text repaired post-hoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)