### PR TITLE
fix(session): re-hydrate demo session mid-navigation — prevent 'No emails yet' (#790)

### DIFF
--- a/__tests__/api-demo-rehydrate.test.ts
+++ b/__tests__/api-demo-rehydrate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Behavioral tests for GET /api/demo/rehydrate — demo session re-hydration (#790).
+ *
+ * PI2-compliant: calls the actual route handler via import, not string-match.
+ * Uses jest.mock to stub createSession / hydrateDemoSession (SQLite not available
+ * in jest environment under SESSIONS_DB_PATH=':memory:' for this path).
+ */
+
+import { webcrypto } from 'node:crypto';
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_ENV = process.env;
+
+// Mock heavy SQLite-dependent modules — the route handler imports them dynamically
+jest.mock('@/lib/session', () => ({
+  createSession: jest.fn().mockReturnValue('mock-session-id-abc'),
+}));
+jest.mock('@/lib/demo-mode/hydrate-demo-session', () => ({
+  hydrateDemoSession: jest.fn(),
+}));
+jest.mock('@/lib/csrf', () => ({
+  generateCsrfToken: jest.fn().mockReturnValue('mock-csrf-token-xyz'),
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    DEMO_AUTH_ENABLED: 'true',
+    DEMO_AUTH_USER: 'admin',
+    DEMO_AUTH_PASSWORD: 'secret',
+    DEMO_AUTH_SECRET: 'test-secret-key-that-is-long-enough!',
+    DEMO_AUTH_COOKIE_DAYS: '30',
+    DEMO_MODE: 'true',
+    NODE_ENV: 'test',
+  };
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+async function makeValidDemoAuthCookie(): Promise<string> {
+  const { signAuthCookie } = await import('../lib/auth/cookie');
+  return signAuthCookie('admin', 'test-secret-key-that-is-long-enough!', 30);
+}
+
+async function callRehydrate(opts: {
+  cookieDemoAuth?: string;
+  next?: string;
+  demoMode?: string;
+}): Promise<Response> {
+  const { demoMode = 'true', cookieDemoAuth, next } = opts;
+  process.env.DEMO_MODE = demoMode;
+
+  const url = new URL('http://localhost/api/demo/rehydrate');
+  if (next) url.searchParams.set('next', next);
+
+  const headers: Record<string, string> = {};
+  if (cookieDemoAuth) headers['cookie'] = `demo_auth=${cookieDemoAuth}`;
+
+  const req = new NextRequest(url.toString(), { headers });
+  const { GET } = await import('../app/api/demo/rehydrate/route');
+  return GET(req);
+}
+
+describe('GET /api/demo/rehydrate (#790)', () => {
+  it('returns 404 when DEMO_MODE is not enabled', async () => {
+    const res = await callRehydrate({ demoMode: '', next: '/matches' });
+    expect(res.status).toBe(404);
+  });
+
+  it('redirects to /login when demo_auth cookie is absent', async () => {
+    const res = await callRehydrate({ next: '/matches' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('redirects to /login when demo_auth cookie is invalid', async () => {
+    const res = await callRehydrate({ cookieDemoAuth: 'invalid-token', next: '/matches' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  describe('valid demo_auth — creates session and redirects', () => {
+    it('redirects to the next param path', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const res = await callRehydrate({ cookieDemoAuth: demoAuth, next: '/matches' });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/matches');
+    });
+
+    it('sets session_id cookie with correct path and HttpOnly', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const res = await callRehydrate({ cookieDemoAuth: demoAuth, next: '/dashboard' });
+
+      const setCookies = res.headers.getSetCookie?.() ?? [];
+      const sessionCookie = setCookies.find(c => c.startsWith('session_id='));
+      expect(sessionCookie).toBeDefined();
+      expect(sessionCookie).toMatch(/Path=\//i);
+      expect(sessionCookie).toMatch(/HttpOnly/i);
+      expect(sessionCookie).toMatch(/SameSite=Lax/i);
+      // Max-Age should be 30 days (cookieDays=30)
+      expect(sessionCookie).toMatch(/Max-Age=2592000/i);
+    });
+
+    it('sets csrf_token cookie', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const res = await callRehydrate({ cookieDemoAuth: demoAuth, next: '/dashboard' });
+
+      const setCookies = res.headers.getSetCookie?.() ?? [];
+      const csrfCookie = setCookies.find(c => c.startsWith('csrf_token='));
+      expect(csrfCookie).toBeDefined();
+      expect(csrfCookie).toMatch(/SameSite=Strict/i);
+    });
+
+    it('defaults to /dashboard when next param is absent', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const res = await callRehydrate({ cookieDemoAuth: demoAuth });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toContain('/dashboard');
+    });
+
+    it('rejects open redirect — non-relative next param falls back to /dashboard', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const res = await callRehydrate({
+        cookieDemoAuth: demoAuth,
+        next: '//evil.example.com/steal',
+      });
+
+      const location = res.headers.get('location') ?? '';
+      expect(location).not.toContain('evil.example.com');
+      expect(location).toContain('/dashboard');
+    });
+  });
+});

--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -71,6 +71,7 @@ describe('middleware auth guard', () => {
       '/api/market/benchmark',
       '/about',
       '/pricing',
+      '/api/demo/rehydrate',
     ];
 
     for (const path of bypassPaths) {

--- a/__tests__/middleware-demo-rehydrate.test.ts
+++ b/__tests__/middleware-demo-rehydrate.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Behavioral tests — middleware re-hydrates demo session when session_id absent.
+ *
+ * Root cause of #790: SESSION_TTL_MS=1h but demo_auth cookie lives 30d.
+ * After 1h the session_id cookie (Max-Age=3600) expires; demo_auth is still valid.
+ * Middleware must detect the gap and redirect to /api/demo/rehydrate so the
+ * Server Component page gets a fresh session_id cookie before rendering.
+ *
+ * PI2-compliant: tests run middleware(req) — a real function call, not string-match.
+ */
+
+import { webcrypto } from 'node:crypto';
+Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+import { NextRequest } from 'next/server';
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = {
+    ...ORIGINAL_ENV,
+    DEMO_AUTH_ENABLED: 'true',
+    DEMO_AUTH_USER: 'admin',
+    DEMO_AUTH_PASSWORD: 'secret',
+    DEMO_AUTH_SECRET: 'test-secret-key-that-is-long-enough!',
+    DEMO_AUTH_COOKIE_DAYS: '30',
+    DEMO_MODE: 'true',
+    NODE_ENV: 'test',
+  };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function makeReq(path: string, cookies: Record<string, string> = {}): NextRequest {
+  const url = `http://localhost${path}`;
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+  const headers: Record<string, string> = {};
+  if (cookieHeader) headers['cookie'] = cookieHeader;
+  return new NextRequest(url, { headers });
+}
+
+async function runMiddleware(req: NextRequest) {
+  const { middleware } = await import('../middleware');
+  return middleware(req);
+}
+
+async function makeValidDemoAuthCookie(): Promise<string> {
+  const { signAuthCookie } = await import('../lib/auth/cookie');
+  return signAuthCookie('admin', 'test-secret-key-that-is-long-enough!', 30);
+}
+
+describe('middleware demo session re-hydration (#790)', () => {
+  describe('DEMO_MODE=true, valid demo_auth, session_id absent', () => {
+    it('redirects /matches to /api/demo/rehydrate with next param', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const req = makeReq('/matches', { demo_auth: demoAuth });
+      const res = await runMiddleware(req);
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toContain('/api/demo/rehydrate');
+      expect(location).toContain('next=');
+      expect(decodeURIComponent(location)).toContain('/matches');
+    });
+
+    it('redirects /dashboard to /api/demo/rehydrate', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const req = makeReq('/dashboard', { demo_auth: demoAuth });
+      const res = await runMiddleware(req);
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toContain('/api/demo/rehydrate');
+    });
+  });
+
+  describe('no re-hydrate redirect when session_id is present', () => {
+    it('passes through /matches when session_id cookie is present (session check is page-level)', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const req = makeReq('/matches', { demo_auth: demoAuth, session_id: 'some-session-id' });
+      const res = await runMiddleware(req);
+
+      // Should not redirect to rehydrate
+      const location = res.headers.get('location') ?? '';
+      expect(location).not.toContain('/api/demo/rehydrate');
+    });
+  });
+
+  describe('API routes are not redirected to rehydrate', () => {
+    it('API route with no session_id passes through (not redirected)', async () => {
+      const demoAuth = await makeValidDemoAuthCookie();
+      const req = makeReq('/api/matches', { demo_auth: demoAuth });
+      const res = await runMiddleware(req);
+
+      const location = res.headers.get('location') ?? '';
+      expect(location).not.toContain('/api/demo/rehydrate');
+    });
+  });
+
+  describe('DEMO_MODE disabled — OAuth path unaffected', () => {
+    it('no re-hydrate redirect when DEMO_MODE is not set', async () => {
+      process.env.DEMO_MODE = '';
+      const demoAuth = await makeValidDemoAuthCookie();
+      const req = makeReq('/matches', { demo_auth: demoAuth });
+      const res = await runMiddleware(req);
+
+      const location = res.headers.get('location') ?? '';
+      expect(location).not.toContain('/api/demo/rehydrate');
+    });
+  });
+
+  describe('/api/demo/rehydrate is in AUTH_BYPASS_PATHS (no redirect loop)', () => {
+    it('rehydrate endpoint itself is not caught by auth guard redirect', async () => {
+      const req = makeReq('/api/demo/rehydrate');
+      const res = await runMiddleware(req);
+
+      // Must NOT redirect to /login (it's bypassed)
+      const location = res.headers.get('location') ?? '';
+      expect(location).not.toContain('/login');
+      // Must NOT cause a 302 to /login — redirect loop prevention
+      if (res.status === 302) {
+        expect(location).not.toContain('/login');
+      }
+    });
+  });
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAuthConfig } from '@/lib/auth/config';
 import { signAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
 import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
+import { DEMO_SESSION_TTL_MS } from '@/lib/constants';
 
 /**
  * Constant-time string comparison to prevent timing attacks.
@@ -83,8 +84,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { createSession } = await import('@/lib/session');
     const { hydrateDemoSession } = await import('@/lib/demo-mode/hydrate-demo-session');
     const { generateCsrfToken } = await import('@/lib/csrf');
-    const sessionId = createSession('demo-seed');
+    // Session TTL matches the auth cookie lifetime so both expire together.
+    const sessionTtlMs = config.cookieDays * 86_400 * 1000;
+    const sessionId = createSession('demo-seed', sessionTtlMs);
     hydrateDemoSession(sessionId);
+    const sessionMaxAge = config.cookieDays * 86_400;
     // Append (do NOT use response.cookies.set — it would clobber the auth cookie
     // already set above via headers.set('Set-Cookie', ...)). Separate Set-Cookie
     // headers coexist, so demo_auth + session_id + csrf_token all survive.
@@ -93,7 +97,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       [
         `session_id=${sessionId}`,
         'Path=/',
-        'Max-Age=3600',
+        `Max-Age=${sessionMaxAge}`,
         'HttpOnly',
         isProduction ? 'Secure' : '',
         'SameSite=Lax',
@@ -108,7 +112,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       [
         `csrf_token=${csrfToken}`,
         'Path=/',
-        'Max-Age=3600',
+        `Max-Age=${sessionMaxAge}`,
         isProduction ? 'Secure' : '',
         'SameSite=Strict',
       ]

--- a/app/api/demo/rehydrate/route.ts
+++ b/app/api/demo/rehydrate/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthConfig } from '@/lib/auth/config';
+import { verifyAuthCookie, AUTH_COOKIE_NAME } from '@/lib/auth/cookie';
+import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
+
+/**
+ * GET /api/demo/rehydrate?next=<path>
+ *
+ * Re-creates the demo session when session_id has expired while demo_auth is still valid.
+ * Root cause of #790: SESSION_TTL_MS (1h) < DEMO_AUTH_COOKIE_DAYS (30d); after 1h the
+ * session_id cookie expires but the user is still authenticated — page.tsx renders empty state.
+ *
+ * Flow: middleware detects session_id absent → redirects here → creates fresh session →
+ * sets session_id cookie → redirects back to the original page.
+ *
+ * This is a Node.js route handler (not edge middleware) so it can use better-sqlite3
+ * via createSession / hydrateDemoSession.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authConfig = getAuthConfig();
+
+  // Only active in DEMO_MODE
+  if (process.env.DEMO_MODE !== 'true') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  // Verify demo_auth cookie — same check as middleware auth guard
+  const cookieValue = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+  const payload = cookieValue && authConfig.secret
+    ? await verifyAuthCookie(cookieValue, authConfig.secret)
+    : null;
+
+  if (!payload) {
+    const loginUrl = new URL('/login', getRequestBaseUrl(request));
+    return NextResponse.redirect(loginUrl, { status: 302 });
+  }
+
+  // Sanitise the `next` redirect target — must be a relative path to prevent open redirect.
+  const rawNext = request.nextUrl.searchParams.get('next') ?? '/dashboard';
+  const safePath =
+    rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/dashboard';
+
+  const { createSession } = await import('@/lib/session');
+  const { hydrateDemoSession } = await import('@/lib/demo-mode/hydrate-demo-session');
+  const { generateCsrfToken } = await import('@/lib/csrf');
+
+  // Session TTL aligned with auth cookie lifetime
+  const sessionTtlMs = authConfig.cookieDays * 86_400 * 1000;
+  const sessionId = createSession('demo-seed', sessionTtlMs);
+  hydrateDemoSession(sessionId);
+
+  const sessionMaxAge = authConfig.cookieDays * 86_400;
+  const isProduction = process.env.NODE_ENV === 'production';
+  const csrfToken = generateCsrfToken();
+
+  const response = NextResponse.redirect(new URL(safePath, getRequestBaseUrl(request)), {
+    status: 302,
+  });
+
+  response.headers.append(
+    'Set-Cookie',
+    [
+      `session_id=${sessionId}`,
+      'Path=/',
+      `Max-Age=${sessionMaxAge}`,
+      'HttpOnly',
+      isProduction ? 'Secure' : '',
+      'SameSite=Lax',
+    ]
+      .filter(Boolean)
+      .join('; '),
+  );
+
+  response.headers.append(
+    'Set-Cookie',
+    [
+      `csrf_token=${csrfToken}`,
+      'Path=/',
+      `Max-Age=${sessionMaxAge}`,
+      isProduction ? 'Secure' : '',
+      'SameSite=Strict',
+    ]
+      .filter(Boolean)
+      .join('; '),
+  );
+
+  return response;
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -59,7 +59,11 @@ export const AI_MODEL_LIGHT = process.env.AI_MODEL_LIGHT || 'gpt-5.5';
  *   (emails, classifications, matches, …). Extending beyond 1 hour increases
  *   `data/sessions.db` size proportionally — evaluate before raising the value.
  */
-export const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
+export const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour — non-demo OAuth sessions
+// Demo sessions: default 30 days so session_id cookie and DB row outlive the demo_auth window.
+// Override via env for testing or custom deployments.
+export const DEMO_SESSION_TTL_MS =
+  parseInt(process.env.DEMO_SESSION_TTL_MS ?? '', 10) || 30 * 24 * 60 * 60 * 1000;
 export const EMAIL_FETCH_COUNT = 50;
 export const MIN_THREAD_LENGTH_FOR_RECAP = 5;
 export const MAX_EMAIL_BODY_CHARS = 3000;

--- a/lib/session-store.ts
+++ b/lib/session-store.ts
@@ -93,7 +93,7 @@ export class SessionStore {
     return this.db;
   }
 
-  createSession(accessToken: string): string {
+  createSession(accessToken: string, ttlMs: number = SESSION_TTL_MS): string {
     const count = this.getSessionCount();
     if (count >= MAX_SESSIONS) {
       // Evict oldest by created_at
@@ -125,7 +125,7 @@ export class SessionStore {
 
     this.db.prepare(
       'INSERT INTO sessions (id, access_token, created_at, expires_at, data) VALUES (?, ?, ?, ?, ?)'
-    ).run(id, accessToken, now, now + SESSION_TTL_MS, serializeData(session));
+    ).run(id, accessToken, now, now + ttlMs, serializeData(session));
 
     return id;
   }

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SessionData } from './types';
 import { getStore } from './session-store';
 
-export function createSession(accessToken: string): string {
+export function createSession(accessToken: string, ttlMs?: number): string {
   getStore().expireOldSessions();
-  return getStore().createSession(accessToken);
+  return getStore().createSession(accessToken, ttlMs);
 }
 
 export function getSession(id: string): SessionData | null {

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,6 +40,8 @@ const AUTH_BYPASS_PATHS = new Set([
   '/api/market/bunker-kpi',
   // benchmark endpoint is "Intentionally public" per route comment (no PII, commodity data only)
   '/api/market/benchmark',
+  // Demo session re-hydration: has its own demo_auth verification; must not loop back to auth guard
+  '/api/demo/rehydrate',
 ]);
 
 const AUTH_BYPASS_PREFIXES = ['/_next/static', '/_next/image', '/_next/webpack'];
@@ -184,6 +186,23 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     // so the pipeline would immediately 403 on all API calls. Redirect to upload CTA instead.
     if (pathname === '/processing' && !request.cookies.get('csrf_token')?.value) {
       return NextResponse.redirect(new URL('/', getRequestBaseUrl(request)), { status: 302 });
+    }
+
+    // Demo session re-hydration (#790): after SESSION_TTL_MS (1h default) the session_id
+    // cookie expires — same Max-Age as the session row. The demo_auth cookie lives
+    // cookieDays (default 30d), so the user is still authenticated but has no session_id.
+    // Server Component pages call getSession() → null → render 'No emails yet'. Redirect to
+    // /api/demo/rehydrate (a Node.js route handler) which creates a fresh session, sets the
+    // session_id cookie, and bounces the user back to this page. Skip for /api/* routes —
+    // those return JSON and must not be interrupted with a browser redirect.
+    if (
+      process.env.DEMO_MODE === 'true' &&
+      !request.cookies.get('session_id')?.value &&
+      !pathname.startsWith('/api/')
+    ) {
+      const rehydrateUrl = new URL('/api/demo/rehydrate', getRequestBaseUrl(request));
+      rehydrateUrl.searchParams.set('next', pathname);
+      return NextResponse.redirect(rehydrateUrl, { status: 302 });
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause (#790)**: `SESSION_TTL_MS=1h` but `demo_auth` cookie lives 30d. After 1h the `session_id` cookie (same `Max-Age=3600`) expires; `demo_auth` is still valid so middleware passes through, but `getSession()` returns null → `/matches` and `/dashboard` render empty 'No emails yet' state.
- **Primary fix**: Middleware detects `session_id` absent in `DEMO_MODE` and redirects to new `/api/demo/rehydrate` endpoint (Node.js handler, can use SQLite). The handler creates a fresh session, hydrates from seed data, sets new cookies, and bounces user back to the original page.
- **Defense (lifetime alignment)**: `createSession()` now accepts an optional `ttlMs` parameter. Login route and rehydrate endpoint both pass `cookieDays * 86400 * 1000` so session DB row and `session_id` cookie expire together with `demo_auth`.

## Files changed

| File | Change |
|------|--------|
| `middleware.ts` | Redirect to rehydrate when `DEMO_MODE + no session_id`; add bypass path |
| `app/api/demo/rehydrate/route.ts` | **New** — creates session, hydrates, sets cookies, redirects |
| `lib/session-store.ts` | Optional `ttlMs` on `createSession` (default `SESSION_TTL_MS`) |
| `lib/session.ts` | Pass `ttlMs` through |
| `lib/constants.ts` | Add `DEMO_SESSION_TTL_MS` (env-configurable, 30d default) |
| `app/api/auth/login/route.ts` | `session_id Max-Age` now uses `cookieDays * 86400` |
| `__tests__/middleware-demo-rehydrate.test.ts` | **New** — TDD behavioral tests |
| `__tests__/api-demo-rehydrate.test.ts` | **New** — behavioral tests for rehydrate route |
| `__tests__/middleware-auth.test.ts` | Add `/api/demo/rehydrate` to `bypassPaths` |

## Out of scope

`SESSIONS_DB_PATH` shared-file swap hazard — documented in code; safe-swap belongs to wave C5.

## Test plan

- [x] 6 behavioral tests for middleware redirect logic (new, GREEN)
- [x] 8 behavioral tests for rehydrate route handler (new, GREEN)
- [x] `lib/__tests__/session-expiry.test.ts` — OAuth path unaffected (GREEN)
- [x] `__tests__/middleware-auth.test.ts` — bypass path registered (GREEN)
- [x] `npx tsc --noEmit` — clean
- [x] `--findRelatedTests` — 280 suites / 2959 tests green

**Post-merge prod acceptance needed:** founder should verify demo navigation after 1h still shows data.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)