### PR TITLE
fix(storage): B17 hygiene — backup label, WAL checkpoint, pm2 reload→restart, seed --window

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -85,7 +85,7 @@ git tag -l --sort=-version:refname | head -5
 git checkout <prev-tag>
 npm ci
 npm run build
-pm2 reload quantika-demo
+pm2 restart quantika-demo --update-env
 
 # 3. Проверить что откат успешен
 curl https://demo.quantika.org/api/health

--- a/docs/runbooks/knowledge-layer-feature-flags.md
+++ b/docs/runbooks/knowledge-layer-feature-flags.md
@@ -42,7 +42,7 @@ The Knowledge Layer introduces real data sources for sanctions screening, port d
   - Smoke test: POST `/api/match` with a clean entity returns `sanctions_hit: false`.
 - **Rollback (< 5 min):**
   1. Set `KNOWLEDGE_SANCTIONS_REAL=false` in `.env.production`.
-  2. Reload: `pm2 reload quantika-demo` or `systemctl restart quantika-demo`.
+  2. Restart: `pm2 restart quantika-demo --update-env` or `systemctl restart quantika-demo`.
   3. Verify: POST `/api/match` completes without 5xx; sanctions logic runs from fixtures.
 - **Phase 1 task:** C6
 
@@ -59,7 +59,7 @@ The Knowledge Layer introduces real data sources for sanctions screening, port d
   - Smoke: 5 known routes (e.g., Shanghai→Rotterdam, Dubai→Hamburg) within ±5% of historical baseline values.
 - **Rollback (< 5 min):**
   1. Set `KNOWLEDGE_LAYER_DISTANCES_ENABLED=false` in `.env.production`.
-  2. Reload: `pm2 reload quantika-demo` or `systemctl restart quantika-demo`.
+  2. Restart: `pm2 restart quantika-demo --update-env` or `systemctl restart quantika-demo`.
   3. Smoke check: POST `/api/match` returns distances based on Haversine (no 5xx, reasonable km values).
 - **Phase 1 task:** D7
 
@@ -76,7 +76,7 @@ The Knowledge Layer introduces real data sources for sanctions screening, port d
   - Regression: POST `/api/match` with a voyage through a safe corridor returns same or lower `war_risk_rate` as before.
 - **Rollback (< 5 min):**
   1. Set `KNOWLEDGE_WAR_RISK_FROM_DB=false` in `.env.production`.
-  2. Reload: `pm2 reload quantika-demo` or `systemctl restart quantika-demo`.
+  2. Restart: `pm2 restart quantika-demo --update-env` or `systemctl restart quantika-demo`.
   3. Verify: `/api/match` returns war-risk values from hardcoded logic (no 5xx).
 - **Phase 1 task:** E3
 
@@ -92,7 +92,7 @@ The Knowledge Layer introduces real data sources for sanctions screening, port d
   - At least 3 RAG smoke queries return relevant knowledge snippets.
 - **Rollback (< 5 min):**
   1. Set `KNOWLEDGE_LAYER_RAG_ENABLED=false` in `.env.production`.
-  2. Reload: `pm2 reload quantika-demo` or `systemctl restart quantika-demo`.
+  2. Restart: `pm2 restart quantika-demo --update-env` or `systemctl restart quantika-demo`.
   3. Verify: endpoints that use RAG fall back to non-RAG logic without errors.
 - **Phase 1 task:** Phase 2 (not scheduled)
 
@@ -126,13 +126,13 @@ Activate in this sequence after Phase 1 deploy. Each step assumes the previous o
 To disable all Knowledge Layer flags in one command:
 
 ```bash
-sed -i.bak -E 's/^(KNOWLEDGE_.*=)true/\1false/' /opt/quantika/.env.production && pm2 reload quantika-demo
+sed -i.bak -E 's/^(KNOWLEDGE_.*=)true/\1false/' /opt/quantika/.env.production && pm2 restart quantika-demo --update-env
 ```
 
 This creates a `.env.production.bak` backup before modification. To restore from backup:
 
 ```bash
-cp /opt/quantika/.env.production.bak /opt/quantika/.env.production && pm2 reload quantika-demo
+cp /opt/quantika/.env.production.bak /opt/quantika/.env.production && pm2 restart quantika-demo --update-env
 ```
 
 ---

--- a/docs/runbooks/vps-searoute-deploy.md
+++ b/docs/runbooks/vps-searoute-deploy.md
@@ -152,7 +152,7 @@ Disable distance auto-resolution without touching the Python service:
 # In /root/work/quantika-demo/.env.local on VPS:
 KNOWLEDGE_LAYER_DISTANCES_ENABLED=false
 
