### PR TITLE
fix(seed): wire parseConsumption into seed generators — prevent -$96k/day TCE in regen (C1 #796 follow-up)

### DIFF
--- a/__tests__/lib/matching/tce-calculator-consumption.test.ts
+++ b/__tests__/lib/matching/tce-calculator-consumption.test.ts
@@ -1,0 +1,59 @@
+import { parseConsumption, computeEstimatedTce, estimateFreightRate } from '@/lib/matching/tce-calculator';
+
+const DEFAULT = 25; // DEFAULT_CONSUMPTION_MT_PER_DAY
+
+describe('parseConsumption — grade-token bug (C1 #796)', () => {
+  it('grade-prefixed: "Ballast: IFO 180 M/E 3.7MT/D" → 3.7 (not 180)', () => {
+    expect(parseConsumption('Ballast: IFO 180 M/E 3.7MT/D')).toBe(3.7);
+  });
+
+  it('plain mt/day: "abt 14 mt/day" → 14', () => {
+    expect(parseConsumption('abt 14 mt/day')).toBe(14);
+  });
+
+  it('empty string → DEFAULT (25)', () => {
+    expect(parseConsumption('')).toBe(DEFAULT);
+  });
+
+  it('no mt/day unit and no grade: "VLSFO only" → DEFAULT (25)', () => {
+    expect(parseConsumption('VLSFO only')).toBe(DEFAULT);
+  });
+
+  it('{value: "IFO 180 M/E 3.7MT/D"} wrapper → 3.7', () => {
+    expect(parseConsumption({ value: 'IFO 180 M/E 3.7MT/D' })).toBe(3.7);
+  });
+
+  it('null → DEFAULT', () => {
+    expect(parseConsumption(null)).toBe(DEFAULT);
+  });
+});
+
+describe('parseConsumption downstream: seed TCE sanity (C1 #796)', () => {
+  it('grade-prefixed consumption yields non-absurd TCE (not -$96k/day)', () => {
+    const freight = estimateFreightRate('GRAIN', 5000, 50000);
+    const tce = computeEstimatedTce(
+      freight,
+      5000,   // distanceNm
+      50000,  // dwtSummer
+      40000,  // quantityMt
+      12,     // speedKts
+      parseConsumption('Ballast: IFO 180 M/E 3.7MT/D'),
+    );
+    // With correct consumption (3.7 mt/day), TCE should be positive and not absurd
+    expect(tce.tce_usd_per_day).toBeGreaterThan(-10000);
+    expect(tce.tce_usd_per_day).toBeLessThan(200000);
+  });
+
+  it('grade-prefixed beats naive parseLeadingNumber (180 mt/day) — confirms fix improves TCE', () => {
+    const freight = estimateFreightRate('GRAIN', 5000, 50000);
+    const tceCorrect = computeEstimatedTce(
+      freight, 5000, 50000, 40000, 12,
+      parseConsumption('Ballast: IFO 180 M/E 3.7MT/D'), // 3.7
+    );
+    const tceNaive = computeEstimatedTce(
+      freight, 5000, 50000, 40000, 12,
+      180, // naive parseLeadingNumber result
+    );
+    expect(tceCorrect.tce_usd_per_day).toBeGreaterThan(tceNaive.tce_usd_per_day);
+  });
+});

--- a/scripts/demo-seed/build.ts
+++ b/scripts/demo-seed/build.ts
@@ -16,7 +16,7 @@ import {
 } from '@/lib/types';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
-import { computeEstimatedTce, estimateFreightRate, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce, estimateFreightRate, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { shiftBodyDates, shiftMonthYear, shiftIsoDate } from './date-utils';
 import type { MatchReadiness } from '@/lib/types';
@@ -791,7 +791,7 @@ export async function build(opts: BuildOptions): Promise<void> {
               v.dwt,
               qty,
               speedKn,
-              parseLeadingNumber(v.vesselItem.consumption),
+              parseConsumption(v.vesselItem.consumption),
             );
 
             best.set(key, {

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -34,7 +34,7 @@ import { cfValue } from '@/lib/types';
 import type { ParsedCargo, ParsedVessel, MatchLevel } from '@/lib/types';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber } from '@/lib/matching/tce-calculator';
+import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { IDLE_HARD_MAX_GAP_DAYS } from '@/lib/matching/pair-analyzer';
 import { rebaseParsedCargoes, rebaseParsedVessels } from '@/lib/sample-data/rebase-parsed';
 import rawCargoes from '@/lib/sample-data/demo-parsed-cargoes.json';
@@ -276,7 +276,7 @@ async function main(): Promise<void> {
       if (distanceResult && distanceResult.nm > 0) {
         const quantityMt = cfValue(cargo.weightMt) ?? 0;
         const speedKts = parseLeadingNumber(vessel.speedLaden);
-        const consumptionMt = parseLeadingNumber(vessel.consumption);
+        const consumptionMt = parseConsumption(vessel.consumption);
         const freightEst = estimateFreightRate(cargoType, distanceResult.nm, dwtSummer);
         const tceEst = computeEstimatedTce(
           freightEst, distanceResult.nm, dwtSummer, quantityMt, speedKts, consumptionMt,


### PR DESCRIPTION
## Summary

- **Gap**: PR #796 wired `parseConsumption` into 4 live-path call-sites but the two seed generators still used `parseLeadingNumber` for `vessel.consumption`. A regen from `scripts/demo-seed/real-matches.ts` or `scripts/demo-seed/build.ts` would bake `180 mt/day` (the fuel-grade digit) back into `demo-seed.db` → TCE ≈ −$96k/day.
- **Fix (surgical, 2 sites)**:
  - `scripts/demo-seed/real-matches.ts:279` — `parseLeadingNumber(vessel.consumption)` → `parseConsumption(vessel.consumption)` + import update
  - `scripts/demo-seed/build.ts:794` — same swap + import update
- `speedLaden` parsing unchanged (correct — no grade tokens in speed fields)
- `tce-calculator.ts` unchanged

## Test plan

- [x] New behavioral test `__tests__/lib/matching/tce-calculator-consumption.test.ts` (8 tests): grade-prefixed → 3.7, plain mt/day → 14, empty → DEFAULT, no-unit string → DEFAULT, `{value:...}` wrapper, null → DEFAULT, downstream TCE non-absurd, grade-fix beats naive 180
- [x] `--findRelatedTests` 39 suites, 365/365 passed
- [x] Full suite: **9091/9091 passed**, 812 suites, exit 0
- [x] `npx tsc --noEmit` clean

## Acceptance table

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `real-matches.ts` uses `parseConsumption` for consumption | ✓ | `scripts/demo-seed/real-matches.ts:279` |
| `build.ts` uses `parseConsumption` for consumption | ✓ | `scripts/demo-seed/build.ts:794` |
| `speedLaden` unchanged (parseLeadingNumber) | ✓ | lines 278, 753 unchanged |
| `tce-calculator.ts` unchanged | ✓ | not in diff |
| Grade-prefixed `"Ballast: IFO 180 M/E 3.7MT/D"` → 3.7 | ✓ | test line 7 |
| Downstream TCE non-absurd with correct consumption | ✓ | test line 37 |
| Full suite green | ✓ | 9091/9091, exit 0 |
| tsc clean | ✓ | no output |

🤖 Generated with [Claude Code](https://claude.com/claude-code)