### PR TITLE
feat(match): Layer C4 — war-risk position + voyage size gate (#784 wire-up)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-waveC4-gates.md
+++ b/docs/superpowers/plans/2026-06-03-waveC4-gates.md
@@ -1,0 +1,30 @@
+# Wave C4 — Hard gates: knock out commercially/physically impossible pairs (#784 + 9 audited violations)
+
+**Branch off `origin/main`.** Tier **L**, **creative=y** (design = founder-approved spec), **risk-override** (matching engine/filters/parser) → mandatory `/test-skill` with real input shapes. Independent of A1/B/C1 (touches `lib/sailing/match-filters.ts`, parse-cargo schema, vessel-restriction parsing — no overlap). Part of the 2026-06-03 QA program; implements **Layer B** of the approved design.
+
+## Design source (READ FIRST — approved 2026-06-02)
+`docs/superpowers/specs/2026-06-02-matching-gates-cap-clean-data-design.md` (scp'd into this worktree) + `docs/superpowers/plans/2026-06-02-matching-gates-engine.md`. Audit data on dev-vps: `~/orchestrator-state/quantika-demo/restriction-audit-2026-06-02.md` (9 confirmed violations; 17/94 cargoes carry a hard vessel requirement). READ the audit before coding.
+
+## Goal
+Few, ironclad matches. Hard gates remove impossible pairs BEFORE scoring, so #784 (5k-DWT war-zone-origin transatlantic) and the 9 audited violations (beam-16-vs-29m, max-25yr-vs-30yr, geared-required-vs-gearless, no-Europe→Constanța, no-Ukraine→Odessa) no longer surface as good matches.
+
+## Scope — Layer B (gate engine) ONLY
+1. **New structured cargo fields** in parse-cargo schema + extraction prompt: `max_vessel_age_yrs`, `gear_required` (bool), `max_loa_m`, `max_beam_m`, `flag_required`/`class_required`. Patterns per spec §B.1 ("max NN yrs", "geared/grd req", "max loa/beam NN", "flag/class XX").
+2. **Vessel voyage/trading-restriction parsing**: structured exclusions from `vessel.restrictions` free text — distinguish **hard** ("no <region> ports", "<region> excl") from **soft** ("not prefer <region>"). §B.2.
+3. **Extend `HardFilterInput` + `runHardFilters()`** (`lib/sailing/match-filters.ts`) to BLOCK (§B.3): age>max; gear_required & gearless & no confirmed cranes; beam/LOA>max; flag/class mismatch; load/discharge port in a vessel **hard**-excluded region (soft → strong penalty + red flag, NOT block). `checkVesselAge` already exists (`match-filters.ts:270`) — wire/extend it. **Conservative on missing data**: unknown built/beam → do NOT block (no false knockouts), surface "could not verify".
+4. **Cranes** (§B.4): not a blanket block; block only when cargo explicitly requires gear and neither vessel nor port provides it; else amber "confirm cranes".
+5. Add a **size-vs-laden-voyage / war-position** consideration for #784 specifically: a tiny vessel (handysize/sub-handy) on a transatlantic laden leg from a war-risk open position is implausible — gate or strong-penalty (use `lib/economics/war-risk.ts` HRA list keyed on the **vessel open position**, not just cargo ports).
+
+## Out of scope (other waves — do NOT do here)
+- **Layer A** clean-source (anonymizer field-safety, `[object Object]`, build-year coverage, date handling, vague-region marmara) → seed wave (C5/Layer A).
+- **Layer C** top-3-per-cargo cap → separate (overlaps #789 floor; coordinate later).
+- **Regenerate + prod-apply** → C5 (local-execution, Rule #22).
+- Crane SWL-vs-unit-weight; ice-class. Do NOT re-architect the LLM pipeline.
+- The gates CODE + unit tests here; the parsed-field *population* + regen come with the seed wave.
+
+## Verify (risk-override — real input shapes, per spec acceptance)
+- Per-gate unit tests with **real shapes**: null / number / string / ConfidenceField wrapper — NOT happy-path only.
+- Acceptance: the 3 reviewed matches change (#2 no-Ukraine→Odessa BLOCKED, #3 no-Europe→Constanța BLOCKED, #1 age BLOCKED iff cargo states a limit); all 9 audited violations gone from good matches; conservative-on-missing-data leaves unknowns un-blocked but flagged.
+- FULL `npm test` (all ~9051) 0 failures; `npx tsc --noEmit` clean; `git status` clean (commit the scp'd design docs too).
+
+Auto-PR to main on QA PASS — but this is a **risky engine wave**: orchestrator HOLDS for founder review before merge (founder asked risky waves shown first). Emit `<<TESTSKILL=PASS|FAIL findings=N>>`.

--- a/lib/economics/war-risk.ts
+++ b/lib/economics/war-risk.ts
@@ -176,6 +176,22 @@ function portMatchesZone(port: string | ResolvedPort, zone: HraZone): boolean {
   });
 }
 
+/**
+ * Returns true if a free-text port string matches any JWC HRA zone keyword.
+ * Used by hard-filter gate to detect war-risk open positions.
+ */
+export function isPortInHra(portText: string | null | undefined): boolean {
+  if (!portText) return false;
+  const lower = portText.toLowerCase().replace(/-/g, ' ');
+  for (const zone of JWC_HRA_ZONES) {
+    for (const keyword of zone.ports) {
+      const re = new RegExp(`\\b${keyword}\\b`, 'i');
+      if (re.test(lower)) return true;
+    }
+  }
+  return false;
+}
+
 export function calculateWarRiskPremium(input: WarRiskInput): WarRiskResult {
   const { route, vesselValueUsd } = input;
 

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -138,6 +138,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     vesselClassSociety: v.classSociety ?? null,
     cargoFlagRequired: c.flagRequired ?? null,
     cargoClassRequired: c.classRequired ?? null,
+    vesselOpenPosition: cfValue(v.openPosition) ?? null,
   });
 
   const hardFilters: MatchHardFilters = {

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -155,6 +155,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     gearRequired: hf.checks.gearRequired,
     voyage: hf.checks.voyage,
     flagClass: hf.checks.flagClass,
+    warPositionVoyage: hf.checks.warPositionVoyage,
   };
 
   const imsbcCheck = checkImsbcLoadability(cfValue(c.cargoDescription), { restrictions: v.restrictions ?? [] });

--- a/lib/sailing/__tests__/match-filters-war-position.test.ts
+++ b/lib/sailing/__tests__/match-filters-war-position.test.ts
@@ -1,0 +1,150 @@
+/**
+ * TDD: checkWarPositionVoyage hard-filter gate (issue #784).
+ * Rule: block when vessel DWT < 25k AND open position is in JWC HRA zone
+ *       AND the laden voyage is intercontinental (≥4 basin hops).
+ * Conservative: any null input → pass.
+ */
+
+import { checkWarPositionVoyage, runHardFilters } from '../match-filters';
+
+describe('checkWarPositionVoyage', () => {
+  it('SEAGULL-12 case: Hodeidah (HRA) + 5328 DWT + Marmara→Veracruz → blocked', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Hodeidah, Yemen',
+      dwtSummer: 5328,
+      originPort: 'Marmara',
+      destinationPort: 'Veracruz',
+    });
+    expect(r.pass).toBe(false);
+    expect(r.reason).toMatch(/war-risk/i);
+  });
+
+  it('non-HRA open position → pass (Rotterdam is not HRA)', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Rotterdam',
+      dwtSummer: 5000,
+      originPort: 'Marmara',
+      destinationPort: 'Veracruz',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('large vessel (> threshold) at HRA + intercontinental → pass (not tiny)', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Hodeidah',
+      dwtSummer: 40000,
+      originPort: 'Marmara',
+      destinationPort: 'Veracruz',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('tiny vessel + HRA + short regional voyage → pass (not intercontinental)', () => {
+    // Rotterdam → Antwerp is same basin (NorthEurope → NorthEurope)
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Aden, Yemen',
+      dwtSummer: 5000,
+      originPort: 'Rotterdam',
+      destinationPort: 'Hamburg',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('vesselOpenPosition null → conservative pass', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: null,
+      dwtSummer: 5000,
+      originPort: 'Marmara',
+      destinationPort: 'Veracruz',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('dwtSummer null → conservative pass', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Hodeidah',
+      dwtSummer: null,
+      originPort: 'Marmara',
+      destinationPort: 'Veracruz',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('originPort null → conservative pass', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Hodeidah',
+      dwtSummer: 5000,
+      originPort: null,
+      destinationPort: 'Veracruz',
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('destinationPort null → conservative pass', () => {
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Hodeidah',
+      dwtSummer: 5000,
+      originPort: 'Marmara',
+      destinationPort: null,
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('Red Sea HRA (Djibouti) + tiny + EastMed→Americas → blocked (3 basin hops)', () => {
+    // Piraeus (EastMed) → Houston (AtlanticNorth) = EastMed→WestMed→AtlanticNorth = 3 hops
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Djibouti',
+      dwtSummer: 8000,
+      originPort: 'Piraeus',
+      destinationPort: 'Houston',
+    });
+    expect(r.pass).toBe(false);
+  });
+
+  it('Gulf of Guinea HRA (Lagos) + tiny + Med→Americas → blocked (3 basin hops)', () => {
+    // Genoa (WestMed) → Houston (AtlanticNorth) = WestMed→AtlanticNorth = 2 hops → NOT blocked
+    // Use Piraeus→Houston (EastMed→AtlanticNorth) = 3 hops → blocked
+    const r = checkWarPositionVoyage({
+      vesselOpenPosition: 'Lagos',
+      dwtSummer: 10000,
+      originPort: 'Piraeus',
+      destinationPort: 'Houston',
+    });
+    expect(r.pass).toBe(false);
+  });
+});
+
+describe('runHardFilters — warPositionVoyage wired', () => {
+  const BASE = {
+    cargoType: 'PROJECT' as const,
+    originPort: 'Marmara',
+    destinationPort: 'Veracruz',
+    weightMt: 1000,
+    cargoDescription: 'project cargo',
+    stowageFactor: null,
+    vesselType: 'mpp',
+    geared: true,
+    draftMax: 5.0,
+    grainCapacity: 8000,
+    dwtSummer: 5328,
+    dwcc: null,
+    vesselRestrictions: [],
+  };
+
+  it('#784 vessel: Hodeidah open + 5328 DWT + Marmara→Veracruz → blocked', () => {
+    const r = runHardFilters({ ...BASE, vesselOpenPosition: 'Hodeidah, Yemen' });
+    expect(r.pass).toBe(false);
+    expect(r.checks.warPositionVoyage?.pass).toBe(false);
+    expect(r.failures.some((f) => /war-risk/i.test(f))).toBe(true);
+  });
+
+  it('same route but large vessel → passes war-position gate', () => {
+    const r = runHardFilters({ ...BASE, dwtSummer: 40000, vesselOpenPosition: 'Hodeidah, Yemen' });
+    expect(r.checks.warPositionVoyage?.pass).toBe(true);
+  });
+
+  it('vesselOpenPosition absent → passes war-position gate (conservative)', () => {
+    const r = runHardFilters({ ...BASE });
+    expect(r.checks.warPositionVoyage?.pass).toBe(true);
+  });
+});

--- a/lib/sailing/match-filters.ts
+++ b/lib/sailing/match-filters.ts
@@ -17,6 +17,8 @@ import { getPortMaster, portCanHandleDraft, portHasShoreCranes } from './port-ma
 import { CargoType, Range, isRange } from '../types';
 import { checkImsbcLoadability } from './imsbc-check';
 import { checkVoyageRestriction, VoyageRestrictionResult } from './voyage-restriction';
+import { isPortInHra } from '../economics/war-risk';
+import { portBasin, voyageBasins } from './voyage-basin';
 
 export interface FilterResult {
   pass: boolean;
@@ -377,6 +379,50 @@ export function checkVesselDimensions(input: VesselDimensionsCheckInput): Filter
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// War-risk open position + tiny vessel + intercontinental voyage gate
+//
+// A sub-handy vessel (DWT < SUB_HANDY_DWT_THRESHOLD) open in a JWC HRA zone
+// on a long intercontinental laden voyage (basin-path length ≥ 4) is
+// commercially implausible — no freight economics work at that distance from
+// a war zone on such a small ship.  Conservative: any null input → pass.
+// ────────────────────────────────────────────────────────────────────────────
+
+const SUB_HANDY_DWT_THRESHOLD = 25_000;
+const INTERCONTINENTAL_BASIN_HOPS = 3;
+
+export interface WarPositionVoyageCheckInput {
+  vesselOpenPosition: string | null;
+  dwtSummer: number | null;
+  originPort: string | null;
+  destinationPort: string | null;
+}
+
+function basinHopCount(from: string | null, to: string | null): number | null {
+  if (!from || !to) return null;
+  const fb = portBasin(from);
+  const tb = portBasin(to);
+  if (!fb || !tb) return null;
+  // voyageBasins returns the BFS corridor set; size = number of distinct basins traversed
+  return voyageBasins(from, to).size;
+}
+
+export function checkWarPositionVoyage(input: WarPositionVoyageCheckInput): FilterResult {
+  const { vesselOpenPosition, dwtSummer, originPort, destinationPort } = input;
+  // Conservative: any unknown input → cannot verify → pass
+  if (!vesselOpenPosition || dwtSummer == null || !originPort || !destinationPort) {
+    return { pass: true };
+  }
+  if (!isPortInHra(vesselOpenPosition)) return { pass: true };
+  if (dwtSummer >= SUB_HANDY_DWT_THRESHOLD) return { pass: true };
+  const hops = basinHopCount(originPort, destinationPort);
+  if (hops == null || hops < INTERCONTINENTAL_BASIN_HOPS) return { pass: true };
+  return {
+    pass: false,
+    reason: `vessel open in war-risk zone (${vesselOpenPosition}), DWT ${dwtSummer} < ${SUB_HANDY_DWT_THRESHOLD} mt, intercontinental voyage ${originPort}→${destinationPort} (${hops} basin hops) is commercially implausible`,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Unified runner
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -422,6 +468,7 @@ export interface HardFilterInput {
   vesselClassSociety?: string | null;
   cargoFlagRequired?: string | null;
   cargoClassRequired?: string | null;
+  vesselOpenPosition?: string | null;
 }
 
 export interface HardFilterResult {
@@ -442,6 +489,7 @@ export interface HardFilterResult {
     gearRequired?: FilterResult;
     voyage?: FilterResult;
     flagClass?: FilterResult;
+    warPositionVoyage?: FilterResult;
   };
 }
 
@@ -497,6 +545,12 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
     cargoClassRequired: input.cargoClassRequired ?? null,
     vesselClassSociety: input.vesselClassSociety ?? null,
   });
+  const warPositionVoyage = checkWarPositionVoyage({
+    vesselOpenPosition: input.vesselOpenPosition ?? null,
+    dwtSummer: input.dwtSummer ?? null,
+    originPort: input.originPort,
+    destinationPort: input.destinationPort ?? null,
+  });
 
   const failures: string[] = [];
   if (!draft.pass && draft.reason) failures.push(draft.reason);
@@ -512,13 +566,14 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
   if (!gearRequired.pass && gearRequired.reason) failures.push(gearRequired.reason);
   if (!voyage.pass && voyage.reason) failures.push(voyage.reason);
   if (!flagClass.pass && flagClass.reason) failures.push(flagClass.reason);
+  if (!warPositionVoyage.pass && warPositionVoyage.reason) failures.push(warPositionVoyage.reason);
 
   return {
     pass: failures.length === 0,
     failures,
     checks: {
       draft, crane, volume, cargoVessel, destDraft, destCrane, cargoWeight, imsbc,
-      vesselAge, dimensions, gearRequired, voyage, flagClass,
+      vesselAge, dimensions, gearRequired, voyage, flagClass, warPositionVoyage,
     },
   };
 }

--- a/lib/sailing/voyage-basin.ts
+++ b/lib/sailing/voyage-basin.ts
@@ -71,6 +71,9 @@ const BASIN_OVERRIDES: Record<string, Basin> = {
   USBAL: 'AtlanticNorth', USSAV: 'AtlanticNorth', USORF: 'AtlanticNorth',
   PABLB: 'AtlanticNorth', SNDKR: 'AtlanticNorth', MACAS: 'AtlanticNorth',
   MATAN: 'AtlanticNorth', GYGEO: 'AtlanticNorth', FRBAY: 'AtlanticNorth',
+  // Gulf of Mexico — Mexico Atlantic/Caribbean ports (lon slightly west of bbox)
+  MXVER: 'AtlanticNorth', MXTAM: 'AtlanticNorth', MXALT: 'AtlanticNorth',
+  MXPRO: 'AtlanticNorth', MXCOS: 'AtlanticNorth',
   // AtlanticSouth — S.America east, W.Africa south of equator
   BRSSZ: 'AtlanticSouth', ARBUE: 'AtlanticSouth', BRPNG: 'AtlanticSouth',
   NGLAG: 'AtlanticSouth', CIABJ: 'AtlanticSouth', TGLFW: 'AtlanticSouth',
@@ -164,8 +167,8 @@ const BASIN_BBOX: Array<{ basin: Basin; lat: [number, number]; lon: [number, num
   { basin: 'Pacific',       lat: [-55, 65],    lon: [-180, -100] },
   // AtlanticSouth — S.America east coast, W.Africa south of equator
   { basin: 'AtlanticSouth', lat: [-55, 0],     lon: [-65, 15] },
-  // AtlanticNorth — N.America east, Mid-Atlantic, W.Africa north of equator, Iberian Atlantic
-  { basin: 'AtlanticNorth', lat: [0, 65],      lon: [-95, -6] },
+  // AtlanticNorth — N.America east, Mid-Atlantic, W.Africa north of equator, Iberian Atlantic, Gulf of Mexico
+  { basin: 'AtlanticNorth', lat: [0, 65],      lon: [-100, -6] },
 ];
 
 let _portByLocode: Map<string, PortRow> | null = null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -390,6 +390,7 @@ export interface MatchHardFilters {
   gearRequired?: HardFilterCheck;
   voyage?: HardFilterCheck;
   flagClass?: HardFilterCheck;
+  warPositionVoyage?: HardFilterCheck;
 }
 
 /** Sanctions screening (see lib/validation/sanctions.ts). */

--- a/scripts/__tests__/data-integrity-check.test.ts
+++ b/scripts/__tests__/data-integrity-check.test.ts
@@ -13,7 +13,16 @@ import Database from 'better-sqlite3';
 import * as sqliteVec from 'sqlite-vec';
 
 const SCRIPT = path.resolve(__dirname, '../data-integrity-check.ts');
-const TSX = path.resolve(__dirname, '../../node_modules/.bin/tsx');
+// Worktrees share node_modules with the repo root (4 levels up from scripts/__tests__/).
+// Direct checkouts have node_modules 2 levels up. Try both.
+function findTsx(): string {
+  const candidates = [
+    path.resolve(__dirname, '../../node_modules/.bin/tsx'),
+    path.resolve(__dirname, '../../../../node_modules/.bin/tsx'),
+  ];
+  return candidates.find(p => fs.existsSync(p)) ?? candidates[0];
+}
+const TSX = findTsx();
 
 function runScript(args: string[]): { stdout: string; stderr: string; code: number } {
   // Destructure out keys the child process should not inherit (NODE_ENV is readonly in Next.js types)


### PR DESCRIPTION
## Summary

- **`checkWarPositionVoyage`** — new hard gate: sub-handy vessel (DWT < 25 000 t) open in a JWC HRA port on an intercontinental voyage (≥ 3 basin hops) is commercially implausible → filtered with explanatory reason string
- **`isPortInHra`** from `lib/economics/war-risk.ts` — reused to detect open-position in war-risk zone
- **`MatchHardFilters` type** + `pair-analyzer.ts` wired: `warPositionVoyage` added to result breakdown so UI can surface the gate reason
- **150-line test suite** `match-filters-war-position.test.ts`: port-in-HRA / port-not-HRA / DWT boundary / basin-hop count / null-input conservatism / full `runHardFilters` integration path

## Gate logic
```
if vessel.openPort ∈ HRA AND vessel.DWT < 25 000 AND voyageBasins(origin, dest).size ≥ 3:
  → FAIL (reason: war-risk zone + sub-handy + intercontinental)
else:
  → PASS  (any null input → conservative PASS)
```

## Test plan
- [ ] `npx jest lib/sailing/__tests__/match-filters-war-position.test.ts` — all 15 cases green
- [ ] `npx jest --findRelatedTests lib/sailing/match-filters.ts lib/types.ts lib/economics/war-risk.ts lib/sailing/voyage-basin.ts lib/matching/pair-analyzer.ts` — no regressions
- [ ] `npx tsc --noEmit` — clean
- [ ] UI: cargo/vessel pair with HRA open port + sub-handy DWT + intercontinental voyage shows red gate badge in match breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)