### PR TITLE
feat(ets): EU ETS in/out-EU 50% coverage factor

### DIFF
--- a/__tests__/api/voyage/tce-ets-autoderive.test.ts
+++ b/__tests__/api/voyage/tce-ets-autoderive.test.ts
@@ -114,7 +114,7 @@ describe('Spec-03: ETS auto-derive euLegPercent', () => {
     expect(body.breakdown.ets_usd).toBeGreaterThan(0);
   });
 
-  it('NLRTM → USNYC (one EU leg): euLegPercent=0.5, ets_usd>0, mode=auto-derived', async () => {
+  it('NLRTM → USNYC (one EU leg): euLegPercent=1.0, ets_usd>0, mode=auto-derived (50% coverage via factor)', async () => {
     const req = makeReq({
       vessel: baseVessel,
       route: {
@@ -135,7 +135,7 @@ describe('Spec-03: ETS auto-derive euLegPercent', () => {
     const body = await res.json();
 
     expect(body.etsResolution).toBeDefined();
-    expect(body.etsResolution.euLegPercent).toBe(0.5);
+    expect(body.etsResolution.euLegPercent).toBe(1.0);
     expect(body.etsResolution.mode).toBe('auto-derived');
     expect(body.breakdown.ets_usd).toBeGreaterThan(0);
   });

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -300,6 +300,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
   }
 
+  // ── EU endpoint flags (for ETS coverage factor) ─────────────────────────────
+  const originEu = isEuCountry(originResolved.country);
+  const destEu = isEuCountry(destinationResolved.country);
+
   // ── ETS euLegPercent auto-derive ──
   let resolvedEuLegPercent = data.euLegPercent;
   let etsMode: 'auto-derived' | 'manual' | 'not-applicable' = 'not-applicable';
@@ -310,16 +314,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       etsMode = 'manual';
       etsReason = 'caller-provided';
     } else {
-      const originEu = isEuCountry(originResolved.country);
-      const destEu = isEuCountry(destinationResolved.country);
       if (originEu && destEu) {
         resolvedEuLegPercent = 1.0;
         etsMode = 'auto-derived';
         etsReason = 'both legs EU (intra-EU voyage)';
       } else if (originEu || destEu) {
-        resolvedEuLegPercent = 0.5;
+        resolvedEuLegPercent = 1.0;
         etsMode = 'auto-derived';
-        etsReason = 'one leg EU (EU MRV 50% default)';
+        etsReason = 'one leg EU — 50% regulatory coverage factor applied';
       } else {
         etsMode = 'not-applicable';
         etsReason = 'no EU leg';
@@ -352,6 +354,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     euaPriceEur,
     durationDays: data.durationDays,
     euLegPercent: resolvedEuLegPercent,
+    originEu: data.includeEuETS ? originEu : undefined,
+    destEu: data.includeEuETS ? destEu : undefined,
     daysInHra: data.daysInHra,
     canalUsd,
     daUsd,

--- a/docs/superpowers/plans/2026-06-03-carbon-inout-eu.md
+++ b/docs/superpowers/plans/2026-06-03-carbon-inout-eu.md
@@ -1,0 +1,35 @@
+# Plan — EU ETS carbon 50% for in/out-EU voyages (T2)
+
+**Tier:** M · risk-override (economics calc) → mandatory `/test-skill` · creative=YES (brainstorm inline below).
+**Branch:** off origin/main (`9cfca018`).
+
+## Gate 0 — TRACE
+- **Target:** `calculateEuEts` (`lib/economics/ets.ts`): `amount = vlsfoBurnMt * cf * euLegPercent * phase * euaPrice`.
+- **Consumers (3):** `lib/economics/voyage-calculator.ts`, `app/api/voyage/tce/route.ts`, `lib/economics/index.ts`.
+- **Entry:** server (request-time P&L; not baked in seed → code-only deploy, NO data-apply).
+- **Real failure data:** current formula applies `euLegPercent * phase` (i.e. 100% of the EU leg) — there is NO 50% reduction for in/out-EU voyages. Founder note (NIGHT-RUN backlog): "для смешанных рейсов ужать до 50% in/out-EU плеч" (~270-340/т at 100% phase 2026 is too high for mixed voyages).
+- **Parity:** n/a.
+
+## Brainstorm (creative — leg classification design, ДО impl)
+EU ETS maritime scope (Directive 2023/959): emissions coverage by voyage type —
+- **Intra-EU** (BOTH ports EU/EEA) → **100%** of emissions dutiable.
+- **In/out-EU** (EXACTLY ONE port EU/EEA) → **50%** of emissions dutiable.
+- **Extra-EU** (NEITHER port EU) → **0%**.
+
+Current `euLegPercent` is the *geographic EU-leg fraction* (a different lever) — it is NOT the coverage factor. Approaches:
+- **H1 (selected):** add an explicit `coverageFactor` derived from EU-endpoint count (`isEuCountry(origin.country)` + `isEuCountry(dest.country)` — `isEuCountry` already exists in `lib/validation/sanctions`): both→1.0, one→0.5, none→0. Multiply: `amount = burn*cf*euLegPercent*phase*euaPrice*coverageFactor`. Explicit, testable, doesn't overload euLegPercent.
+- **H2 (rejected):** fold 0.5 into euLegPercent at the caller — conflates geographic fraction with regulatory coverage; breaks the meaning of euLegPercent for other consumers.
+- **Selected H1** — caller (voyage-calculator/tce-route) passes origin/dest EU flags (or country codes) → ets computes coverageFactor.
+
+## Scope
+- `lib/economics/ets.ts`: extend `EuEtsInput` with origin/dest EU flags (or `coverageFactor`); compute factor {both:1, one:0.5, none:0}; multiply into amount. Guard: if flags absent → default 1.0 (conservative, current behavior) to avoid silent under-charge regressions.
+- `lib/economics/voyage-calculator.ts` + `app/api/voyage/tce/route.ts`: pass EU-endpoint flags (use `isEuCountry` on resolved port countries already available in tce/route as `originResolved.country`/`destinationResolved.country`).
+
+## Acceptance
+- Unit tests: intra-EU (both EU) → coverage 1.0; in/out-EU (one EU) → 0.5; extra-EU → 0. Backward-compat: absent flags → 1.0 (existing ets tests stay green).
+- `/test-skill` cold QA PASS. Code-only (no seed/prod-data write).
+
+## Out-of-scope
+- Do NOT change phase-in schedule or Cf factors. Do NOT touch matching/seed. MGO-grade is a SEPARATE backlog item — not here.
+
+## If stuck → QUESTIONS.md + state.md + stop.

--- a/lib/economics/__tests__/ets.test.ts
+++ b/lib/economics/__tests__/ets.test.ts
@@ -1,5 +1,48 @@
 import { calculateEuEts } from '../ets';
 
+describe('calculateEuEts — EU coverage factor', () => {
+  const BASE = { distanceNm: 3000, vlsfoBurnMt: 200, euaPrice: 87.5, year: 2026 };
+
+  it('intra-EU (both EU) → coverageFactor=1.0 → same as no flags', () => {
+    const result = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: true, destEu: true });
+    const baseline = calculateEuEts({ ...BASE, euLegPercent: 1.0 });
+    expect(result.amountEur).toBe(baseline.amountEur);
+    expect(result.applicable).toBe(true);
+  });
+
+  it('in/out-EU (one EU port, originEu=true) → coverageFactor=0.5 → half of intra-EU', () => {
+    const intraEu = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: true, destEu: true });
+    const inOut = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: true, destEu: false });
+    expect(inOut.amountEur).toBeCloseTo(intraEu.amountEur * 0.5, 1);
+    expect(inOut.applicable).toBe(true);
+  });
+
+  it('in/out-EU (one EU port, destEu=true) → coverageFactor=0.5 → half of intra-EU', () => {
+    const intraEu = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: true, destEu: true });
+    const inOut = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: false, destEu: true });
+    expect(inOut.amountEur).toBeCloseTo(intraEu.amountEur * 0.5, 1);
+    expect(inOut.applicable).toBe(true);
+  });
+
+  it('extra-EU (no EU port) → coverageFactor=0 → amountEur=0, applicable=false', () => {
+    const result = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: false, destEu: false });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('absent flags → coverageFactor=1.0 (backward-compat, no change to amount)', () => {
+    const withBothEu = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: true, destEu: true });
+    const noFlags = calculateEuEts({ ...BASE, euLegPercent: 1.0 });
+    expect(noFlags.amountEur).toBe(withBothEu.amountEur);
+  });
+
+  it('in/out-EU concrete: 200t VLSFO euLeg=1.0 at 87.5 EUR → ~27571 EUR', () => {
+    // 200 × 3.151 × 1.0 × 1.0 × 87.5 × 0.5 = 27571.25
+    const result = calculateEuEts({ ...BASE, euLegPercent: 1.0, originEu: true, destEu: false });
+    expect(result.amountEur).toBeCloseTo(27571.25, 0);
+  });
+});
+
 describe('calculateEuEts', () => {
   it('returns applicable=false and 0 amount when EU leg is 0%', () => {
     const result = calculateEuEts({

--- a/lib/economics/ets.ts
+++ b/lib/economics/ets.ts
@@ -35,6 +35,12 @@ export interface EuEtsInput {
   fuelType?: string;
   /** Calendar year for MRV phase-in. Default = current year (2026+ → 1.0). */
   year?: number;
+  /**
+   * EU ETS coverage factor — derived from whether voyage endpoints are in EU/EEA.
+   * Both EU → 1.0; exactly one EU → 0.5; neither → 0. Absent → 1.0 (backward-compat).
+   */
+  originEu?: boolean;
+  destEu?: boolean;
 }
 
 export interface EuEtsResult {
@@ -54,9 +60,18 @@ export function calculateEuEts(input: EuEtsInput): EuEtsResult {
     return { amountEur: 0, applicable: false };
   }
 
+  // EU ETS regulatory coverage: intra-EU=100%, in/out-EU=50%, extra-EU=0%.
+  // Absent flags → 1.0 (conservative backward-compat; avoids silent under-charge).
+  let coverageFactor = 1.0;
+  if (input.originEu !== undefined || input.destEu !== undefined) {
+    const euCount = (input.originEu ? 1 : 0) + (input.destEu ? 1 : 0);
+    coverageFactor = euCount === 2 ? 1.0 : euCount === 1 ? 0.5 : 0.0;
+  }
+  if (coverageFactor === 0) return { amountEur: 0, applicable: false };
+
   const cf = cfForFuel(fuelType ?? 'VLSFO');
   const phase = phaseIn(year ?? new Date().getFullYear());
-  const amount = vlsfoBurnMt * cf * euLegPercent * phase * euaPrice;
+  const amount = vlsfoBurnMt * cf * euLegPercent * phase * euaPrice * coverageFactor;
   return {
     amountEur: Math.round(amount * 100) / 100,
     applicable: amount > 0,

--- a/lib/economics/voyage-calculator.ts
+++ b/lib/economics/voyage-calculator.ts
@@ -58,6 +58,9 @@ export interface VoyageInput {
   durationDays: number;
   /** EU leg percentage (0–1). Default 0 (no ETS). */
   euLegPercent?: number;
+  /** EU ETS coverage: true if origin/dest port is in EU/EEA. Absent → coverageFactor=1.0. */
+  originEu?: boolean;
+  destEu?: boolean;
   /** Days spent in HRA zones for war-risk premium. Default = durationDays. */
   daysInHra?: number;
   /** Pre-computed canal dues USD (from quoteCanal). 0 if no canal. */
@@ -185,6 +188,8 @@ export function calculateTCE(input: VoyageInput): TCEResult {
     euLegPercent,
     vlsfoBurnMt,
     euaPrice,
+    originEu: input.originEu,
+    destEu: input.destEu,
   });
   const etsEur = etsResult.amountEur;
   const etsUsd = Math.round(etsEur * EUR_TO_USD);

--- a/tests/regression/eu_ets_coverage_adversarial.test.ts
+++ b/tests/regression/eu_ets_coverage_adversarial.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Adversarial QA — EU ETS coverage factor (feat/carbon-inout-eu)
+ *
+ * Cold-start reviewer. Zero context from feature session.
+ * Goal: break the code, not confirm it works.
+ *
+ * Attack surface:
+ *   Class 1 — Math precision
+ *   Class 2 — Backward compat (absent flags)
+ *   Class 3 — Edge cases (partial flags, NaN, false+false)
+ *   Class 4 — Double-counting (euLegPercent + coverageFactor interaction)
+ *   Class 5 — Extra-EU early exit overrides euLegPercent>0
+ */
+
+import { calculateEuEts } from '../../lib/economics/ets';
+import { calculateTCE } from '../../lib/economics/voyage-calculator';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared base fixture (year=2026 → phaseIn=1.0, no noise from phase-in)
+// ─────────────────────────────────────────────────────────────────────────────
+const BASE_ETS = {
+  distanceNm: 3000,
+  vlsfoBurnMt: 100,
+  euaPrice: 100,
+  year: 2026,
+};
+
+// Expected full-coverage amount (no flags, euLegPercent=1.0):
+// 100 × 3.151 × 1.0 × 1.0 × 100 × 1.0 = 31510
+const FULL_AMOUNT = 100 * 3.151 * 1.0 * 1.0 * 100 * 1.0; // 31510
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLASS 1 — Math precision
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Class 1 — Math precision', () => {
+  it('both-EU amount equals no-flag amount EXACTLY (not just approximately)', () => {
+    const withFlags = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: true,
+    });
+    const noFlags = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+    });
+    // Must be bit-identical, not just close
+    expect(withFlags.amountEur).toBe(noFlags.amountEur);
+    // Sanity check the actual value
+    expect(withFlags.amountEur).toBe(Math.round(FULL_AMOUNT * 100) / 100);
+  });
+
+  it('one-EU amount is exactly HALF of both-EU amount (before rounding)', () => {
+    const bothEu = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: true,
+    });
+    const oneEu = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: false,
+    });
+    // 31510 / 2 = 15755 — both are round numbers, so rounding artifacts do not apply here
+    expect(oneEu.amountEur).toBe(bothEu.amountEur / 2);
+  });
+
+  it('rounding: 2 decimal places preserved on fractional result', () => {
+    // 100 × 3.151 × 0.33 × 1.0 × 100 × 0.5 = 5198.85 (3.151*33 = 103.983, *50 = 5199.15... let's compute)
+    // Actually: 100 * 3.151 * 0.33 * 1.0 * 100 * 0.5 = 100 * 3.151 * 16.5 = 5199.15
+    const raw = 100 * 3.151 * 0.33 * 1.0 * 100 * 0.5;
+    const expected = Math.round(raw * 100) / 100;
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 0.33,
+      originEu: true,
+      destEu: false,
+    });
+    expect(result.amountEur).toBe(expected);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLASS 2 — Backward compat (absent flags = coverageFactor 1.0)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Class 2 — Backward compat (absent flags)', () => {
+  it('absent originEu and destEu: coverageFactor must be 1.0 (conservative)', () => {
+    const result = calculateEuEts({ ...BASE_ETS, euLegPercent: 1.0 });
+    expect(result.amountEur).toBe(Math.round(FULL_AMOUNT * 100) / 100);
+    expect(result.applicable).toBe(true);
+  });
+
+  it('absent flags with euLegPercent=0.5: amount is 50% of full (euLegPercent does the work)', () => {
+    const halfLeg = calculateEuEts({ ...BASE_ETS, euLegPercent: 0.5 });
+    // 100 × 3.151 × 0.5 × 1.0 × 100 × 1.0 = 15755
+    const expected = Math.round(100 * 3.151 * 0.5 * 1.0 * 100 * 1.0 * 100) / 100;
+    expect(halfLeg.amountEur).toBe(expected);
+  });
+
+  it('explicitly undefined originEu and destEu: same as fully absent', () => {
+    const withUndefined = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: undefined,
+      destEu: undefined,
+    });
+    const fullyAbsent = calculateEuEts({ ...BASE_ETS, euLegPercent: 1.0 });
+    expect(withUndefined.amountEur).toBe(fullyAbsent.amountEur);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLASS 3 — Edge cases (partial flags, boolean coercion, zero/NaN inputs)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Class 3 — Edge cases', () => {
+  it('originEu=true, destEu=undefined: triggers 0.5 (one flag defined = one EU port)', () => {
+    // originEu !== undefined is true → enters the block; euCount = 1 → coverageFactor = 0.5
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: undefined,
+    });
+    // Should be HALF of full (coverageFactor=0.5)
+    const expected = Math.round(FULL_AMOUNT * 0.5 * 100) / 100;
+    expect(result.amountEur).toBe(expected);
+    expect(result.applicable).toBe(true);
+  });
+
+  it('originEu=undefined, destEu=true: also triggers 0.5 (one flag defined)', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: undefined,
+      destEu: true,
+    });
+    const expected = Math.round(FULL_AMOUNT * 0.5 * 100) / 100;
+    expect(result.amountEur).toBe(expected);
+    expect(result.applicable).toBe(true);
+  });
+
+  it('originEu=false, destEu=undefined: triggers block; euCount=0 → coverageFactor=0 → applicable=false', () => {
+    // originEu !== undefined is true → enters block; originEu=false→0, destEu=undefined→0; euCount=0
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: false,
+      destEu: undefined,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('both flags false: coverageFactor=0 → amountEur=0, applicable=false', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      euaPrice: 87.5,
+      vlsfoBurnMt: 200,
+      distanceNm: 3000,
+      originEu: false,
+      destEu: false,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('NaN in euaPrice returns applicable=false even with valid EU flags', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      euaPrice: NaN,
+      originEu: true,
+      destEu: true,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('Infinity in vlsfoBurnMt returns applicable=false', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      vlsfoBurnMt: Infinity,
+      originEu: true,
+      destEu: true,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('euLegPercent=0 causes early exit (applicable=false) BEFORE coverageFactor matters', () => {
+    // Guards check euLegPercent <= 0 before coverageFactor — should short-circuit
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 0,
+      originEu: true,
+      destEu: true,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLASS 4 — Double-counting: euLegPercent + coverageFactor interaction
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Class 4 — Double-counting', () => {
+  // ADVERSARIAL: manual caller passes euLegPercent=0.5 AND one-EU flags
+  // This is NOT how the route.ts uses it (route always sets euLegPercent=1.0),
+  // but a direct API caller to calculateEuEts could do this.
+  // Formula: vlsfoBurnMt * cf * euLegPercent * phase * euaPrice * coverageFactor
+  //   = 100 * 3.151 * 0.5 * 1.0 * 100 * 0.5 = 7877.5  ← DOUBLE-COUNTED
+  // vs correct one-EU amount:
+  //   = 100 * 3.151 * 1.0 * 1.0 * 100 * 0.5 = 15755    ← CORRECT
+  it('DOUBLE-COUNT PROBE: euLegPercent=0.5 + one-EU flags → effectively 0.25 coverage (potential misuse)', () => {
+    const doubleCounted = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 0.5,
+      originEu: true,
+      destEu: false,
+    });
+    const correctOneEu = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: false,
+    });
+    const oldStyleOneEu = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 0.5,
+      // no flags → coverageFactor=1.0
+    });
+
+    // Document the double-count: doubleCounted should be HALF of correctOneEu
+    // This exposes that callers who pass euLegPercent=0.5 AND one-EU flags
+    // will get 25% coverage instead of 50%. This is a API misuse trap.
+    expect(doubleCounted.amountEur).toBe(correctOneEu.amountEur / 2);
+
+    // Also confirm old-style (no flags) euLegPercent=0.5 == new-style euLegPercent=1.0 + flags
+    expect(oldStyleOneEu.amountEur).toBe(correctOneEu.amountEur);
+  });
+
+  // Verify one-EU end-to-end from voyage-calculator: euLegPercent=1.0 + flags
+  // Expected: 100 * 3.151 * 1.0 * 1.0 * 100 * 0.5 = 15755
+  it('one-EU end-to-end via calculateTCE: originEu=true + destEu=false + euLegPercent=1.0 → ets_eur≈15755', () => {
+    const result = calculateTCE({
+      vessel: { dwt: 30000, valueUsd: 0, speedKts: 13, consumptionMtPerDay: 100 },
+      route: { originPort: 'NLRTM', destinationPort: 'USNYC', distanceNm: 3000 },
+      cargo: { quantityMt: 25000, freightRateUsdPerMt: 30 },
+      bunkerPriceUsdPerMt: 0, // isolate ETS
+      euaPriceEur: 100,
+      durationDays: 1,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: false,
+    });
+    // 100 * 3.151 * 1.0 * 1.0 * 100 * 0.5 = 15755
+    expect(result.breakdown.ets_eur).toBeCloseTo(15755, 1);
+    expect(result.breakdown.applicable.ets).toBe(true);
+  });
+
+  // Verify backward-compat: no flags, euLegPercent=0.5 → same 15755
+  it('backward-compat end-to-end via calculateTCE: no flags + euLegPercent=0.5 → ets_eur≈15755 (no double-count)', () => {
+    const result = calculateTCE({
+      vessel: { dwt: 30000, valueUsd: 0, speedKts: 13, consumptionMtPerDay: 100 },
+      route: { originPort: 'NLRTM', destinationPort: 'USNYC', distanceNm: 3000 },
+      cargo: { quantityMt: 25000, freightRateUsdPerMt: 30 },
+      bunkerPriceUsdPerMt: 0, // isolate ETS
+      euaPriceEur: 100,
+      durationDays: 1,
+      euLegPercent: 0.5,
+      // no originEu / destEu → coverageFactor=1.0
+    });
+    // 100 * 3.151 * 0.5 * 1.0 * 100 * 1.0 = 15755
+    expect(result.breakdown.ets_eur).toBeCloseTo(15755, 1);
+    expect(result.breakdown.applicable.ets).toBe(true);
+  });
+
+  it('both-EU end-to-end via calculateTCE: both flags + euLegPercent=1.0 → ets_eur≈31510 (full coverage)', () => {
+    const result = calculateTCE({
+      vessel: { dwt: 30000, valueUsd: 0, speedKts: 13, consumptionMtPerDay: 100 },
+      route: { originPort: 'NLRTM', destinationPort: 'DEHAM', distanceNm: 3000 },
+      cargo: { quantityMt: 25000, freightRateUsdPerMt: 30 },
+      bunkerPriceUsdPerMt: 0,
+      euaPriceEur: 100,
+      durationDays: 1,
+      euLegPercent: 1.0,
+      originEu: true,
+      destEu: true,
+    });
+    // 100 * 3.151 * 1.0 * 1.0 * 100 * 1.0 = 31510
+    expect(result.breakdown.ets_eur).toBeCloseTo(31510, 1);
+    expect(result.breakdown.applicable.ets).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLASS 5 — Extra-EU early exit must override euLegPercent>0
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Class 5 — Extra-EU early exit overrides euLegPercent', () => {
+  it('originEu=false, destEu=false, euLegPercent=0.5 → applicable=false, amountEur=0', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 0.5,
+      originEu: false,
+      destEu: false,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('originEu=false, destEu=false, euLegPercent=1.0 → applicable=false (euLegPercent=1.0 does not rescue it)', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      originEu: false,
+      destEu: false,
+    });
+    expect(result.amountEur).toBe(0);
+    expect(result.applicable).toBe(false);
+  });
+
+  it('extra-EU via calculateTCE: originEu=false, destEu=false → ets_eur=0, ets_usd=0', () => {
+    const result = calculateTCE({
+      vessel: { dwt: 30000, valueUsd: 0, speedKts: 13, consumptionMtPerDay: 100 },
+      route: { originPort: 'SGSIN', destinationPort: 'AEDXB', distanceNm: 3000 },
+      cargo: { quantityMt: 25000, freightRateUsdPerMt: 30 },
+      bunkerPriceUsdPerMt: 0,
+      euaPriceEur: 100,
+      durationDays: 1,
+      euLegPercent: 1.0, // non-zero — should still yield 0 because of coverage factor
+      originEu: false,
+      destEu: false,
+    });
+    expect(result.breakdown.ets_eur).toBe(0);
+    expect(result.breakdown.ets_usd).toBe(0);
+    expect(result.breakdown.applicable.ets).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLASS 6 — Phase-in year edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Class 6 — Phase-in year edge cases', () => {
+  it('year=2023 → phaseIn=0 → amountEur=0 even with both EU flags', () => {
+    const result = calculateEuEts({
+      ...BASE_ETS,
+      euLegPercent: 1.0,
+      year: 2023,
+      originEu: true,
+      destEu: true,
+    });
+    expect(result.amountEur).toBe(0);
+    // Note: applicable could be true or false here depending on formula path
+    // The guards don't check phase directly, but amount will be 0
+    // The return will be applicable: amount > 0 → false
+    expect(result.applicable).toBe(false);
+  });
+
+  it('year=2024 → phaseIn=0.4 → amount is 40% of 2026 amount', () => {
+    const base2026 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2026, originEu: true, destEu: true,
+    });
+    const result2024 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2024, originEu: true, destEu: true,
+    });
+    expect(result2024.amountEur).toBeCloseTo(base2026.amountEur * 0.4, 1);
+  });
+
+  it('year=2025 → phaseIn=0.7 → amount is 70% of 2026 amount', () => {
+    const base2026 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2026, originEu: true, destEu: true,
+    });
+    const result2025 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2025, originEu: true, destEu: true,
+    });
+    expect(result2025.amountEur).toBeCloseTo(base2026.amountEur * 0.7, 1);
+  });
+
+  it('year=2027+ → phaseIn=1.0 (no regression; schedule capped at 100%)', () => {
+    const result2026 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2026, originEu: true, destEu: true,
+    });
+    const result2027 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2027, originEu: true, destEu: true,
+    });
+    const result2030 = calculateEuEts({
+      ...BASE_ETS, euLegPercent: 1.0, year: 2030, originEu: true, destEu: true,
+    });
+    expect(result2027.amountEur).toBe(result2026.amountEur);
+    expect(result2030.amountEur).toBe(result2026.amountEur);
+  });
+});


### PR DESCRIPTION
Backlog T2 (founder). Adds EU ETS coverage factor to `calculateEuEts`:
- intra-EU (both ports EU) → 100% · in/out-EU (one EU) → **50%** · extra-EU → 0% · absent flags → 1.0 (backward-compat).
- Via `isEuCountry` on resolved endpoint countries; one-EU auto-derive sets euLegPercent=1.0 (coverage now handled by factor, math unchanged).

Code-only (server P&L, no seed/prod-data write). Tests: 671 pass / 24 adversarial. /test-skill APPROVE (0 HIGH). Plan in docs/superpowers/plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)