### PR TITLE
fix(demo): disable 5 fake buttons + Demo tooltip (b1b-fake-buttons)

### DIFF
--- a/__tests__/components/QuoteTab.test.tsx
+++ b/__tests__/components/QuoteTab.test.tsx
@@ -40,41 +40,30 @@ beforeEach(() => {
 });
 
 describe('QuoteTab — Save Draft + Send Quote handlers', () => {
-  it('Save Draft click shows "Сохранено" toast', async () => {
-    const user = userEvent.setup();
+  it('Save Draft is disabled in demo', () => {
     renderQuoteTab();
-
-    await user.click(screen.getByRole('button', { name: 'Save Draft' }));
-
-    await waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent('Сохранено')
-    );
+    expect(screen.getByRole('button', { name: 'Save Draft' })).toBeDisabled();
   });
 
-  it('Save Draft persists draft text to sessionStorage', async () => {
+  it('Save Draft does not write to sessionStorage (button disabled in demo)', async () => {
     const user = userEvent.setup();
     renderQuoteTab({ cargoEmailId: 'email-42' });
 
     const textarea = screen.getByRole('textbox');
     await user.type(textarea, 'Rate: $15,000/day');
 
-    await user.click(screen.getByRole('button', { name: 'Save Draft' }));
-
-    expect(sessionStorage.getItem('quote_draft_email-42')).toBe('Rate: $15,000/day');
+    // Button is disabled — click is a no-op; sessionStorage must remain empty.
+    expect(sessionStorage.getItem('quote_draft_email-42')).toBeNull();
   });
 
-  it('Send Quote click shows "Отправлено" toast when draft is non-empty', async () => {
+  it('Send Quote is always disabled in demo regardless of draft content', async () => {
     const user = userEvent.setup();
     renderQuoteTab();
 
     const textarea = screen.getByRole('textbox');
     await user.type(textarea, 'Demo quote text');
 
-    await user.click(screen.getByRole('button', { name: 'Send Quote' }));
-
-    await waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent('Отправлено')
-    );
+    expect(screen.getByRole('button', { name: 'Send Quote' })).toBeDisabled();
   });
 
   it('Send Quote is disabled when draft is empty', () => {

--- a/__tests__/components/demo-buttons-disabled.test.tsx
+++ b/__tests__/components/demo-buttons-disabled.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guard: 5 demo buttons must be disabled + carry title="Not available in demo".
+ * Founder decision (b1b-fake-buttons): disable without wiring real sending.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ── QuoteTab deps ──────────────────────────────────────────────────────────
+jest.mock('@/lib/csrf-client', () => ({ csrfFetch: jest.fn() }));
+jest.mock('@/components/audit-trail', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ success: jest.fn(), error: jest.fn() }),
+}));
+
+// ── VesselsClient / CargoClient deps ──────────────────────────────────────
+jest.mock('@/design-system/patterns/useMode', () => ({
+  useMode: () => ({ isOwner: true, isCharterer: true, mode: 'owner', setMode: jest.fn() }),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+jest.mock('@/lib/utils/abbr-port', () => ({ abbrPort: (s: string) => s }));
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+  ) as jest.Mock;
+});
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+import { QuoteTab } from '@/components/match/QuoteTab';
+import VesselsClient from '@/app/vessels/VesselsClient';
+import CargoClient from '@/app/cargo/CargoClient';
+
+const DEMO_TITLE = 'Not available in demo';
+
+describe('Demo buttons — disabled + title (b1b-fake-buttons)', () => {
+  describe('QuoteTab', () => {
+    beforeEach(() => render(<QuoteTab cargoEmailId="email-1" />));
+
+    it('Send Quote is disabled in demo', () => {
+      expect(screen.getByRole('button', { name: 'Send Quote' })).toBeDisabled();
+    });
+
+    it('Send Quote carries demo tooltip', () => {
+      expect(screen.getByRole('button', { name: 'Send Quote' })).toHaveAttribute(
+        'title',
+        DEMO_TITLE,
+      );
+    });
+
+    it('Save Draft is disabled in demo', () => {
+      expect(screen.getByRole('button', { name: 'Save Draft' })).toBeDisabled();
+    });
+
+    it('Save Draft carries demo tooltip', () => {
+      expect(screen.getByRole('button', { name: 'Save Draft' })).toHaveAttribute(
+        'title',
+        DEMO_TITLE,
+      );
+    });
+  });
+
+  describe('VesselsClient', () => {
+    beforeEach(() =>
+      render(<VesselsClient rows={[]} total={0} />)
+    );
+
+    it('Import CSV is disabled in demo', () => {
+      expect(screen.getByRole('button', { name: /Import CSV/i })).toBeDisabled();
+    });
+
+    it('Import CSV carries demo tooltip', () => {
+      expect(screen.getByRole('button', { name: /Import CSV/i })).toHaveAttribute(
+        'title',
+        DEMO_TITLE,
+      );
+    });
+
+    it('New vessel is disabled in demo', () => {
+      expect(screen.getByRole('button', { name: /New vessel/i })).toBeDisabled();
+    });
+
+    it('New vessel carries demo tooltip', () => {
+      expect(screen.getByRole('button', { name: /New vessel/i })).toHaveAttribute(
+        'title',
+        DEMO_TITLE,
+      );
+    });
+  });
+
+  describe('CargoClient', () => {
+    beforeEach(() =>
+      render(<CargoClient rows={[]} total={0} />)
+    );
+
+    it('Parse is disabled in demo', () => {
+      expect(screen.getByRole('button', { name: 'Parse' })).toBeDisabled();
+    });
+
+    it('Parse carries demo tooltip', () => {
+      expect(screen.getByRole('button', { name: 'Parse' })).toHaveAttribute(
+        'title',
+        DEMO_TITLE,
+      );
+    });
+  });
+});

--- a/app/cargo/CargoClient.tsx
+++ b/app/cargo/CargoClient.tsx
@@ -430,10 +430,10 @@ export default function CargoClient({ rows, total }: Props) {
             aria-label="AI parse input"
           />
           <button
-            onClick={() => setParseText('')}
-            className="relative z-10 h-[34px] px-4 rounded-[9px] bg-[#0f172a] text-white text-[13.5px] font-medium transition-all hover:-translate-y-px disabled:opacity-40"
+            disabled
+            title="Not available in demo"
+            className="relative z-10 h-[34px] px-4 rounded-[9px] bg-[#0f172a] text-white text-[13.5px] font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ boxShadow: '0 1px 0 rgba(255,255,255,0.06) inset, 0 1px 2px rgba(15,23,42,0.15)' }}
-            disabled={!parseText}
           >
             Parse
           </button>

--- a/app/vessels/VesselsClient.tsx
+++ b/app/vessels/VesselsClient.tsx
@@ -223,11 +223,17 @@ export default function VesselsClient({ rows, total }: Props) {
             </span>
           </h2>
           <div className="flex items-center gap-2.5">
-            <button className="h-[38px] px-3.5 rounded-[9px] border border-[#e2e8f0] bg-white text-[13.5px] font-medium text-[#0f172a] flex items-center gap-2 hover:border-[#cbd5e1] hover:bg-[#fafbfc] transition-all">
+            <button
+              disabled
+              title="Not available in demo"
+              className="h-[38px] px-3.5 rounded-[9px] border border-[#e2e8f0] bg-white text-[13.5px] font-medium text-[#0f172a] flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
               ⇪ Import CSV
             </button>
             <button
-              className="h-[38px] px-3.5 rounded-[9px] bg-[#0f172a] text-white text-[13.5px] font-medium flex items-center gap-2 transition-all hover:-translate-y-px"
+              disabled
+              title="Not available in demo"
+              className="h-[38px] px-3.5 rounded-[9px] bg-[#0f172a] text-white text-[13.5px] font-medium flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
               style={{ boxShadow: '0 1px 0 rgba(255,255,255,0.06) inset, 0 1px 2px rgba(15,23,42,0.15)' }}
             >
               + New vessel

--- a/components/__tests__/quote-tab-generate-draft.test.tsx
+++ b/components/__tests__/quote-tab-generate-draft.test.tsx
@@ -111,11 +111,11 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
     expect(sendBtn).toBeDisabled();
   });
 
-  it('Send Quote is enabled after draft textarea is filled', () => {
+  it('Send Quote remains disabled in demo even after draft textarea is filled', () => {
     mockFetchResponses('');
     renderWithToast(<QuoteTab cargoEmailId="email-001" />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT' } });
     const sendBtn = screen.getByRole('button', { name: /send quote/i });
-    expect(sendBtn).not.toBeDisabled();
+    expect(sendBtn).toBeDisabled();
   });
 });

--- a/components/match/QuoteTab.tsx
+++ b/components/match/QuoteTab.tsx
@@ -90,15 +90,15 @@ export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
       <div className="flex gap-2">
         <button
           className="rounded bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
-          disabled={blockSend || !draft.trim()}
-          title={blockSend ? `${blockedFields.length} critical field(s) uncertain: ${blockedFields.join(', ')}` : undefined}
-          onClick={handleSendQuote}
+          disabled
+          title="Not available in demo"
         >
           Send Quote
         </button>
         <button
-          className="rounded border border-gray-200 px-4 py-2 text-sm"
-          onClick={handleSaveDraft}
+          className="rounded border border-gray-200 px-4 py-2 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          disabled
+          title="Not available in demo"
         >
           Save Draft
         </button>

--- a/components/match/__tests__/MatchTabs.test.tsx
+++ b/components/match/__tests__/MatchTabs.test.tsx
@@ -168,13 +168,13 @@ describe('MatchTabs', () => {
       expect(btn).toBeDisabled();
     });
 
-    it('is enabled when draft has content and blockSend is false', () => {
+    it('is always disabled in demo even with draft content and blockSend=false', () => {
       const match = { ...baseMatch, confidence: mockConfidenceVerified };
       renderWithToast(<MatchTabs match={match} />);
       fireEvent.click(screen.getByRole('tab', { name: /quote/i }));
       fireEvent.change(screen.getByRole('textbox'), { target: { value: 'USD 15/MT offer' } });
       const btn = screen.getByRole('button', { name: /send quote/i });
-      expect(btn).not.toBeDisabled();
+      expect(btn).toBeDisabled();
     });
 
     it('is disabled when blockSend is true even with draft content', () => {


### PR DESCRIPTION
## Summary

- **Send Quote** (QuoteTab) — was toast-only stub → now `disabled` + tooltip
- **Save Draft** (QuoteTab) — was sessionStorage-only, no restore → now `disabled` + tooltip
- **Import CSV** (VesselsClient) — had no onClick → now `disabled` + tooltip
- **New Vessel** (VesselsClient) — had no onClick → now `disabled` + tooltip
- **Parse** (CargoClient) — just cleared the input field → now `disabled` + tooltip

All 5 get `title="Not available in demo"`. Buttons already have `disabled:opacity-40` CSS.

**DO NOT TOUCH** (real): CounterModal POST, draft-quote-card — unchanged.

## Scope

3 source files changed, surgical. Guard test asserts all 5 buttons `disabled` + `title`. 5 existing test expectations updated to reflect removed fake behavior (4 QuoteTab + 1 MatchTabs).

## Test plan

- [x] Guard test `__tests__/components/demo-buttons-disabled.test.tsx` — 10/10 pass
- [x] `npx jest --findRelatedTests` — 91/91 pass across 12 suites
- [ ] Gate5 founder visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)