### PR TITLE
feat(seed): backfill-815-weights --allow-missing flag (#815 broad-apply)

### DIFF
--- a/scripts/demo-seed/__tests__/backfill-815-weights.test.ts
+++ b/scripts/demo-seed/__tests__/backfill-815-weights.test.ts
@@ -214,4 +214,178 @@ describe('backfill-815-weights', () => {
     // Summary must show 0 updates
     expect(output).toMatch(/updated=0/i);
   });
+
+  it('summary always includes all four counters', () => {
+    const { stdout, stderr } = runBackfill(dbPath);
+    const output = stdout + stderr;
+    expect(output).toMatch(/updated=\d+/);
+    expect(output).toMatch(/skipped-already-correct=\d+/);
+    expect(output).toMatch(/skipped-missing=\d+/);
+    expect(output).toMatch(/skipped-ambiguous=\d+/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --allow-missing mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a DB where:
+ * - one fixture emailId has NO row              → SKIPPED-MISSING
+ * - one fixture emailId has an EMPTY items row  → SKIPPED-AMBIGUOUS (itemIndex OOB + no fingerprint match)
+ * - MARMARA_EMAIL_ID has STALE weights          → will be UPDATED
+ * - all other emailIds have correct fixture data → skipped-already-correct
+ */
+function createAllowMissingDb(dbPath: string): { missingId: string; ambiguousId: string } {
+  const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as Array<{
+    emailId: string;
+    itemIndex: number;
+    [key: string]: unknown;
+  }>;
+
+  const byEmail = new Map<string, typeof fixture>();
+  for (const item of fixture) {
+    const arr = byEmail.get(item.emailId) ?? [];
+    arr.push(item);
+    byEmail.set(item.emailId, arr);
+  }
+
+  const otherIds = [...byEmail.keys()].filter((id) => id !== MARMARA_EMAIL_ID);
+  const MISSING_ID = otherIds[0];
+  const AMBIGUOUS_ID = otherIds[1];
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS parsed_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      account_id TEXT NOT NULL DEFAULT 'demo',
+      gmail_message_id TEXT NOT NULL,
+      parse_type TEXT NOT NULL,
+      parser_version TEXT NOT NULL DEFAULT '1.0',
+      result_json TEXT NOT NULL,
+      parsed_at INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+
+  const insert = db.prepare(
+    `INSERT INTO parsed_results (gmail_message_id, parse_type, result_json) VALUES (?, 'cargo', ?)`,
+  );
+
+  for (const [emailId, items] of byEmail) {
+    if (emailId === MISSING_ID) continue; // absent → SKIPPED-MISSING
+
+    if (emailId === AMBIGUOUS_ID) {
+      // Empty array: itemIndex OOB + no fingerprint match → SKIPPED-AMBIGUOUS
+      insert.run(emailId, JSON.stringify([]));
+      continue;
+    }
+
+    if (emailId === MARMARA_EMAIL_ID) {
+      insert.run(emailId, JSON.stringify([MARMARA_STALE_ITEM_0, MARMARA_ITEM_1]));
+      continue;
+    }
+
+    insert.run(emailId, JSON.stringify(items));
+  }
+
+  db.close();
+  return { missingId: MISSING_ID, ambiguousId: AMBIGUOUS_ID };
+}
+
+describe('backfill-815-weights --allow-missing', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-815-allowmissing-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips MISSING_ROW + AMBIGUOUS_MATCH, applies matched updates, exits 0', () => {
+    const db = path.join(tmpDir, 'test.db');
+    const { missingId, ambiguousId } = createAllowMissingDb(db);
+
+    const { stdout, stderr, exitCode } = runBackfill(db, ['--allow-missing']);
+    const output = stdout + stderr;
+
+    expect(exitCode).toBe(0);
+    expect(output).toMatch(/SKIPPED-MISSING/);
+    expect(output).toMatch(/SKIPPED-AMBIGUOUS/);
+
+    const conn = new Database(db, { readonly: true });
+    const sel = conn.prepare(
+      `SELECT result_json FROM parsed_results WHERE gmail_message_id=? AND parse_type='cargo'`,
+    );
+
+    // Marmara was updated
+    const marmaraRow = sel.get(MARMARA_EMAIL_ID) as { result_json: string };
+    const items = JSON.parse(marmaraRow.result_json);
+    expect(items[0].weightMtMax).toBe(186);
+    expect(items[0].weightMt).toMatchObject({ value: 186, confidence: 'interpreted' });
+
+    // Ambiguous row must be unchanged (empty array — never corrupted)
+    const ambiguousRow = sel.get(ambiguousId) as { result_json: string };
+    expect(JSON.parse(ambiguousRow.result_json)).toEqual([]);
+
+    // Missing row must still have no DB entry
+    const missingRow = sel.get(missingId);
+    expect(missingRow).toBeUndefined();
+
+    conn.close();
+  });
+
+  it('strict mode (no flag) with missing row → ABORT, no writes', () => {
+    const emptyDbPath = path.join(tmpDir, 'empty.db');
+    const emptyDb = new Database(emptyDbPath);
+    emptyDb.exec(`
+      CREATE TABLE parsed_results (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        account_id TEXT NOT NULL DEFAULT 'demo',
+        gmail_message_id TEXT NOT NULL,
+        parse_type TEXT NOT NULL,
+        parser_version TEXT NOT NULL DEFAULT '1.0',
+        result_json TEXT NOT NULL,
+        parsed_at INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    emptyDb.close();
+
+    const { stdout, stderr, exitCode } = runBackfill(emptyDbPath);
+    const output = stdout + stderr;
+
+    expect(exitCode).not.toBe(0);
+    expect(output).toMatch(/MISSING_ROW/);
+  });
+
+  it('--allow-missing --dry: exits 0, leaves DB unchanged, logs expected markers', () => {
+    const db = path.join(tmpDir, 'dry.db');
+    createAllowMissingDb(db);
+
+    const before = fs.readFileSync(db);
+    const { stdout, stderr, exitCode } = runBackfill(db, ['--allow-missing', '--dry']);
+    const after = fs.readFileSync(db);
+    const output = stdout + stderr;
+
+    expect(exitCode).toBe(0);
+    expect(before.equals(after)).toBe(true);
+    expect(output).toMatch(/SKIPPED-MISSING/);
+    expect(output).toMatch(/SKIPPED-AMBIGUOUS/);
+    expect(output).toMatch(/WOULD-UPDATE/);
+  });
+
+  it('--allow-missing idempotent: second run produces 0 updates', () => {
+    const db = path.join(tmpDir, 'idem.db');
+    createAllowMissingDb(db);
+
+    const r1 = runBackfill(db, ['--allow-missing']);
+    expect(r1.exitCode).toBe(0);
+
+    const r2 = runBackfill(db, ['--allow-missing']);
+    const output = r2.stdout + r2.stderr;
+    expect(r2.exitCode).toBe(0);
+    expect(output).not.toMatch(/\bUPDATED emailId=/);
+    expect(output).toMatch(/updated=0/i);
+  });
 });

--- a/scripts/demo-seed/backfill-815-weights.ts
+++ b/scripts/demo-seed/backfill-815-weights.ts
@@ -7,11 +7,17 @@
  * changed by PR #815). All other fields are untouched.
  *
  * Usage:
- *   npx tsx scripts/demo-seed/backfill-815-weights.ts --db data/demo-seed.db [--dry]
+ *   npx tsx scripts/demo-seed/backfill-815-weights.ts --db data/demo-seed.db [--dry] [--allow-missing]
  *
- * --dry  Preview only — logs WOULD-UPDATE lines, writes nothing.
+ * --dry            Preview only — logs WOULD-UPDATE lines, writes nothing.
+ * --allow-missing  Skip MISSING_ROW and AMBIGUOUS_MATCH rows instead of aborting.
+ *                  Logs SKIPPED-MISSING / SKIPPED-AMBIGUOUS and proceeds with
+ *                  cleanly-matched updates. Without this flag (default), any
+ *                  MISSING_ROW or AMBIGUOUS_MATCH causes a non-zero exit (strict).
  *
- * Exits non-zero if ANY fixture cargo has no parsed_results row (MISSING_ROW).
+ * Summary line (always printed):
+ *   done — updated=N skipped-already-correct=M skipped-missing=K skipped-ambiguous=A
+ *
  * Idempotent: re-run on already-patched DB produces 0 changes.
  */
 
@@ -52,6 +58,7 @@ function arg(k: string): string | undefined {
 }
 
 const DRY = process.argv.includes('--dry');
+const ALLOW_MISSING = process.argv.includes('--allow-missing');
 const dbPath = arg('--db') ?? path.resolve(process.cwd(), 'data/demo-seed.db');
 const fixtureDir = path.resolve(process.cwd(), 'lib/sample-data/demo-parsed-cargoes.json');
 
@@ -67,7 +74,7 @@ function jsonEqual(a: unknown, b: unknown): boolean {
 }
 
 async function main() {
-  console.log(`[backfill-815] db=${dbPath}${DRY ? ' (DRY)' : ''}`);
+  console.log(`[backfill-815] db=${dbPath}${DRY ? ' (DRY)' : ''}${ALLOW_MISSING ? ' (allow-missing)' : ''}`);
 
   if (!fs.existsSync(dbPath)) {
     console.error(`[backfill-815] ERROR: db not found: ${dbPath}`);
@@ -93,7 +100,9 @@ async function main() {
 
   let updates = 0;
   let skipped = 0;
-  let missingRows = 0;
+  let skippedMissing = 0;
+  let skippedAmbiguous = 0;
+  let missingRows = 0; // strict-mode counter only; triggers abort at end
 
   // Group fixture items by emailId
   const byEmail = new Map<string, FixtureCargo[]>();
@@ -106,8 +115,13 @@ async function main() {
   for (const [emailId, cargoes] of byEmail) {
     const row = selectRow.get(emailId) as { result_json: string } | undefined;
     if (!row) {
-      console.error(`[backfill-815] MISSING_ROW emailId=${emailId}`);
-      missingRows++;
+      if (ALLOW_MISSING) {
+        console.log(`[backfill-815] SKIPPED-MISSING emailId=${emailId}`);
+        skippedMissing++;
+      } else {
+        console.error(`[backfill-815] MISSING_ROW emailId=${emailId}`);
+        missingRows++;
+      }
       continue;
     }
 
@@ -121,8 +135,13 @@ async function main() {
         const fp = fingerprint(c);
         target = items.find((it) => fingerprint(it) === fp);
         if (!target) {
-          console.error(`[backfill-815] AMBIGUOUS_MATCH emailId=${emailId} itemIndex=${c.itemIndex}`);
-          missingRows++;
+          if (ALLOW_MISSING) {
+            console.log(`[backfill-815] SKIPPED-AMBIGUOUS emailId=${emailId} itemIndex=${c.itemIndex}`);
+            skippedAmbiguous++;
+          } else {
+            console.error(`[backfill-815] AMBIGUOUS_MATCH emailId=${emailId} itemIndex=${c.itemIndex}`);
+            missingRows++;
+          }
           continue;
         }
       }
@@ -159,7 +178,7 @@ async function main() {
     }
   }
 
-  console.log(`[backfill-815] done — ${DRY ? 'would-update' : 'updated'}=${updates} skipped(already-correct)=${skipped} missing=${missingRows}`);
+  console.log(`[backfill-815] done — updated=${updates} skipped-already-correct=${skipped} skipped-missing=${skippedMissing} skipped-ambiguous=${skippedAmbiguous}`);
 
   if (missingRows > 0) {
     console.error(`[backfill-815] ABORT — ${missingRows} MISSING_ROW or AMBIGUOUS_MATCH; no writes performed`);


### PR DESCRIPTION
## Summary

- Adds `--allow-missing` flag to `scripts/demo-seed/backfill-815-weights.ts`
- Default (no flag): strict all-or-nothing abort on MISSING_ROW or AMBIGUOUS_MATCH — unchanged
- With `--allow-missing`: logs `SKIPPED-MISSING emailId=…` / `SKIPPED-AMBIGUOUS emailId=… itemIndex=…`, skips unresolvable rows, proceeds with all cleanly-matched weight updates; exits 0
- Summary line always emits all four counters: `updated=N skipped-already-correct=M skipped-missing=K skipped-ambiguous=A`
- Never silently corrupts: only skips unmatched rows; never guesses a target item

## Test plan

- [x] Strict mode (no flag) with missing row → ABORT, no writes, exit 1
- [x] `--allow-missing` with 1 missing + 1 ambiguous + N matched → applies matched, logs SKIPPED-*, asserts ambiguous row unchanged + missing row absent from DB, exits 0
- [x] `--allow-missing --dry` → exit 0, DB byte-identical, output contains SKIPPED-MISSING / SKIPPED-AMBIGUOUS / WOULD-UPDATE
- [x] `--allow-missing` idempotent: second run → `updated=0`, no UPDATED lines
- [x] Summary always includes all four counters (existing + new runs)
- All 10 tests green (`npx jest --findRelatedTests ... --maxWorkers=1`)
- tsc clean (no errors)
- test-skill verdict: APPROVE-WITH-FOLLOWUPS (0 blocking findings; 3 coverage gaps addressed before merge)

Refs: #815 (Candidate B prod-apply plan — broad weight refresh mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)