### PR TITLE
fix(auth): bypass 5 demo/market paths in middleware (#667)

### DIFF
--- a/__tests__/middleware-auth.test.ts
+++ b/__tests__/middleware-auth.test.ts
@@ -53,6 +53,7 @@ describe('middleware auth guard', () => {
       '/login',
       '/api/auth/login',
       '/api/auth/logout',
+      '/api/auth/google',
       '/favicon.ico',
       '/api/admin/cron-heartbeat',
       '/api/admin/market/upload-csv',
@@ -68,9 +69,13 @@ describe('middleware auth guard', () => {
       '/design',
       '/api/market/baltic-kpi',
       '/api/market/bunker-kpi',
+      '/api/market/eua-kpi',
+      '/api/market/tmi',
+      '/api/market/indices',
       '/api/market/benchmark',
       '/about',
       '/pricing',
+      '/api/sample',
       '/api/demo/rehydrate',
     ];
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,8 @@ const AUTH_BYPASS_PATHS = new Set([
   '/login',
   '/api/auth/login',
   '/api/auth/logout',
+  // Google OAuth callback — Google GETs this with ?code=; must not redirect to /login (was #667)
+  '/api/auth/google',
   '/favicon.ico',
   '/api/health',
   // Cron heartbeat has its own X-Cron-Secret auth — must not be redirected to /login
@@ -38,8 +40,14 @@ const AUTH_BYPASS_PATHS = new Set([
   // Market KPI endpoints — public index data (BDI/BHSI/bunker prices), safe for anonymous
   '/api/market/baltic-kpi',
   '/api/market/bunker-kpi',
+  // EUA carbon price (KPI), TMI latest, and multi-index history — GET-only public commodity data, no PII
+  '/api/market/eua-kpi',
+  '/api/market/tmi',
+  '/api/market/indices',
   // benchmark endpoint is "Intentionally public" per route comment (no PII, commodity data only)
   '/api/market/benchmark',
+  // Demo onboarding: "Try Demo" POST creates a session and validates its own CSRF token — must not 401 first
+  '/api/sample',
   // Demo session re-hydration: has its own demo_auth verification; must not loop back to auth guard
   '/api/demo/rehydrate',
 ]);


### PR DESCRIPTION
## What
Adds 5 paths to `AUTH_BYPASS_PATHS` (middleware.ts) so they aren't redirected to /login / 401'd when `DEMO_AUTH_ENABLED=true`. Each keeps its OWN auth/safety:
- `/api/auth/google` — OAuth callback (Google GETs ?code=); IS the login. **Root of #667.**
- `/api/sample` — Try-Demo POST, validates its own CSRF token
- `/api/market/{eua-kpi,tmi,indices}` — GET-only public commodity data, no PII (siblings of already-bypassed baltic-kpi/bunker-kpi/benchmark)

## Why
DEMO_AUTH on → these 401'd → demo onboarding (Try Demo / Connect Gmail) + Market widgets silently broke.

## Safety
Per .claude/rules/admin-api.md: bypass-path must keep own auth. Verified — none becomes an unauth'd mutation/PII surface. +5 cases in middleware-auth.test.ts (49/49).

## Risk
auth/middleware risk-override → cold security review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)