### PR TITLE
fix(prompts): harden source_text as exact contiguous substring

### DIFF
--- a/docs/superpowers/plans/2026-06-03-parse-prompt-harden.md
+++ b/docs/superpowers/plans/2026-06-03-parse-prompt-harden.md
@@ -1,0 +1,27 @@
+# Plan — parse-prompt hardening against source_text annotations (T3)
+
+**Tier:** M · risk-override (parser/prompt) → mandatory `/test-skill` · creative=no.
+**Branch:** off origin/main (`9cfca018`).
+**NOTE:** the re-parse that PROVES the fix needs the local-only corpus (`.private` raw emails) → that verification is an orchestrator LOCAL-LANE tail AFTER this code lands. Subagent delivers prompt-hardening + a validator/unit test only.
+
+## Gate 0 — TRACE
+- **Target:** `source_text` field emitted by the cargo/vessel parse prompts.
+- **Consumers:** `lib/prompts/parse-cargo.ts` + `lib/prompts/parse-vessel.ts` (the LLM prompts); `lib/sample-data/__tests__/source-text-validity.test.ts` (the guard that source_text is a verbatim substring of the email body).
+- **Entry:** seed/re-parse (`scripts/build-sample-data.ts` via `AI_PROVIDER=claude-cli`, corpus-driven — LOCAL only).
+- **Real failure data:** during the 2026-06-02 re-parse, Opus-4.8 added parenthetical clarifications / ellipsis ("…") into `source_text` despite the prompt saying "verbatim, character-for-character" (L185-187 of parse-cargo.ts) → 46 entries needed a post-hoc "longest verbatim substring" REPAIR in the regen (band-aid). Root fix = strengthen the prompt so future re-parses need no repair.
+- **Parity:** n/a.
+
+## Scope
+- `lib/prompts/parse-cargo.ts` + `lib/prompts/parse-vessel.ts`: tighten the source_text instruction to be unambiguous and example-driven:
+  - "`source_text` MUST be an EXACT, CONTIGUOUS substring copied character-for-character from the email body. Do NOT add ellipsis (`…` or `...`), parentheticals, clarifications, or summaries. Do NOT join non-adjacent fragments. If the relevant text is long, copy a SHORTER exact contiguous substring rather than paraphrasing or eliding."
+  - Add a ✓/✗ example pair (✗ `"loads grain (HSS) … 25000mt"` with inserted ellipsis; ✓ `"25000mt HSS"` exact substring).
+- Optional: a unit test asserting the prompt CONTAINS the hardening clause (cheap regression guard), since the behavioral proof needs the corpus.
+
+## Acceptance
+- Subagent: prompt hardened + prompt-contains-clause unit test green; `/test-skill` cold QA PASS; full jest green (ignore governance path-artifact).
+- **Orchestrator local-lane tail (AFTER merge):** re-parse corpus → `source-text-validity.test.ts` passes with ZERO repairs needed (annotations 0). This is the real proof; flagged for orchestrator, not the subagent.
+
+## Out-of-scope
+- Do NOT run the re-parse (needs local corpus — orchestrator does it). Do NOT change parse SCHEMAS or other prompt rules. Do NOT touch matching/economics.
+
+## If stuck → QUESTIONS.md + state.md + stop.

--- a/lib/prompts/__tests__/source-text-clause.test.ts
+++ b/lib/prompts/__tests__/source-text-clause.test.ts
@@ -36,7 +36,7 @@ describe('source_text hardening clause — parse-vessel prompt', () => {
   });
 
   it('explicitly forbids ellipsis', () => {
-    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('Do NOT add ellipsis');
+    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('Do NOT insert new ellipsis');
   });
 
   it('explicitly forbids joining non-adjacent fragments', () => {

--- a/lib/prompts/__tests__/source-text-clause.test.ts
+++ b/lib/prompts/__tests__/source-text-clause.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression guard: parse-cargo and parse-vessel prompts must contain the
+ * hardened source_text clause introduced in 2026-06-03 (parse-prompt-harden).
+ *
+ * Root cause guarded: Opus-4.8 added ellipsis ("…") into source_text fields
+ * during re-parse despite "verbatim / character-for-character" wording.  The
+ * fix strengthened the instruction with EXACT, CONTIGUOUS + ✓/✗ examples.
+ * This test ensures the clause is never accidentally regressed by a prompt edit.
+ */
+
+import { CARGO_INQUIRY_PARSER_PROMPT } from '@/lib/prompts/parse-cargo';
+import { VESSEL_POSITION_PARSER_PROMPT } from '@/lib/prompts/parse-vessel';
+
+describe('source_text hardening clause — parse-cargo prompt', () => {
+  it('contains EXACT, CONTIGUOUS instruction', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toContain('EXACT,\nCONTIGUOUS substring');
+  });
+
+  it('explicitly forbids ellipsis', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toContain('Do NOT add ellipsis');
+  });
+
+  it('explicitly forbids joining non-adjacent fragments', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toContain('Do NOT join non-adjacent fragments');
+  });
+
+  it('provides the ✗/✓ example pair', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toContain('loads grain (HSS)');
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toContain('exact contiguous substring');
+  });
+});
+
+describe('source_text hardening clause — parse-vessel prompt', () => {
+  it('contains EXACT, CONTIGUOUS instruction', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('EXACT,\nCONTIGUOUS substring');
+  });
+
+  it('explicitly forbids ellipsis', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('Do NOT add ellipsis');
+  });
+
+  it('explicitly forbids joining non-adjacent fragments', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('Do NOT join non-adjacent fragments');
+  });
+
+  it('provides the ✗/✓ example pair', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('loads grain (HSS)');
+    expect(VESSEL_POSITION_PARSER_PROMPT).toContain('exact contiguous substring');
+  });
+});

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -324,9 +324,17 @@ CONFIDENCE RUBRIC:
 
 Rule: when the source text contains the exact value — even embedded in a compound phrase — use "confirmed". Only use "interpreted" when you actually derived or calculated the value.
 
