### PR TITLE
[code-only] fix(landing): prefetch=false on Connect Gmail Link — stop CORS-blocked RSC prefetch

### DIFF
--- a/__tests__/components/public-landing.test.tsx
+++ b/__tests__/components/public-landing.test.tsx
@@ -10,6 +10,13 @@ jest.mock('@/components/market/LiveStrip', () => ({
   LiveStrip: () => <div data-testid="live-strip-stub" />,
 }));
 
+// Capture prefetch prop so the guard test can assert it
+jest.mock('next/link', () => {
+  return function MockLink({ children, href, prefetch, ...rest }: { children: React.ReactNode; href: string; prefetch?: boolean; [key: string]: unknown }) {
+    return <a href={href} data-prefetch={String(prefetch)} {...rest}>{children}</a>;
+  };
+});
+
 import { PublicLanding } from '@/components/PublicLanding';
 
 describe('PublicLanding', () => {
@@ -40,5 +47,12 @@ describe('PublicLanding', () => {
   it('renders market strip placeholder', () => {
     render(<PublicLanding />);
     expect(screen.getByTestId('live-strip-stub')).toBeInTheDocument();
+  });
+
+  it('Connect Gmail link has prefetch=false to prevent CORS-blocked RSC prefetch on /api/ route', () => {
+    render(<PublicLanding />);
+    const link = screen.getByRole('link', { name: /Connect Gmail/i });
+    expect(link).toHaveAttribute('data-prefetch', 'false');
+    expect(link).toHaveAttribute('href', '/api/auth/google');
   });
 });

--- a/components/PublicLanding.tsx
+++ b/components/PublicLanding.tsx
@@ -35,6 +35,7 @@ export function PublicLanding() {
         <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
           <Link
             href="/api/auth/google"
+            prefetch={false}
             className="inline-block px-8 py-3 bg-ds-accent text-ds-accent-fg font-semibold rounded-ds-lg hover:bg-ds-accent/90 transition-colors text-sm"
           >
             Connect Gmail →


### PR DESCRIPTION
## What
Add `prefetch={false}` to the "Connect Gmail" `<Link href="/api/auth/google">` on the public landing page.

## Why
Post-deploy smoke FAILed on `/` after #830 (auth-bypass). #830 correctly un-gated `/api/auth/google`, but Next.js RSC-prefetches the Connect-Gmail `<Link>` on landing render → handler 302-redirects cross-origin to accounts.google.com → browser CORS-blocks the prefetch → console error (CORS + `net::ERR_FAILED`) on every landing load. Page renders fine (HTTP 200) but `console_errors` tripped the smoke gate.

`prefetch={false}` stops the on-render prefetch; clicking the link still starts OAuth normally. No auth/middleware logic touched (#830 is correct).

## Test
- New guard: `__tests__/components/public-landing.test.tsx` asserts the Connect Gmail Link renders with `prefetch={false}`.
- Related suites: 9/9 pass. (Full `tsc` OOM'd on dev-vps — CI TypeCheck is the gate; 1-line valid prop.)

Fixes the post-deploy-smoke regression from #830 · relates to #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)