### PR TITLE
fix(tce): round-trip duration + conservative weight — fixes absurd TCE (#782 part b)

### DIFF
--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -225,13 +225,37 @@ describe('computeEstimatedTce', () => {
     expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
   });
 
-  it('zero quantity uses dwt*0.9 fallback', () => {
+  it('zero quantity uses conservative dwt*0.65 fallback — lower freight than stated 45k qty', () => {
     const est = estimateFreightRate('BULK', 3000, 50000);
-    const withQty = computeEstimatedTce(est, 3000, 50000, 45000);
     const withZeroQty = computeEstimatedTce(est, 3000, 50000, 0);
-    // Both should be finite, zero-qty result uses 50000*0.9=45000 so should be similar
+    const withFullQty = computeEstimatedTce(est, 3000, 50000, 45000);
+    // Finite result with conservative fallback (50000 * 0.65 = 32500 < 45000).
     expect(Number.isFinite(withZeroQty.tce_usd_per_day)).toBe(true);
-    expect(withZeroQty.tce_usd_per_day).toBeCloseTo(withQty.tce_usd_per_day, -3);
+    // Conservative load → lower TCE than explicitly stated 45k cargo.
+    expect(withZeroQty.tce_usd_per_day).toBeLessThan(withFullQty.tce_usd_per_day);
+  });
+
+  // PI2 behavioral: round-trip duration exceeds laden-only, so $/day is realistic (#782).
+  it('round-trip voyage (3000nm) produces lower $/day than laden-only duration would', () => {
+    const est = estimateFreightRate('BULK', 3000, 50000);
+    // Round-trip: ladenDays(3000nm,12kts)=10.42 × 2 + 2portDays = 22.83 days.
+    // Laden-only would give 10.42 days → $/day ~2.2× higher (~$97k).
+    const roundTrip = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25);
+    // Verify round-trip TCE is substantially below what laden-only would give.
+    // Laden-only net/$97k → round-trip net/22.83d = ~$36k — below the $50k threshold.
+    expect(roundTrip.tce_usd_per_day).toBeLessThan(50_000);
+    expect(Number.isFinite(roundTrip.tce_usd_per_day)).toBe(true);
+  });
+
+  // PI2 behavioral: SEAGULL 71-like case — 8.1k DWT small handysize, short voyage (#782 part b).
+  it('SEAGULL 71 scenario — 8.1k DWT, 700nm laden — TCE in plausible handysize range', () => {
+    const freight = estimateFreightRate('GRAIN', 700, 8100);
+    const result = computeEstimatedTce(freight, 700, 8100, 0, 12, 8);
+    // With round-trip duration (2×700nm + 2 port days) and conservative weight (8100×0.65=5265mt),
+    // TCE must be below $20k/day (old laden-only was ~$53k, clearly wrong for a small handysize).
+    expect(result.tce_usd_per_day).toBeLessThan(20_000);
+    // And finite — no NaN or Infinity.
+    expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
   });
 
   it('higher freight rate → higher TCE', () => {

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -142,10 +142,15 @@ export function computeEstimatedTce(
 ): TceEstimate {
   const safeDist = distance_nm > 0 ? distance_nm : 0;
   const safeDwt = vessel_dwt > 0 ? vessel_dwt : 10000;
-  const safeQty = quantity_mt > 0 ? quantity_mt : safeDwt * 0.9;
+  // Conservative estimate when cargo weight unknown: 65% of DWT avoids inflating freight revenue.
+  // Fit-breakdown already penalizes weight-not-stated; 90% fabricated a near-full load (#782).
+  const safeQty = quantity_mt > 0 ? quantity_mt : safeDwt * 0.65;
   const safeSpeed = speed_kts > 0 ? speed_kts : DEFAULT_SPEED_KTS;
   const safeCons = consumption_mt_per_day > 0 ? consumption_mt_per_day : DEFAULT_CONSUMPTION_MT_PER_DAY;
-  const durationDays = safeDist > 0 ? safeDist / (safeSpeed * 24) : 10;
+  // Round-trip duration: laden + ballast (≈ same distance) + 2 port days (load + discharge).
+  // Laden-only divided full freight by 1–4 days → absurd $/day on short voyages (#782).
+  const ladenDays = safeDist > 0 ? safeDist / (safeSpeed * 24) : 0;
+  const durationDays = safeDist > 0 ? ladenDays * 2 + 2 : 10;
 
   const result = calculateTCE({
     vessel: {


### PR DESCRIPTION
## Summary

- **Duration fix**: `durationDays` was laden-leg only (`dist/speed/24` ≈ 1–4 days). Now round-trip: `ladenDays * 2 + 2` (laden + ballast + 2 port days) → 2–5× longer denominator eliminates absurd \$/day on short voyages
- **Weight fix**: unknown cargo fell back to `dwt × 0.9` (near-full load), inflating freight revenue. Now `dwt × 0.65` (conservative); fit-breakdown already penalises weight-not-stated
- Test updated: `zero quantity` expectation updated to new conservative-fallback contract; 2 new PI2 behavioral tests added (round-trip < laden-only threshold, SEAGULL 71 scenario < \$20k/day)

## Issue

Closes #782 (part b — absurd high TCE; part a negative TCE was fixed in #796/C1)

## Acceptance

| Issue | Criterion | Status | Evidence |
|-------|-----------|--------|----------|
| #782 | SEAGULL 71 (\$53k on 8.1k DWT) fixed | ✓ | `SEAGULL 71 scenario` test: `tce_usd_per_day < 20_000` passes |
| #782 | Round-trip > laden-only for voyages with ballast | ✓ | `round-trip voyage` test: result < \$50k (laden-only was ~\$97k) |
| #782 | Conservative weight when unknown (not fabricated full load) | ✓ | `conservative dwt*0.65` test: zero-qty TCE < explicit-45k-qty TCE |
| #782 | All related tests green | ✓ | 357/357 tests, 38 suites |

## Test plan
- `npx jest "lib/matching/__tests__/tce-calculator" --maxWorkers=1 --ci --forceExit` → 43 passed
- `npx jest --findRelatedTests lib/matching/tce-calculator.ts --maxWorkers=1 --ci --forceExit` → 357/357 passed, 38 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)