-pm2 restart quantika-demo   # picks up new env
+pm2 restart quantika-demo --update-env   # picks up new env
 ```
 
 To also stop the searoute service:

--- a/scripts/demo-seed/__tests__/seed-all-window.test.ts
+++ b/scripts/demo-seed/__tests__/seed-all-window.test.ts
@@ -1,0 +1,25 @@
+// Unit test for --window flag parsing logic used in seed-all.ts
+describe('seed-all --window flag parsing', () => {
+  const makeGet = (argv: string[]) => (k: string) => {
+    const i = argv.indexOf(k);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+
+  it('defaults to 14 when --window absent', () => {
+    const get = makeGet([]);
+    const demoWindowDays = parseInt(get('--window') ?? '14', 10);
+    expect(demoWindowDays).toBe(14);
+  });
+
+  it('parses --window 7', () => {
+    const get = makeGet(['--window', '7']);
+    const demoWindowDays = parseInt(get('--window') ?? '14', 10);
+    expect(demoWindowDays).toBe(7);
+  });
+
+  it('parses --window when mixed with other flags', () => {
+    const get = makeGet(['--frozen-date', '2026-01-01', '--window', '30', '--model', 'claude-opus-4-8']);
+    const demoWindowDays = parseInt(get('--window') ?? '14', 10);
+    expect(demoWindowDays).toBe(30);
+  });
+});

--- a/scripts/demo-seed/seed-all.ts
+++ b/scripts/demo-seed/seed-all.ts
@@ -20,6 +20,7 @@ async function main(): Promise<void> {
   const rawDir = path.resolve(get('--raw-dir') ?? '.private/raw-emails');
   const frozenDate = get('--frozen-date') ?? new Date().toISOString().slice(0, 10);
   const model = get('--model') ?? 'claude-opus-4-8';
+  const demoWindowDays = parseInt(get('--window') ?? '14', 10);
   const manifestPath = path.resolve('scripts/demo-seed/manifest.json');
   const outDb = path.resolve('data/demo-seed.db');
 
@@ -164,7 +165,7 @@ async function main(): Promise<void> {
 
   // 3. Analyze (offsets + merge reconcile anonymization)
   console.log('[seed-all] 3/5 analyze (date offsets)…');
-  const manifest = await analyze({ rawDir, frozenDate, demoWindowDays: 14, seedAnonymization: rec.anonymization });
+  const manifest = await analyze({ rawDir, frozenDate, demoWindowDays, seedAnonymization: rec.anonymization });
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
 
   // 4. Build

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -49,6 +49,9 @@ npx tsx scripts/migrate.ts
 echo "==> Seeding port-DA estimates ($SESSIONS_DB_PATH)..."
 npx tsx scripts/seed-port-da.ts
 
+echo "==> WAL checkpoint ($SESSIONS_DB_PATH) — flush WAL before restart..."
+sqlite3 "$SESSIONS_DB_PATH" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
+
 echo "==> Restarting PM2 (--update-env picks up .env.local changes)..."
 npx pm2 restart quantika-demo --update-env
 npx pm2 save

--- a/scripts/ops/backup.sh
+++ b/scripts/ops/backup.sh
@@ -46,7 +46,7 @@ HEARTBEAT_URL="${HEARTBEAT_URL:-http://localhost:3000/api/admin/cron-heartbeat}"
 declare -a SOURCES=(
   "${APP_DIR}/.env.local"
   "/root/.config/gcp/quantika-vertex-ai.json"
-  "${APP_DIR}/data/quantika.db"
+  "${APP_DIR}/data/quantika.db"   # deadlines DB (check-deadlines.ts); RAG corpus now lives in sessions.db
   "${APP_DIR}/data/sessions.db"
 )
 # Add uploads dir only if it exists (not present in all envs)


### PR DESCRIPTION
## Summary

- **(a) backup.sh**: Added inline comment to `quantika.db` entry clarifying it's the deadlines DB (RAG corpus moved to `sessions.db`)
- **(e) deploy-vps.sh**: Added `sqlite3 PRAGMA wal_checkpoint(TRUNCATE)` on `SESSIONS_DB_PATH` before `pm2 restart` to flush WAL before process restart
- **(f) docs**: Replaced all `pm2 reload quantika-demo` with `pm2 restart quantika-demo --update-env` in `docs/deploy.md` (×1), `docs/runbooks/knowledge-layer-feature-flags.md` (×6), `docs/runbooks/vps-searoute-deploy.md` (×1 — added missing `--update-env`)
- **(g) seed-all.ts**: Wired `--window N` CLI flag through to `analyze()` call (default 14); added unit test for flag-parsing logic

## SCOPE MATCH

Only: `backup.sh`, `deploy-vps.sh`, `docs/deploy.md`, `docs/runbooks/knowledge-layer-feature-flags.md`, `docs/runbooks/vps-searoute-deploy.md`, `seed-all.ts`, `seed-all-window.test.ts` (7 files)

## Test plan

- [ ] `npx jest --findRelatedTests scripts/demo-seed/__tests__/seed-all-window.test.ts` → 3 passed
- [ ] `NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit` → no errors
- [ ] Verify no `pm2 reload` outside of archive/plans dirs: `grep -rn "pm2 reload" docs/ scripts/ app/ lib/`
- [ ] On VPS after deploy: `sqlite3 data/demo-seed.db "PRAGMA wal_checkpoint(TRUNCATE);"` call visible in deploy log before pm2 restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)