### PR TITLE
fix(display): same-day laycan single date + floor-filtered count in heading/badge

### DIFF
--- a/__tests__/matches-556-laycan-expired.test.ts
+++ b/__tests__/matches-556-laycan-expired.test.ts
@@ -154,6 +154,13 @@ describe('fmtLaycan (formatter parity)', () => {
     expect(fmtLaycan(ts, null)).toMatch(/Jun 15/);
     expect(fmtLaycan(null, ts)).toMatch(/Jun 15/);
   });
+
+  it('shows single date when start equals end (same-day laycan)', () => {
+    const ts = new Date('2026-05-15T00:00:00Z').getTime();
+    const result = fmtLaycan(ts, ts);
+    expect(result).toMatch(/May 15/);
+    expect(result).not.toContain('–');
+  });
 });
 
 // ── Structural: detail page uses fmtLaycan ───────────────────────────────────

--- a/__tests__/matches-buckets.test.tsx
+++ b/__tests__/matches-buckets.test.tsx
@@ -136,7 +136,8 @@ describe('app/matches/MatchesClient.tsx — bucket tabs', () => {
 
   it('shows the matches counter in the tab header', () => {
     const src = readSource(clientPath);
-    expect(src).toMatch(/modeFiltered\.length/);
+    // Tab badge uses floor-filtered (≥60% fit) count — not pre-floor modeFiltered.length
+    expect(src).toMatch(/floorFilteredCount|modeFiltered\.filter.*fit_percent/);
   });
 
   it('renders an empty state for an empty bucket', () => {

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -318,6 +318,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
 
   // Mode-based count for "All" chip: charterer sees cargo-side, owner sees vessel-side
   const modeFiltered = filterMatchesByMode(matches, isOwner, cargoEmailIds, vesselEmailIds);
+  const floorFilteredCount = modeFiltered.filter((m) => (m.fit_percent ?? 0) >= 60).length;
 
   // All-chip count: mode + status + advanced filters (excluding quick-filter so the badge
   // reflects "how many match your current advanced criteria" regardless of quick-filter tab)
@@ -378,7 +379,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
         {/* ===== BUCKET TABS (Wave B) — main list + two read-only realism buckets ===== */}
         <div className="flex items-center gap-1 border-b border-ds-border" role="tablist" aria-label="Match buckets">
           {([
-            { id: 'matches' as Tab, label: 'Matches', count: modeFiltered.length, testid: 'tab-matches' },
+            { id: 'matches' as Tab, label: 'Matches', count: floorFilteredCount, testid: 'tab-matches' },
             // Review / Insufficient buckets hidden from the board (founder 2026-06-02):
             // surface only the ironclad main matches. Buckets stay in DB, not shown.
           ]).map(({ id, label, count, testid }) => (

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -78,10 +78,12 @@ export default async function MatchesPage() {
     -1_000_000,
   );
 
+  const qualifyingCount = matches.filter((m) => (m.fit_percent ?? 0) >= 60).length;
+
   return (
     <main className="min-h-screen bg-gray-50 px-4 py-12">
       <div className="max-w-[1280px] mx-auto space-y-6">
-        <h1 className="text-2xl font-bold">Matches {matches.length} results</h1>
+        <h1 className="text-2xl font-bold">Matches {qualifyingCount} results</h1>
         <Suspense fallback={<PageSkeleton />}>
           <MatchesClient initialMatches={matches} isComputing={isComputing}
             cargoEmailIds={cargoEmailIds}

--- a/lib/utils/fmt-laycan.ts
+++ b/lib/utils/fmt-laycan.ts
@@ -2,7 +2,7 @@ export function fmtLaycan(start: number | null, end: number | null): string {
   if (!start && !end) return '—';
   const fmt = (ts: number) =>
     new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
-  if (start && end) return `${fmt(start)}–${fmt(end)}`;
+  if (start && end && start !== end) return `${fmt(start)}–${fmt(end)}`;
   if (start) return fmt(start);
   return fmt(end!);
 }


### PR DESCRIPTION
## Summary

- **FIX 1 — fmt-laycan.ts**: `start === end` → single date, no dash (was 'May 15–May 15', now 'May 15')
- **FIX 2a — page.tsx h1**: shows `qualifyingCount` (≥60% fit floor) instead of raw `matches.length` so heading matches visible cards
- **FIX 2b — MatchesClient.tsx tab badge**: uses `floorFilteredCount` instead of pre-floor `modeFiltered.length`

Display-only. No engine, no seed changes.

## Test plan

- [x] `fmtLaycan(T, T)` → single date (new behavioral test in `matches-556-laycan-expired.test.ts`)
- [x] All 5 edge cases: start=end, start≠end, only-start, only-end, both null
- [x] `npx jest --findRelatedTests` → 99/99 pass (8 suites)
- [x] Full suite → 9071/9098 pass, 810 suites, 27 pre-existing skips, exit 0
- [x] `tsc --noEmit --skipLibCheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)