### PR TITLE
fix(display): full port names, TBN fallback, EN strings + en-US locale (#785/#786/#788)

### DIFF
--- a/__tests__/fixes/516-518-522.test.tsx
+++ b/__tests__/fixes/516-518-522.test.tsx
@@ -111,10 +111,10 @@ describe('#516 — abbrPort: no "(" in output for common port names with country
     expect(result).not.toContain('(');
   });
 
-  it('MatchesClient.tsx uses abbrPort instead of raw .slice(0,4) for route display', () => {
+  it('MatchesClient.tsx renders full port names in the route cell (#785)', () => {
     const src = readSrc('app/matches/MatchesClient.tsx');
-    // Should import abbrPort
-    expect(src).toMatch(/import.*abbrPort.*abbr-port/);
+    // #785: full names rendered directly — no abbreviation function in route cell
+    expect(src).not.toMatch(/abbrPort\(match\.(load|discharge)_port\)/);
     // Should NOT have raw .slice(0,4).toUpperCase() on load_port/discharge_port
     expect(src).not.toMatch(/load_port\.slice\(0,\s*4\)\.toUpperCase/);
     expect(src).not.toMatch(/discharge_port\.slice\(0,\s*4\)\.toUpperCase/);

--- a/__tests__/matches-buckets.test.tsx
+++ b/__tests__/matches-buckets.test.tsx
@@ -129,7 +129,7 @@ describe('app/matches/MatchesClient.tsx — bucket tabs', () => {
 
   it('labels the single Матчи tab (no Review/Insufficient labels)', () => {
     const src = readSource(clientPath);
-    expect(src).toMatch(/Матчи/);
+    expect(src).toMatch(/Matches/);
     expect(src).not.toMatch(/На проверку/);
     expect(src).not.toMatch(/Мало данных/);
   });

--- a/__tests__/matches-table-layout.test.tsx
+++ b/__tests__/matches-table-layout.test.tsx
@@ -25,20 +25,21 @@ describe('MatchesClient.tsx — VESSEL column wraps long names (#636 pattern)', 
   it('table view vessel cells use break-words, not truncate', () => {
     // Extract the table view section (after "TABLE VIEW" comment)
     const tableSection = src.slice(src.indexOf('TABLE VIEW'));
-    // All vessel_id spans in table view must use break-words
-    const vesselSpans = [...tableSection.matchAll(/vessel_id[^<]*<\/span>/g)];
+    // All vessel name spans in table view must use break-words (#786: TBN fallback replaces vessel_id)
+    const vesselSpans = [...tableSection.matchAll(/break-words[^>]*>\{match\.vessel_name[^<]*<\/span>/g)];
     expect(vesselSpans.length).toBeGreaterThan(0);
 
-    // No vessel_id span in the table section should have truncate class
+    // No vessel name span in the table section should have truncate class
     const truncatedVessel = tableSection.match(
-      /className="[^"]*truncate[^"]*"[^>]*>\{match\.vessel_id\}/
+      /className="[^"]*truncate[^"]*"[^>]*>\{match\.vessel_name/
     );
     expect(truncatedVessel).toBeNull();
   });
 
   it('table view vessel cells use break-words class', () => {
     const tableSection = src.slice(src.indexOf('TABLE VIEW'));
-    expect(tableSection).toMatch(/break-words[^>]*>\{match\.vessel_name \?\? match\.vessel_id\}|className="[^"]*break-words[^"]*"[^>]*>\{match\.vessel_name \?\? match\.vessel_id\}/);
+    // #786: TBN placeholder replaced raw vessel_id fallback — guard follows refactor
+    expect(tableSection).toMatch(/break-words[^>]*>\{match\.vessel_name \?\? 'TBN'\}|className="[^"]*break-words[^"]*"[^>]*>\{match\.vessel_name \?\? 'TBN'\}/);
   });
 
   it('outer wrapper does not use overflow-x-hidden (which clips scrollable table)', () => {

--- a/__tests__/ui/matches-vessel-wrap.test.tsx
+++ b/__tests__/ui/matches-vessel-wrap.test.tsx
@@ -60,7 +60,7 @@ const LONG_VESSEL = 'MV Supra-Ultramax Eastern Mediterranean Pacific Star VIII';
 const longVesselMatch: StoredMatch = {
   id: 1,
   cargo_id: 'cargo:wrap:0',
-  vessel_id: LONG_VESSEL,
+  vessel_id: 'vessel-hash-abc123',
   score: 85,
   reason: 'test',
   status: 'shortlist',
@@ -78,7 +78,7 @@ const longVesselMatch: StoredMatch = {
   distance_nm: null,
   freight_rate_usd_per_mt: null,
   freight_rate_source: null,
-  vessel_name: null,
+  vessel_name: LONG_VESSEL,
   cargo_ref: null,
 };
 

--- a/app/admin/knowledge/_components/SourceTable.tsx
+++ b/app/admin/knowledge/_components/SourceTable.tsx
@@ -156,7 +156,7 @@ export function SourceTable({ sources }: SourceTableProps) {
                           : 'Never'}
                       </td>
                       <td className="px-4 py-3 text-sm text-gray-500">
-                        {source.row_count?.toLocaleString() ?? '—'}
+                        {source.row_count?.toLocaleString('en-US') ?? '—'}
                       </td>
                       <td className="px-4 py-3 text-sm">
                         <button

--- a/app/laytime/page.tsx
+++ b/app/laytime/page.tsx
@@ -469,8 +469,8 @@ export default function LaytimePage() {
                         </div>
 
                         <div className="text-xs text-ds-text-muted space-y-1">
-                          <div>Demurrage Rate: ${result.dd.breakdown.demurrageRate.toLocaleString()}/day</div>
-                          <div>Despatch Rate: ${result.dd.breakdown.despatchRate.toLocaleString()}/day</div>
+                          <div>Demurrage Rate: ${result.dd.breakdown.demurrageRate.toLocaleString('en-US')}/day</div>
+                          <div>Despatch Rate: ${result.dd.breakdown.despatchRate.toLocaleString('en-US')}/day</div>
                           <div>Demurrage Hours: {result.dd.breakdown.demurrageHours.toFixed(1)}h</div>
                           <div>Despatch Hours: {result.dd.breakdown.despatchHours.toFixed(1)}h</div>
                         </div>

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function MatchDetailPage({ params }: Props) {
     .join(' → ');
   const subMeta = [
     storedMatch.cargo_type,
-    storedMatch.vessel_dwt ? `${storedMatch.vessel_dwt.toLocaleString()} DWT` : null,
+    storedMatch.vessel_dwt ? `${storedMatch.vessel_dwt.toLocaleString('en-US')} DWT` : null,
     laycanDisplay,
   ].filter(Boolean).join(' · ');
 
@@ -177,7 +177,7 @@ export default async function MatchDetailPage({ params }: Props) {
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2 mb-1">
                 <h1 className="text-lg sm:text-2xl font-semibold text-white truncate">
-                  {storedMatch.vessel_name ?? storedMatch.vessel_id}
+                  {storedMatch.vessel_name ?? 'TBN'}
                 </h1>
                 {badgeCfg && (
                   <Badge className="bg-ds-accent-soft text-ds-accent-soft-fg border-0 text-xs">
@@ -213,7 +213,7 @@ export default async function MatchDetailPage({ params }: Props) {
                 <dl className="space-y-1 text-sm">
                   <div className="flex justify-between gap-2">
                     <dt className="text-ds-text-muted">Name</dt>
-                    <dd className="font-medium text-ds-text truncate">{storedMatch.vessel_name ?? storedMatch.vessel_id}</dd>
+                    <dd className="font-medium text-ds-text truncate">{storedMatch.vessel_name ?? 'TBN'}</dd>
                   </div>
                   <div className="flex justify-between gap-2">
                     <dt className="text-ds-text-muted">Status</dt>

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -11,7 +11,6 @@ import { useLiveJobs } from '@/design-system/patterns/useLiveJobs';
 import { useMode } from '@/design-system/patterns/useMode';
 import { filterMatchesByMode } from '@/lib/matching/mode-filter';
 import { useToast } from '@/components/ui/toast';
-import { abbrPort } from '@/lib/utils/abbr-port';
 import { fmtLaycan, isLaycanExpired } from '@/lib/utils/fmt-laycan';
 import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 import { useDemoNow } from '@/lib/clock-client';
@@ -377,7 +376,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
         {/* ===== BUCKET TABS (Wave B) — main list + two read-only realism buckets ===== */}
         <div className="flex items-center gap-1 border-b border-ds-border" role="tablist" aria-label="Match buckets">
           {([
-            { id: 'matches' as Tab, label: 'Матчи', count: modeFiltered.length, testid: 'tab-matches' },
+            { id: 'matches' as Tab, label: 'Matches', count: modeFiltered.length, testid: 'tab-matches' },
             // Review / Insufficient buckets hidden from the board (founder 2026-06-02):
             // surface only the ironclad main matches. Buckets stay in DB, not shown.
           ]).map(({ id, label, count, testid }) => (
@@ -736,7 +735,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                               Cargo: <span className="text-gray-700">{match.cargo_ref ?? match.cargo_id}</span>
                             </div>
                             <div className="font-medium text-sm">
-                              Vessel: <span className="text-gray-700">{match.vessel_name ?? match.vessel_id}</span>
+                              Vessel: <span className="text-gray-700">{match.vessel_name ?? 'TBN'}</span>
                             </div>
                             {match.cargo_type && (
                               <span className="inline-block text-xs bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded mt-0.5">
@@ -1029,9 +1028,9 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                           <td className="py-[13px] px-3 align-middle">
                             <div className="flex items-center gap-[10px]">
                               <span className="w-7 h-7 rounded-[7px] bg-ds-accent text-ds-accent-fg flex-shrink-0 inline-flex items-center justify-center font-mono text-[11.5px] font-medium">
-                                {vesselInitials(match.vessel_name ?? match.vessel_id)}
+                                {vesselInitials(match.vessel_name ?? 'TBN')}
                               </span>
-                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_name ?? match.vessel_id}</span>
+                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_name ?? 'TBN'}</span>
                             </div>
                           </td>
                         )}
@@ -1039,9 +1038,9 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                         <td className="py-[13px] px-3 align-middle">
                           {(match.load_port || match.discharge_port) ? (
                             <span className="font-mono text-[13px] inline-flex items-center gap-2 whitespace-nowrap">
-                              {match.load_port && <span>{abbrPort(match.load_port)}</span>}
+                              {match.load_port && <span>{match.load_port}</span>}
                               {match.load_port && match.discharge_port && <span className="text-slate-300">→</span>}
-                              {match.discharge_port && <span>{abbrPort(match.discharge_port)}</span>}
+                              {match.discharge_port && <span>{match.discharge_port}</span>}
                             </span>
                           ) : (
                             <span className="font-mono text-slate-300">—</span>
@@ -1064,9 +1063,9 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                           <td className="py-[13px] px-3 align-middle">
                             <div className="flex items-center gap-[10px]">
                               <span className="w-7 h-7 rounded-[7px] bg-ds-accent text-ds-accent-fg flex-shrink-0 inline-flex items-center justify-center font-mono text-[11.5px] font-medium">
-                                {vesselInitials(match.vessel_name ?? match.vessel_id)}
+                                {vesselInitials(match.vessel_name ?? 'TBN')}
                               </span>
-                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_name ?? match.vessel_id}</span>
+                              <span className="font-medium text-sm tracking-[-0.005em] break-words">{match.vessel_name ?? 'TBN'}</span>
                             </div>
                           </td>
                         ) : (

--- a/components/economics/BunkerComparisonTable.tsx
+++ b/components/economics/BunkerComparisonTable.tsx
@@ -65,15 +65,15 @@ export function BunkerComparisonTable({
     <div className="space-y-3">
       {liftTonnes != null && (
         <p data-testid="lift-header" className="text-xs font-medium text-gray-700">
-          Нужно залить ~{liftTonnes.toLocaleString()} т
+          Need to lift ~{liftTonnes.toLocaleString('en-US')} t
           {capacityMt != null && capacityMt > 0 && (
             <span className="ml-1 text-gray-500 font-normal">
-              (бункерная ёмкость ~{capacityMt.toLocaleString()} т)
+              (tank capacity ~{capacityMt.toLocaleString('en-US')} t)
             </span>
           )}
           {liftCapped && (
             <span data-testid="lift-capped-warn" className="ml-1 text-amber-700 font-normal">
-              ⚠ упёрлись в ёмкость — потребуется промежуточный бункер
+              ⚠ hit capacity — intermediate bunkering required
             </span>
           )}
         </p>
@@ -86,13 +86,13 @@ export function BunkerComparisonTable({
         >
           <thead>
             <tr className="border-b border-gray-200 text-gray-500 text-left">
-              <th className="py-1 pr-2 font-medium">Порт</th>
-              <th className="py-1 pr-2 font-medium text-right">$/т</th>
-              <th className="py-1 pr-2 font-medium text-right">Крюк</th>
-              <th className="py-1 pr-2 font-medium text-right">+Топл $</th>
-              <th className="py-1 pr-2 font-medium text-right">Время×$сут</th>
-              <th className="py-1 pr-2 font-medium text-right">Углерод $/т</th>
-              <th className="py-1 font-medium text-right">ЭФФ. $/т</th>
+              <th className="py-1 pr-2 font-medium">Port</th>
+              <th className="py-1 pr-2 font-medium text-right">$/t</th>
+              <th className="py-1 pr-2 font-medium text-right">Detour</th>
+              <th className="py-1 pr-2 font-medium text-right">+Fuel $</th>
+              <th className="py-1 pr-2 font-medium text-right">Time×$/day</th>
+              <th className="py-1 pr-2 font-medium text-right">Carbon $/t</th>
+              <th className="py-1 font-medium text-right">Eff. $/t</th>
             </tr>
           </thead>
           <tbody>
@@ -111,7 +111,7 @@ export function BunkerComparisonTable({
                 >
                   <td data-testid={`port-${i}`} className="py-1 pr-2 flex items-center gap-1">
                     {isWinner && (
-                      <span data-testid="winner-badge" aria-label="Лучший вариант" className="text-emerald-600">
+                      <span data-testid="winner-badge" aria-label="Best option" className="text-emerald-600">
                         ✅
                       </span>
                     )}
@@ -150,7 +150,7 @@ export function BunkerComparisonTable({
           data-testid="recommended-split"
           className="rounded border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-800"
         >
-          <span className="font-medium">Рекомендованный сплит: </span>
+          <span className="font-medium">Recommended split: </span>
           {recommendedSplit}
         </div>
       )}
@@ -159,11 +159,11 @@ export function BunkerComparisonTable({
         data-testid="human-decision-flags"
         className="rounded border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-800 space-y-1"
       >
-        <p className="font-semibold text-amber-900">Решает человек ⚠</p>
+        <p className="font-semibold text-amber-900">Human decision required ⚠</p>
         <ul className="list-disc list-inside space-y-0.5">
-          <li>Laycan risk — проверьте, укладывается ли крюк в laycan</li>
-          <li>Fuel quality — VLSFO spec различается по порту; проверить бункерный отчёт</li>
-          <li>Charter type — при TC off-hire detour может требовать разрешения</li>
+          <li>Laycan risk — verify detour fits within laycan window</li>
+          <li>Fuel quality — VLSFO spec varies by port; check bunker report</li>
+          <li>Charter type — TC off-hire detour may require owner consent</li>
         </ul>
       </div>
     </div>

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -390,7 +390,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
           )}
           {overrideTce != null && (
             <p data-testid="override-tce-result" className="text-xs font-medium text-emerald-700">
-              Recalculated TCE: ${overrideTce.toLocaleString()}/day
+              Recalculated TCE: ${overrideTce.toLocaleString('en-US')}/day
             </p>
           )}
           <div className="flex gap-2 items-end">
@@ -491,7 +491,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
 
       {bunkerCandidates.length > 0 && (
         <div data-testid="bunker-comparison-section" className="rounded border border-gray-200 bg-white p-3">
-          <h3 className="text-xs font-semibold text-gray-700 mb-2">Бункеровка — сравнение портов</h3>
+          <h3 className="text-xs font-semibold text-gray-700 mb-2">Bunkering — port comparison</h3>
           <BunkerComparisonTable
             candidates={bunkerCandidates}
             liftTonnes={bunkerLift?.liftTonnes}
@@ -566,25 +566,25 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
             <div className="flex justify-between">
               <span className="text-gray-600">Hull premium:</span>
               <span data-testid="warrisk-hull" className="font-medium">
-                ${warRiskBreakdown.hullPremiumUsd.toLocaleString()}
+                ${warRiskBreakdown.hullPremiumUsd.toLocaleString('en-US')}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Crew war bonus:</span>
               <span data-testid="warrisk-crew" className="font-medium">
-                ${warRiskBreakdown.crewWarBonusUsd.toLocaleString()}
+                ${warRiskBreakdown.crewWarBonusUsd.toLocaleString('en-US')}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">P&amp;I surcharge:</span>
               <span data-testid="warrisk-pi" className="font-medium">
-                ${warRiskBreakdown.piSurchargeUsd.toLocaleString()}
+                ${warRiskBreakdown.piSurchargeUsd.toLocaleString('en-US')}
               </span>
             </div>
             <div className="flex justify-between pt-1 border-t border-orange-200">
               <span className="text-gray-700 font-medium">Total:</span>
               <span data-testid="warrisk-total" className="font-semibold text-orange-900">
-                ${warRiskBreakdown.totalPremiumUsd.toLocaleString()}
+                ${warRiskBreakdown.totalPremiumUsd.toLocaleString('en-US')}
               </span>
             </div>
           </div>

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -64,15 +64,15 @@ export function MatchWorksheet({ worksheet }: Props) {
     },
     {
       label: '⚖️ Weight',
-      vessel: v.dwtSummer != null ? `${v.dwtSummer.toLocaleString()} DWT${v.dwcc != null ? ` / ${v.dwcc.toLocaleString()} DWCC` : ''}` : '—',
-      cargoPort: c.weightMt != null ? `${c.weightMt.toLocaleString()} mt` : '—',
+      vessel: v.dwtSummer != null ? `${v.dwtSummer.toLocaleString('en-US')} DWT${v.dwcc != null ? ` / ${v.dwcc.toLocaleString('en-US')} DWCC` : ''}` : '—',
+      cargoPort: c.weightMt != null ? `${c.weightMt.toLocaleString('en-US')} mt` : '—',
       verdict: util != null
         ? `${util}% utilisation${util >= 85 ? ' ✅' : util >= 70 ? ' ⚠️' : ' ❌'}`
         : verdictBadge(hf.volume.pass, hf.volume.reason),
     },
     {
       label: '📦 Volume',
-      vessel: v.grainCapacity != null ? `${v.grainCapacity.toLocaleString()} ${v.grainCapacityUnit ?? 'cbm'}` : '—',
+      vessel: v.grainCapacity != null ? `${v.grainCapacity.toLocaleString('en-US')} ${v.grainCapacityUnit ?? 'cbm'}` : '—',
       cargoPort: '—',
       verdict: verdictBadge(hf.volume.pass, hf.volume.reason),
     },


### PR DESCRIPTION
## Summary

- **#785** Drop `abbrPort()` from MatchesClient route cell — list now shows full readable port names (e.g. `Thisvi → Monfalcone`) instead of 4-char truncation garbage (`THIS → MONF`)
- **#786** Replace `vessel_name ?? vessel_id` with `?? 'TBN'` in all display paths — list rows, owner cell, detail page hero and vessel panel; raw email hashes no longer leak into UI
- **#788** Translate 16 RU strings in `BunkerComparisonTable`, `EconomicsTab`, and Matches tab label to English; pin all bare `.toLocaleString()` to `'en-US'` across 7 files (fixes comma-decimal `21,56` → `21.56` on non-EN browsers)

## Files changed

| File | Change |
|------|--------|
| `app/matches/MatchesClient.tsx` | Remove abbrPort import+usage; `'Matches'` tab label; `?? 'TBN'` ×4 |
| `app/match/[id]/page.tsx` | `?? 'TBN'` hero+panel; `.toLocaleString('en-US')` DWT |
| `components/economics/BunkerComparisonTable.tsx` | 16 EN strings + `toLocaleString('en-US')` ×2 |
| `components/match/EconomicsTab.tsx` | EN header + `toLocaleString('en-US')` ×5 |
| `components/match/MatchWorksheet.tsx` | `toLocaleString('en-US')` ×4 |
| `app/admin/knowledge/_components/SourceTable.tsx` | `toLocaleString('en-US')` |
| `app/laytime/page.tsx` | `toLocaleString('en-US')` ×2 |
| `__tests__/matches-buckets.test.tsx` | `/Матчи/` → `/Matches/` |
| `__tests__/fixes/516-518-522.test.tsx` | abbrPort import guard → full-port render guard |
| `__tests__/ui/matches-vessel-wrap.test.tsx` | fixture: `vessel_name: LONG_VESSEL` (not vessel_id) |

## Test plan

- [x] `npx jest --findRelatedTests <all changed files>` — 137/137 pass
- [x] `npx tsc --noEmit` — clean
- [x] No bare `.toLocaleString()` without `'en-US'` in touched surfaces (grep clean)
- [x] No RU strings in touched surfaces (grep clean)
- [x] `git status --porcelain` clean

Closes #785
Closes #786
Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)