### PR TITLE
fix(matches): laycan ms fix + fit floor + list dedup (#665/#789/#787)

### DIFF
--- a/__tests__/cargo-laycan-render.test.ts
+++ b/__tests__/cargo-laycan-render.test.ts
@@ -122,8 +122,8 @@ describe('cargo laycan render — parse+format pipeline', () => {
   });
 
   it('fmtLaycan with valid timestamps produces month-day output', () => {
-    const start = Math.floor(new Date('2026-06-02T00:00:00Z').getTime() / 1000);
-    const end   = Math.floor(new Date('2026-06-09T00:00:00Z').getTime() / 1000);
+    const start = new Date('2026-06-02T00:00:00Z').getTime();
+    const end   = new Date('2026-06-09T00:00:00Z').getTime();
     expect(fmtLaycan(start, end)).toBe('Jun 2–Jun 9');
   });
 });

--- a/__tests__/fmt-laycan-tz-boundary.test.ts
+++ b/__tests__/fmt-laycan-tz-boundary.test.ts
@@ -17,11 +17,11 @@
 import { fmtLaycan } from '@/lib/utils/fmt-laycan';
 
 /**
- * Returns a Unix-second timestamp for midnight UTC of a given ISO date.
- * E.g. '2025-03-01' → Unix seconds for 2025-03-01T00:00:00Z
+ * Returns a Unix-ms timestamp for midnight UTC of a given ISO date.
+ * E.g. '2025-03-01' → Unix ms for 2025-03-01T00:00:00Z
  */
 function midnightUtc(isoDate: string): number {
-  return Math.floor(new Date(`${isoDate}T00:00:00Z`).getTime() / 1000);
+  return new Date(`${isoDate}T00:00:00Z`).getTime();
 }
 
 describe('fmtLaycan — UTC timezone pinning (#676)', () => {
@@ -36,7 +36,7 @@ describe('fmtLaycan — UTC timezone pinning (#676)', () => {
   it('renders the expected UTC calendar day at 23:59 UTC (last minute of day)', () => {
     // 2025-03-31T23:59:00Z — one minute before end of March
     // On UTC+1 this would already be Apr 1.
-    const ts = midnightUtc('2025-04-01') - 60; // 23:59:00Z of Mar 31
+    const ts = midnightUtc('2025-04-01') - 60000; // 23:59:00Z of Mar 31
     const result = fmtLaycan(ts, null);
     expect(result).toBe('Mar 31');
   });

--- a/__tests__/match-laycan-unify.test.ts
+++ b/__tests__/match-laycan-unify.test.ts
@@ -24,14 +24,14 @@ describe('worksheet readiness laycan → fmtLaycan roundtrip (behavioral)', () =
   it('converts ISO laycanStart/End to fmtLaycan-compatible Unix timestamps', () => {
     const isoStart = '2026-06-03';
     const isoEnd = '2026-06-06';
-    const toTs = (iso: string) => Math.floor(new Date(iso + 'T00:00:00Z').getTime() / 1000);
+    const toTs = (iso: string) => new Date(iso + 'T00:00:00Z').getTime();
     const result = fmtLaycan(toTs(isoStart), toTs(isoEnd));
     expect(result).toMatch(/Jun 3/);
     expect(result).toMatch(/Jun 6/);
   });
 
   it('single ISO date round-trips correctly', () => {
-    const toTs = (iso: string) => Math.floor(new Date(iso + 'T00:00:00Z').getTime() / 1000);
+    const toTs = (iso: string) => new Date(iso + 'T00:00:00Z').getTime();
     expect(fmtLaycan(toTs('2026-06-03'), null)).toMatch(/Jun 3/);
     expect(fmtLaycan(null, toTs('2026-06-06'))).toMatch(/Jun 6/);
   });
@@ -98,7 +98,7 @@ describe('app/match/[id]/page.tsx — laycan unified fallback chain (#laycan-uni
 // Mirrors the laycanDisplay IIFE logic to verify precedence without hitting Next.js server infra.
 
 describe('laycanDisplay precedence — behavioral (#laycan-precedence)', () => {
-  const toTs = (iso: string) => Math.floor(new Date(iso + 'T00:00:00Z').getTime() / 1000);
+  const toTs = (iso: string) => new Date(iso + 'T00:00:00Z').getTime();
 
   function computeLaycanDisplay(
     storedMatch: { laycan_start: number | null; laycan_end: number | null },

--- a/__tests__/matches-556-laycan-expired.test.ts
+++ b/__tests__/matches-556-laycan-expired.test.ts
@@ -17,9 +17,9 @@ const detailSrc = () => fs.readFileSync(path.join(ROOT, 'app/match/[id]/page.tsx
 // ── isLaycanExpired — pure function ──────────────────────────────────────────
 
 describe('isLaycanExpired (behavioral)', () => {
-  const PAST = 1000000000;    // Sep 2001 — clearly expired
-  const FUTURE = 9999999999;  // Nov 2286 — clearly not expired
-  const NOW = Math.floor(Date.now() / 1000);
+  const PAST = 1000000000000;    // Sep 2001 in ms — clearly expired
+  const FUTURE = 9999999999000;  // Nov 2286 in ms — clearly not expired
+  const NOW = Date.now();
 
   it('returns false when both start and end are null', () => {
     expect(isLaycanExpired(null, null)).toBe(false);
@@ -45,10 +45,10 @@ describe('isLaycanExpired (behavioral)', () => {
     expect(isLaycanExpired(FUTURE, PAST)).toBe(false);
   });
 
-  it('respects explicit nowSec override', () => {
-    const fixedNow = 2000000000;
-    expect(isLaycanExpired(1999999999, null, fixedNow)).toBe(true);
-    expect(isLaycanExpired(2000000001, null, fixedNow)).toBe(false);
+  it('respects explicit nowMs override', () => {
+    const fixedNow = 2000000000000;
+    expect(isLaycanExpired(1999999999000, null, fixedNow)).toBe(true);
+    expect(isLaycanExpired(2000000001000, null, fixedNow)).toBe(false);
   });
 
   it('boundary: timestamp exactly equal to now is NOT expired', () => {
@@ -64,26 +64,26 @@ function isFreshMatchWithLaycan(
   now: number,
 ): boolean {
   if (now === 0) return false;
-  if (isLaycanExpired(m.laycan_end, m.laycan_start, Math.floor(now / 1000))) return false;
-  return now / 1000 - m.created_at < 7200;
+  if (isLaycanExpired(m.laycan_end, m.laycan_start, now)) return false;
+  return now - m.created_at < 7200000;
 }
 
 describe('isFreshMatch laycan-expiry guard (behavioral)', () => {
   const nowMs = Date.now();
-  const recentCreatedAt = nowMs / 1000 - 60; // created 1 minute ago (seconds)
+  const recentCreatedAt = nowMs - 60000; // created 1 minute ago (ms)
 
   it('returns false for expired laycan regardless of created_at recency', () => {
-    const expiredLaycan = { created_at: recentCreatedAt, laycan_end: 1000000000, laycan_start: 999000000 };
+    const expiredLaycan = { created_at: recentCreatedAt, laycan_end: 1000000000000, laycan_start: 999000000000 };
     expect(isFreshMatchWithLaycan(expiredLaycan, nowMs)).toBe(false);
   });
 
   it('returns true for fresh match with future laycan', () => {
-    const freshMatch = { created_at: recentCreatedAt, laycan_end: 9999999999, laycan_start: 9998000000 };
+    const freshMatch = { created_at: recentCreatedAt, laycan_end: 9999999999000, laycan_start: 9998000000000 };
     expect(isFreshMatchWithLaycan(freshMatch, nowMs)).toBe(true);
   });
 
   it('returns false when now=0 (SSR sentinel) even with future laycan', () => {
-    const futureLaycan = { created_at: 0, laycan_end: 9999999999, laycan_start: null };
+    const futureLaycan = { created_at: 0, laycan_end: 9999999999000, laycan_start: null };
     expect(isFreshMatchWithLaycan(futureLaycan, 0)).toBe(false);
   });
 
@@ -98,7 +98,7 @@ describe('isFreshMatch laycan-expiry guard (behavioral)', () => {
 
 function effectiveScore(m: { score: number; laycan_end: number | null; laycan_start: number | null }, nowMs: number): number {
   if (nowMs === 0) return m.score;
-  if (isLaycanExpired(m.laycan_end, m.laycan_start, Math.floor(nowMs / 1000))) {
+  if (isLaycanExpired(m.laycan_end, m.laycan_start, nowMs)) {
     return Math.min(m.score, 70);
   }
   return m.score;
@@ -106,8 +106,8 @@ function effectiveScore(m: { score: number; laycan_end: number | null; laycan_st
 
 describe('effectiveScore (behavioral)', () => {
   const nowMs = Date.now();
-  const PAST_LAYCAN = 1000000000;
-  const FUTURE_LAYCAN = 9999999999;
+  const PAST_LAYCAN = 1000000000000;    // Sep 2001 in ms
+  const FUTURE_LAYCAN = 9999999999000;  // Nov 2286 in ms
 
   it('caps score at 70 when laycan is expired', () => {
     expect(effectiveScore({ score: 92, laycan_end: PAST_LAYCAN, laycan_start: null }, nowMs)).toBe(70);
@@ -135,11 +135,11 @@ describe('effectiveScore (behavioral)', () => {
 // ── fmtLaycan formatter (shared between list and detail) ─────────────────────
 
 describe('fmtLaycan (formatter parity)', () => {
-  it('formats a Unix-second timestamp the same way in both views', () => {
-    // Dec 20, 2024 in Unix seconds
-    const dec20 = Math.floor(new Date('2024-12-20').getTime() / 1000);
-    // Sep 24, 2024 in Unix seconds
-    const sep24 = Math.floor(new Date('2024-09-24').getTime() / 1000);
+  it('formats a Unix-ms timestamp the same way in both views', () => {
+    // Dec 20, 2024 in Unix ms
+    const dec20 = new Date('2024-12-20T00:00:00Z').getTime();
+    // Sep 24, 2024 in Unix ms
+    const sep24 = new Date('2024-09-24T00:00:00Z').getTime();
     const result = fmtLaycan(sep24, dec20);
     expect(result).toMatch(/Sep 24/);
     expect(result).toMatch(/Dec 20/);
@@ -150,7 +150,7 @@ describe('fmtLaycan (formatter parity)', () => {
   });
 
   it('returns single date when only one value present', () => {
-    const ts = Math.floor(new Date('2025-06-15').getTime() / 1000);
+    const ts = new Date('2025-06-15T00:00:00Z').getTime();
     expect(fmtLaycan(ts, null)).toMatch(/Jun 15/);
     expect(fmtLaycan(null, ts)).toMatch(/Jun 15/);
   });

--- a/__tests__/matches-hydration-418.test.ts
+++ b/__tests__/matches-hydration-418.test.ts
@@ -101,30 +101,30 @@ describe('MatchesClient hydration safety (#543 regression)', () => {
 
 function isFreshMatch(m: { created_at: number }, now: number): boolean {
   if (now === 0) return false;
-  return now / 1000 - m.created_at < 7200;
+  return now - m.created_at < 7200000;
 }
 
 describe('isFreshMatch invariant (behavioral)', () => {
   it('returns false when now=0 regardless of created_at', () => {
-    const justCreated = { created_at: Date.now() / 1000 };
+    const justCreated = { created_at: Date.now() };
     expect(isFreshMatch(justCreated, 0)).toBe(false);
   });
 
   it('returns true for a match created 1 hour ago when now is real', () => {
     const now = Date.now();
-    const oneHourAgo = { created_at: now / 1000 - 3600 };
+    const oneHourAgo = { created_at: now - 3600000 };
     expect(isFreshMatch(oneHourAgo, now)).toBe(true);
   });
 
   it('returns false for a match created 3 hours ago', () => {
     const now = Date.now();
-    const threeHoursAgo = { created_at: now / 1000 - 10800 };
+    const threeHoursAgo = { created_at: now - 10800000 };
     expect(isFreshMatch(threeHoursAgo, now)).toBe(false);
   });
 
   it('boundary: match exactly at 7200s is not fresh', () => {
     const now = Date.now();
-    const atBoundary = { created_at: now / 1000 - 7200 };
+    const atBoundary = { created_at: now - 7200000 };
     expect(isFreshMatch(atBoundary, now)).toBe(false);
   });
 });

--- a/__tests__/matches-page.test.tsx
+++ b/__tests__/matches-page.test.tsx
@@ -234,3 +234,67 @@ describe('app/matches/MatchesClient.tsx — type imports', () => {
     expect(src).toMatch(/StoredMatch/);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #789 — render-side fit_percent >= 60 floor (structural + behavioral)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('MatchesClient.tsx — fit_percent floor (#789)', () => {
+  it('filtered pipeline has fit_percent >= 60 guard in source', () => {
+    const src = readSource(clientPath);
+    expect(src).toMatch(/fit_percent\s*==\s*null\s*\|\|\s*m\.fit_percent\s*>=\s*60/);
+  });
+
+  it('behavioral: match with fit_percent=42 is excluded; null and 60+ pass through', () => {
+    const fitFloor = (m: { fit_percent: number | null }) =>
+      m.fit_percent == null || m.fit_percent >= 60;
+
+    expect(fitFloor({ fit_percent: 42 })).toBe(false);
+    expect(fitFloor({ fit_percent: 59 })).toBe(false);
+    expect(fitFloor({ fit_percent: 60 })).toBe(true);
+    expect(fitFloor({ fit_percent: 85 })).toBe(true);
+    expect(fitFloor({ fit_percent: null })).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// #787 — render-side dedup in page.tsx (structural + behavioral)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('app/matches/page.tsx — content dedup (#787)', () => {
+  it('page.tsx calls dedupMatches in source', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/dedupMatches/);
+  });
+
+  it('dedup key includes vessel_name, cargo_ref, load_port, laycan_start', () => {
+    const src = readSource(pagePath);
+    expect(src).toMatch(/vessel_name/);
+    expect(src).toMatch(/cargo_ref/);
+    expect(src).toMatch(/load_port/);
+    expect(src).toMatch(/laycan_start/);
+  });
+
+  it('behavioral: identical vessel+cargo+port+laycan rows collapse to one', () => {
+    type Row = { id: number; vessel_name: string | null; cargo_ref: string | null; cargo_id: string; load_port: string | null; laycan_start: number | null };
+    function dedupMatches(rows: Row[]): Row[] {
+      const seen = new Map<string, Row>();
+      for (const r of rows) {
+        const k = `${r.vessel_name ?? ''}|${r.cargo_ref ?? r.cargo_id}|${r.load_port ?? ''}|${r.laycan_start ?? ''}`;
+        if (!seen.has(k)) seen.set(k, r);
+      }
+      return [...seen.values()];
+    }
+
+    const base = { vessel_name: 'MV ALPHA', cargo_ref: 'GRAIN-001', cargo_id: 'c1', load_port: 'UAODS', laycan_start: 1748908800000 };
+    const rows: Row[] = [
+      { ...base, id: 1 },
+      { ...base, id: 2 },
+      { ...base, id: 3, vessel_name: 'MV BETA' },
+    ];
+    const result = dedupMatches(rows);
+    expect(result.length).toBe(2);
+    expect(result[0].id).toBe(1);
+    expect(result[1].vessel_name).toBe('MV BETA');
+  });
+});

--- a/__tests__/matches-sort.test.tsx
+++ b/__tests__/matches-sort.test.tsx
@@ -84,7 +84,7 @@ describe('MatchesClient.tsx — sort controls (#350)', () => {
   it('Boundary Class 5 — 50+ elements: sort applied to all filtered results', () => {
     const src = readSource();
     // No slice before sort that would limit to < 50 elements
-    const filteredBlock = src.match(/const filtered[\s\S]{0,800}/)?.[0] ?? '';
+    const filteredBlock = src.match(/const filtered[\s\S]{0,1200}/)?.[0] ?? '';
     // Must have .sort in this block
     expect(filteredBlock).toMatch(/\.sort\s*\(/);
   });

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -86,7 +86,7 @@ export default async function MatchDetailPage({ params }: Props) {
     const rs = worksheet?.readiness?.laycanStart;
     const re = worksheet?.readiness?.laycanEnd;
     if (rs || re) {
-      const toTs = (iso: string) => Math.floor(new Date(iso + 'T00:00:00Z').getTime() / 1000);
+      const toTs = (iso: string) => new Date(iso + 'T00:00:00Z').getTime();
       return fmtLaycan(rs ? toTs(rs) : null, re ? toTs(re) : null);
     }
     if (storedMatch.laycan_start || storedMatch.laycan_end) {

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -74,8 +74,8 @@ function formatAge(ts: number): string {
 // sits near the 2-hour boundary (same fix pattern as SubsCountdown).
 function isFreshMatch(m: StoredMatch, now: number): boolean {
   if (now === 0) return false; // pre-mount sentinel → no fresh badge in SSR
-  if (isLaycanExpired(m.laycan_end, m.laycan_start, Math.floor(now / 1000))) return false;
-  return now / 1000 - m.created_at < 7200;
+  if (isLaycanExpired(m.laycan_end, m.laycan_start, now)) return false;
+  return now - m.created_at < 7200000;
 }
 
 // Display score is capped at 70 for expired laycans — the stored score reflects
@@ -83,7 +83,7 @@ function isFreshMatch(m: StoredMatch, now: number): boolean {
 // match is no longer actionable at the original confidence level.
 function effectiveScore(m: StoredMatch, nowMs: number): number {
   if (nowMs === 0) return m.score;
-  if (isLaycanExpired(m.laycan_end, m.laycan_start, Math.floor(nowMs / 1000))) {
+  if (isLaycanExpired(m.laycan_end, m.laycan_start, nowMs)) {
     return Math.min(m.score, 70);
   }
   return m.score;
@@ -327,7 +327,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
       (cargoTypes.length === 0 || cargoTypes.includes(m.cargo_type ?? ''))
   ).length;
 
-  // Client-side filter: mode + status + cargo_type + quick filter; then sort
+  // Client-side filter: mode + status + cargo_type + fit floor + quick filter; then sort
   const filtered = matches
     .filter(
       (m) =>
@@ -335,6 +335,8 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
         (isOwner
           ? vesselEmailIds.length === 0 || vesselEmailIds.includes(m.vessel_id)
           : cargoEmailIds.length === 0 || cargoEmailIds.includes(m.cargo_id)) &&
+        // render-side fit floor: hide sub-60% fit matches (#789)
+        (m.fit_percent == null || m.fit_percent >= 60) &&
         (!filterStatus || m.status === filterStatus) &&
         (cargoTypes.length === 0 || cargoTypes.includes(m.cargo_type ?? '')) &&
         (quickFilter === 'all' ||

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers';
 import Link from 'next/link';
 import { getSession } from '@/lib/session';
 import { getStore } from '@/lib/session-store';
-import { listMatches } from '@/lib/matching/matches-repository';
+import { listMatches, type StoredMatch } from '@/lib/matching/matches-repository';
 import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
 import { toBucketRows } from '@/lib/matching/session-buckets';
 import MatchesClient from './MatchesClient';
@@ -50,7 +50,8 @@ export default async function MatchesPage() {
   if (session.matches.length > 0) {
     persistSessionMatches(db, sessionId!, session.matches, session.parsedCargos, session.parsedVessels);
   }
-  const matches = listMatches(db, { user_id: sessionId!, sortBy: 'score', sortDir: 'desc' });
+  const rawMatches = listMatches(db, { user_id: sessionId!, sortBy: 'score', sortDir: 'desc' });
+  const matches = dedupMatches(rawMatches);
 
   // Computing only when BOTH cargo and vessel are present — matches require both sides.
   const hasCargo = session.parsedCargos.length > 0;
@@ -92,4 +93,14 @@ export default async function MatchesPage() {
       </div>
     </main>
   );
+}
+
+/** Keep one row per vessel_name+cargo_ref+load_port+laycan_start key (#787). */
+function dedupMatches(rows: StoredMatch[]): StoredMatch[] {
+  const seen = new Map<string, StoredMatch>();
+  for (const r of rows) {
+    const k = `${r.vessel_name ?? ''}|${r.cargo_ref ?? r.cargo_id}|${r.load_port ?? ''}|${r.laycan_start ?? ''}`;
+    if (!seen.has(k)) seen.set(k, r);
+  }
+  return [...seen.values()];
 }

--- a/lib/cargo-render.ts
+++ b/lib/cargo-render.ts
@@ -25,8 +25,8 @@ export function formatCargoLaycanDisplay(
   const parsed = parseLaycan(raw, refYear);
   if (!parsed) return raw;
   return fmtLaycan(
-    Math.floor(parsed.start.getTime() / 1000),
-    Math.floor(parsed.end.getTime() / 1000),
+    parsed.start.getTime(),
+    parsed.end.getTime(),
   );
 }
 

--- a/lib/utils/__tests__/fmt-laycan.test.ts
+++ b/lib/utils/__tests__/fmt-laycan.test.ts
@@ -1,8 +1,8 @@
 import { fmtLaycan } from '../fmt-laycan';
 
 describe('fmtLaycan — #498 laycan date range formatter', () => {
-  const MAY_10 = new Date('2026-05-10T12:00:00Z').getTime() / 1000;
-  const MAY_25 = new Date('2026-05-25T12:00:00Z').getTime() / 1000;
+  const MAY_10 = new Date('2026-05-10T12:00:00Z').getTime();
+  const MAY_25 = new Date('2026-05-25T12:00:00Z').getTime();
 
   it('returns "—" when both start and end are null', () => {
     expect(fmtLaycan(null, null)).toBe('—');

--- a/lib/utils/fmt-laycan.ts
+++ b/lib/utils/fmt-laycan.ts
@@ -1,7 +1,7 @@
 export function fmtLaycan(start: number | null, end: number | null): string {
   if (!start && !end) return '—';
   const fmt = (ts: number) =>
-    new Date(ts * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+    new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
   if (start && end) return `${fmt(start)}–${fmt(end)}`;
   if (start) return fmt(start);
   return fmt(end!);
@@ -9,13 +9,13 @@ export function fmtLaycan(start: number | null, end: number | null): string {
 
 // Returns true when the laycan window has already passed.
 // Uses laycan_end as the primary expiry reference; falls back to laycan_start.
-// Both values are Unix seconds (same unit as laycan_start/laycan_end in StoredMatch).
+// Both values are Unix milliseconds (canonical unit; same as laycan_start/laycan_end in StoredMatch).
 export function isLaycanExpired(
   end: number | null,
   start: number | null,
-  nowSec?: number,
+  nowMs?: number,
 ): boolean {
-  const now = nowSec ?? Math.floor(Date.now() / 1000);
+  const now = nowMs ?? Date.now();
   const ref = end ?? start;
   if (ref === null) return false;
   return ref < now;


### PR DESCRIPTION
## Summary
- **#665**: Fix laycan dates display (was treating ms timestamps as seconds → Apr 25–Jan 1 garbage); fix `fmt-laycan.ts`, `isLaycanExpired`, `isFreshMatch`, `effectiveScore`, `created_at` freshness
- **#789**: Add render-side `fit_percent >= 60` floor on Matches tab (defense-in-depth — seed floor not applied in render)
- **#787**: Add content-dedup on matches list keyed on vessel+cargo+port+laycan (mirror of #723)

## Wave
Part of 2026-06-03 QA-matches fix program (Wave A2). Canonical unit = milliseconds (DB already stores ms; only fix readers). Risk-override applied: TDD + full npm test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)