### PR TITLE
fix(market): B13 — demo-snapshot label on market surfaces, drop Live copy

### DIFF
--- a/__tests__/market-snapshot-label.test.tsx
+++ b/__tests__/market-snapshot-label.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * B13 — demo-snapshot label on market surfaces
+ *
+ * Strategy: static JSX source analysis (testEnvironment: 'node').
+ * Verifies that all market-data surfaces carry the correct demo-snapshot label
+ * and that the misleading "Live" copy has been removed from the about page.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+
+function readSource(filePath: string): string {
+  return fs.readFileSync(path.join(ROOT, filePath), 'utf8');
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// app/market/page.tsx — badge must show "demo snapshot", not "Live · synced"
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('app/market/page.tsx — demo snapshot badge', () => {
+  const src = readSource('app/market/page.tsx');
+
+  it('contains "demo snapshot" label text', () => {
+    expect(src).toContain('demo snapshot');
+  });
+
+  it('no longer shows "Live · synced"', () => {
+    expect(src).not.toContain('Live · synced');
+  });
+
+  it('no longer shows stale "Last sync:" text in badge', () => {
+    expect(src).not.toContain('Last sync:');
+  });
+
+  it('still keeps isStale variable (used as prop for MarketKpiTile)', () => {
+    expect(src).toContain('const isStale =');
+    // prop usage
+    expect(src).toMatch(/isStale=\{isStale\}/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// components/market/LiveStrip.tsx — caption added, aria-label updated
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('components/market/LiveStrip.tsx — demo snapshot caption', () => {
+  const src = readSource('components/market/LiveStrip.tsx');
+
+  it('renders "demo snapshot" caption', () => {
+    expect(src).toContain('demo snapshot');
+  });
+
+  it('uses correct caption styling classes', () => {
+    expect(src).toContain('text-[10px] font-mono text-slate-400 text-right tracking-wide');
+  });
+
+  it('wraps in space-y-1.5 container', () => {
+    expect(src).toContain('space-y-1.5');
+  });
+
+  it('aria-label is "Market data" (not "Live market data")', () => {
+    expect(src).toContain('aria-label="Market data"');
+    expect(src).not.toContain('aria-label="Live market data"');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// components/dashboard/MarketIntelligence.tsx — caption added
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('components/dashboard/MarketIntelligence.tsx — demo data caption', () => {
+  const src = readSource('components/dashboard/MarketIntelligence.tsx');
+
+  it('renders "demo data" caption', () => {
+    expect(src).toContain('demo data');
+  });
+
+  it('caption appears before noActiveDeals block', () => {
+    const captionIdx = src.indexOf('demo data');
+    const noActiveDealsIdx = src.indexOf('noActiveDeals &&');
+    expect(captionIdx).toBeGreaterThan(0);
+    expect(noActiveDealsIdx).toBeGreaterThan(captionIdx);
+  });
+
+  it('uses correct caption styling classes', () => {
+    expect(src).toContain('text-[10px] font-mono text-slate-400 text-right tracking-wide');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// components/dashboard/DashboardKpiStrip.tsx — caption added
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('components/dashboard/DashboardKpiStrip.tsx — demo data caption', () => {
+  const src = readSource('components/dashboard/DashboardKpiStrip.tsx');
+
+  it('renders "demo data" caption', () => {
+    expect(src).toContain('demo data');
+  });
+
+  it('wraps grid in space-y-1 container', () => {
+    expect(src).toContain('space-y-1');
+  });
+
+  it('uses correct caption styling classes', () => {
+    expect(src).toContain('text-[10px] font-mono text-slate-400 text-right tracking-wide');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// app/about/page.tsx — "Live " prefix removed from market intelligence desc
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('app/about/page.tsx — market intelligence copy', () => {
+  const src = readSource('app/about/page.tsx');
+
+  it('does not say "Live Baltic Exchange"', () => {
+    expect(src).not.toContain('Live Baltic Exchange');
+  });
+
+  it('says "Baltic Exchange indices" without the Live prefix', () => {
+    expect(src).toContain('Baltic Exchange indices (BDI, BCI, BSI, BHSI)');
+  });
+});

--- a/__tests__/market/market-page.test.ts
+++ b/__tests__/market/market-page.test.ts
@@ -98,7 +98,7 @@ describe('MarketPage — sync badge staleness', () => {
     jest.restoreAllMocks();
   });
 
-  it('shows LAST SYNC badge (not Live · synced) when data is >24h old', async () => {
+  it('shows demo snapshot badge (not Last sync / Live · synced) when data is >24h old', async () => {
     const staleDate = new Date(Date.now() - 17 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     const staleData = [{ index_date: staleDate, value: 500, unit: 'points', source: 'test' }];
 
@@ -109,13 +109,14 @@ describe('MarketPage — sync badge staleness', () => {
     render(React.createElement(MarketPage));
 
     await waitFor(() => {
-      expect(screen.getByText(/last sync:/i)).toBeInTheDocument();
+      expect(screen.getByText(/demo snapshot/i)).toBeInTheDocument();
     });
 
     expect(screen.queryByText(/live · synced/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/last sync:/i)).not.toBeInTheDocument();
   });
 
-  it('shows Live · synced badge when data is <24h old', async () => {
+  it('shows demo snapshot badge (not Live · synced) when data is <24h old', async () => {
     const freshDate = new Date().toISOString().slice(0, 10);
     const freshData = [{ index_date: freshDate, value: 500, unit: 'points', source: 'test' }];
 
@@ -126,15 +127,16 @@ describe('MarketPage — sync badge staleness', () => {
     render(React.createElement(MarketPage));
 
     await waitFor(() => {
-      expect(screen.getByText(/live · synced/i)).toBeInTheDocument();
+      expect(screen.getByText(/demo snapshot/i)).toBeInTheDocument();
     });
 
+    expect(screen.queryByText(/live · synced/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/last sync:/i)).not.toBeInTheDocument();
   });
 
-  it('#545 — LAST SYNC shows BDI period date when BDI is older than market_indices data', async () => {
+  it('#545 — demo snapshot shows BDI period date when BDI is older than market_indices data', async () => {
     // BDI period is 17 days old; market_indices data (bhsi/tmi/drewry) is 5 days old.
-    // The LAST SYNC label must show the older BDI date (min across all sources).
+    // The demo snapshot label must show the older BDI date (min across all sources).
     const bdiDate = new Date(Date.now() - 17 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     const indicesDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
@@ -156,13 +158,13 @@ describe('MarketPage — sync badge staleness', () => {
     render(React.createElement(MarketPage));
 
     await waitFor(() => {
-      expect(screen.getByText(/last sync:/i)).toBeInTheDocument();
+      expect(screen.getByText(/demo snapshot/i)).toBeInTheDocument();
     });
 
     // The label should show bdiDate, not indicesDate
-    expect(screen.getByText(/last sync:/i).textContent).toContain(bdiDate);
+    expect(screen.getByText(/demo snapshot/i).textContent).toContain(bdiDate);
     // Check badge text specifically — indicesDate may appear in chart table rows (not in the badge)
-    expect(screen.getByText(/last sync:/i).textContent).not.toContain(indicesDate);
+    expect(screen.getByText(/demo snapshot/i).textContent).not.toContain(indicesDate);
   });
 });
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -42,7 +42,7 @@ export default function AboutPage() {
             {[
               { icon: '📧', title: 'Email parsing', desc: 'Extracts cargo specs, vessel details, and laycan windows from plain-text emails using LLMs trained on shipping industry language.' },
               { icon: '🤝', title: 'Smart matching', desc: 'Scores vessel-cargo pairs on DWT compatibility, route fit, laycan overlap, and TCE economics — ranked by overall match quality.' },
-              { icon: '📊', title: 'Market intelligence', desc: 'Live Baltic Exchange indices (BDI, BCI, BSI, BHSI), TCE estimates for major tradelanes, and bunker price feeds.' },
+              { icon: '📊', title: 'Market intelligence', desc: 'Baltic Exchange indices (BDI, BCI, BSI, BHSI), TCE estimates for major tradelanes, and bunker price feeds.' },
               { icon: '🔒', title: 'Compliance checks', desc: 'Automatic OFAC and EU sanctions screening on all counterparties before a fixture goes firm.' },
             ].map(({ icon, title, desc }) => (
               <li key={title} className="flex gap-3">

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -265,17 +265,10 @@ export default function MarketPage() {
               <span className="text-slate-900">London 16:30 GMT</span>
             </p>
           </div>
-          {isStale ? (
-            <div className="flex items-center gap-2 font-mono text-[11.5px] uppercase tracking-widest text-slate-400">
-              <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
-              Last sync: {latestDate}
-            </div>
-          ) : (
-            <div className="flex items-center gap-2 font-mono text-[11.5px] uppercase tracking-widest text-slate-400">
-              <span className="w-1.5 h-1.5 rounded-full bg-green-600 animate-pulse" />
-              Live · synced
-            </div>
-          )}
+          <div className="flex items-center gap-2 font-mono text-[11.5px] uppercase tracking-widest text-slate-400">
+            <span className="w-1.5 h-1.5 rounded-full bg-amber-400" />
+            {latestDate ? `Market data · demo snapshot as of ${latestDate}` : 'Market data · demo snapshot'}
+          </div>
         </header>
 
         {/* KPI Strip — Baltic indices + bunker + EUA */}

--- a/components/dashboard/DashboardKpiStrip.tsx
+++ b/components/dashboard/DashboardKpiStrip.tsx
@@ -9,6 +9,7 @@ interface DashboardKpiStripProps {
 
 export function DashboardKpiStrip({ openMatches, activeCargoes }: DashboardKpiStripProps) {
   return (
+    <div className="space-y-1">
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="kpi-strip">
       {/* Tile 1: Open Matches */}
       <Link
@@ -49,6 +50,8 @@ export function DashboardKpiStrip({ openMatches, activeCargoes }: DashboardKpiSt
 
       {/* Tile 4: HSS Med Rate */}
       <KpiCard label="HSS MED RATE" url="/api/market/benchmark?indicator=BHSI" unit="index" />
+    </div>
+      <p className="text-[10px] font-mono text-slate-400 text-right tracking-wide">demo data</p>
     </div>
   );
 }

--- a/components/dashboard/MarketIntelligence.tsx
+++ b/components/dashboard/MarketIntelligence.tsx
@@ -39,6 +39,7 @@ export function MarketIntelligence({ noActiveDeals }: MarketIntelligenceProps) {
           unit="EUR/tCO₂"
         />
       </div>
+      <p className="text-[10px] font-mono text-slate-400 text-right tracking-wide">demo data</p>
       {noActiveDeals && (
         <p className="text-sm text-gray-500 text-center py-2">
           No active deals yet.{' '}

--- a/components/market/LiveStrip.tsx
+++ b/components/market/LiveStrip.tsx
@@ -4,10 +4,13 @@ import { KpiCard } from './KpiCard';
 
 export function LiveStrip() {
   return (
-    <div className="grid grid-cols-3 gap-3" role="region" aria-label="Live market data">
-      <KpiCard label="BDI" url="/api/market/baltic-kpi?code=BDI" unit="pts" />
-      <KpiCard label="BHSI" url="/api/market/baltic-kpi?code=BHSI" unit="pts" />
-      <KpiCard label="VLSFO RTM" url="/api/market/bunker-kpi?grade=VLSFO" unit="$/mt" />
+    <div className="space-y-1.5" role="region" aria-label="Market data">
+      <div className="grid grid-cols-3 gap-3">
+        <KpiCard label="BDI" url="/api/market/baltic-kpi?code=BDI" unit="pts" />
+        <KpiCard label="BHSI" url="/api/market/baltic-kpi?code=BHSI" unit="pts" />
+        <KpiCard label="VLSFO RTM" url="/api/market/bunker-kpi?grade=VLSFO" unit="$/mt" />
+      </div>
+      <p className="text-[10px] font-mono text-slate-400 text-right tracking-wide">demo snapshot</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `app/market/page.tsx`: Replace stale/live conditional badge with single always-visible `Market data · demo snapshot as of {date}` label — drops misleading "Live · synced" wording
- `components/market/LiveStrip.tsx`, `components/dashboard/MarketIntelligence.tsx`, `components/dashboard/DashboardKpiStrip.tsx`: Add subtle `demo snapshot` / `demo data` caption below market KPI tiles
- `app/about/page.tsx`: Drop "Live " prefix from "Live Baltic Exchange indices" copy

## Test Plan

- [ ] 49 tests passing (`npm test` findRelatedTests)
- [ ] Market page header always shows amber dot + "Market data · demo snapshot as of YYYY-MM-DD"
- [ ] LiveStrip on landing shows "demo snapshot" caption below BDI/BHSI/VLSFO tiles
- [ ] Dashboard tiles show "demo data" caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)