### PR TITLE
fix(matches): truncate route cell — prevent long port names overflowing DWT column

### DIFF
--- a/__tests__/ui/matches-route-overflow.test.tsx
+++ b/__tests__/ui/matches-route-overflow.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral regression test for route-column overflow:
+ * long port names must truncate with ellipsis inside the Route <td>,
+ * not spill into the adjacent DWT column.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/design-system/patterns/useMode', () => ({
+  useMode: () => ({
+    mode: 'charterer',
+    isCharterer: true,
+    isOwner: false,
+    setMode: jest.fn(),
+    t: (k: string) => k,
+  }),
+}));
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+jest.mock('@/design-system/patterns/useLiveJobs', () => ({
+  useLiveJobs: () => ({ jobs: [], latestMatch: null, dismissMatch: jest.fn() }),
+}));
+
+jest.mock('@/components/ui/toast', () => ({
+  useToast: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    action: jest.fn(),
+  }),
+}));
+
+jest.mock('@/design-system/patterns/LiveStrip', () => ({
+  LiveStrip: () => null,
+}));
+
+jest.mock('@/design-system/patterns/MatchToast', () => ({
+  MatchToast: () => null,
+}));
+
+import MatchesClient from '@/app/matches/MatchesClient';
+import type { StoredMatch } from '@/lib/matching/matches-repository';
+
+const LONG_LOAD = 'East Coast Greece port (unspecified)';
+const LONG_DISCHARGE = 'North European Continent Atlantic Coast port';
+
+const longRouteMatch: StoredMatch = {
+  id: 2,
+  cargo_id: 'cargo:route:0',
+  vessel_id: 'vessel-hash-def456',
+  score: 80,
+  reason: 'test',
+  status: 'shortlist',
+  user_id: null,
+  created_at: Date.now() - 1000,
+  updated_at: Date.now() - 1000,
+  reason_structured: null,
+  cargo_type: 'BULK',
+  load_port: LONG_LOAD,
+  discharge_port: LONG_DISCHARGE,
+  laycan_start: null,
+  laycan_end: null,
+  vessel_dwt: 58000,
+  tce_usd_per_day: 14500,
+  distance_nm: null,
+  freight_rate_usd_per_mt: null,
+  freight_rate_source: null,
+  vessel_name: 'MV Test',
+  cargo_ref: null,
+};
+
+describe('MatchesClient — route cell overflow (#route-col-overflow)', () => {
+  it('renders load_port text in the route span', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longRouteMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    expect(screen.getByText(LONG_LOAD)).toBeInTheDocument();
+  });
+
+  it('route span has no whitespace-nowrap (overflow allowed to truncate)', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longRouteMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    const loadText = screen.getByText(LONG_LOAD);
+    const routeSpan = loadText.closest('span[title]');
+    expect(routeSpan).not.toBeNull();
+    expect(routeSpan!.className).not.toMatch(/whitespace-nowrap/);
+  });
+
+  it('route span has overflow-hidden to prevent column bleed', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longRouteMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    const loadText = screen.getByText(LONG_LOAD);
+    const routeSpan = loadText.closest('span[title]');
+    expect(routeSpan).not.toBeNull();
+    expect(routeSpan!.className).toMatch(/overflow-hidden/);
+  });
+
+  it('route span title carries full load → discharge string for hover', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longRouteMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    const loadText = screen.getByText(LONG_LOAD);
+    const routeSpan = loadText.closest('span[title]');
+    expect(routeSpan).not.toBeNull();
+    expect(routeSpan!.getAttribute('title')).toBe(`${LONG_LOAD} → ${LONG_DISCHARGE}`);
+  });
+
+  it('load_port span has truncate class for ellipsis', () => {
+    render(
+      <MatchesClient
+        initialMatches={[longRouteMatch]}
+        isComputing={false}
+        cargoEmailIds={[]}
+        vesselEmailIds={[]}
+      />
+    );
+    const loadText = screen.getByText(LONG_LOAD);
+    expect(loadText.className).toMatch(/truncate/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -1039,10 +1039,13 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                         {/* Route */}
                         <td className="py-[13px] px-3 align-middle">
                           {(match.load_port || match.discharge_port) ? (
-                            <span className="font-mono text-[13px] inline-flex items-center gap-2 whitespace-nowrap">
-                              {match.load_port && <span>{match.load_port}</span>}
-                              {match.load_port && match.discharge_port && <span className="text-slate-300">→</span>}
-                              {match.discharge_port && <span>{match.discharge_port}</span>}
+                            <span
+                              className="font-mono text-[13px] flex items-center gap-1 overflow-hidden"
+                              title={[match.load_port, match.discharge_port].filter(Boolean).join(' → ')}
+                            >
+                              {match.load_port && <span className="truncate min-w-0">{match.load_port}</span>}
+                              {match.load_port && match.discharge_port && <span className="text-slate-300 flex-shrink-0">→</span>}
+                              {match.discharge_port && <span className="truncate min-w-0">{match.discharge_port}</span>}
                             </span>
                           ) : (
                             <span className="font-mono text-slate-300">—</span>


### PR DESCRIPTION
## Summary

- Long port names like `East Coast Greece port (unspecified)` overflowed the Route `<td>` into the adjacent DWT column (founder-reported prod bug)
- Root cause: `whitespace-nowrap` on the flex container prevented any truncation
- Fix: remove `whitespace-nowrap`, add `overflow-hidden` + `min-w-0 truncate` on port name spans + `flex-shrink-0` on the arrow separator + `title` attribute with full `load → discharge` text for hover

## Files changed

| File | Change |
|------|--------|
| `app/matches/MatchesClient.tsx` | Route cell: drop whitespace-nowrap, add overflow-hidden + truncate + title |
| `__tests__/ui/matches-route-overflow.test.tsx` | New behavioral regression test (5 assertions) |

## Regression guard

New test `matches-route-overflow.test.tsx` verifies:
1. Port text renders
2. Route span has no `whitespace-nowrap`
3. Route span has `overflow-hidden`
4. `title` attribute carries full `load → discharge` string
5. Port span has `truncate` class

Mobile/list card route (`lines ~437, ~746`) — untouched (already uses `truncate`).

## Test plan

- [x] `npx jest --findRelatedTests MatchesClient.tsx` — 7/7 pass
- [x] Full suite: 9075/9102 pass (27 skipped), 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] `git status --porcelain` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)