### PR TITLE
fix(tce): parseConsumption skips fuel-grade tokens — fixes -$96k/day TCE (#782)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-waveC1-tce-parse.md
+++ b/docs/superpowers/plans/2026-06-03-waveC1-tce-parse.md
@@ -1,0 +1,23 @@
+# Wave C1 — TCE consumption parse fix (#782a, the −$96.3k case)
+
+**Branch off `origin/main`.** Tier S, **risk-override** (parser) → mandatory `/test-skill` with real input shapes. Independent of A1/B/C4 (only `lib/matching/tce-calculator.ts`). Part of the 2026-06-03 QA program.
+
+## Goal
+Kill the extreme negative TCE (−$96.3k/day) shown as a "match". Root: `parseLeadingNumber` (`lib/matching/tce-calculator.ts:58-67`) does `s.match(/(\d+(?:\.\d+)?)/)` — grabs the FIRST number in the string. For LADY ANITA the consumption field is `"Ballast: IFO 180 M/E 3.7MT/D; ..."` → it returns **180** (the fuel-grade "IFO 180"), not the real ~3.7 mt/day. 180 mt/day → bunker = 180×days×$600 → millions → −$96k/day. Correct parse (~3.7) → +$7k/day.
+
+## Fix
+In `lib/matching/tce-calculator.ts`, make the **consumption** parse skip fuel-grade tokens. Either:
+- a dedicated `parseConsumption(s)` that extracts the `…MT/D` / `mt/day` figure (e.g. `/(\d+(?:\.\d+)?)\s*(?:MT\/?D|mt\/?day|t\/day)/i`), falling back to `DEFAULT_CONSUMPTION_MT_PER_DAY` when absent; OR
+- make `parseLeadingNumber`, when used for consumption, strip fuel-grade tokens (`IFO 180/380/500`, `VLSFO`, `LSMGO`, `MGO`, `M/E`, `A/E`) before matching.
+Keep `parseLeadingNumber` behavior unchanged for speed and other numeric fields (don't break its other callers — grep them first).
+
+## Verify (real input shapes — risk-override)
+- `"Ballast: IFO 180 M/E 3.7MT/D"` → **3.7** (not 180); `"abt 14 mt/day"` → 14; `"14.5"` → 14.5; `""`/null → default; `{value:'3.7MT/D'}` wrapper → recurse → 3.7; a string with NO mt/day figure → default (not a stray grade number).
+- Re-derive: LADY ANITA TCE flips from ≈−$96k to a sane positive figure.
+- FULL `npm test` (all ~9051) 0 failures; `npx tsc --noEmit` clean; `git status` clean.
+
+## Out of scope (other waves)
+- TCE duration = laden-only + `dwt×0.9` weight fabrication (#782b) → Wave C2.
+- Fold economics into fit (#783) → C3. Gates (#784) → C4. No display/seed.
+
+Auto-PR to main on QA PASS. Emit `<<TESTSKILL=PASS|FAIL findings=N>>`.

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -27,6 +27,7 @@ import {
   estimateFreightRate,
   computeEstimatedTce,
   parseLeadingNumber,
+  parseConsumption,
   buildMatchEconomics,
 } from '@/lib/matching/tce-calculator';
 
@@ -76,6 +77,64 @@ describe('parseLeadingNumber', () => {
 
   it('returns 0 for an object without a value field', () => {
     expect(parseLeadingNumber({ confidence: 'estimated' })).toBe(0);
+  });
+});
+
+describe('parseConsumption', () => {
+  const DEFAULT = 25; // DEFAULT_CONSUMPTION_MT_PER_DAY
+
+  it('extracts MT/D figure from "Ballast: IFO 180 M/E 3.7MT/D" — not the grade 180', () => {
+    expect(parseConsumption('Ballast: IFO 180 M/E 3.7MT/D; Laden: IFO 180 M/E 3.7MT/D')).toBe(3.7);
+  });
+
+  it('parses "abt 14 mt/day" → 14', () => {
+    expect(parseConsumption('abt 14 mt/day')).toBe(14);
+  });
+
+  it('parses bare number string "14.5" → 14.5', () => {
+    expect(parseConsumption('14.5')).toBe(14.5);
+  });
+
+  it('returns default for empty string', () => {
+    expect(parseConsumption('')).toBe(DEFAULT);
+  });
+
+  it('returns default for null', () => {
+    expect(parseConsumption(null)).toBe(DEFAULT);
+  });
+
+  it('returns default for undefined', () => {
+    expect(parseConsumption(undefined)).toBe(DEFAULT);
+  });
+
+  it('unwraps ConfidenceField {value:"3.7MT/D"} → 3.7', () => {
+    expect(parseConsumption({ value: '3.7MT/D', confidence: 'confirmed' })).toBe(3.7);
+  });
+
+  it('returns default for string with only a fuel-grade token (no MT/D figure)', () => {
+    expect(parseConsumption('IFO 180')).toBe(DEFAULT);
+    expect(parseConsumption('VLSFO M/E')).toBe(DEFAULT);
+  });
+
+  it('passes through a raw positive number', () => {
+    expect(parseConsumption(25)).toBe(25);
+    expect(parseConsumption(3.7)).toBe(3.7);
+  });
+
+  it('returns default for 0 or negative numbers', () => {
+    expect(parseConsumption(0)).toBe(DEFAULT);
+    expect(parseConsumption(-5)).toBe(DEFAULT);
+  });
+
+  it('LADY ANITA scenario: consumption 180→3.7 flips TCE from extreme negative to positive', () => {
+    const freight = estimateFreightRate('GRAIN', 3000, 28000);
+    const badCons = 180; // what parseLeadingNumber("IFO 180 M/E 3.7MT/D") would return
+    const goodCons = parseConsumption('Ballast: IFO 180 M/E 3.7MT/D');
+    const badTce = computeEstimatedTce(freight, 3000, 28000, 25000, 12, badCons);
+    const goodTce = computeEstimatedTce(freight, 3000, 28000, 25000, 12, goodCons);
+    expect(goodCons).toBe(3.7);
+    expect(goodTce.tce_usd_per_day).toBeGreaterThan(0);
+    expect(goodTce.tce_usd_per_day).toBeGreaterThan(badTce.tce_usd_per_day + 50_000);
   });
 });
 

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -8,7 +8,7 @@ import { MATCH_PROMPT } from '@/lib/prompts';
 import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 
@@ -75,7 +75,7 @@ export async function computeAndPersistMatches(
     const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? 0) : 0;
     const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
-    const consumptionMt = vessel ? parseLeadingNumber(vessel.consumption) : 0;
+    const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 
     let tce_usd_per_day: number | null = null;
     let freight_rate_usd_per_mt: number | null = null;

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -20,7 +20,7 @@ import { validateDates, isLaycanValid } from '@/lib/sailing/date-sanity';
 import { checkSanctions } from '@/lib/validation/sanctions';
 import { enrichReasons } from '@/lib/matching/reason-enricher';
 import { applyHoldCleanliness } from '@/lib/matching/hold-cleanliness';
-import { buildMatchEconomics, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { buildMatchEconomics, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 import type Database from 'better-sqlite3';
@@ -759,7 +759,7 @@ export async function analyzePairs(
       vesselDwt: ecoDwt,
       quantityMt: ecoQty,
       speedKts: ecoSpeed,
-      consumptionMt: parseLeadingNumber(vessel.consumption),
+      consumptionMt: parseConsumption(vessel.consumption),
       loadPort,
       dischargePort,
       calculatedAt: economicsCalcAt,

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -4,7 +4,7 @@ import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
 import { createMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 
@@ -35,7 +35,7 @@ export function persistSessionMatches(
       : null;
     const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
-    const consumptionMt = vessel ? parseLeadingNumber(vessel.consumption) : 0;
+    const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 
     let tce_usd_per_day: number | null = null;
     let freight_rate_usd_per_mt: number | null = null;

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -3,7 +3,7 @@ import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
 import type { StoredMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 
 /**
  * Convert the session-only realism buckets (`lowConfidenceMatches` /
@@ -47,7 +47,7 @@ export function toBucketRows(
       : null;
     const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
-    const consumptionMt = vessel ? parseLeadingNumber(vessel.consumption) : 0;
+    const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 
     let tce_usd_per_day: number | null = null;
     let freight_rate_usd_per_mt: number | null = null;

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -66,6 +66,41 @@ export function parseLeadingNumber(s: unknown): number {
   return m ? Number(m[1]) : 0;
 }
 
+// Matches an explicit MT/D unit: "3.7MT/D", "14 mt/day", "25 t/day"
+const MT_PER_DAY_RE = /(\d+(?:\.\d+)?)\s*(?:MT\/?D|mt\/?day|t\/day)/i;
+// Fuel-grade tokens that appear before the actual consumption figure
+const FUEL_GRADE_RE = /\b(?:IFO|VLSFO|LSMGO|MGO|HFO|HSFO)\s*\d+(?:\/\d+)?\b|M\/E|A\/E/gi;
+
+/**
+ * Parse a fuel-consumption field, skipping fuel-grade tokens like "IFO 180".
+ *
+ * parseLeadingNumber grabs the first digit sequence, which is the grade number
+ * (e.g. 180 from "IFO 180 M/E 3.7MT/D") rather than the actual MT/day figure.
+ * This function looks for an explicit MT/D unit first; if absent it strips grade
+ * tokens before falling back to a leading-number heuristic. Strings with no
+ * recoverable consumption figure return DEFAULT_CONSUMPTION_MT_PER_DAY.
+ */
+export function parseConsumption(s: unknown): number {
+  if (s == null) return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  if (typeof s === 'number') return Number.isFinite(s) && s > 0 ? s : DEFAULT_CONSUMPTION_MT_PER_DAY;
+  if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
+    return parseConsumption((s as { value: unknown }).value);
+  }
+  if (typeof s !== 'string') return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  const str = s.trim();
+  if (!str) return DEFAULT_CONSUMPTION_MT_PER_DAY;
+
+  const mtd = str.match(MT_PER_DAY_RE);
+  if (mtd) return Number(mtd[1]);
+
+  // Strip fuel-grade tokens then try a plain leading number
+  const stripped = str.replace(FUEL_GRADE_RE, ' ').replace(/\s+/g, ' ').trim();
+  const m = stripped.match(/(\d+(?:\.\d+)?)/);
+  if (m) return Number(m[1]);
+
+  return DEFAULT_CONSUMPTION_MT_PER_DAY;
+}
+
 // Longer voyages warrant higher rates per mt
 function distanceFactor(nm: number): number {
   if (nm <= 0) return 1.0;


### PR DESCRIPTION
## Summary

- **Root cause**: `parseLeadingNumber` grabbed the first digit from `vessel.consumption` — for `"IFO 180 M/E 3.7MT/D"` that returned **180** (the fuel grade) instead of **3.7** (mt/day). At 180 mt/day, bunker cost ≈ \$1.5M/voyage → TCE crashes to −\$96k/day.
- **Fix**: New `parseConsumption` function in `tce-calculator.ts` that (1) looks for an explicit `MT/D`-unit regex first, (2) strips fuel-grade tokens (`IFO NNN`, `VLSFO`, `LSMGO`, `MGO`, `M/E`, `A/E`) before trying a leading-number heuristic, (3) returns `DEFAULT_CONSUMPTION_MT_PER_DAY` (25) when no consumption figure is recoverable. `parseLeadingNumber` unchanged.
- **Wired in**: `compute-matches`, `session-buckets`, `persist-session-matches`, `pair-analyzer` — all four consumption parse call-sites updated.

## LADY ANITA verification (spec):
| Input | Old | New |
|---|---|---|
| `"Ballast: IFO 180 M/E 3.7MT/D"` | 180 → TCE ≈ −\$96k | 3.7 → TCE ≈ +\$7k |
| `"abt 14 mt/day"` | 14 ✓ | 14 ✓ |
| `"14.5"` | 14.5 ✓ | 14.5 ✓ |
| `""`/`null` | 0 (→ fallback 25) | 25 directly |
| `{value:"3.7MT/D"}` | 3.7 ✓ | 3.7 ✓ |
| `"IFO 180"` (no MT/D) | **180 ✗** | **25 ✓** |

## Test plan
- [x] 11 new behavioral tests in `tce-calculator.test.ts` covering all 7 spec input shapes + LADY ANITA TCE flip assertion
- [x] 89/89 tests pass across all 8 changed/related test suites
- [x] Full test suite (excl. regression) passed (exit code 0) — confirmed 2×
- [x] `npx tsc --noEmit` clean

## Out of scope (other waves)
- C2: TCE duration = laden-only + weight fabrication
- C3: Fold economics into fit score
- C4: Gates

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)