### PR TITLE
fix(security): B20a/B20b/B20c — days clamp, sample rate-limit, auth/google safe origin

### DIFF
--- a/__tests__/api/auth-google.test.ts
+++ b/__tests__/api/auth-google.test.ts
@@ -76,4 +76,29 @@ describe('GET /api/auth/google', () => {
     expect(res.status).toBe(307);
     expect(res.headers.get('location')).toContain('error=auth_failed');
   });
+
+  // B20c: open-redirect fix — redirect origin must NOT echo untrusted Host header
+  it('does NOT echo an arbitrary Host header into the redirect URL (open-redirect guard)', async () => {
+    process.env = { ...origEnv }; // no NEXT_PUBLIC_APP_URL
+    const { GET } = await import('@/app/api/auth/google/route');
+    const req = new NextRequest('http://localhost/api/auth/google?error=access_denied', {
+      headers: { host: 'evil.example.com' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location') ?? '';
+    expect(location).not.toContain('evil.example.com');
+  });
+
+  it('uses NEXT_PUBLIC_APP_URL when set, ignores Host header', async () => {
+    process.env = { ...origEnv, NEXT_PUBLIC_APP_URL: 'https://app.quantika.org' };
+    const { GET } = await import('@/app/api/auth/google/route');
+    const req = new NextRequest('http://localhost/api/auth/google?error=access_denied', {
+      headers: { host: 'evil.example.com' },
+    });
+    const res = await GET(req);
+    const location = res.headers.get('location') ?? '';
+    expect(location).toContain('app.quantika.org');
+    expect(location).not.toContain('evil.example.com');
+  });
 });

--- a/__tests__/api/market-indices.test.ts
+++ b/__tests__/api/market-indices.test.ts
@@ -347,3 +347,41 @@ describe('GET /api/market/indices — bunker and EUA history', () => {
     expect(json).toEqual([]);
   });
 });
+
+// ── B20a: days upper-bound clamp ─────────────────────────────────────────────
+
+describe('GET /api/market/indices — B20a days clamp', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration019.up(db);
+    migration027.up(db);
+    testDb = db;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('accepts days=365 (upper bound) without error', async () => {
+    const { GET } = await import('@/app/api/market/indices/route');
+    const req = new Request('http://localhost/api/market/indices?name=bdi&days=365');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('clamps days=9999 to 365 (returns 200, not 400)', async () => {
+    const { GET } = await import('@/app/api/market/indices/route');
+    const req = new Request('http://localhost/api/market/indices?name=bdi&days=9999');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('clamps days=366 to 365 (returns 200, not 400)', async () => {
+    const { GET } = await import('@/app/api/market/indices/route');
+    const req = new Request('http://localhost/api/market/indices?name=bdi&days=366');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/roi.test.ts
+++ b/__tests__/api/roi.test.ts
@@ -175,4 +175,25 @@ describe('GET /api/analytics/roi', () => {
     expect(json.totalSavingsUsd).toBe(0);
     expect(json.roiMultiple).toBe(0);
   });
+
+  // B20a: days upper-bound clamp
+  it('clamps days=9999 to 365 — returns 200, not 400', async () => {
+    process.env.ROI_GUARANTEE_ENABLED = 'true';
+
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi?days=9999');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts days=365 without error', async () => {
+    process.env.ROI_GUARANTEE_ENABLED = 'true';
+
+    const { GET } = await import('@/app/api/analytics/roi/route');
+    const req = new NextRequest('http://localhost:3000/api/analytics/roi?days=365');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+  });
 });

--- a/__tests__/api/sample-route.test.ts
+++ b/__tests__/api/sample-route.test.ts
@@ -107,4 +107,23 @@ describe('POST /api/sample', () => {
     expect(session!.insufficientData).toBeDefined();
     expect(session!.insufficientData!.length).toBeGreaterThan(0);
   });
+
+  // B20b: per-IP rate limit
+  it('returns 429 after rate limit is exhausted for the same IP', async () => {
+    jest.resetModules();
+    const { POST } = await import('@/app/api/sample/route');
+    const ip = '1.2.3.4';
+    function makeIpReq(): NextRequest {
+      return new NextRequest('http://localhost/api/sample', {
+        method: 'POST',
+        headers: { 'x-forwarded-for': ip },
+      });
+    }
+    // Drive through the rate limit window (sampleRateLimiter allows 10/60s)
+    let lastRes: Awaited<ReturnType<typeof POST>> | null = null;
+    for (let i = 0; i < 11; i++) {
+      lastRes = await POST(makeIpReq());
+    }
+    expect(lastRes!.status).toBe(429);
+  });
 });

--- a/app/api/analytics/roi/route.ts
+++ b/app/api/analytics/roi/route.ts
@@ -78,7 +78,7 @@ export async function GET(request: NextRequest) {
       if (parsed < 0) {
         return NextResponse.json({ error: "Invalid days parameter: cannot be negative" }, { status: 400 });
       }
-      days = parsed;
+      days = Math.min(365, parsed);
     }
 
     // Seed minimal demo data if the table is empty

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -4,6 +4,7 @@ import { exchangeCodeForToken, fetchGmailProfile, getAuthUrl } from '@/lib/googl
 import { logger } from '@/lib/logger';
 import { createSession, updateSession } from '@/lib/session';
 import { generateCsrfToken } from '@/lib/csrf';
+import { getRequestBaseUrl } from '@/lib/auth/redirect-url';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -11,7 +12,7 @@ export async function GET(request: NextRequest) {
   const error = searchParams.get('error');
 
   if (error) {
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `https://${request.headers.get('host')}`;
+    const baseUrl = getRequestBaseUrl(request);
     return NextResponse.redirect(new URL('/?error=access_denied', baseUrl));
   }
 
@@ -33,7 +34,7 @@ export async function GET(request: NextRequest) {
     }
     const csrfToken = generateCsrfToken();
 
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `https://${request.headers.get('host')}`;
+    const baseUrl = getRequestBaseUrl(request);
     const response = NextResponse.redirect(new URL('/processing', baseUrl));
     response.cookies.set('session_id', sessionId, {
       httpOnly: true,
@@ -54,7 +55,7 @@ export async function GET(request: NextRequest) {
     return response;
   } catch (err) {
     logger.error({ err }, 'OAuth error');
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `https://${request.headers.get('host')}`;
+    const baseUrl = getRequestBaseUrl(request);
     return NextResponse.redirect(new URL('/?error=auth_failed', baseUrl));
   }
 }

--- a/app/api/market/indices/route.ts
+++ b/app/api/market/indices/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     if (isNaN(parsed) || parsed <= 0) {
       return NextResponse.json({ error: 'days must be positive integer' }, { status: 400 });
     }
-    days = parsed;
+    days = Math.min(365, parsed);
   }
 
   const db = getStore().getDatabase();

--- a/app/api/sample/route.ts
+++ b/app/api/sample/route.ts
@@ -1,11 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { generateCsrfToken, validateCsrf } from '@/lib/csrf';
 import { createDemoSession } from '@/lib/sample-data/create-demo-session';
+import { sampleRateLimiter } from '@/lib/rate-limit';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
   if (!validateCsrf(request)) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'anonymous';
+  const { allowed, retryAfterMs } = sampleRateLimiter.check(ip);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(Math.ceil(retryAfterMs / 1000)) } },
+    );
+  }
+
   const sessionId = createDemoSession();
 
   const csrfToken = generateCsrfToken();

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -64,3 +64,7 @@ export const loginRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests:
 // L-3: throttle credential-guessing against /api/admin/* shared-secret endpoints.
 // Admin tooling is low-frequency; cap at 10 attempts / 60s per IP.
 export const adminRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 10 });
