### PR TITLE
chore(matches): remove dead formatAge() — never called

### DIFF
--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -62,13 +62,6 @@ function vesselInitials(vid: string): string {
   return (a + b).slice(0, 2);
 }
 
-function formatAge(ts: number): string {
-  const diff = Date.now() / 1000 - ts;
-  if (diff < 3600) return 'now';
-  if (diff < 86400) return new Date(ts * 1000).toTimeString().slice(0, 5);
-  return new Date(ts * 1000).toLocaleDateString('en-US', { weekday: 'short' });
-}
-
 // Defer Date.now() to post-mount: SSR and first client paint must produce
 // identical HTML, otherwise React #418 hydration mismatch fires when a match
 // sits near the 2-hour boundary (same fix pattern as SubsCountdown).


### PR DESCRIPTION
## What
Removes the unused `formatAge()` from MatchesClient.tsx (6 lines).

## Why
It used real `Date.now()` (flagged in audit as a frozen-clock leak) but has **zero callers** — time-on-page renders via `fmtLaycan` + `isFreshMatch`/`effectiveScore` (already on `useDemoNow`). Removing the dead fn kills a false 'leak' that reads like a bug. **No behavior change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)