-CRITICAL: source_text is REQUIRED for every ConfidenceField. It MUST be a verbatim
-substring copied character-for-character from the email body. Omitting source_text is
-a parsing error. Paraphrasing is NOT allowed — copy the exact characters.
+CRITICAL: source_text is REQUIRED for every ConfidenceField. It MUST be an EXACT,
+CONTIGUOUS substring copied character-for-character from the email body.
+Do NOT add ellipsis (\`…\` or \`...\`), parentheticals, clarifications, or summaries.
+Do NOT join non-adjacent fragments with ellipsis or any separator.
+If the relevant text is long, copy a SHORTER exact contiguous substring rather than
+paraphrasing or eliding.
+
+  ✗ source_text: "loads grain (HSS) … 25000mt"  ← inserted ellipsis joins non-adjacent fragments
+  ✓ source_text: "25000mt HSS"                  ← exact contiguous substring
+
+Omitting source_text is a parsing error. Paraphrasing is NOT allowed — copy the exact characters.
 
 CORRECT:   { "value": "Rotterdam", "confidence": "confirmed", "source_text": "Load: Rotterdam" }
 CORRECT:   { "value": 5000, "confidence": "interpreted", "source_text": "abt 5k mts wheat" }

--- a/lib/prompts/parse-vessel.ts
+++ b/lib/prompts/parse-vessel.ts
@@ -287,11 +287,19 @@ For numeric fields (DWT, DWCC, LOA, beam, draft, built-year, grain capacity, etc
 
 CRITICAL: never use 'interpreted' for an exact number with no hedge just because you "interpreted the context". If the number is typed, it's confirmed.
 
-CRITICAL: source_text is REQUIRED for every ConfidenceField. It MUST be a verbatim
-substring copied character-for-character from the email body. Keep source_text BRIEF —
-use the shortest unique substring that identifies the value (typically 20–100 characters;
-never copy entire paragraphs or long contract clauses). Omitting source_text is a parsing
-error. Paraphrasing is NOT allowed — copy the exact characters.
+CRITICAL: source_text is REQUIRED for every ConfidenceField. It MUST be an EXACT,
+CONTIGUOUS substring copied character-for-character from the email body.
+Do NOT add ellipsis (\`…\` or \`...\`), parentheticals, clarifications, or summaries.
+Do NOT join non-adjacent fragments with ellipsis or any separator.
+If the relevant text is long, copy a SHORTER exact contiguous substring rather than
+paraphrasing or eliding. Keep source_text BRIEF — use the shortest unique substring
+that identifies the value (typically 20–100 characters; never copy entire paragraphs
+or long contract clauses).
+
+  ✗ source_text: "loads grain (HSS) … 25000mt"  ← inserted ellipsis joins non-adjacent fragments
+  ✓ source_text: "25000mt HSS"                  ← exact contiguous substring
+
+Omitting source_text is a parsing error. Paraphrasing is NOT allowed — copy the exact characters.
 
 CORRECT:   { "value": "Rotterdam", "confidence": "confirmed", "source_text": "Load: Rotterdam" }
 CORRECT:   { "value": 5000, "confidence": "interpreted", "source_text": "abt 5k mts wheat" }

--- a/lib/prompts/parse-vessel.ts
+++ b/lib/prompts/parse-vessel.ts
@@ -289,7 +289,8 @@ CRITICAL: never use 'interpreted' for an exact number with no hedge just because
 
 CRITICAL: source_text is REQUIRED for every ConfidenceField. It MUST be an EXACT,
 CONTIGUOUS substring copied character-for-character from the email body.
-Do NOT add ellipsis (\`…\` or \`...\`), parentheticals, clarifications, or summaries.
+Do NOT insert new ellipsis (\`…\` or \`...\`), parentheticals, clarifications, or summaries
+not present verbatim in the original email.
 Do NOT join non-adjacent fragments with ellipsis or any separator.
 If the relevant text is long, copy a SHORTER exact contiguous substring rather than
 paraphrasing or eliding. Keep source_text BRIEF — use the shortest unique substring


### PR DESCRIPTION
Backlog T3 (founder). Hardens `lib/prompts/parse-cargo.ts` + `parse-vessel.ts` so `source_text` is an EXACT contiguous substring (no ellipsis/parentheticals/joined fragments) — eliminates the post-hoc repair band-aid future re-parses needed. + prompt-contains-clause unit test.

Tests: 565 pass. /test-skill APPROVE-WITH-FOLLOWUPS (med: parse-recap.ts also unhardened = pre-existing/out-of-scope follow-up; low: addressed in follow-up commit). **Re-parse corpus verification = orchestrator local-lane tail.** Plan in docs/superpowers/plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)