+
+// B20b: prevent session-flooding on the public demo endpoint. 10 demo sessions
+// per IP per minute is generous for a human and easy to enforce.
+export const sampleRateLimiter = new RateLimiter({ windowMs: 60_000, maxRequests: 10 });


### PR DESCRIPTION
## Summary

- **B20a** `app/api/market/indices` + `app/api/analytics/roi`: clamp `?days` to `Math.min(365, parsed)` — prevents unbounded DB scans (days=9999 previously accepted)
- **B20b** `app/api/sample`: add per-IP rate limit (10 req/60 s) via existing `RateLimiter` from `lib/rate-limit.ts`; IP key from `x-forwarded-for`
- **B20c** `app/api/auth/google`: replace 3× `process.env.NEXT_PUBLIC_APP_URL || \`https://${request.headers.get('host')}\`` with `getRequestBaseUrl(request)` from `lib/auth/redirect-url.ts` — fails-closed to `https://demo.quantika.org` for untrusted non-local Host headers (open-redirect fix)

## Files changed

| File | Change |
|------|--------|
| `app/api/market/indices/route.ts` | `Math.min(365, parsed)` clamp |
| `app/api/analytics/roi/route.ts` | `Math.min(365, parsed)` clamp |
| `lib/rate-limit.ts` | `sampleRateLimiter` singleton (10/60s) |
| `app/api/sample/route.ts` | IP-keyed rate-limit check before session creation |
| `app/api/auth/google/route.ts` | import + 3× `getRequestBaseUrl(request)` |
| `__tests__/api/market-indices.test.ts` | B20a clamp acceptance tests |
| `__tests__/api/roi.test.ts` | B20a clamp acceptance tests |
| `__tests__/api/sample-route.test.ts` | B20b 429 exhaustion test |
| `__tests__/api/auth-google.test.ts` | B20c open-redirect guard tests |

## Test plan

- [ ] `npx jest "__tests__/api/(market-indices|roi|sample-route|auth-google)" --forceExit` — 46 tests pass
- [ ] Related-tests run: 212 tests pass (25 suites)
- [ ] Middleware tests unaffected (`__tests__/middleware-auth.test.ts`, `middleware-rate-limit.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)