### PR TITLE
fix(weight): #791 + #792 cargo-weight wiring (A+B+C+D+E+F)

### DIFF
--- a/__tests__/adversarial/cargo-weight-adversarial.test.ts
+++ b/__tests__/adversarial/cargo-weight-adversarial.test.ts
@@ -1,0 +1,213 @@
+/**
+ * test-skill cold adversarial regression — #791 / #792
+ *
+ * Written by an independent reviewer to break the resolveCargoWeight helper,
+ * the parity-check utility, and the overload gate boundary. Failure here is
+ * actionable: the production fix has an edge case the unit tests missed.
+ */
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+import { checkCargoWeight } from '@/lib/sailing/match-filters';
+import { diffParsed } from '@/scripts/eval/parity-check-parsed-cargoes';
+import type { ParsedCargo } from '@/lib/types';
+
+function cargoWith(overrides: Partial<ParsedCargo>): ParsedCargo {
+  return {
+    emailId: 'adv',
+    itemIndex: 0,
+    originPort: { value: 'X', confidence: 'confirmed' },
+    originCountry: null,
+    destinationPort: { value: 'Y', confidence: 'confirmed' },
+    destinationCountry: null,
+    cargoDescription: { value: 'salt', confidence: 'confirmed' },
+    weightMt: null,
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BULK',
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    ...overrides,
+  } as ParsedCargo;
+}
+
+describe('ADVERSARIAL #791 — resolveCargoWeight rejects bad numerics', () => {
+  it('rejects negative weightMtMax (falls through to weightMt or null)', () => {
+    const c = cargoWith({ weightMtMax: -100 });
+    expect(resolveCargoWeight(c)).toBeNull();
+  });
+
+  it('rejects negative weightMtMax but accepts valid weightMt fallback', () => {
+    const c = cargoWith({
+      weightMt: { value: 500, confidence: 'confirmed' },
+      weightMtMax: -100,
+    });
+    expect(resolveCargoWeight(c)).toBe(500);
+  });
+
+  it('rejects Infinity weightMtMax (silent overflow guard)', () => {
+    const c = cargoWith({ weightMtMax: Number.POSITIVE_INFINITY });
+    expect(resolveCargoWeight(c)).toBeNull();
+  });
+
+  it('rejects weightMt.value=NaN inside ConfidenceField', () => {
+    const c = cargoWith({
+      weightMt: { value: Number.NaN, confidence: 'confirmed' },
+    });
+    expect(resolveCargoWeight(c)).toBeNull();
+  });
+
+  it('rejects weightMt.value=-50 inside ConfidenceField', () => {
+    const c = cargoWith({
+      weightMt: { value: -50, confidence: 'confirmed' },
+    });
+    expect(resolveCargoWeight(c)).toBeNull();
+  });
+
+  it('handles tiny positive weights (0.1 mt) — accepts as valid', () => {
+    const c = cargoWith({ weightMtMax: 0.1 });
+    expect(resolveCargoWeight(c)).toBe(0.1);
+  });
+
+  it('handles huge weights (1e9 mt) — accepts (capacity check is downstream)', () => {
+    const c = cargoWith({ weightMtMax: 1e9 });
+    expect(resolveCargoWeight(c)).toBe(1e9);
+  });
+});
+
+describe('ADVERSARIAL #792 — overload gate boundary cases', () => {
+  it('passes EXACTLY at capacity × MARGIN (4200 == 4000 × 1.05)', () => {
+    const r = checkCargoWeight({ weightMt: 4200, dwtSummer: null, dwcc: 4000 });
+    expect(r.pass).toBe(true);
+  });
+
+  it('fails one mt above the boundary (4201 > 4200)', () => {
+    const r = checkCargoWeight({ weightMt: 4201, dwtSummer: null, dwcc: 4000 });
+    expect(r.pass).toBe(false);
+  });
+
+  it('range cargo with min above DWCC×1.05 still fails (uses max bound)', () => {
+    const r = checkCargoWeight({
+      weightMt: { min: 4300, max: 4500 },
+      dwtSummer: null,
+      dwcc: 4000,
+    });
+    expect(r.pass).toBe(false);
+  });
+
+  it('NaN cargo weight degrades to graceful pass (does not crash)', () => {
+    const r = checkCargoWeight({
+      weightMt: Number.NaN,
+      dwtSummer: 2570,
+      dwcc: null,
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('negative DWCC fallback to DWT path', () => {
+    const r = checkCargoWeight({
+      weightMt: 3000,
+      dwtSummer: 5000,
+      dwcc: -1,
+    });
+    // -1 not > 0 → falls to DWT × 0.90 × 1.05 = 4725. 3000 ≤ 4725 → pass.
+    expect(r.pass).toBe(true);
+  });
+
+  it('Infinity cargo weight handled (rejects via finite-check or graceful pass)', () => {
+    // checkCargoWeight: !Number.isFinite(effectiveWeight) → graceful pass
+    const r = checkCargoWeight({
+      weightMt: Number.POSITIVE_INFINITY,
+      dwtSummer: 2570,
+      dwcc: null,
+    });
+    expect(r.pass).toBe(true);
+  });
+});
+
+describe('ADVERSARIAL #791 cause C — parity-check guards', () => {
+  it('treats duplicate-key items in old as last-wins (no crash)', () => {
+    const oldArr = [
+      { emailId: 'a', itemIndex: 0, weightMt: { value: 100 } },
+      { emailId: 'a', itemIndex: 0, weightMt: { value: 200 } }, // duplicate
+    ];
+    const newArr = [{ emailId: 'a', itemIndex: 0, weightMt: { value: 200 } }];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.value_changed).toHaveLength(0);
+  });
+
+  it('treats float precision drift as value_changed (not as a regression)', () => {
+    // JSON.stringify(0.1 + 0.2) = "0.30000000000000004"
+    // JSON.stringify(0.3) = "0.3"
+    // → counted as value_changed but NOT populated_now_null
+    const oldArr = [{ emailId: 'a', itemIndex: 0, weightMt: { value: 0.3 } }];
+    const newArr = [{ emailId: 'a', itemIndex: 0, weightMt: { value: 0.1 + 0.2 } }];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.populated_now_null).toHaveLength(0);
+    // value_changed expected (drift), but not a regression.
+    expect(r.value_changed.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('treats array order shifts as value_changed (JSON.stringify is order-sensitive)', () => {
+    const oldArr = [{
+      emailId: 'a', itemIndex: 0,
+      missingInfo: ['a', 'b'],
+    }];
+    const newArr = [{
+      emailId: 'a', itemIndex: 0,
+      missingInfo: ['b', 'a'],
+    }];
+    const r = diffParsed(oldArr, newArr);
+    // Order shift is treated as value_changed (not populated→null)
+    expect(r.value_changed).toHaveLength(1);
+    expect(r.populated_now_null).toHaveLength(0);
+  });
+
+  it('treats both null and undefined as absent (no false populated→null)', () => {
+    const oldArr = [{ emailId: 'a', itemIndex: 0, dimensions: null }];
+    const newArr = [{ emailId: 'a', itemIndex: 0, dimensions: undefined }];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.populated_now_null).toHaveLength(0);
+  });
+
+  it('does NOT crash on empty input arrays', () => {
+    expect(() => diffParsed([], [])).not.toThrow();
+  });
+
+  it('does NOT crash on null fields in old where new has data', () => {
+    const r = diffParsed(
+      [{ emailId: 'a', itemIndex: 0, weightMt: null }],
+      [{ emailId: 'a', itemIndex: 0, weightMt: { value: 500 } }],
+    );
+    expect(r.null_now_populated).toHaveLength(1);
+  });
+});
+
+describe('ADVERSARIAL #791 — helper monotonicity property', () => {
+  // Property: if cargo A's max ≥ cargo B's max, then resolveCargoWeight(A) ≥ resolveCargoWeight(B).
+  // Guards against accidental swap of min/max in the helper.
+  it('monotonic in weightMtMax for range cargoes', () => {
+    const cA = cargoWith({ weightMtMax: 5000 });
+    const cB = cargoWith({ weightMtMax: 3000 });
+    expect(resolveCargoWeight(cA)!).toBeGreaterThan(resolveCargoWeight(cB)!);
+  });
+
+  it('idempotent: calling twice returns the same result', () => {
+    const c = cargoWith({
+      weightMt: { value: 28000, confidence: 'interpreted' },
+      weightMtMin: 25200,
+      weightMtMax: 30800,
+    });
+    expect(resolveCargoWeight(c)).toBe(resolveCargoWeight(c));
+  });
+});

--- a/__tests__/components/match/EconomicsTab-compare-inputs.test.tsx
+++ b/__tests__/components/match/EconomicsTab-compare-inputs.test.tsx
@@ -68,7 +68,10 @@ describe('EconomicsTab — Compare button readiness', () => {
   });
 
   test('missing-hint lists cargo weight when absent', async () => {
-    const noCargo = { ...fullCargo, weightMt: null } as unknown as ParsedCargo;
+    // After #791: resolveCargoWeight also reads weightMtMax. "Missing weight" = both null.
+    const noCargo = {
+      ...fullCargo, weightMt: null, weightMtMin: null, weightMtMax: null,
+    } as unknown as ParsedCargo;
     await act(async () => { render(<EconomicsTab vessel={fullVessel} cargo={noCargo} />); });
     const hint = screen.getByTestId('compare-missing-hint');
     expect(hint.textContent).toMatch(/quantity|weight/i);

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import type { ParsedVessel, ParsedCargo } from '@/lib/types';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { RouteCompareModal } from '@/components/economics/RouteCompareModal';
 import { VoyageBreakdownChart } from '@/components/economics/VoyageBreakdownChart';
 import { BunkerComparisonTable } from '@/components/economics/BunkerComparisonTable';
@@ -224,7 +225,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const speedKts = parseLeadingNumber(vessel?.speedLaden);
     const rawConsumption = parseLeadingNumber(vessel?.consumption);
     const consumption = resolveConsMtPerDay(rawConsumption, dwt);
-    const quantityMt = cargo?.weightMt?.value ?? 0;
+    const quantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
 
     const ready =
       origin.length > 0 &&
@@ -275,7 +276,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const consumptionMtPerDay = resolveConsMtPerDay(rawConsumptionMtPerDay, dwt);
     const originPort = cargo?.originPort?.value ?? '';
     const destinationPort = cargo?.destinationPort?.value ?? '';
-    const quantityMt = cargo?.weightMt?.value ?? 0;
+    const quantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
     const distanceNm = routeDistanceNm ?? 0;
     const freightRateUsdPerMt = currentRate ?? storedFreightRate ?? 28;
     const durationDays = estimateVoyageDays(distanceNm, speedKts);

--- a/docs/superpowers/plans/2026-06-04-791-weight-economics.md
+++ b/docs/superpowers/plans/2026-06-04-791-weight-economics.md
@@ -1,0 +1,1082 @@
+# #791 + #792 — Cargo Weight Reaches Fit / Economics / Overload Gate
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the chain of bugs that causes parsed cargo weight to drop on the way to fit-breakdown, TCE/economics, and the hard overload gate, so #791 (weight not stated → conservative scoring + bogus TCE) and #792 (overload gate marks pair "Possible" instead of rejecting) are both resolved end-to-end.
+
+**Architecture:** Three independent causes converge on the same symptom. (A) **Range weight** — ~31 cargoes in the corpus store `weightMt = null` + `weightMtMax = N` (range notation); many consumers only read `cargo.weightMt.value` and miss the range upper bound. The correct pattern `cargo.weightMtMax ?? cfValue(cargo.weightMt)` already exists in 4 places (`fit-breakdown.ts:499`, `pair-analyzer.ts:116–118`, `match-scoring.ts:299`, `match-filters.ts:130/167`) — we extract it into one helper `resolveCargoWeight()` and apply it at the remaining ~12 sites. (B) **Item-index mismatch** — `scripts/demo-seed/real-matches.ts` INSERT (`:405–416`) never writes `cargo_item_index` / `vessel_item_index`; `hydrate-demo-session.ts:140` defaults to `0`. For multi-item emails the stored `fit_breakdown` is computed for the dedup winner but Source Attribution displays itemIndex=0 → "not stated" on the wrong item. We mirror `regenerate-matches.ts:222` and write the indexes. (C) **Parse gap** — 3 cargoes have `weightMt = null` AND `weightMtMax = null`; of those, **1 is recoverable** (Marmara/Veracruz storage tanks emailId `19d5de87705baf9b/0`, body lists `10 × 15,000 kg + 4 × 9,000 kg = 186 MT` but no aggregate). We tighten the parser prompt to sum piece-weights into the aggregate `weight_mt` for PROJECT cargo, then re-parse the corpus on dev-VPS via claude-cli (allowed in scripts only — see `.claude/rules/ai-provider.md`) under PARITY validation (no previously-populated field becomes null). The remaining 2 null/null cargoes are genuine unknowns (`19e07cc3ba833475/0` grain trader no commodity, `19e07d011dbc661e/2` scrap "tonnage not specified") and stay null.
+
+**Tech Stack:** TypeScript / Next.js / better-sqlite3 / Jest / claude-cli (Anthropic CLI provider, scripts only) / Anthropic Claude Opus for re-parse / GitHub Actions (CI).
+
+**Out-of-scope (do NOT touch):**
+- #665 laycan polish (separate bundle).
+- The polish bundle (display tweaks #806/#807/#808).
+- Unrelated matching scoring (no changes to weights/multipliers in `match-scoring.ts` beyond the helper swap on line 299).
+- Reseeding `parsed_results` for the 2 truly-missing cargoes (`19e07cc3ba833475/0`, `19e07d011dbc661e/2`) — they stay null by design.
+
+---
+
+## File Structure
+
+| Path | Status | Responsibility |
+|---|---|---|
+| `lib/sailing/cargo-weight.ts` | **CREATE** | Single helper `resolveCargoWeight(cargo)` — the canonical weight extractor. |
+| `lib/sailing/__tests__/cargo-weight.test.ts` | **CREATE** | Unit tests for all 5 weight shapes (null / number / ConfidenceField / range / piece-aggregate). |
+| `lib/sailing/fit-breakdown.ts` | MODIFY (`:499`) | Replace inline `cargo.weightMtMax ?? cfValue(cargo.weightMt)` with `resolveCargoWeight(cargo)`. |
+| `lib/sailing/match-scoring.ts` | MODIFY (`:299`) | Same swap in `applyOverloadGuard`. |
+| `lib/sailing/match-filters.ts` | NO-OP for `:130`/`:167` (input is already `Range\|number\|null`, helper not applicable at gate boundary). |
+| `lib/matching/pair-analyzer.ts` | MODIFY (`:116–118`, `:769`) | Use helper at hard-filter wiring AND economics loop. |
+| `lib/matching/tce-calculator.ts` | NO-OP (input is already `quantity_mt: number`; callers must pass via helper). |
+| `lib/matching/freight-resolver.ts` | NO-OP (input is `quantityMt: number`; callers must pass via helper). |
+| `lib/matching/compute-matches.ts` | MODIFY (`:76`) | Use helper for `quantityMt`. |
+| `lib/matching/persist-session-matches.ts` | MODIFY (`:36`) | Use helper for `quantityMt`. |
+| `lib/matching/session-buckets.ts` | MODIFY (`:48`) | Use helper for `quantityMt`. |
+| `lib/matching/pair-analyzer.ts` | MODIFY (`:769` — listed above; covered in same task). |
+| `components/match/EconomicsTab.tsx` | MODIFY (`:227`, `:278`) | Use helper for `quantityMt`. |
+| `scripts/demo-seed/build.ts` | MODIFY (`:722`, `:786`) | Use helper instead of `unwrapNum(cargo.weightMt)`. |
+| `scripts/demo-seed/real-matches.ts` | MODIFY (`:167`, `:184–188`, `:277`, `:405–416`, `:418–427`) | Helper at 3 read-sites + add `cargo_item_index`, `vessel_item_index` to INSERT columns + values. |
+| `lib/prompts/parse-cargo.ts` | MODIFY (`:457–466` and add new rule) | Add PIECE-AGGREGATE RULE: "When per-piece weights are given without an aggregate, sum them into `weight_mt`." |
+| `scripts/eval/reparse-cargo-corpus.ts` | **CREATE** | One-shot script: re-parse the 153-email corpus via claude-cli, write to a sibling JSON, run PARITY check vs. live `demo-parsed-cargoes.json`, fail loud on any populated→null regression. |
+| `scripts/eval/parity-check-parsed-cargoes.ts` | **CREATE** | Pure compare utility (no LLM); diff old vs. new JSON, report `populated_now_null`, `null_now_populated`, `value_changed`. |
+| `lib/__tests__/matching/cargo-weight-integration.test.ts` | **CREATE** | End-to-end behavioral test: parse cargo with range, hydrate session, run matcher → assert overload-pair hard-rejected; assert TCE non-zero. |
+| `lib/sailing/__tests__/overload-gate-792.test.ts` | **CREATE** | Behavioral test: corn 3000 mt cargo vs. 2570 DWT vessel → `checkCargoWeight.pass === false`. |
+| `scripts/demo-seed/apply-to-prod.md` | **CREATE** | Runbook for Rule-22 prod apply (dry → counts → backup → wal_checkpoint → restart → verify). |
+
+### Decomposition principles applied
+
+- **Files that change together stay together**: the helper is its own tiny file (no behavior beyond extraction), so a single change to its signature would touch one file. The 16 consumer sites are spread across `lib/matching`, `lib/sailing`, `components/`, `scripts/demo-seed/` — these are existing files, modify in place per task. Do not preemptively restructure.
+- **Existing patterns**: `lib/sailing/` already houses `match-filters.ts`, `match-scoring.ts`, `fit-breakdown.ts` — `cargo-weight.ts` fits naturally there. Tests mirror in `lib/sailing/__tests__/`.
+- **Why `weightMtMax` (worst-case) is the right representative for overload feasibility**: a range cargo `weightMtMin=4000, weightMtMax=4800` could load up to 4800 mt. If the vessel cannot carry 4800 mt, the match is infeasible (any actual stowing in `[4000, 4800]` may still exceed capacity). For utilisation scoring the worst-case is also the right default — `scoreUtilisation` already operates on `cargoWtMax`. (Documented in `match-filters.ts:132,170` comment "Use max bound for conservative capacity check (worst-case scenario)".)
+
+---
+
+## Task 1: Create `resolveCargoWeight()` helper + unit tests
+
+**Files:**
+- Create: `lib/sailing/cargo-weight.ts`
+- Create: `lib/sailing/__tests__/cargo-weight.test.ts`
+
+- [ ] **Step 1: Write the failing tests (5 input shapes)**
+
+```typescript
+// lib/sailing/__tests__/cargo-weight.test.ts
+import { resolveCargoWeight } from '../cargo-weight';
+import type { ParsedCargo } from '@/lib/types';
+
+const baseCargo = (overrides: Partial<ParsedCargo> = {}): ParsedCargo => ({
+  emailId: 'e1',
+  itemIndex: 0,
+  cargoDescription: { value: 'Test cargo', confidence: 'confirmed', sourceText: 'test' },
+  cargoType: 'BULK',
+  originPort: { value: 'X', confidence: 'confirmed', sourceText: 'X' },
+  destinationPort: { value: 'Y', confidence: 'confirmed', sourceText: 'Y' },
+  weightMt: null,
+  weightMtMin: null,
+  weightMtMax: null,
+  volumeCbm: null,
+  stowageFactor: null,
+  laycan: null,
+  ...overrides,
+} as ParsedCargo);
+
+describe('resolveCargoWeight', () => {
+  it('returns null when weightMt and weightMtMax are both null', () => {
+    expect(resolveCargoWeight(baseCargo())).toBeNull();
+  });
+
+  it('returns the ConfidenceField value when weightMt is wrapped', () => {
+    const c = baseCargo({ weightMt: { value: 3000, confidence: 'confirmed', sourceText: '3000mt' } });
+    expect(resolveCargoWeight(c)).toBe(3000);
+  });
+
+  it('returns weightMtMax for range cargoes (worst-case)', () => {
+    const c = baseCargo({ weightMt: null, weightMtMin: 4000, weightMtMax: 4800 });
+    expect(resolveCargoWeight(c)).toBe(4800);
+  });
+
+  it('prefers weightMtMax over weightMt when both present (MOLOO ranges)', () => {
+    const c = baseCargo({
+      weightMt: { value: 28000, confidence: 'interpreted', sourceText: '28k MOLOO' },
+      weightMtMin: 25200,
+      weightMtMax: 30800,
+    });
+    expect(resolveCargoWeight(c)).toBe(30800);
+  });
+
+  it('returns null safely when cargo is null/undefined', () => {
+    expect(resolveCargoWeight(null)).toBeNull();
+    expect(resolveCargoWeight(undefined)).toBeNull();
+  });
+
+  it('handles plain-number weightMt (post-reparse aggregate from piece-weights)', () => {
+    // After Task 4 re-parse, piece-summed aggregates land in weightMt as a ConfidenceField.
+    // This test guards against accidental plain-number wrapping.
+    const c = baseCargo({
+      weightMt: { value: 186, confidence: 'interpreted', sourceText: '10 × 15,000 kg + 4 × 9,000 kg' },
+    });
+    expect(resolveCargoWeight(c)).toBe(186);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /root/work/quantika-demo
+npx jest lib/sailing/__tests__/cargo-weight.test.ts --maxWorkers=1 --no-coverage
+```
+Expected: FAIL with `Cannot find module '../cargo-weight'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// lib/sailing/cargo-weight.ts
+import { cfValue } from '@/lib/confidence';
+import type { ParsedCargo } from '@/lib/types';
+
+/**
+ * Canonical cargo-weight extractor.
+ *
+ * Returns the worst-case weight (upper bound) for capacity / scoring decisions:
+ *   - `weightMtMax` (range upper) wins when present
+ *   - falls back to `cfValue(weightMt)` (single value)
+ *   - null when neither is populated
+ *
+ * Why worst-case: for a range cargo `[4000, 4800]`, any actual loading may
+ * reach the upper bound; using min would silently pass infeasible matches
+ * through the hard overload gate (#792).
+ */
+export function resolveCargoWeight(
+  cargo: ParsedCargo | null | undefined,
+): number | null {
+  if (!cargo) return null;
+  if (cargo.weightMtMax != null && Number.isFinite(cargo.weightMtMax) && cargo.weightMtMax > 0) {
+    return cargo.weightMtMax;
+  }
+  const v = cfValue(cargo.weightMt);
+  return v != null && Number.isFinite(v) && v > 0 ? v : null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx jest lib/sailing/__tests__/cargo-weight.test.ts --maxWorkers=1 --no-coverage
+```
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: TypeCheck**
+
+```bash
+npx tsc --noEmit 2>&1 | head -10
+```
+Expected: no output (clean).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sailing/cargo-weight.ts lib/sailing/__tests__/cargo-weight.test.ts
+git commit -m "feat(weight): add resolveCargoWeight() helper for range-cargo support (#791)"
+```
+
+---
+
+## Task 2: Apply `resolveCargoWeight()` at all consumer sites
+
+**Files:**
+- Modify: `lib/sailing/fit-breakdown.ts:499`
+- Modify: `lib/sailing/match-scoring.ts:299`
+- Modify: `lib/matching/pair-analyzer.ts:116–118, :769`
+- Modify: `lib/matching/compute-matches.ts:76`
+- Modify: `lib/matching/persist-session-matches.ts:36`
+- Modify: `lib/matching/session-buckets.ts:48`
+- Modify: `components/match/EconomicsTab.tsx:227, :278`
+- Modify: `scripts/demo-seed/build.ts:722, :786`
+- Modify: `scripts/demo-seed/real-matches.ts:167, :184–188, :277`
+
+**Boundary note (PI3 safeguard):** `lib/sailing/match-filters.ts` (`checkVolume:130`, `checkCargoWeight:167`) accepts `weightMt: Range<number> | number | null` at its function signature — it is the **gate input boundary**, not a consumer of `ParsedCargo`. The helper is NOT applied here; instead its callers (`pair-analyzer.ts:116–118`) pass `weightMt` correctly. Touching the gate signatures would balloon scope. Leave gates alone.
+
+- [ ] **Step 1: Write the failing integration test (drives the apply pass)**
+
+```typescript
+// lib/__tests__/matching/cargo-weight-integration.test.ts
+import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+
+describe('cargo-weight integration — range cargoes flow into fit/economics', () => {
+  const rangeCargo = {
+    emailId: 'e1', itemIndex: 0,
+    cargoDescription: { value: 'Salt', confidence: 'confirmed', sourceText: 'salt' },
+    cargoType: 'BULK',
+    originPort: { value: 'Marmara', confidence: 'confirmed', sourceText: 'M' },
+    destinationPort: { value: 'Constanța', confidence: 'confirmed', sourceText: 'C' },
+    weightMt: null,
+    weightMtMin: 4000,
+    weightMtMax: 4800,
+    volumeCbm: null,
+    stowageFactor: null,
+    laycan: null,
+  } as unknown as ParsedCargo;
+
+  const goodVessel = {
+    emailId: 'v1', itemIndex: 0,
+    name: 'TEST',
+    vesselType: 'BULKER',
+    dwtSummer: { value: 5500, confidence: 'confirmed', sourceText: 'dwt 5500' },
+    dwcc: { value: 5200, confidence: 'confirmed', sourceText: 'dwcc 5200' },
+    geared: true,
+    openPosition: { value: 'Istanbul', confidence: 'confirmed', sourceText: 'open ist' },
+    speedLaden: '12',
+    consumption: '20',
+  } as unknown as ParsedVessel;
+
+  it('utilisation factor is NOT "not stated" for a range cargo', () => {
+    const bd = computeFitBreakdown({
+      cargo: rangeCargo,
+      vessel: goodVessel,
+      readiness: { laycanFit: 'fit', distanceNm: 100, etaDate: null },
+      sanctions: null,
+      hardFilters: null,
+      refYear: 2026,
+    } as never);
+    const util = bd.factors.find((f) => f.id === 'utilisation');
+    expect(util?.note).not.toMatch(/not stated/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes — it likely already passes since `:499` is correct)**
+
+```bash
+npx jest lib/__tests__/matching/cargo-weight-integration.test.ts --maxWorkers=1 --no-coverage
+```
+Expected: PASS already (because `fit-breakdown.ts:499` has the correct inline pattern today). The test guards the apply pass below from regressing it.
+
+- [ ] **Step 3: Replace inline pattern at `fit-breakdown.ts:499`**
+
+Edit `lib/sailing/fit-breakdown.ts`:
+
+```typescript
+// BEFORE (line 499)
+const cargoWtMax = cargo.weightMtMax ?? cfValue(cargo.weightMt);
+
+// AFTER
+import { resolveCargoWeight } from './cargo-weight'; // top of file with other imports
+
+// then inside computeFitBreakdown:
+const cargoWtMax = resolveCargoWeight(cargo);
+```
+
+- [ ] **Step 4: Replace inline pattern at `match-scoring.ts:299`**
+
+Edit `lib/sailing/match-scoring.ts`:
+
+```typescript
+// add import at top
+import { resolveCargoWeight } from './cargo-weight';
+
+// BEFORE (line 299, inside applyOverloadGuard)
+const weightMax = cargo?.weightMtMax ?? (cargo ? cfValue(cargo.weightMt) : null);
+
+// AFTER
+const weightMax = resolveCargoWeight(cargo);
+```
+
+- [ ] **Step 5: Fix `pair-analyzer.ts:116–118` (hard-filter wiring) and `:769` (economics loop)**
+
+Edit `lib/matching/pair-analyzer.ts`:
+
+```typescript
+// add import at top
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+
+// At :116–118 — KEEP the range-detection branch (Range<number> is required by gate input),
+// only swap the else-branch fallback:
+weightMt: (c.weightMtMin !== null && c.weightMtMax !== null && c.weightMtMin !== c.weightMtMax)
+  ? { min: c.weightMtMin, max: c.weightMtMax }
+  : resolveCargoWeight(c),
+
+// At :769 — full swap:
+// BEFORE
+const ecoQty = cfValue(cargo.weightMt) ?? 0;
+// AFTER
+const ecoQty = resolveCargoWeight(cargo) ?? 0;
+```
+
+- [ ] **Step 6: Fix `compute-matches.ts:76`, `persist-session-matches.ts:36`, `session-buckets.ts:48` (uniform pattern)**
+
+Each has the identical shape `const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;`. Replace with:
+
+```typescript
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+
+const quantityMt = resolveCargoWeight(cargo) ?? 0;
+```
+
+Apply in all three files.
+
+- [ ] **Step 7: Fix `EconomicsTab.tsx:227, :278`**
+
+Edit `components/match/EconomicsTab.tsx`:
+
+```typescript
+// add import at top
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+
+// BEFORE (both lines)
+const quantityMt = cargo?.weightMt?.value ?? 0;
+// AFTER
+const quantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
+```
+
+- [ ] **Step 8: Fix `scripts/demo-seed/build.ts:722, :786`**
+
+Edit `scripts/demo-seed/build.ts`:
+
+```typescript
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+
+// BEFORE (both lines, approximately)
+const weight = unwrapNum(cargo.weightMt) ?? 0;
+// AFTER
+const weight = resolveCargoWeight(cargo) ?? 0;
+```
+
+Inspect `:722` and `:786` to confirm `unwrapNum` is the same as `cfValue` semantically; if it does extra coercion, retain it for non-weight cases and only swap the cargo.weightMt sites.
+
+- [ ] **Step 9: Fix `scripts/demo-seed/real-matches.ts:167, :184–188, :277` (3 read sites)**
+
+Edit `scripts/demo-seed/real-matches.ts`:
+
+```typescript
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+
+// At each of :167, :184–188, :277, swap cfValue(cargo.weightMt) ?? 0
+// → resolveCargoWeight(cargo) ?? 0
+```
+
+(The INSERT change is in Task 3 — keep this commit read-only.)
+
+- [ ] **Step 10: Run affected tests**
+
+```bash
+npx jest --findRelatedTests \
+  lib/sailing/fit-breakdown.ts \
+  lib/sailing/match-scoring.ts \
+  lib/matching/pair-analyzer.ts \
+  lib/matching/compute-matches.ts \
+  lib/matching/persist-session-matches.ts \
+  lib/matching/session-buckets.ts \
+  components/match/EconomicsTab.tsx \
+  --maxWorkers=1 --no-coverage 2>&1 | tail -15
+```
+Expected: all green.
+
+- [ ] **Step 11: TypeCheck**
+
+```bash
+npx tsc --noEmit 2>&1 | head -10
+```
+Expected: no output.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add lib/sailing/fit-breakdown.ts lib/sailing/match-scoring.ts \
+  lib/matching/pair-analyzer.ts lib/matching/compute-matches.ts \
+  lib/matching/persist-session-matches.ts lib/matching/session-buckets.ts \
+  components/match/EconomicsTab.tsx scripts/demo-seed/build.ts \
+  scripts/demo-seed/real-matches.ts \
+  lib/__tests__/matching/cargo-weight-integration.test.ts
+git commit -m "fix(weight): use resolveCargoWeight at all 12 consumer sites (#791)"
+```
+
+---
+
+## Task 3: Fix `real-matches.ts` INSERT to persist `cargo_item_index` / `vessel_item_index`
+
+**Files:**
+- Modify: `scripts/demo-seed/real-matches.ts:405–427` (INSERT statement + INSERT.run() bindings)
+
+**Why no migration:** migration `044-matches-item-index.ts:24` already added the column (`ALTER TABLE matches ADD COLUMN cargo_item_index INTEGER NOT NULL DEFAULT 0`). The repository (`matches-repository.ts:115`) gates writes on `hasItemIndexColumns(db)`. The bug is purely that `real-matches.ts` (older seed path) constructs its INSERT manually without those columns. Existing rows already have `cargo_item_index = 0` (default), so parity is preserved — only new seeds (and re-seeds) will populate non-zero indexes for multi-item emails.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// scripts/demo-seed/__tests__/real-matches-item-index.test.ts
+import Database from 'better-sqlite3';
+import { runRealMatchesSeed } from '../real-matches'; // export this if not already
+// ... or directly invoke the INSERT path on a temp DB
+
+describe('real-matches seed — writes cargo_item_index', () => {
+  it('persists cargo_item_index and vessel_item_index for multi-item emails', async () => {
+    const db = new Database(':memory:');
+    // Set up schema (mirror migrations 001…044 minimal): create matches table with item-index cols.
+    db.exec(`
+      CREATE TABLE matches (
+        cargo_id TEXT, vessel_id TEXT,
+        cargo_item_index INTEGER NOT NULL DEFAULT 0,
+        vessel_item_index INTEGER NOT NULL DEFAULT 0,
+        score INTEGER, reason TEXT, status TEXT, user_id TEXT,
+        created_at INTEGER, updated_at INTEGER,
+        cargo_type TEXT, load_port TEXT, discharge_port TEXT,
+        laycan_start INTEGER, laycan_end INTEGER, vessel_dwt INTEGER,
+        tce_usd_per_day REAL, distance_nm REAL,
+        freight_rate_usd_per_mt REAL, freight_rate_source TEXT,
+        fit_percent REAL, fit_breakdown TEXT, worksheet_json TEXT,
+        reason_structured TEXT
+      );
+    `);
+
+    // Inject fixture: 1 cargo email with 2 items, 1 vessel.
+    // Run seed.
+    // SELECT cargo_item_index FROM matches WHERE cargo_id = '<the multi-item email>';
+    // Expect: at least one row with cargo_item_index != 0.
+
+    // [Implementation detail — adapt to current seed API surface; the assertion shape is the contract.]
+    expect(true).toBe(true); // replace once you wire the seed-in-memory pattern.
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (or stub-passes; the contract is what matters)**
+
+```bash
+npx jest scripts/demo-seed/__tests__/real-matches-item-index.test.ts --maxWorkers=1 --no-coverage
+```
+
+- [ ] **Step 3: Modify the INSERT in `real-matches.ts:405–416`**
+
+```typescript
+// BEFORE (:405)
+const insert = db.prepare(`
+  INSERT INTO matches
+    (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+     cargo_type, load_port, discharge_port, laycan_start, laycan_end, vessel_dwt,
+     tce_usd_per_day, distance_nm, freight_rate_usd_per_mt, freight_rate_source,
+     fit_percent, fit_breakdown, worksheet_json, reason_structured)
+  VALUES
+    (?, ?, ?, ?, 'shortlist', ?, ?, ?,
+     ?, ?, ?, ?, ?, ?,
+     ?, ?, ?, ?,
+     ?, ?, ?, ?)
+`);
+
+// AFTER — add cargo_item_index, vessel_item_index columns + bindings.
+// Mirror regenerate-matches.ts:222 column ordering.
+const hasIdxCol = (db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>)
+  .some((c) => c.name === 'cargo_item_index');
+
+const insert = db.prepare(`
+  INSERT INTO matches
+    (cargo_id, vessel_id${hasIdxCol ? ', cargo_item_index, vessel_item_index' : ''},
+     score, reason, status, user_id, created_at, updated_at,
+     cargo_type, load_port, discharge_port, laycan_start, laycan_end, vessel_dwt,
+     tce_usd_per_day, distance_nm, freight_rate_usd_per_mt, freight_rate_source,
+     fit_percent, fit_breakdown, worksheet_json, reason_structured)
+  VALUES
+    (?, ?${hasIdxCol ? ', ?, ?' : ''}, ?, ?, 'shortlist', ?, ?, ?,
+     ?, ?, ?, ?, ?, ?,
+     ?, ?, ?, ?,
+     ?, ?, ?, ?)
+`);
+```
+
+- [ ] **Step 4: Extend `SeedRow` shape + INSERT.run() bindings**
+
+```typescript
+// in the SeedRow type declaration earlier in real-matches.ts, add:
+type SeedRow = {
+  // ... existing fields
+  cargoItemIndex: number;
+  vesselItemIndex: number;
+};
+
+// when building rows (search for the place SeedRow is constructed from Match objects),
+// populate from the Match:
+//   cargoItemIndex: m.cargoItemIndex ?? 0,
+//   vesselItemIndex: m.vesselItemIndex ?? 0,
+
+// In the insertMany transaction (:418–427), update the run() call:
+insert.run(
+  r.cargoId, r.vesselId,
+  ...(hasIdxCol ? [r.cargoItemIndex, r.vesselItemIndex] : []),
+  r.score, r.reason, userId, nowMs, nowMs,
+  r.cargoType, r.loadPort, r.dischargePort, r.laycanStart, r.laycanEnd, r.vesselDwt,
+  r.tceUsdPerDay, r.distanceNm, r.freightRateUsdPerMt, r.freightRateSource,
+  r.fitPercent, r.fitBreakdown, r.worksheetJson, r.reasonStructured,
+);
+```
+
+- [ ] **Step 5: Run test to verify it passes + TypeCheck**
+
+```bash
+npx jest scripts/demo-seed/__tests__/real-matches-item-index.test.ts --maxWorkers=1 --no-coverage
+npx tsc --noEmit 2>&1 | head -10
+```
+Expected: PASS + clean tsc.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/demo-seed/real-matches.ts \
+  scripts/demo-seed/__tests__/real-matches-item-index.test.ts
+git commit -m "fix(seed): persist cargo_item_index in real-matches INSERT (#791 cause B)"
+```
+
+---
+
+## Task 4: Tighten parser prompt to sum piece-weights into aggregate `weight_mt`
+
+**Files:**
+- Modify: `lib/prompts/parse-cargo.ts` (add new rule between current rules 9 and 10)
+
+**Risk surface:** prompt-only change. No code logic touched. Verified against fixture: only 1 cargo of 111 has piece-weights with computable total (`19d5de87705baf9b/0` = 186 MT). The remaining 30 range-cargoes (`weightMtMin`/`weightMtMax` populated) are unaffected — the rule fires only when both are null AND piece-weights are present.
+
+- [ ] **Step 1: Edit `lib/prompts/parse-cargo.ts` — insert PIECE-AGGREGATE RULE in CARGO DESCRIPTION RULES**
+
+Add immediately after rule 9 (currently line ~167):
+
+```
+9a. PIECE-AGGREGATE RULE — for PROJECT or BREAK_BULK cargo, when the email gives
+    per-piece weights with explicit counts but NO aggregate cargo tonnage:
+    - Compute weight_mt = Σ (piece_count_i × piece_weight_i_in_metric_tons).
+    - Convert kg to metric tons (÷1000) before summing.
+    - Return weight_mt as a ConfidenceField with confidence='interpreted' and
+      source_text quoting the contiguous fragment of the email listing the
+      piece weights (e.g. "10 × 15,000 kg + 4 × 9,000 kg").
+    - Set weight_mt_min = weight_mt_max = computed_total (single derived value).
+    - ALSO keep a missing_info note explaining the derivation:
+      "Aggregate cargo weight derived from per-piece weights: 10 × 15,000 kg
+       + 4 × 9,000 kg = 186 MT (sender did not state aggregate)."
+    Example:
+      Email body: "10x 15,000 kg storage tanks + 4x 9,000 kg additional units"
+      → weight_mt: { value: 186, confidence: "interpreted",
+                     source_text: "10x 15,000 kg storage tanks + 4x 9,000 kg additional units" }
+      → weight_mt_min: 186, weight_mt_max: 186
+      → missing_info: ["Aggregate cargo weight derived from per-piece weights:
+                       10 × 15,000 kg + 4 × 9,000 kg = 186 MT (sender did not state aggregate)."]
+    DO NOT apply this rule when:
+      - piece weights or counts are themselves ambiguous (use 'uncertain' or null);
+      - only one of count or per-piece weight is given;
+      - the cargo is BULK (per-piece weight doesn't apply).
+```
+
+- [ ] **Step 2: Add a prompt-eval test (snapshot the prompt change does not regress unrelated rules)**
+
+```typescript
+// lib/prompts/__tests__/parse-cargo-prompt.test.ts (add or extend if exists)
+import { CARGO_INQUIRY_PARSER_PROMPT } from '../parse-cargo';
+
+describe('CARGO_INQUIRY_PARSER_PROMPT contains piece-aggregate rule (#791 cause C)', () => {
+  it('includes PIECE-AGGREGATE RULE for project cargo', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/PIECE-AGGREGATE RULE/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/15,000 kg/); // canonical example
+  });
+
+  it('preserves the existing range rule', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/RANGE RULE/);
+  });
+
+  it('preserves the MOLOO rule', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/MOLOO RULE/);
+  });
+});
+```
+
+- [ ] **Step 3: Run prompt test + TypeCheck**
+
+```bash
+npx jest lib/prompts/__tests__/parse-cargo-prompt.test.ts --maxWorkers=1 --no-coverage
+npx tsc --noEmit 2>&1 | head -10
+```
+Expected: PASS + clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/prompts/parse-cargo.ts lib/prompts/__tests__/parse-cargo-prompt.test.ts
+git commit -m "feat(parse): sum per-piece weights into aggregate weight_mt (#791 cause C)"
+```
+
+---
+
+## Task 5: Re-parse corpus on dev-VPS via claude-cli + PARITY validation
+
+**Files:**
+- Create: `scripts/eval/reparse-cargo-corpus.ts`
+- Create: `scripts/eval/parity-check-parsed-cargoes.ts`
+
+**Constraints:**
+- `claude-cli` provider is FORBIDDEN in Next.js request handlers (`.claude/rules/ai-provider.md`) — these scripts must NOT be imported by `app/`. They live under `scripts/eval/` and are executed via `tsx`/`node`.
+- Re-parse on dev-VPS only (corpus is hash-identical to mac copy). Do not run locally.
+- AI_PROVIDER=claude-cli (per dispatch). Sets cargo parser scope env if needed (`PARSE_CARGO_PROVIDER`).
+
+- [ ] **Step 1: Write parity-check utility**
+
+```typescript
+// scripts/eval/parity-check-parsed-cargoes.ts
+import { readFileSync, writeFileSync } from 'node:fs';
+
+type ParsedCargo = Record<string, unknown> & {
+  emailId: string;
+  itemIndex: number;
+};
+
+type ParityReport = {
+  total: number;
+  populated_now_null: Array<{ emailId: string; itemIndex: number; field: string; old: unknown }>;
+  null_now_populated: Array<{ emailId: string; itemIndex: number; field: string; new: unknown }>;
+  value_changed: Array<{ emailId: string; itemIndex: number; field: string; old: unknown; new: unknown }>;
+};
+
+function keyOf(c: ParsedCargo) { return `${c.emailId}::${c.itemIndex}`; }
+
+export function diffParsed(oldPath: string, newPath: string): ParityReport {
+  const oldArr = JSON.parse(readFileSync(oldPath, 'utf8')) as ParsedCargo[];
+  const newArr = JSON.parse(readFileSync(newPath, 'utf8')) as ParsedCargo[];
+  const oldMap = new Map(oldArr.map((c) => [keyOf(c), c]));
+  const report: ParityReport = {
+    total: oldArr.length,
+    populated_now_null: [], null_now_populated: [], value_changed: [],
+  };
+  for (const n of newArr) {
+    const k = keyOf(n);
+    const o = oldMap.get(k);
+    if (!o) continue; // new cargoes not part of parity scope
+    for (const field of Object.keys(o)) {
+      if (field === 'emailId' || field === 'itemIndex') continue;
+      const oVal = JSON.stringify((o as any)[field]);
+      const nVal = JSON.stringify((n as any)[field]);
+      if (oVal === nVal) continue;
+      const oIsNull = (o as any)[field] == null;
+      const nIsNull = (n as any)[field] == null;
+      if (!oIsNull && nIsNull) {
+        report.populated_now_null.push({ emailId: o.emailId, itemIndex: o.itemIndex, field, old: (o as any)[field] });
+      } else if (oIsNull && !nIsNull) {
+        report.null_now_populated.push({ emailId: o.emailId, itemIndex: o.itemIndex, field, new: (n as any)[field] });
+      } else {
+        report.value_changed.push({ emailId: o.emailId, itemIndex: o.itemIndex, field, old: (o as any)[field], new: (n as any)[field] });
+      }
+    }
+  }
+  return report;
+}
+
+if (require.main === module) {
+  const [oldPath, newPath, outPath] = process.argv.slice(2);
+  if (!oldPath || !newPath) {
+    console.error('Usage: tsx parity-check-parsed-cargoes.ts <old.json> <new.json> [out.json]');
+    process.exit(2);
+  }
+  const r = diffParsed(oldPath, newPath);
+  const summary = {
+    total: r.total,
+    populated_now_null_count: r.populated_now_null.length,
+    null_now_populated_count: r.null_now_populated.length,
+    value_changed_count: r.value_changed.length,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (outPath) writeFileSync(outPath, JSON.stringify(r, null, 2));
+  // Exit non-zero ONLY for regressions (populated→null on non-weight fields).
+  const regressions = r.populated_now_null.filter((d) => !d.field.startsWith('weightMt'));
+  if (regressions.length > 0) {
+    console.error(`PARITY FAIL — ${regressions.length} populated→null regressions on non-weight fields`);
+    process.exit(1);
+  }
+}
+```
+
+- [ ] **Step 2: Write the re-parse runner**
+
+```typescript
+// scripts/eval/reparse-cargo-corpus.ts
+//
+// Re-parse the demo corpus through claude-cli (Opus) with the updated prompt
+// (Task 4). Outputs a sibling JSON next to demo-parsed-cargoes.json. Does NOT
+// overwrite. Use scripts/eval/parity-check-parsed-cargoes.ts to validate.
+//
+// USAGE (dev-VPS only):
+//   AI_PROVIDER=claude-cli PARSE_CARGO_PROVIDER=claude-cli \
+//     tsx scripts/eval/reparse-cargo-corpus.ts \
+//       --corpus /root/orchestrator-state/quantika-demo/email-corpus.jsonl \
+//       --out /tmp/demo-parsed-cargoes.reparsed.json
+//
+// NOTES:
+// - claude-cli must be on PATH. Re-parse is ~153 emails, ETA ≈ 25–40 min.
+// - Per .claude/rules/ai-provider.md: claude-cli is allowed in scripts, NOT in
+//   Next.js request handlers. This script never imports from app/.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseCargoAi } from '@/lib/parsing/parse-cargo-ai'; // existing parser fn
+
+type EmailRow = { id: string; subject: string; from: string; body: string; date: string };
+
+async function main() {
+  const corpusPath = arg('--corpus');
+  const outPath = arg('--out');
+  if (!corpusPath || !outPath) {
+    console.error('Usage: tsx reparse-cargo-corpus.ts --corpus <jsonl> --out <json>');
+    process.exit(2);
+  }
+  const lines = readFileSync(corpusPath, 'utf8').trim().split('\n');
+  const out: unknown[] = [];
+  for (const [i, line] of lines.entries()) {
+    const email = JSON.parse(line) as EmailRow;
+    process.stdout.write(`[${i + 1}/${lines.length}] ${email.id}… `);
+    try {
+      const result = await parseCargoAi({
+        emailId: email.id, subject: email.subject, from: email.from,
+        body: email.body, date: email.date,
+        provider: 'claude-cli' as never, // override via env preferred
+        timeoutMs: 120_000,
+      } as never);
+      if (Array.isArray(result?.items)) {
+        for (let idx = 0; idx < result.items.length; idx++) {
+          out.push({ ...result.items[idx], emailId: email.id, itemIndex: idx });
+        }
+      }
+      process.stdout.write('ok\n');
+    } catch (e) {
+      process.stdout.write(`FAIL ${(e as Error).message}\n`);
+    }
+  }
+  writeFileSync(outPath, JSON.stringify(out, null, 2));
+  console.log(`\nWrote ${out.length} cargo items → ${outPath}`);
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 3: Add a unit test for the parity utility (deterministic, no LLM)**
+
+```typescript
+// scripts/eval/__tests__/parity-check.test.ts
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { diffParsed } from '../parity-check-parsed-cargoes';
+
+describe('parity-check', () => {
+  it('detects populated→null regression', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parity-'));
+    const oldP = join(dir, 'old.json');
+    const newP = join(dir, 'new.json');
+    writeFileSync(oldP, JSON.stringify([{ emailId: 'a', itemIndex: 0, originPort: { value: 'X' } }]));
+    writeFileSync(newP, JSON.stringify([{ emailId: 'a', itemIndex: 0, originPort: null }]));
+    const r = diffParsed(oldP, newP);
+    expect(r.populated_now_null).toHaveLength(1);
+    expect(r.populated_now_null[0].field).toBe('originPort');
+  });
+
+  it('records weight null→populated as a win, not a regression', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parity-'));
+    const oldP = join(dir, 'old.json');
+    const newP = join(dir, 'new.json');
+    writeFileSync(oldP, JSON.stringify([{ emailId: 'a', itemIndex: 0, weightMt: null }]));
+    writeFileSync(newP, JSON.stringify([{ emailId: 'a', itemIndex: 0, weightMt: { value: 186, confidence: 'interpreted' } }]));
+    const r = diffParsed(oldP, newP);
+    expect(r.null_now_populated).toHaveLength(1);
+    expect(r.populated_now_null).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 4: Run the parity utility test**
+
+```bash
+npx jest scripts/eval/__tests__/parity-check.test.ts --maxWorkers=1 --no-coverage
+```
+Expected: PASS.
+
+- [ ] **Step 5: EXEC on dev-VPS — re-parse + parity (operator action, NOT executed by an automated PR)**
+
+```bash
+# On dev-VPS, root@dev-vps:
+cd /root/work/quantika-demo
+git checkout <this-branch>
+AI_PROVIDER=claude-cli PARSE_CARGO_PROVIDER=claude-cli \
+  npx tsx scripts/eval/reparse-cargo-corpus.ts \
+  --corpus /root/orchestrator-state/quantika-demo/email-corpus.jsonl \
+  --out /tmp/demo-parsed-cargoes.reparsed.json
+
+# Parity check:
+npx tsx scripts/eval/parity-check-parsed-cargoes.ts \
+  lib/sample-data/demo-parsed-cargoes.json \
+  /tmp/demo-parsed-cargoes.reparsed.json \
+  /tmp/parity-report.json
+
+# Inspect report:
+jq '{populated_now_null_count, null_now_populated_count, value_changed_count}' /tmp/parity-report.json
+# Manual review the populated_now_null list — must be EMPTY (excluding weightMt fields).
+# null_now_populated should include at least 19d5de87705baf9b/0 → weightMt {value: 186}.
+```
+
+**Halt criteria** (DO NOT promote the new file unless ALL true):
+- `populated_now_null` on non-weight fields = 0
+- `null_now_populated` includes `19d5de87705baf9b/0` with `weightMt.value ≈ 186`
+- `value_changed` reviewed by hand for the 31 range-cargoes; their `weightMt`/`weightMtMin`/`weightMtMax` triple may change but the upper bound must be within ±5% (rounding tolerance)
+
+- [ ] **Step 6: Promote re-parsed JSON into the repo fixture**
+
+```bash
+# Only after Step 5 halt criteria all pass:
+cp /tmp/demo-parsed-cargoes.reparsed.json lib/sample-data/demo-parsed-cargoes.json
+git add lib/sample-data/demo-parsed-cargoes.json
+git commit -m "data: re-parse demo corpus to sum piece-weights into aggregate (#791 cause C)"
+```
+
+- [ ] **Step 7: Commit the eval scripts**
+
+```bash
+git add scripts/eval/reparse-cargo-corpus.ts \
+  scripts/eval/parity-check-parsed-cargoes.ts \
+  scripts/eval/__tests__/parity-check.test.ts
+git commit -m "tools(eval): reparse corpus + parity-check utilities (#791 cause C)"
+```
+
+---
+
+## Task 6: Regenerate matches + add overload-gate behavioral test
+
+**Files:**
+- Create: `lib/sailing/__tests__/overload-gate-792.test.ts`
+- Run (locally): `npx tsx scripts/demo-seed/regenerate-matches.ts` — writes to repo `demo-seed.db` for dev verify.
+
+- [ ] **Step 1: Write the overload-gate behavioral test (closes #792 directly)**
+
+```typescript
+// lib/sailing/__tests__/overload-gate-792.test.ts
+import { checkCargoWeight } from '../match-filters';
+
+describe('checkCargoWeight — #792 overload gate', () => {
+  it('hard-rejects corn 3000mt vs vessel DWT 2570', () => {
+    const r = checkCargoWeight({ weightMt: 3000, dwtSummer: 2570, dwcc: null });
+    expect(r.pass).toBe(false);
+    expect(r.reason).toMatch(/exceeds vessel capacity/i);
+  });
+
+  it('hard-rejects range-cargo at upper bound vs vessel DWT', () => {
+    // worst-case upper: 4800 > 4000 × 0.90 × 1.05 = 3780 → fail
+    const r = checkCargoWeight({ weightMt: { min: 4000, max: 4800 }, dwtSummer: 4000, dwcc: null });
+    expect(r.pass).toBe(false);
+  });
+
+  it('passes a 3000mt cargo on a 4000 DWCC vessel (within tolerance)', () => {
+    // 3000 < 4000 × 1.05 = 4200 → pass
+    const r = checkCargoWeight({ weightMt: 3000, dwtSummer: null, dwcc: 4000 });
+    expect(r.pass).toBe(true);
+  });
+
+  it('preserves graceful-pass on null weight (existing invariant)', () => {
+    const r = checkCargoWeight({ weightMt: null, dwtSummer: 2570, dwcc: null });
+    expect(r.pass).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test (should already pass — gate code is correct, weight wiring is what Tasks 1–5 fix)**
+
+```bash
+npx jest lib/sailing/__tests__/overload-gate-792.test.ts --maxWorkers=1 --no-coverage
+```
+Expected: PASS.
+
+- [ ] **Step 3: Locally regenerate matches against the dev demo-seed.db (sanity check only — DO NOT touch prod yet)**
+
+```bash
+# Local worktree:
+npx tsx scripts/demo-seed/regenerate-matches.ts
+# Inspect counts:
+sqlite3 demo-seed.db "
+  SELECT COUNT(*) total,
+         SUM(CASE WHEN cargo_item_index > 0 THEN 1 ELSE 0 END) with_nonzero_cargo_idx,
+         SUM(CASE WHEN tce_usd_per_day != 0 THEN 1 ELSE 0 END) with_tce
+  FROM matches WHERE user_id IS NULL;
+"
+# Expected (rough): with_nonzero_cargo_idx > 0; with_tce > previous baseline.
+
+# Check the previously-broken pair specifically:
+sqlite3 demo-seed.db "
+  SELECT cargo_id, cargo_item_index, vessel_id, fit_percent, tce_usd_per_day, status
+  FROM matches
+  WHERE cargo_id LIKE '19d5de87705baf9b%' OR cargo_id LIKE '19e07d011dbc661e%'
+  ORDER BY cargo_id, cargo_item_index;
+"
+```
+
+- [ ] **Step 4: Commit the test (regen DB is NOT committed; demo-seed.db should be gitignored)**
+
+```bash
+git add lib/sailing/__tests__/overload-gate-792.test.ts
+git commit -m "test(overload): hard-reject corn vs SEAGULL 2 once weight wired (#792)"
+```
+
+---
+
+## Task 7: Prod-apply runbook (Rule-22 — operator-driven, NOT auto-executed)
+
+**Files:**
+- Create: `scripts/demo-seed/apply-to-prod.md`
+
+**This task delivers a RUNBOOK, not code execution.** The orchestrator/founder signs the `--dry` step separately. The PR ships the runbook + the supporting `--dry` flag in `regenerate-matches.ts` (if not already present).
+
+- [ ] **Step 1: Verify `regenerate-matches.ts` supports `--dry`**
+
+```bash
+grep -n "'--dry'\|process.argv" scripts/demo-seed/regenerate-matches.ts | head
+```
+If `--dry` is NOT supported: add a minimal flag that prints planned inserts/deletes without committing the transaction. (Trivial wrapper around the existing `db.transaction(...)`; skip the `.run()`.)
+
+- [ ] **Step 2: Write the runbook**
+
+```markdown
+# Prod-apply demo-seed.db — #791 weight fix
+
+> **DO NOT execute autonomously. Founder signs each step.**
+
+## Pre-flight (on dev-VPS)
+
+1. `git pull && git checkout <merged-main-after-PR>`
+2. `npm ci && npm run build`
+3. Re-parsed fixture must be in repo (Task 5 Step 6 committed).
+
+## Step A — Dry-run regenerate
+
+```bash
+cd /root/work/quantika-demo
+npx tsx scripts/demo-seed/regenerate-matches.ts --dry > /tmp/regen-dry.log 2>&1
+wc -l /tmp/regen-dry.log
+grep -c '^DELETE\|^INSERT' /tmp/regen-dry.log
+```
+Inspect: planned DELETE and INSERT counts. **Founder approval required to proceed.**
+
+## Step B — Backup prod demo-seed.db
+
+```bash
+DB=/root/work/quantika-demo/demo-seed.db
+cp -a "$DB" "$DB.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+ls -la "$DB"*
+```
+
+## Step C — wal_checkpoint (truncate any pending WAL before swap)
+
+```bash
+sqlite3 "$DB" 'PRAGMA wal_checkpoint(TRUNCATE);'
+```
+
+## Step D — Execute regen (live)
+
+```bash
+npx tsx scripts/demo-seed/regenerate-matches.ts > /tmp/regen-live.log 2>&1
+tail -30 /tmp/regen-live.log
+```
+
+## Step E — Verify in DB
+
+```bash
+sqlite3 "$DB" "
+  -- Counts: did we get the previously-broken pairs?
+  SELECT cargo_id, cargo_item_index, fit_percent, tce_usd_per_day, status, reason
+    FROM matches
+    WHERE cargo_id LIKE '19d5de87705baf9b%' OR cargo_id LIKE '19e07d011dbc661e%'
+    ORDER BY cargo_id, cargo_item_index, score DESC LIMIT 30;
+  -- Was SEAGULL 2 / corn pair removed by the gate?
+  SELECT m.cargo_id, m.cargo_item_index, m.vessel_id, m.status, m.reason
+    FROM matches m
+    WHERE m.cargo_id LIKE '19e07d011dbc661e%' AND m.cargo_item_index = 0
+      AND m.vessel_id LIKE '%SEAGULL%';
+  -- General health:
+  SELECT status, COUNT(*) FROM matches GROUP BY status;
+"
+```
+
+## Step F — Restart Next.js (env-bake refresh — see CLAUDE.md)
+
+```bash
+pm2 restart quantika-demo --update-env
+pm2 logs quantika-demo --lines 50 --nostream
+```
+
+## Step G — Visual verify (browser)
+
+- Navigate to `/match/<the previously-broken match id>`
+- Confirm Source Attribution shows correct cargo line
+- Confirm Economics tab shows non-zero TCE
+- Confirm previously-marked "Possible / Overload" pair is gone from shortlist
+- Confirm fit% no longer shows "weight not stated" for the 31 range-cargoes
+
+## Rollback (if any Step E/F/G fails)
+
+```bash
+pm2 stop quantika-demo
+cp -a "$DB.bak.<timestamp>" "$DB"
+pm2 start quantika-demo --update-env
+```
+```
+
+- [ ] **Step 3: Commit runbook**
+
+```bash
+git add scripts/demo-seed/apply-to-prod.md
+git commit -m "docs(seed): runbook for prod demo-seed.db apply (#791 D)"
+```
+
+---
+
+## Sequencing & PR Strategy (F)
+
+**Branch:** `plan-791-weight` (this worktree).
+
+**Single PR, ordered commits:**
+1. Task 1 — helper + tests (foundation).
+2. Task 2 — apply helper at 12 sites (no behavior change for non-range cargoes).
+3. Task 3 — `real-matches.ts` INSERT writes item indexes (no behavior change for existing rows; only affects re-seed).
+4. Task 4 — parser prompt rule (prompt-only).
+5. Task 6 Step 1 — overload-gate behavioral test (passes today; locks the gate semantics).
+6. Task 7 Step 1+2 — runbook + `--dry` flag.
+
+**Out-of-PR operator steps** (must run on dev-VPS, signed by founder):
+- Task 5 Steps 5–7 — re-parse corpus + parity check + commit refreshed fixture. (Lands as a follow-up commit on the same branch BEFORE PR merge; only commit if parity halt-criteria pass.)
+- Task 7 Steps A–G — prod-apply to demo-seed.db AFTER PR merges to main.
+
+**Rationale:** Tasks 1–4 + 6 + 7-doc are pure code/test changes — safe to ship as a normal PR. Task 5 (re-parse) requires claude-cli on dev-VPS and human review of the parity report — it MUST be operator-driven. Task 7 (prod apply) requires the runbook + founder approval at each step; ship the runbook in the PR, execute the runbook after merge.
+
+**Expected PR fingerprint:**
+- ~13 files touched
+- ~6 commits
+- All new tests behavioral (PI2-compliant: drive parser/seed/matcher functions, not string-grep)
+- Zero changes to existing test expectations (PI3-compliant)
+
+---
+
+## Self-review checklist (planner)
+
+- [x] Cause A — helper extraction + 12-site sweep enumerated with file:line refs.
+- [x] Cause B — `real-matches.ts` INSERT augmented; migration not needed (044 already added column).
+- [x] Cause C — prompt rule + re-parse runner + parity guard.
+- [x] D — prod-apply runbook with --dry / backup / wal_checkpoint / restart / verify / rollback.
+- [x] E — TDD specs enumerate 5 input shapes (null, plain number, ConfidenceField, range, piece-aggregate) + overload behavioral test.
+- [x] F — sequencing splits code-PR vs operator-exec.
+- [x] No placeholders, no "TBD", every code step shows actual code.
+- [x] Out-of-scope explicit: #665 laycan, polish bundle, scoring weights.
+- [x] PI3 enforcement: no existing test expectations rewritten.
+- [x] PI2 enforcement: behavioral tests, not string-greps.
+- [x] `.claude/rules/ai-provider.md` honored: claude-cli only in scripts.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-04-791-weight-economics.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh executor per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in one session using `superpowers:executing-plans`, batched with checkpoints.
+
+Operator must additionally run Task 5 Steps 5–7 (re-parse on dev-VPS) and Task 7 Steps A–G (prod apply) — these are NOT for autonomous execution.

--- a/lib/__tests__/matching/cargo-weight-integration.test.ts
+++ b/lib/__tests__/matching/cargo-weight-integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration test for #791 cause A — range cargo weight reaches fit-breakdown.
+ *
+ * Guards against regression on the apply-helper sweep (`resolveCargoWeight`):
+ * a range cargo (`weightMt=null, weightMtMin=4000, weightMtMax=4800`) MUST
+ * NOT produce "not stated" on the utilisation factor in computeFitBreakdown.
+ */
+import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import type {
+  MatchHardFilters,
+  MatchReadiness,
+  MatchSanctions,
+  ParsedCargo,
+  ParsedVessel,
+} from '@/lib/types';
+
+const SANCTIONS_OK: MatchSanctions = { risk: 'NONE', blocking: false };
+const HF_PASS: MatchHardFilters = {
+  draft: { pass: true },
+  crane: { pass: true },
+  volume: { pass: true },
+  cargoVessel: { pass: true },
+  destDraft: { pass: true },
+  destCrane: { pass: true },
+  cargoWeight: { pass: true },
+};
+
+const READY: MatchReadiness = {
+  openDate: '2026-09-13',
+  laycanStart: '2026-09-15',
+  laycanEnd: '2026-09-25',
+  distanceNm: 100,
+  distanceExact: true,
+  speedKn: 11,
+  sailingDays: 0.4,
+  arrivalDate: '2026-09-14',
+  gapDays: 1,
+  verdict: 'ideal',
+  explanation: 'ideal',
+};
+
+function makeRangeCargo(): ParsedCargo {
+  return {
+    emailId: 'e-range',
+    itemIndex: 0,
+    originPort: { value: 'Marmara', confidence: 'confirmed' },
+    originCountry: null,
+    destinationPort: { value: 'Constanța', confidence: 'confirmed' },
+    destinationCountry: null,
+    cargoDescription: { value: 'salt', confidence: 'confirmed' },
+    weightMt: null,
+    weightMtMin: 4000,
+    weightMtMax: 4800,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BULK',
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: { value: '15-25 Sep', confidence: 'confirmed' },
+    laycan: '15-25 Sep',
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+  };
+}
+
+function makeGoodVessel(): ParsedVessel {
+  return {
+    emailId: 'v1',
+    itemIndex: 0,
+    vesselName: { value: 'TEST', confidence: 'confirmed' },
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: { value: 5500, confidence: 'confirmed' },
+    dwcc: { value: 5200, confidence: 'confirmed' },
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: 7000,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: true,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: 'Handysize Bulker',
+    openPosition: { value: 'Istanbul', confidence: 'confirmed' },
+    openDate: { value: '13 Sep', confidence: 'confirmed' },
+    direction: null,
+    restrictions: [],
+    lastCargoes: 'salt',
+    speedLaden: '12',
+    speedBallast: null,
+    consumption: '20',
+    deckCapacity: null,
+    specialFeatures: [],
+  };
+}
+
+describe('cargo-weight integration — range cargoes flow into fit/economics (#791)', () => {
+  it('utilisation factor is NOT "not stated" for a range cargo with weightMt=null + weightMtMax=4800', () => {
+    const bd = computeFitBreakdown({
+      cargo: makeRangeCargo(),
+      vessel: makeGoodVessel(),
+      readiness: READY,
+      sanctions: SANCTIONS_OK,
+      hardFilters: HF_PASS,
+      refYear: 2026,
+    });
+
+    const util = bd.components.find((c) => c.factor === 'utilisation');
+    expect(util).toBeDefined();
+    expect(util?.rationale ?? '').not.toMatch(/not stated/i);
+  });
+
+  it('utilisation contributes >0 weighted points for a range cargo (worst-case 4800 mt on 5200 dwcc)', () => {
+    const bd = computeFitBreakdown({
+      cargo: makeRangeCargo(),
+      vessel: makeGoodVessel(),
+      readiness: READY,
+      sanctions: SANCTIONS_OK,
+      hardFilters: HF_PASS,
+      refYear: 2026,
+    });
+
+    const util = bd.components.find((c) => c.factor === 'utilisation');
+    expect(util?.score).toBeGreaterThan(0);
+  });
+});

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import type { ParsedCargo, ParsedVessel } from '@/lib/types';
 import { cfValue } from '@/lib/types';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { analyzePairs, type AiScorer, type RawMatch } from '@/lib/matching/pair-analyzer';
 import { createMatch, listMatches } from '@/lib/matching/matches-repository';
 import { callAiJson } from '@/lib/ai-provider';
@@ -73,7 +74,7 @@ export async function computeAndPersistMatches(
     const distanceResult = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
 
     const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? 0) : 0;
-    const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
+    const quantityMt = resolveCargoWeight(cargo) ?? 0;
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
     const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -13,6 +13,7 @@ import { computeMatchConfidence } from '@/lib/confidence';
 import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
 import { applyReadinessScoring, computeScoreBreakdown, deriveMatchLevel, applyBallastSizeCap } from '@/lib/sailing/match-scoring';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { runHardFilters } from '@/lib/sailing/match-filters';
 import { checkImsbcLoadability } from '@/lib/sailing/imsbc-check';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
@@ -115,7 +116,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     destinationPort: cfValue(c.destinationPort),
     weightMt: (c.weightMtMin !== null && c.weightMtMax !== null && c.weightMtMin !== c.weightMtMax)
       ? { min: c.weightMtMin, max: c.weightMtMax }
-      : cfValue(c.weightMt),
+      : resolveCargoWeight(c),
     cargoDescription: cfValue(c.cargoDescription),
     stowageFactor: c.stowageFactor,
     vesselType: v.vesselType,
@@ -766,7 +767,7 @@ export async function analyzePairs(
         : (cargo.cargoType as string | null);
 
     const ecoDwt = cfValue(vessel.dwtSummer) ?? 0;
-    const ecoQty = cfValue(cargo.weightMt) ?? 0;
+    const ecoQty = resolveCargoWeight(cargo) ?? 0;
     const ecoSpeed = parseLeadingNumber(vessel.speedLaden);
     const resolvedFreight = resolveFreightRate({
       cargoType,

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import { cfValue } from '@/lib/types';
 import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { createMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
@@ -33,7 +34,7 @@ export function persistSessionMatches(
           ? (cargo.cargoType as unknown as { value: string }).value
           : cargo.cargoType as string)
       : null;
-    const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
+    const quantityMt = resolveCargoWeight(cargo) ?? 0;
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
     const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -1,5 +1,6 @@
 import { cfValue } from '@/lib/types';
 import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import type { StoredMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
@@ -45,7 +46,7 @@ export function toBucketRows(
           ? (cargo.cargoType as unknown as { value: string }).value
           : cargo.cargoType as string)
       : null;
-    const quantityMt = cargo ? (cfValue(cargo.weightMt) ?? 0) : 0;
+    const quantityMt = resolveCargoWeight(cargo) ?? 0;
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
     const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 

--- a/lib/prompts/__tests__/parse-cargo-prompt.test.ts
+++ b/lib/prompts/__tests__/parse-cargo-prompt.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Snapshot guard for the parse-cargo prompt (#791 cause C).
+ *
+ * Prompt-text tests are intentionally narrow: they only protect the WIRING of
+ * structural rules into the prompt. They do not assert LLM behavior — that is
+ * covered by the corpus re-parse (scripts/eval/reparse-cargo-corpus.ts) under
+ * parity validation.
+ */
+import { CARGO_INQUIRY_PARSER_PROMPT } from '../parse-cargo';
+
+describe('CARGO_INQUIRY_PARSER_PROMPT contains piece-aggregate rule (#791 cause C)', () => {
+  it('includes PIECE-AGGREGATE RULE for project / break-bulk cargo', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/PIECE-AGGREGATE RULE/);
+  });
+
+  it('includes the canonical 15,000 kg + 9,000 kg derivation example', () => {
+    // The Marmara/Veracruz storage-tanks fixture (emailId 19d5de87705baf9b/0)
+    // sums to 186 MT — the example the LLM must mirror.
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/15,000 kg/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/9,000 kg/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/186 MT/);
+  });
+
+  it('specifies the kg → MT unit conversion (divide by 1000)', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/Convert kg to metric tons \(÷1000\)/);
+  });
+
+  it('writes confidence=interpreted for derived aggregates (not confirmed)', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/confidence='interpreted'/);
+  });
+
+  it('preserves the existing RANGE RULE', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/RANGE RULE/);
+  });
+
+  it('preserves the existing MOLOO RULE', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/MOLOO RULE/);
+  });
+
+  it('does NOT apply piece-aggregate to BULK cargo (guard against fabrication)', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/the cargo is BULK \(per-piece weight doesn't apply\)/);
+  });
+});

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -165,6 +165,28 @@ cargo_description MUST be human-readable English. Required contents:
 7. Normalize European decimal comma to period: "1,25" → "1.25"
 8. Do NOT copy-paste raw source text verbatim as cargo_description.
 9. For PROJECT cargo: dimensions and per-piece weights are MANDATORY.
+9a. PIECE-AGGREGATE RULE — for PROJECT or BREAK_BULK cargo, when the email gives
+    per-piece weights with explicit counts but NO aggregate cargo tonnage:
+    - Compute weight_mt = Σ (piece_count_i × piece_weight_i_in_metric_tons).
+    - Convert kg to metric tons (÷1000) before summing.
+    - Return weight_mt as a ConfidenceField with confidence='interpreted' and
+      source_text quoting the contiguous fragment of the email listing the
+      piece weights (e.g. "10 × 15,000 kg + 4 × 9,000 kg").
+    - Set weight_mt_min = weight_mt_max = computed_total (single derived value).
+    - ALSO append a missing_info note explaining the derivation:
+      "Aggregate cargo weight derived from per-piece weights: 10 × 15,000 kg
+       + 4 × 9,000 kg = 186 MT (sender did not state aggregate)."
+    Example:
+      Email body: "10x 15,000 kg storage tanks + 4x 9,000 kg additional units"
+      → weight_mt: { value: 186, confidence: "interpreted",
+                     source_text: "10x 15,000 kg storage tanks + 4x 9,000 kg additional units" }
+      → weight_mt_min: 186, weight_mt_max: 186
+      → missing_info: ["Aggregate cargo weight derived from per-piece weights:
+                       10 × 15,000 kg + 4 × 9,000 kg = 186 MT (sender did not state aggregate)."]
+    DO NOT apply this rule when:
+      - piece weights or counts are themselves ambiguous (use 'uncertain' or null);
+      - only one of count or per-piece weight is given;
+      - the cargo is BULK (per-piece weight doesn't apply).
 10. For BREAK_BULK: per-unit weight and packaging details are MANDATORY if given.
 10a. For BULK cargo: stowage factor is MANDATORY in cargo_description if stated in the email.
    ✗ Corn in bulk  (email says stw 51-52)

--- a/lib/sailing/__tests__/cargo-weight.test.ts
+++ b/lib/sailing/__tests__/cargo-weight.test.ts
@@ -1,0 +1,89 @@
+import { resolveCargoWeight } from '../cargo-weight';
+import type { ParsedCargo } from '@/lib/types';
+
+const baseCargo = (overrides: Partial<ParsedCargo> = {}): ParsedCargo =>
+  ({
+    emailId: 'e1',
+    itemIndex: 0,
+    originPort: { value: 'X', confidence: 'confirmed', sourceText: 'X' },
+    originCountry: null,
+    destinationPort: { value: 'Y', confidence: 'confirmed', sourceText: 'Y' },
+    destinationCountry: null,
+    cargoDescription: { value: 'Test cargo', confidence: 'confirmed', sourceText: 'test' },
+    weightMt: null,
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BULK',
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    ...overrides,
+  } as ParsedCargo);
+
+describe('resolveCargoWeight', () => {
+  it('returns null when weightMt and weightMtMax are both null', () => {
+    expect(resolveCargoWeight(baseCargo())).toBeNull();
+  });
+
+  it('returns the ConfidenceField value when weightMt is wrapped', () => {
+    const c = baseCargo({
+      weightMt: { value: 3000, confidence: 'confirmed', sourceText: '3000mt' },
+    });
+    expect(resolveCargoWeight(c)).toBe(3000);
+  });
+
+  it('returns weightMtMax for range cargoes (worst-case)', () => {
+    const c = baseCargo({ weightMt: null, weightMtMin: 4000, weightMtMax: 4800 });
+    expect(resolveCargoWeight(c)).toBe(4800);
+  });
+
+  it('prefers weightMtMax over weightMt when both present (MOLOO ranges)', () => {
+    const c = baseCargo({
+      weightMt: { value: 28000, confidence: 'interpreted', sourceText: '28k MOLOO' },
+      weightMtMin: 25200,
+      weightMtMax: 30800,
+    });
+    expect(resolveCargoWeight(c)).toBe(30800);
+  });
+
+  it('returns null safely when cargo is null/undefined', () => {
+    expect(resolveCargoWeight(null)).toBeNull();
+    expect(resolveCargoWeight(undefined)).toBeNull();
+  });
+
+  it('handles plain-number weightMt (post-reparse aggregate from piece-weights)', () => {
+    // After Task 4 re-parse, piece-summed aggregates land in weightMt as a ConfidenceField.
+    const c = baseCargo({
+      weightMt: {
+        value: 186,
+        confidence: 'interpreted',
+        sourceText: '10 × 15,000 kg + 4 × 9,000 kg',
+      },
+    });
+    expect(resolveCargoWeight(c)).toBe(186);
+  });
+
+  it('returns null when weightMtMax is non-finite (NaN guard)', () => {
+    const c = baseCargo({ weightMtMax: Number.NaN as unknown as number });
+    expect(resolveCargoWeight(c)).toBeNull();
+  });
+
+  it('returns null when both weightMt value and weightMtMax are zero/negative (no-quantity guard)', () => {
+    const c = baseCargo({
+      weightMt: { value: 0, confidence: 'confirmed' },
+      weightMtMax: 0,
+    });
+    expect(resolveCargoWeight(c)).toBeNull();
+  });
+});

--- a/lib/sailing/__tests__/overload-gate-792.test.ts
+++ b/lib/sailing/__tests__/overload-gate-792.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Behavioral tests for the cargo-weight hard-filter gate (#792).
+ *
+ * Closes the #792 symptom: SEAGULL 2 (DWT 2570) showed "Possible" for a
+ * 3000 mt corn cargo. Root cause was a chain in the weight-extraction path
+ * (#791) — once weight resolves at the gate boundary, this gate hard-rejects
+ * infeasible pairs.
+ */
+import { checkCargoWeight } from '../match-filters';
+
+describe('checkCargoWeight — #792 overload gate', () => {
+  it('hard-rejects 3000 mt corn vs DWT 2570 (no DWCC)', () => {
+    // capacity = 2570 × 0.90 = 2313; capacityWithMargin = 2313 × 1.05 = 2429
+    // 3000 > 2429 → fail
+    const r = checkCargoWeight({ weightMt: 3000, dwtSummer: 2570, dwcc: null });
+    expect(r.pass).toBe(false);
+    expect(r.reason ?? '').toMatch(/exceeds vessel capacity/i);
+  });
+
+  it('hard-rejects range cargo at upper bound vs DWT 4000', () => {
+    // capacity = 4000 × 0.90 = 3600; capacityWithMargin = 3780
+    // 4800 > 3780 → fail
+    const r = checkCargoWeight({
+      weightMt: { min: 4000, max: 4800 },
+      dwtSummer: 4000,
+      dwcc: null,
+    });
+    expect(r.pass).toBe(false);
+  });
+
+  it('passes a 3000 mt cargo on a 4000 DWCC vessel (within tolerance)', () => {
+    // capacity = 4000; capacityWithMargin = 4200; 3000 ≤ 4200 → pass
+    const r = checkCargoWeight({ weightMt: 3000, dwtSummer: null, dwcc: 4000 });
+    expect(r.pass).toBe(true);
+  });
+
+  it('graceful-passes when cargo weight is null (existing invariant for unknown weight)', () => {
+    const r = checkCargoWeight({ weightMt: null, dwtSummer: 2570, dwcc: null });
+    expect(r.pass).toBe(true);
+  });
+
+  it('graceful-passes when DWT and DWCC both null (vessel capacity unknown)', () => {
+    const r = checkCargoWeight({ weightMt: 3000, dwtSummer: null, dwcc: null });
+    expect(r.pass).toBe(true);
+  });
+
+  it('prefers DWCC over DWT when both are present', () => {
+    // DWCC 2800: capacityWithMargin = 2800 × 1.05 = 2940. 3000 > 2940 → fail.
+    // If it used DWT 5000 instead: capacity = 5000 × 0.90 × 1.05 = 4725 → would pass.
+    const r = checkCargoWeight({ weightMt: 3000, dwtSummer: 5000, dwcc: 2800 });
+    expect(r.pass).toBe(false);
+    expect(r.reason ?? '').toMatch(/DWCC/);
+  });
+
+  it('range cargo at lower bound passes when upper bound also passes', () => {
+    // {3000, 3200} vs DWCC 4000: 3200 ≤ 4200 → pass
+    const r = checkCargoWeight({
+      weightMt: { min: 3000, max: 3200 },
+      dwtSummer: null,
+      dwcc: 4000,
+    });
+    expect(r.pass).toBe(true);
+  });
+});

--- a/lib/sailing/cargo-weight.ts
+++ b/lib/sailing/cargo-weight.ts
@@ -1,0 +1,29 @@
+import { cfValue } from '@/lib/types';
+import type { ParsedCargo } from '@/lib/types';
+
+/**
+ * Canonical cargo-weight extractor.
+ *
+ * Returns the worst-case weight (upper bound) for capacity / scoring decisions:
+ *   - `weightMtMax` (range upper) wins when present
+ *   - falls back to `cfValue(weightMt)` (single value)
+ *   - null when neither is populated
+ *
+ * Worst-case rationale: for a range cargo `[4000, 4800]`, any actual loading
+ * may reach the upper bound; using min would silently pass infeasible matches
+ * through the hard overload gate (#792).
+ */
+export function resolveCargoWeight(
+  cargo: ParsedCargo | null | undefined,
+): number | null {
+  if (!cargo) return null;
+  if (
+    cargo.weightMtMax != null &&
+    Number.isFinite(cargo.weightMtMax) &&
+    cargo.weightMtMax > 0
+  ) {
+    return cargo.weightMtMax;
+  }
+  const v = cfValue(cargo.weightMt);
+  return v != null && Number.isFinite(v) && v > 0 ? v : null;
+}

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -31,6 +31,7 @@ import type {
   ParsedVessel,
 } from '@/lib/types';
 import { cfValue } from '@/lib/types';
+import { resolveCargoWeight } from './cargo-weight';
 import { computeVesselVetting } from './vessel-vetting';
 import { classifyVesselByDwt } from './readiness-gap';
 import { BALLAST_GOOD_MAX_NM, isPartCargo } from './match-scoring';
@@ -496,7 +497,7 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
   const desc = cfValue(cargo.cargoDescription);
   const partCargo = isPartCargo(desc);
 
-  const cargoWtMax = cargo.weightMtMax ?? cfValue(cargo.weightMt);
+  const cargoWtMax = resolveCargoWeight(cargo);
   const dwt = cfValue(vessel.dwtSummer);
   const dwcc = cfValue(vessel.dwcc);
   const capacity = dwcc != null && dwcc > 0 ? dwcc : dwt;

--- a/lib/sailing/match-scoring.ts
+++ b/lib/sailing/match-scoring.ts
@@ -4,6 +4,7 @@ import type {
   ParsedCargo, ParsedVessel, ScoreBreakdown, ScoreBreakdownComponent,
 } from '@/lib/types';
 import { cfValue } from '@/lib/types';
+import { resolveCargoWeight } from './cargo-weight';
 
 // ────────────────────────────────────────────────────────────────────────────
 // Confidence multipliers (Spec-05)
@@ -296,7 +297,7 @@ export function applyOverloadGuard(
   vessel: ParsedVessel | null | undefined,
 ): Match {
   const dwcc = vessel ? cfValue(vessel.dwcc) : null;
-  const weightMax = cargo?.weightMtMax ?? (cargo ? cfValue(cargo.weightMt) : null);
+  const weightMax = resolveCargoWeight(cargo);
   if (dwcc != null && dwcc > 0 && weightMax != null && weightMax > dwcc) {
     const updated: Match = { ...match };
     updated.matchLevel = 'weak';

--- a/lib/sample-data/demo-parsed-cargoes.json
+++ b/lib/sample-data/demo-parsed-cargoes.json
@@ -22,7 +22,7 @@
     "weightMt": {
       "value": 186,
       "confidence": "interpreted",
-      "sourceText": "160 m3 VT Storage (10 tanks):\nLxHxW 4.3m x 15.7m x4.3m - Weight 15000 kg each tank\n80 m3 GMMOS Tanks (4 tanks): \nLxHxW 12.1m x 3.2m x3.2m - Weight 9000 kg each tank"
+      "sourceText": "160 m3 VT Storage (10 tanks):\r\nLxHxW 4.3m x 15.7m x4.3m - Weight 15000 kg each tank\r\n80 m3 GMMOS Tanks (4 tanks): \r\nLxHxW 12.1m x 3.2m x3.2m - Weight 9000 kg each tank"
     },
     "weightMtMin": 186,
     "weightMtMax": 186,

--- a/lib/sample-data/demo-parsed-cargoes.json
+++ b/lib/sample-data/demo-parsed-cargoes.json
@@ -19,9 +19,13 @@
       "confidence": "interpreted",
       "sourceText": "\nLxHxW 4.3m x 15.7m x4.3m - Weight 15000 kg each tank"
     },
-    "weightMt": null,
-    "weightMtMin": null,
-    "weightMtMax": null,
+    "weightMt": {
+      "value": 186,
+      "confidence": "interpreted",
+      "sourceText": "160 m3 VT Storage (10 tanks):\nLxHxW 4.3m x 15.7m x4.3m - Weight 15000 kg each tank\n80 m3 GMMOS Tanks (4 tanks): \nLxHxW 12.1m x 3.2m x3.2m - Weight 9000 kg each tank"
+    },
+    "weightMtMin": 186,
+    "weightMtMax": 186,
     "volumeCbm": 1920,
     "dimensions": "VT: 4.3m x 15.7m x 4.3m; GMMOS: 12.1m x 3.2m x 3.2m",
     "cargoType": "PROJECT",

--- a/scripts/demo-seed/__tests__/real-matches-item-index.test.ts
+++ b/scripts/demo-seed/__tests__/real-matches-item-index.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Behavioral test for #791 cause B — real-matches seed persists cargo_item_index
+ * and vessel_item_index on INSERT (fixes Source Attribution itemIndex=0 default
+ * masking the correct cargo line in hydrate-demo-session.ts).
+ */
+import Database from 'better-sqlite3';
+import {
+  buildMatchInsertSql,
+  tableHasItemIndexCols,
+} from '../real-matches';
+
+function setupSchemaWithIdxCols(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE matches (
+      cargo_id TEXT NOT NULL,
+      vessel_id TEXT NOT NULL,
+      cargo_item_index INTEGER NOT NULL DEFAULT 0,
+      vessel_item_index INTEGER NOT NULL DEFAULT 0,
+      score INTEGER NOT NULL,
+      reason TEXT,
+      status TEXT NOT NULL,
+      user_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      cargo_type TEXT,
+      load_port TEXT,
+      discharge_port TEXT,
+      laycan_start INTEGER,
+      laycan_end INTEGER,
+      vessel_dwt INTEGER,
+      tce_usd_per_day REAL,
+      distance_nm REAL,
+      freight_rate_usd_per_mt REAL,
+      freight_rate_source TEXT,
+      fit_percent REAL,
+      fit_breakdown TEXT,
+      worksheet_json TEXT,
+      reason_structured TEXT
+    );
+  `);
+}
+
+function setupSchemaLegacy(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE matches (
+      cargo_id TEXT NOT NULL,
+      vessel_id TEXT NOT NULL,
+      score INTEGER NOT NULL,
+      reason TEXT,
+      status TEXT NOT NULL,
+      user_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      cargo_type TEXT,
+      load_port TEXT,
+      discharge_port TEXT,
+      laycan_start INTEGER,
+      laycan_end INTEGER,
+      vessel_dwt INTEGER,
+      tce_usd_per_day REAL,
+      distance_nm REAL,
+      freight_rate_usd_per_mt REAL,
+      freight_rate_source TEXT,
+      fit_percent REAL,
+      fit_breakdown TEXT,
+      worksheet_json TEXT,
+      reason_structured TEXT
+    );
+  `);
+}
+
+describe('buildMatchInsertSql (#791 cause B)', () => {
+  it('includes cargo_item_index / vessel_item_index when hasIdxCol=true', () => {
+    const sql = buildMatchInsertSql(true);
+    expect(sql).toMatch(/cargo_item_index/);
+    expect(sql).toMatch(/vessel_item_index/);
+  });
+
+  it('omits item-index columns for legacy DBs (hasIdxCol=false)', () => {
+    const sql = buildMatchInsertSql(false);
+    expect(sql).not.toMatch(/cargo_item_index/);
+    expect(sql).not.toMatch(/vessel_item_index/);
+  });
+});
+
+describe('tableHasItemIndexCols (#791 cause B)', () => {
+  it('returns true when matches has cargo_item_index column (post-mig 044)', () => {
+    const db = new Database(':memory:');
+    setupSchemaWithIdxCols(db);
+    expect(tableHasItemIndexCols(db)).toBe(true);
+    db.close();
+  });
+
+  it('returns false for legacy matches schema', () => {
+    const db = new Database(':memory:');
+    setupSchemaLegacy(db);
+    expect(tableHasItemIndexCols(db)).toBe(false);
+    db.close();
+  });
+});
+
+describe('real-matches INSERT persists item indexes (#791 cause B)', () => {
+  it('writes non-zero cargo_item_index when the cargo email had multiple items', () => {
+    const db = new Database(':memory:');
+    setupSchemaWithIdxCols(db);
+
+    const insert = db.prepare(buildMatchInsertSql(true));
+    // Mirror real-matches.ts: bindings order matches buildMatchInsertSql.
+    insert.run(
+      'cargo-multi-email', 'vessel-1',
+      2, 0,                                         // cargoItemIndex=2 (3rd item), vesselItemIndex=0
+      82, 'good fit', 'sentinel-user', 1_700_000_000, 1_700_000_000,
+      'BULK', 'Marmara', 'Constanța', 1_700_001_000, 1_700_002_000, 5500,
+      9000, 100, 28, 'baltic',
+      82.5, '{}', '{}', '{}',
+    );
+
+    const row = db.prepare(
+      'SELECT cargo_item_index, vessel_item_index FROM matches WHERE cargo_id = ?',
+    ).get('cargo-multi-email') as { cargo_item_index: number; vessel_item_index: number };
+
+    expect(row.cargo_item_index).toBe(2);
+    expect(row.vessel_item_index).toBe(0);
+    db.close();
+  });
+
+  it('legacy DB (no idx cols) accepts inserts without item-index bindings', () => {
+    const db = new Database(':memory:');
+    setupSchemaLegacy(db);
+
+    const insert = db.prepare(buildMatchInsertSql(false));
+    insert.run(
+      'cargo-legacy', 'vessel-legacy',
+      75, 'legacy fit', null, 1_700_000_000, 1_700_000_000,
+      'BULK', 'Karasu', 'Mykolaiv', 1_700_001_000, 1_700_002_000, 5000,
+      8000, 200, 30, 'baltic',
+      75.0, '{}', '{}', '{}',
+    );
+
+    const cnt = (db.prepare('SELECT COUNT(*) AS n FROM matches').get() as { n: number }).n;
+    expect(cnt).toBe(1);
+    db.close();
+  });
+});

--- a/scripts/demo-seed/apply-to-prod.md
+++ b/scripts/demo-seed/apply-to-prod.md
@@ -1,0 +1,118 @@
+# Prod-apply demo-seed.db — #791 weight fix
+
+> **DO NOT execute autonomously. Founder signs each step.**
+>
+> This runbook applies the #791 / #792 weight-economics fix to the production
+> demo-seed.db after the PR merges. The code-side fix (helper + 12 call sites +
+> INSERT cols + parse-prompt + re-parsed corpus) lands via PR; this runbook
+> takes the re-parsed fixture from main → produces matches in the prod DB.
+
+## Pre-flight (on dev-VPS, root@dev-vps)
+
+1. `cd /root/work/quantika-demo`
+2. `git pull && git checkout main`
+3. `npm ci && npm run build`
+4. Confirm the re-parsed fixture is on main:
+   `git log -1 --pretty=format:'%h %s' lib/sample-data/demo-parsed-cargoes.json`
+   → must reference the #791 re-parse commit.
+
+## Step A — Dry-run regenerate
+
+```bash
+cd /root/work/quantika-demo
+npx tsx scripts/demo-seed/regenerate-matches.ts --dry > /tmp/regen-dry.log 2>&1
+wc -l /tmp/regen-dry.log
+grep -cE 'planned (INSERT|DELETE)' /tmp/regen-dry.log
+tail -30 /tmp/regen-dry.log
+```
+
+Inspect: planned DELETE and INSERT counts. **Founder approval required to proceed.**
+
+## Step B — Backup prod demo-seed.db
+
+```bash
+DB=/root/work/quantika-demo/demo-seed.db
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+cp -a "$DB" "$DB.bak.$TS"
+ls -la "$DB"*
+```
+
+Record `$DB.bak.$TS` for rollback. Keep ≥7 days.
+
+## Step C — wal_checkpoint (flush WAL before swap)
+
+```bash
+sqlite3 "$DB" 'PRAGMA wal_checkpoint(TRUNCATE);'
+```
+
+## Step D — Execute regen (live)
+
+```bash
+npx tsx scripts/demo-seed/regenerate-matches.ts > /tmp/regen-live.log 2>&1
+tail -30 /tmp/regen-live.log
+```
+
+## Step E — Verify in DB
+
+```bash
+sqlite3 "$DB" "
+  -- Targeted: previously-broken pairs (Marmara storage tanks + grain trader).
+  SELECT cargo_id, cargo_item_index, vessel_id,
+         fit_percent, tce_usd_per_day, status, reason
+    FROM matches
+    WHERE cargo_id LIKE '19d5de87705baf9b%'
+       OR cargo_id LIKE '19e07d011dbc661e%'
+    ORDER BY cargo_id, cargo_item_index, score DESC LIMIT 30;
+
+  -- #792 — SEAGULL 2 / corn pair must be either gated (status='filtered')
+  -- or absent from shortlist.
+  SELECT m.cargo_id, m.cargo_item_index, m.vessel_id, m.status, m.reason
+    FROM matches m
+    WHERE m.cargo_id LIKE '19e07d011dbc661e%'
+      AND m.cargo_item_index = 0
+      AND m.vessel_id LIKE '%SEAGULL%';
+
+  -- General health: bucket distribution.
+  SELECT status, COUNT(*) FROM matches GROUP BY status;
+
+  -- cargo_item_index distribution: must show non-zero values for multi-item emails.
+  SELECT cargo_item_index, COUNT(*)
+    FROM matches WHERE user_id IS NULL
+    GROUP BY cargo_item_index ORDER BY cargo_item_index;
+"
+```
+
+Pass criteria:
+- The Marmara cargo `19d5de87705baf9b/0` shows non-null `tce_usd_per_day` and `fit_percent`.
+- SEAGULL 2 vs corn either not in shortlist OR `status='filtered'` with overload reason.
+- `cargo_item_index > 0` count > 0 (proves Task 3 INSERT fix is live).
+
+## Step F — Restart Next.js (env-bake refresh — see CLAUDE.md)
+
+```bash
+pm2 restart quantika-demo --update-env
+pm2 logs quantika-demo --lines 50 --nostream
+```
+
+## Step G — Visual verify (browser)
+
+- Navigate to `/match/<previously-broken match id>`
+- Source Attribution shows correct cargo line (not itemIndex=0 default for non-zero items)
+- Economics tab shows non-zero TCE for range-cargoes
+- Previously "Possible / Overload" pair is gone from shortlist or marked Overload
+- fit-% no longer shows "weight not stated" for the 31 range-cargoes
+
+## Rollback (if any Step E/F/G fails)
+
+```bash
+pm2 stop quantika-demo
+cp -a "$DB.bak.$TS" "$DB"
+pm2 start quantika-demo --update-env
+pm2 logs quantika-demo --lines 30 --nostream
+```
+
+## Post-apply
+
+- Note Step A `regen-dry.log` counts in the deploy log.
+- Confirm `pm2 logs quantika-demo --err` is clean for 10 min post-restart.
+- File a follow-up if any regression surfaces (link this runbook + commit SHA).

--- a/scripts/demo-seed/build.ts
+++ b/scripts/demo-seed/build.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/types';
 import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { computeEstimatedTce, estimateFreightRate, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { shiftBodyDates, shiftMonthYear, shiftIsoDate } from './date-utils';
@@ -719,7 +720,7 @@ export async function build(opts: BuildOptions): Promise<void> {
         const layEnd = new Date(laycan.end).getTime();
 
         // Extract cargo weight and port fields; unwrap ConfidenceField wrappers if present.
-        const cargoWeightMt = unwrapNum(cargo.weightMt);
+        const cargoWeightMt = resolveCargoWeight(cargo as never) ?? 0;
         const cargoDestPort = unwrapStr(cargo.destinationPort);
         const cargoOriginPort = unwrapStr(cargo.originPort);
 
@@ -783,7 +784,7 @@ export async function build(opts: BuildOptions): Promise<void> {
             });
 
             // Compute TCE
-            const qty = unwrapNum(cargo.weightMt);
+            const qty = resolveCargoWeight(cargo as never) ?? 0;
             const freightRate = estimateFreightRate(unwrapStr(cargo.cargoType), distanceNm ?? 0, v.dwt);
             const tceResult = computeEstimatedTce(
               freightRate,

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -72,6 +72,36 @@ function arg(k: string): string | undefined {
 }
 
 /**
+ * Build the seed-matches INSERT SQL with optional cargo_item_index / vessel_item_index
+ * columns. Migration 044 adds these columns; older DBs without the column are tolerated
+ * via the `hasIdxCol` switch (mirrors regenerate-matches.ts:220).
+ *
+ * Exported so the seed-INSERT contract is unit-testable without booting the full seed
+ * pipeline (#791 cause B). DO NOT inline this back into the seed function — the test
+ * relies on the exported shape.
+ */
+export function buildMatchInsertSql(hasIdxCol: boolean): string {
+  return `
+    INSERT INTO matches
+      (cargo_id, vessel_id${hasIdxCol ? ', cargo_item_index, vessel_item_index' : ''},
+       score, reason, status, user_id, created_at, updated_at,
+       cargo_type, load_port, discharge_port, laycan_start, laycan_end, vessel_dwt,
+       tce_usd_per_day, distance_nm, freight_rate_usd_per_mt, freight_rate_source,
+       fit_percent, fit_breakdown, worksheet_json, reason_structured)
+    VALUES
+      (?, ?${hasIdxCol ? ', ?, ?' : ''}, ?, ?, 'shortlist', ?, ?, ?,
+       ?, ?, ?, ?, ?, ?,
+       ?, ?, ?, ?,
+       ?, ?, ?, ?)
+  `;
+}
+
+export function tableHasItemIndexCols(db: Database.Database): boolean {
+  const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+  return cols.some((c) => c.name === 'cargo_item_index');
+}
+
+/**
  * Score a surviving pair using the same heuristic as build.ts:
  *   Base 60 + timing bonus (5-25) + DWT utilisation bonus (3-15)
  * Capped at 100. No LLM dependency.
@@ -133,6 +163,8 @@ async function main(): Promise<void> {
   interface SeedRow {
     cargoId: string;
     vesselId: string;
+    cargoItemIndex: number;
+    vesselItemIndex: number;
     score: number;
     matchLevel: MatchLevel;
     reason: string;
@@ -316,6 +348,8 @@ async function main(): Promise<void> {
       const row: SeedRow = {
         cargoId: cargo.emailId,
         vesselId: vessel.emailId,
+        cargoItemIndex: cargo.itemIndex ?? 0,
+        vesselItemIndex: vessel.itemIndex ?? 0,
         score,
         matchLevel,
         reason,
@@ -403,23 +437,15 @@ async function main(): Promise<void> {
     `DELETE FROM matches WHERE user_id IS NULL OR user_id = '__demo_review__' OR user_id = '__demo_insufficient__'`,
   ).run();
 
-  const insert = db.prepare(`
-    INSERT INTO matches
-      (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
-       cargo_type, load_port, discharge_port, laycan_start, laycan_end, vessel_dwt,
-       tce_usd_per_day, distance_nm, freight_rate_usd_per_mt, freight_rate_source,
-       fit_percent, fit_breakdown, worksheet_json, reason_structured)
-    VALUES
-      (?, ?, ?, ?, 'shortlist', ?, ?, ?,
-       ?, ?, ?, ?, ?, ?,
-       ?, ?, ?, ?,
-       ?, ?, ?, ?)
-  `);
+  const hasIdxCol = tableHasItemIndexCols(db);
+  const insert = db.prepare(buildMatchInsertSql(hasIdxCol));
 
   const insertMany = db.transaction((seedRows: SeedRow[], userId: string | null) => {
     for (const r of seedRows) {
       insert.run(
-        r.cargoId, r.vesselId, r.score, r.reason, userId, nowMs, nowMs,
+        r.cargoId, r.vesselId,
+        ...(hasIdxCol ? [r.cargoItemIndex, r.vesselItemIndex] : []),
+        r.score, r.reason, userId, nowMs, nowMs,
         r.cargoType, r.loadPort, r.dischargePort, r.laycanStart, r.laycanEnd, r.vesselDwt,
         r.tceUsdPerDay, r.distanceNm, r.freightRateUsdPerMt, r.freightRateSource,
         r.fitPercent, r.fitBreakdown, r.worksheetJson, r.reasonStructured,
@@ -468,7 +494,9 @@ async function main(): Promise<void> {
   console.log('[real-matches] Done.');
 }
 
-main().catch((err) => {
-  console.error('[real-matches] FATAL:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[real-matches] FATAL:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -33,6 +33,7 @@ import { allMigrations } from '@/lib/migrations/index';
 import { cfValue } from '@/lib/types';
 import type { ParsedCargo, ParsedVessel, MatchLevel } from '@/lib/types';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { IDLE_HARD_MAX_GAP_DAYS } from '@/lib/matching/pair-analyzer';
@@ -164,7 +165,7 @@ async function main(): Promise<void> {
     const laycan = parseLaycan(cargo.laycan, refYear);
     const loadPort = cfValue(cargo.originPort);
     const dischargePort = cfValue(cargo.destinationPort);
-    const cargoWeightMt = cfValue(cargo.weightMt) ?? 0;
+    const cargoWeightMt = resolveCargoWeight(cargo) ?? 0;
     const cargoType =
       typeof cargo.cargoType === 'object' && cargo.cargoType !== null && 'value' in cargo.cargoType
         ? (cargo.cargoType as unknown as { value: string }).value
@@ -185,7 +186,7 @@ async function main(): Promise<void> {
           cargo.weightMtMin != null && cargo.weightMtMax != null &&
           cargo.weightMtMin !== cargo.weightMtMax
             ? { min: cargo.weightMtMin, max: cargo.weightMtMax }
-            : cfValue(cargo.weightMt),
+            : resolveCargoWeight(cargo),
         cargoDescription: cfValue(cargo.cargoDescription),
         stowageFactor: cargo.stowageFactor,
         vesselType: vessel.vesselType,
@@ -274,7 +275,7 @@ async function main(): Promise<void> {
       let freightRateUsdPerMt: number | null = null;
       let freightRateSource: string | null = null;
       if (distanceResult && distanceResult.nm > 0) {
-        const quantityMt = cfValue(cargo.weightMt) ?? 0;
+        const quantityMt = resolveCargoWeight(cargo) ?? 0;
         const speedKts = parseLeadingNumber(vessel.speedLaden);
         const consumptionMt = parseConsumption(vessel.consumption);
         const freightEst = estimateFreightRate(cargoType, distanceResult.nm, dwtSummer);

--- a/scripts/eval/__tests__/parity-check.test.ts
+++ b/scripts/eval/__tests__/parity-check.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the parity-check utility (#791 cause C).
+ *
+ * Deterministic (no LLM, no DB) — guards the parity contract used by the
+ * corpus re-parse runner.
+ */
+import { diffParsed, diffParsedFromPaths } from '../parity-check-parsed-cargoes';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('parity-check (#791 cause C)', () => {
+  it('detects populated→null regression on non-weight field', () => {
+    const oldArr = [{
+      emailId: 'a', itemIndex: 0,
+      originPort: { value: 'X', confidence: 'confirmed' },
+    }];
+    const newArr = [{
+      emailId: 'a', itemIndex: 0,
+      originPort: null,
+    }];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.populated_now_null).toHaveLength(1);
+    expect(r.populated_now_null[0].field).toBe('originPort');
+  });
+
+  it('records weight null→populated as a win, not a regression', () => {
+    const oldArr = [{ emailId: 'a', itemIndex: 0, weightMt: null }];
+    const newArr = [{
+      emailId: 'a', itemIndex: 0,
+      weightMt: { value: 186, confidence: 'interpreted' },
+    }];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.null_now_populated).toHaveLength(1);
+    expect(r.null_now_populated[0].field).toBe('weightMt');
+    expect(r.populated_now_null).toHaveLength(0);
+  });
+
+  it('reports value_changed when a populated field shifts', () => {
+    const oldArr = [{
+      emailId: 'a', itemIndex: 0,
+      cargoDescription: { value: 'Salt', confidence: 'confirmed' },
+    }];
+    const newArr = [{
+      emailId: 'a', itemIndex: 0,
+      cargoDescription: { value: 'Sea salt', confidence: 'interpreted' },
+    }];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.value_changed).toHaveLength(1);
+    expect(r.value_changed[0].field).toBe('cargoDescription');
+  });
+
+  it('skips items missing from old (new emails are out of parity scope)', () => {
+    const oldArr = [{ emailId: 'a', itemIndex: 0, originPort: { value: 'X' } }];
+    const newArr = [
+      { emailId: 'a', itemIndex: 0, originPort: { value: 'X' } },
+      { emailId: 'b', itemIndex: 0, originPort: { value: 'Y' } },
+    ];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.total).toBe(1);
+    expect(r.populated_now_null).toHaveLength(0);
+    expect(r.null_now_populated).toHaveLength(0);
+    expect(r.value_changed).toHaveLength(0);
+  });
+
+  it('keys by (emailId, itemIndex) — multi-item emails matched per-item', () => {
+    const oldArr = [
+      { emailId: 'a', itemIndex: 0, weightMt: { value: 100 } },
+      { emailId: 'a', itemIndex: 1, weightMt: { value: 200 } },
+    ];
+    const newArr = [
+      { emailId: 'a', itemIndex: 0, weightMt: { value: 100 } },
+      { emailId: 'a', itemIndex: 1, weightMt: { value: 250 } },
+    ];
+    const r = diffParsed(oldArr, newArr);
+    expect(r.value_changed).toHaveLength(1);
+    expect(r.value_changed[0].itemIndex).toBe(1);
+  });
+
+  it('diffParsedFromPaths reads JSON files and computes the same report', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'parity-'));
+    const oldP = join(dir, 'old.json');
+    const newP = join(dir, 'new.json');
+    writeFileSync(oldP, JSON.stringify([{ emailId: 'a', itemIndex: 0, weightMt: null, weightMtMax: 4800 }]));
+    writeFileSync(newP, JSON.stringify([{
+      emailId: 'a', itemIndex: 0, weightMt: null, weightMtMax: 4800,
+    }]));
+    const r = diffParsedFromPaths(oldP, newP);
+    expect(r.populated_now_null).toHaveLength(0);
+    expect(r.null_now_populated).toHaveLength(0);
+    expect(r.value_changed).toHaveLength(0);
+  });
+
+  it('treats undefined and null as equivalent (both "absent")', () => {
+    const oldArr = [{ emailId: 'a', itemIndex: 0, dimensions: null }];
+    const newArr = [{ emailId: 'a', itemIndex: 0 }];
+    const r = diffParsed(oldArr, newArr);
+    // null in old, missing/undefined in new — no change.
+    expect(r.populated_now_null).toHaveLength(0);
+    expect(r.value_changed).toHaveLength(0);
+  });
+});

--- a/scripts/eval/parity-check-parsed-cargoes.ts
+++ b/scripts/eval/parity-check-parsed-cargoes.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Parity-check utility for parsed-cargoes JSON re-parse (#791 cause C).
+ *
+ * Pure compare (no LLM): diff old vs. new ParsedCargo arrays keyed by
+ * (emailId, itemIndex). Reports `populated_now_null`, `null_now_populated`,
+ * `value_changed`. Used by scripts/eval/reparse-cargo-corpus.ts and as a
+ * unit-testable building block.
+ *
+ * Non-zero exit ONLY on populated→null regressions in non-weight fields.
+ * weightMt → null is expected for range cargoes (info shifts into
+ * weightMtMin / weightMtMax).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+export type ParsedCargoLike = Record<string, unknown> & {
+  emailId: string;
+  itemIndex: number;
+};
+
+export interface ParityReport {
+  total: number;
+  populated_now_null: Array<{ emailId: string; itemIndex: number; field: string; old: unknown }>;
+  null_now_populated: Array<{ emailId: string; itemIndex: number; field: string; new: unknown }>;
+  value_changed: Array<{ emailId: string; itemIndex: number; field: string; old: unknown; new: unknown }>;
+}
+
+function keyOf(c: ParsedCargoLike): string {
+  return `${c.emailId}::${c.itemIndex}`;
+}
+
+function isNullish(v: unknown): boolean {
+  return v == null;
+}
+
+export function diffParsed(oldArr: ParsedCargoLike[], newArr: ParsedCargoLike[]): ParityReport {
+  const oldMap = new Map(oldArr.map((c) => [keyOf(c), c]));
+  const report: ParityReport = {
+    total: oldArr.length,
+    populated_now_null: [],
+    null_now_populated: [],
+    value_changed: [],
+  };
+  for (const n of newArr) {
+    const k = keyOf(n);
+    const o = oldMap.get(k);
+    if (!o) continue;
+    for (const field of Object.keys(o)) {
+      if (field === 'emailId' || field === 'itemIndex') continue;
+      const oVal = JSON.stringify((o as Record<string, unknown>)[field] ?? null);
+      const nVal = JSON.stringify((n as Record<string, unknown>)[field] ?? null);
+      if (oVal === nVal) continue;
+      const oIsNull = isNullish((o as Record<string, unknown>)[field]);
+      const nIsNull = isNullish((n as Record<string, unknown>)[field]);
+      if (!oIsNull && nIsNull) {
+        report.populated_now_null.push({
+          emailId: o.emailId,
+          itemIndex: o.itemIndex,
+          field,
+          old: (o as Record<string, unknown>)[field],
+        });
+      } else if (oIsNull && !nIsNull) {
+        report.null_now_populated.push({
+          emailId: o.emailId,
+          itemIndex: o.itemIndex,
+          field,
+          new: (n as Record<string, unknown>)[field],
+        });
+      } else {
+        report.value_changed.push({
+          emailId: o.emailId,
+          itemIndex: o.itemIndex,
+          field,
+          old: (o as Record<string, unknown>)[field],
+          new: (n as Record<string, unknown>)[field],
+        });
+      }
+    }
+  }
+  return report;
+}
+
+export function diffParsedFromPaths(oldPath: string, newPath: string): ParityReport {
+  const oldArr = JSON.parse(readFileSync(oldPath, 'utf8')) as ParsedCargoLike[];
+  const newArr = JSON.parse(readFileSync(newPath, 'utf8')) as ParsedCargoLike[];
+  return diffParsed(oldArr, newArr);
+}
+
+if (require.main === module) {
+  const [oldPath, newPath, outPath] = process.argv.slice(2);
+  if (!oldPath || !newPath) {
+    console.error('Usage: tsx parity-check-parsed-cargoes.ts <old.json> <new.json> [out.json]');
+    process.exit(2);
+  }
+  const r = diffParsedFromPaths(oldPath, newPath);
+  const summary = {
+    total: r.total,
+    populated_now_null_count: r.populated_now_null.length,
+    null_now_populated_count: r.null_now_populated.length,
+    value_changed_count: r.value_changed.length,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (outPath) writeFileSync(outPath, JSON.stringify(r, null, 2));
+  const regressions = r.populated_now_null.filter((d) => !d.field.startsWith('weightMt'));
+  if (regressions.length > 0) {
+    console.error(`PARITY FAIL — ${regressions.length} populated→null regressions on non-weight fields`);
+    process.exit(1);
+  }
+}

--- a/scripts/eval/reparse-cargo-corpus.ts
+++ b/scripts/eval/reparse-cargo-corpus.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Re-parse the demo cargo corpus through the updated CARGO_INQUIRY_PARSER_PROMPT
+ * (#791 cause C — PIECE-AGGREGATE RULE). Writes a sibling JSON; does NOT overwrite
+ * the live fixture. Use scripts/eval/parity-check-parsed-cargoes.ts to validate.
+ *
+ * USAGE (dev-VPS only):
+ *   AI_PROVIDER=claude-cli PARSE_CARGO_PROVIDER=claude-cli \
+ *     npx tsx scripts/eval/reparse-cargo-corpus.ts \
+ *       --raw-dir /root/work/quantika-demo/.private/raw-emails \
+ *       --old-parsed lib/sample-data/demo-parsed-cargoes.json \
+ *       --out /tmp/demo-parsed-cargoes.reparsed.json
+ *
+ * NOTES:
+ *  - claude-cli must be on PATH. Re-parse touches ~82 cargo emails, ETA ≈ 25-40 min.
+ *  - Per .claude/rules/ai-provider.md: claude-cli is allowed in scripts, NOT in
+ *    Next.js request handlers. This script never imports from app/.
+ *  - Only emails that already appear in --old-parsed are re-parsed (parity scope).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import 'dotenv/config';
+import dotenv from 'dotenv';
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local'), override: false });
+
+import { callAiText, extractJson } from '@/lib/ai-provider';
+import { CARGO_INQUIRY_PARSER_PROMPT } from '@/lib/prompts/parse-cargo';
+import { PARSE_CARGO_SCHEMA } from '@/lib/schemas';
+import { buildCargoPrompts, parseCargoAIResponse } from '@/lib/parsing/parse-cargo-ai';
+import { normalizeRawEmail, type FlatEmail } from '@/scripts/demo-seed/analyze';
+import type { Email, ParsedCargo } from '@/lib/types';
+
+const LLM_TIMEOUT_MS = 180_000;
+const DEFAULT_MODEL = 'claude-opus-4-8';
+const DEFAULT_MAX_BUDGET = 5.0;
+
+interface Args {
+  rawDir: string;
+  oldParsedPath: string;
+  outPath: string;
+  model: string;
+  maxBudget: number;
+  limit: number | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (k: string): string | undefined => {
+    const i = argv.indexOf(k);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  return {
+    rawDir: path.resolve(get('--raw-dir') ?? '.private/raw-emails'),
+    oldParsedPath: path.resolve(get('--old-parsed') ?? 'lib/sample-data/demo-parsed-cargoes.json'),
+    outPath: path.resolve(get('--out') ?? '/tmp/demo-parsed-cargoes.reparsed.json'),
+    model: get('--model') ?? DEFAULT_MODEL,
+    maxBudget: parseFloat(get('--max-budget') ?? String(DEFAULT_MAX_BUDGET)),
+    limit: get('--limit') ? parseInt(get('--limit')!, 10) : null,
+  };
+}
+
+function flatToEmail(flat: FlatEmail): Email {
+  return {
+    id: flat.messageId,
+    threadId: flat.threadId,
+    from: flat.fromName ? `${flat.fromName} <${flat.fromEmail ?? ''}>` : (flat.fromEmail ?? ''),
+    fromName: flat.fromName ?? null,
+    fromEmail: flat.fromEmail ?? null,
+    to: '',
+    subject: flat.subject ?? '',
+    date: flat.date,
+    body: flat.body,
+    snippet: flat.body.slice(0, 200),
+    labelIds: [],
+  };
+}
+
+function loadCargoEmailIds(oldParsedPath: string): Set<string> {
+  const oldArr = JSON.parse(fs.readFileSync(oldParsedPath, 'utf8')) as Array<{ emailId: string }>;
+  return new Set(oldArr.map((c) => c.emailId));
+}
+
+function loadEmailFromRaw(rawDir: string, emailId: string): Email | null {
+  const filePath = path.join(rawDir, `${emailId}.json`);
+  if (!fs.existsSync(filePath)) return null;
+  const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const flat = normalizeRawEmail(raw);
+  return flatToEmail(flat);
+}
+
+async function reparseCargo(email: Email, model: string, maxBudget: number): Promise<ParsedCargo[]> {
+  const prompt = buildCargoPrompts([email])[0];
+  const raw = await callAiText('PARSE_CARGO', CARGO_INQUIRY_PARSER_PROMPT, prompt, {
+    timeoutMs: LLM_TIMEOUT_MS,
+    responseSchema: PARSE_CARGO_SCHEMA,
+    model,
+    maxBudgetUsd: maxBudget,
+  });
+  return parseCargoAIResponse(extractJson(raw), email.id);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!fs.existsSync(args.rawDir)) {
+    console.error(`Raw dir does not exist: ${args.rawDir}`);
+    process.exit(2);
+  }
+  if (!fs.existsSync(args.oldParsedPath)) {
+    console.error(`Old parsed JSON does not exist: ${args.oldParsedPath}`);
+    process.exit(2);
+  }
+
+  const cargoEmailIds = Array.from(loadCargoEmailIds(args.oldParsedPath));
+  const targetIds = args.limit ? cargoEmailIds.slice(0, args.limit) : cargoEmailIds;
+  console.log(
+    `[reparse-cargo] re-parsing ${targetIds.length} cargo emails (model=${args.model}, max-budget=$${args.maxBudget})`,
+  );
+
+  const out: ParsedCargo[] = [];
+  let failures = 0;
+  const t0 = Date.now();
+
+  for (let i = 0; i < targetIds.length; i++) {
+    const emailId = targetIds[i];
+    process.stdout.write(`[${i + 1}/${targetIds.length}] ${emailId}… `);
+    const email = loadEmailFromRaw(args.rawDir, emailId);
+    if (!email) {
+      console.log('MISSING raw email file — skipping');
+      failures++;
+      continue;
+    }
+    const tStart = Date.now();
+    try {
+      const parsed = await reparseCargo(email, args.model, args.maxBudget);
+      out.push(...parsed);
+      console.log(`${((Date.now() - tStart) / 1000).toFixed(1)}s → ${parsed.length} items`);
+    } catch (e) {
+      console.log(`FAIL (${e instanceof Error ? e.message.slice(0, 80) : 'error'})`);
+      failures++;
+    }
+    fs.writeFileSync(args.outPath, JSON.stringify(out, null, 2));
+  }
+
+  const elapsedMin = ((Date.now() - t0) / 60_000).toFixed(1);
+  console.log(
+    `\n[reparse-cargo] Done in ${elapsedMin}min. ${out.length} items written. ${failures} failures.`,
+  );
+  console.log(`  → ${args.outPath}`);
+  if (failures > 0) process.exit(1);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[reparse-cargo] FATAL:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the chain of bugs (#791) where parsed cargo weight failed to reach fit-breakdown / TCE / overload gate, plus the #792 symptom (corn 3000mt vs SEAGULL 2 DWT 2570 wrongly marked "Possible").

Three independent causes, all addressed:

- **(A) Range cargo extraction** — 31 cargoes carry `weightMt=null` + `weightMtMax=N`. Adds `resolveCargoWeight(cargo)` helper, applies at 12 consumer sites.
- **(B) Item-index mismatch** — `scripts/demo-seed/real-matches.ts` INSERT never wrote `cargo_item_index` / `vessel_item_index`. Source Attribution showed itemIndex=0 on the wrong item for multi-item emails.
- **(C) Parse-gap** — 1 of 3 null/null cargoes is recoverable (Marmara/Veracruz piece-aggregate). Adds PIECE-AGGREGATE RULE to parse-cargo prompt + corpus re-parse under PARITY validation.

## Test plan

- [x] `npx jest lib/sailing/__tests__/cargo-weight.test.ts` — 8/8 (helper unit)
- [x] `npx jest lib/__tests__/matching/cargo-weight-integration.test.ts` — 2/2 (utilisation not "not stated" for range)
- [x] `npx jest scripts/demo-seed/__tests__/real-matches-item-index.test.ts` — 6/6 (INSERT contract + idx-col defensive switch)
- [x] `npx jest lib/prompts/__tests__/parse-cargo-prompt.test.ts` — 7/7 (PIECE-AGGREGATE rule snapshot)
- [x] `npx jest scripts/eval/__tests__/parity-check.test.ts` — 7/7 (parity utility)
- [x] `npx jest lib/sailing/__tests__/overload-gate-792.test.ts` — 7/7 (gate boundary, #792 closes once weight wired)
- [x] `npx jest __tests__/adversarial/cargo-weight-adversarial.test.ts` — 21/21 (cold-QA: NaN, Infinity, negative, boundary, float drift, dup keys)
- [x] `npx tsc --noEmit` — clean
- [x] `__tests__/components/match/EconomicsTab-compare-inputs.test.tsx` — 6/6 (fixture updated; old fixture was self-contradictory)
- [x] Re-parsed `lib/sample-data/demo-parsed-cargoes.json` (claude-cli, 82 cargo emails). PARITY-validated: no populated→null on non-weight fields.
- [x] Local regen run on `data/demo-seed.db` verified end-to-end (gitignored).

## Out of scope (deferred)

- Prod `demo-seed.db` apply — separate founder-signed Rule-22 step using `scripts/demo-seed/apply-to-prod.md`.
- Reseeding the 2 truly-missing cargoes (`19e07cc3ba833475/0` grain trader, `19e07d011dbc661e/2` scrap "tonnage not specified") — stay null by design.
- Polish bundle (#806/#807/#808).
- #665 laycan polish.

Closes #791
Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)