### PR TITLE
fix(match): EU-discharge cap no longer fires on non-EU look-alike ports

### DIFF
--- a/lib/sailing/__tests__/fit-breakdown.test.ts
+++ b/lib/sailing/__tests__/fit-breakdown.test.ts
@@ -357,3 +357,39 @@ describe('computeFitBreakdown — EU-discharge age penalty (founder rule 2026-06
     expect(fb.appliedCap?.reason ?? '').not.toMatch(/EU discharge|EU PSC/i);
   });
 });
+
+describe('computeFitBreakdown — EU-discharge false-positive guard (cold QA 2026-06-02)', () => {
+  // Concrete NON-EU place names that merely CONTAIN an EU-country word must NOT
+  // trigger the 25yr+ EU-discharge cap. The loose country-substring fallback
+  // (EU_DISCHARGE_KEYWORDS) wrongly flagged these real, non-European ports.
+  it.each([
+    ['Dutch Harbor', 'Alaska — real US port'],
+    ['New Germany', 'Durban suburb, South Africa'],
+    ['Poland Spring', 'Maine, USA'],
+    ['Spanish Town', 'Jamaica'],
+    ['Spanish Wells', 'Bahamas'],
+    ['French Guiana', 'South America'],
+  ])('25yr+ vessel + non-EU "%s" (%s) → NO EU-age cap', (port) => {
+    const cargo = makeCargo({ destinationPort: { value: port, confidence: 'confirmed' } });
+    const vessel = makeVessel({ built: 1998 }); // age 28 @ refYear 2026
+    const fb = computeFitBreakdown({ cargo, vessel, readiness: READY_IDEAL, sanctions: SANCTIONS_OK, hardFilters: HF_PASS, refYear: 2026 });
+    expect(fb.appliedCap?.reason ?? '').not.toMatch(/EU discharge|EU PSC/i);
+    expect(fb.fitPercent).toBeGreaterThan(55);
+  });
+
+  // Vague EU region descriptors (no concrete port resolves) MUST still cap —
+  // guards the fix doesn't over-correct into false negatives. "European
+  // continent" specifically is not flagged vague by isVagueRegion, so it locks
+  // in the inline qualifier regex's coverage of "continent".
+  it.each([
+    'East Coast Greece port (unspecified)',
+    'East Coast Italy port (unspecified)',
+    'European continent',
+  ])('25yr+ vessel + vague EU "%s" → still capped ≤55', (port) => {
+    const cargo = makeCargo({ destinationPort: { value: port, confidence: 'uncertain' } });
+    const vessel = makeVessel({ built: 1998 });
+    const fb = computeFitBreakdown({ cargo, vessel, readiness: READY_IDEAL, sanctions: SANCTIONS_OK, hardFilters: HF_PASS, refYear: 2026 });
+    expect(fb.appliedCap?.reason).toMatch(/EU discharge|EU PSC/i);
+    expect(fb.fitPercent).toBeLessThanOrEqual(55);
+  });
+});

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -37,6 +37,7 @@ import { BALLAST_GOOD_MAX_NM, isPartCargo } from './match-scoring';
 import { portHasShoreCranes } from './port-master';
 import { STOWAGE_FACTORS } from './match-filters';
 import { regionMatchesPort } from './voyage-restriction';
+import { resolvePort } from '@/lib/ports/resolve';
 
 // ── Weights — sum to 100. Tunable per anchor calibration. ──────────────────
 //
@@ -439,15 +440,35 @@ export function scoreVetting(vessel: ParsedVessel, refYear?: number): FitBreakdo
 const EU_DISCHARGE_KEYWORDS =
   /\b(greece|greek|italy|italian|romania|romanian|constanta|bulgaria|bulgarian|spain|spanish|france|french|netherlands|dutch|belgium|belgian|germany|german|croatia|croatian|slovenia|slovenian|portugal|portuguese|cyprus|cypriot|malta|maltese|poland|polish|european continent|ara range)\b/i;
 
+// Region-vagueness markers. The country-substring fallback is consulted ONLY for
+// descriptors that read as a vague AREA — "East Coast Greece port (unspecified)",
+// "Greece (1 port)", "European Continent (ARA range)" — and never for concrete
+// place names that merely contain an EU-country word: "Dutch Harbor" (Alaska),
+// "New Germany" (Durban), "Poland Spring" (Maine), "Spanish Town", "French
+// Guiana". Without this gate the loose substring regex flagged those as EU.
+// (Cold QA 2026-06-02.)
+const VAGUE_DESCRIPTOR_RX =
+  /\b(unspecified|range|coast|ports?|anchorage|area|region|basin|cluster|terminal|continent|gulf)\b|\(/i;
+
 /**
- * EU-discharge detector for the age cap. True when the port resolves to Europe
- * via the canonical region map OR the raw descriptor names an EU/near-EU country.
- * Isolated from regionMatchesPort so widening detection here does NOT affect the
- * hard voyage-restriction gate (its other consumer).
+ * EU-discharge detector for the age cap. True when EITHER:
+ *   1. the port resolves to Europe via the canonical region map, OR
+ *   2. the descriptor is a vague AREA (no concrete port resolves) that names an
+ *      EU/near-EU country via EU_DISCHARGE_KEYWORDS.
+ *
+ * The country-substring fallback (2) is double-gated — `resolvePort` returns null
+ * (so it is not a concrete port) AND the text looks like a vague area — so a
+ * concrete non-EU port whose name merely contains an EU-country word is not
+ * mis-flagged. Isolated from regionMatchesPort so widening detection here does
+ * NOT affect the hard voyage-restriction gate (its other consumer).
  */
 function isEuropeanDischarge(port: string | null | undefined): boolean {
   if (!port) return false;
   if (regionMatchesPort('europe', port)) return true;
+  // A concrete port the region map did NOT place in Europe → trust that verdict.
+  if (resolvePort(port) !== null) return false;
+  // Not a vague area descriptor → do not guess EU from a bare country substring.
+  if (!VAGUE_DESCRIPTOR_RX.test(port)) return false;
   const folded = port.normalize('NFKD').replace(/\p{Diacritic}/gu, '');
   return EU_DISCHARGE_KEYWORDS.test(folded);
 }


### PR DESCRIPTION
## What & why

Follow-up to the **Gate5 #2 EU-age fit cap** ([#776](https://github.com/Vitali2011/quantika-demo/pull/776)). Cold QA (2026-06-02) found the cap's vague-discharge detector produced **false positives**: the loose country-substring fallback (`EU_DISCHARGE_KEYWORDS`) fired on concrete **non-EU** place names that merely contain an EU-country word.

Confirmed wrongly-capped ports:

| Port | Reality | Matched keyword |
|---|---|---|
| Dutch Harbor | Alaska, USA (real port) | `dutch` |
| New Germany | Durban suburb, South Africa | `germany` |
| Poland Spring | Maine, USA | `poland` |
| Spanish Town / Spanish Wells | Jamaica / Bahamas | `spanish` |
| French Guiana | South America | `french` |

The cap is soft (lowers fit ≤55, item stays in Review) and **today's impact is zero** — none of these appear in the shipped `demo-parsed-cargoes.json`. This is the durability fix so future re-parses can't trip it.

## Fix

`isEuropeanDischarge()` now double-gates the country-substring fallback (option (a) of the QA write-up):

1. `regionMatchesPort('europe', …)` — concrete EU ports resolve here as before.
2. **NEW:** the substring fallback runs only when `resolvePort(port) === null` (not a concrete port) **AND** the text reads as a vague area (`VAGUE_DESCRIPTOR_RX` — `unspecified` / `range` / `coast` / `port(s)` / `continent` / `(…)` / …).

Concrete ports keep `regionMatchesPort`'s verdict; only genuine region descriptors consult the keywords. `isVagueRegion` was deliberately **not** reused — it classifies `"European continent"` as non-vague, which would reintroduce a false negative.

## Verification

- **No false-negative regression on real data:** all 19 EU-keyword hits in the shipped demo data (7 distinct strings — `Greece (1 port)`, `Cyprus (port unspecified)`, `East Coast Greece/Italy port (unspecified)`, `European Continent (ARA range)`, `Constanța`) still cap. Confirmed via probe on the exact strings.
- **Tests:** +6 adversarial NO-cap rows (Dutch Harbor, New Germany, Poland Spring, Spanish Town, Spanish Wells, French Guiana) — RED before, GREEN after. +3 vague-EU still-cap rows (incl. `European continent`). Existing #2 tests untouched & green.
- **Full `npx jest`:** 805/805 suites, 8988 passed, 27 skipped, 0 failed. ESLint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
