### PR TITLE
fix(seed): Phase 1 — durable reference-table seeding into demo-seed.db

### DIFF
--- a/docs/ROADMAP-CURRENT-STATE.md
+++ b/docs/ROADMAP-CURRENT-STATE.md
@@ -1,5 +1,71 @@
 # Quantika Demo — ROADMAP (Текущее состояние)
 
+## 0. МАТЧИНГ — forward roadmap L1→L4 «к 100%» (2026-06-06 audit)
+
+> **Forward-часть** (что осталось), в отличие от changelog ниже. Источник: 3-агентный read-only аудит scoring-пайплайна 2026-06-06 (spine / economics-L2 / passport-L3), все три независимо сошлись. Планка фаундера = **L3** («практические 100%» на бесплатных данных).
+> **Контекст дня:** PR #841 (true-voyage TCE: ballast reposition + Suez canal + economic floor) merged + прод-реген применён — main-bucket neg-TCE **18→0**, avg **−$308→+$9,664/день**. См. state.md + `docs/superpowers/golden-set/`.
+>
+> **✅ Reality-verified 2026-06-06 (3 read-only агента, claim-vs-prod/code/PR):** прод HEAD = `0c564a29` (#841, deployed); demo-seed buckets = **main 69 / review 261 / insuf 60**; neg-TCE main = 0. **⚠️ §1-§3 НИЖЕ содержат стале-claims** (не правлены построчно — см. state.md за полной таблицей): prod HEAD `d3c62d0e`→#841; bucket-счётчики 28/126/571→69/261/60; §1.2 data-layer counts описывают `sessions.db`, а live = пустой demo-seed.db (см. ПРОД-БАГ); routes 50→**69**, pages 23→**35**; F5/F6/F7 (битые страницы) УЖЕ FIXED; Gate5-round-2 / 4-fix-WIP / #819 B(c) / rate-limiter `/api/parser/email` — ЗАКРЫТЫ (#781/#776/#777/#826/#829/#463/#835); baltic/bunker/eua не «stale CSV», а свежие (таймеры). Genuinely open: #589, eslint-10 (#754), tailwind-4, PWA, full-RTL, Quote-PDF, Stripe, dark-mode, partner-data калибровка, F8 Resend.
+
+### 🔴 ГЛАВНОЕ — структурный хвост (НЕ «данные»): ранжирование слепо к новой машинерии
+
+Движок считает **ДВА несвязанных числа на матч**:
+
+- **`m.score`** (старый `computeScoreBreakdown`: гео 20 / тип 20 / краны 15 / объём 15 / laycan 20 / dwt 10) → **рулит сортировкой главного списка + корзиной (main/review/insufficient) + matchLevel** (`pair-analyzer.ts:711, 588`). **Ноль экономики, ноль ветинга.**
+- **`fitPercent` + `fitBreakdown`** (util 23 / timing 18 / ballast 18 / classFit 11 / cargoType 7 / cranes 7 / volume 4 / **vetting 9** / draft 3) → **только отображение** (`pair-analyzer.ts:693`).
+
+Код фиксирует это намеренно: economics «Display-only … can never affect score, ranking, or bucketing» (`pair-analyzer.ts:741`). В сиде **0/425** строк имеют `score==fit_percent`; бывает `score=90` (топ, shortlisted) при `fit=54`, `tce=−1260/день`.
+
+**TCE (#841) влияет ТОЛЬКО на корзинный floor** (`pair-analyzer.ts:819-848` — ниже class-breakeven → review), но **не ранжирует внутри main и не входит в `m.score`**. Ветинг — то же (только в fit-%).
+
+→ **Высший рычаг: переключить ранжирование+бакетинг на `fitPercent`** (свернув в него true-voyage TCE + ветинг), а не гонять параллельный старый 6-факторный score. Это не «дописать данные» — **развилка дизайна, нужно решение фаундера** (brainstorm).
+
+### 🔴 ПРОД-БАГ (verified 2026-06-06): 11 reference/RAG-таблиц ПУСТЫ в живом demo-seed.db
+
+App в DEMO_MODE читает ВСЁ из `SESSIONS_DB_PATH=data/demo-seed.db` (`lib/db/index.ts:5-6`; retriever-sqlite `getDb()` без override; отдельного knowledge-DB нет). НО в живом demo-seed.db **пусты:** `charterers`=0, `port_da_estimates`=0, `psc_detention_history`=0, `port_distances`=0, `port_master`=0, `eca_zones`=0, `war_risk_zones`=0, `imsbc/igc/jwc/bimco_fts`=0. Данные живут в осиротевшем `data/sessions.db` (41MB, app его НЕ читает). Корень: seed-пайплайн пишет в demo-seed.db только МАТЧИ + таймер-таблицы (market/ofac/fx — те живые); reference/RAG туда не копировались, а DEMO_MODE-переключение (~May29) увело app на demo-seed.db. **Севериті:** ядро демо работает (matches — distance/TCE запечены в сид), но RAG/clauses, charterer-credit, PSC-история, ECA-топливо, runtime port-resolution = пустые. **Это ПРЕРЕКВИЗИТ для L3-данных:** «PSC→ветинг» и RAG бессмысленны, пока данные в неправильном файле. Фикс = разовая data-миграция sessions.db→demo-seed.db (Rule#22, обратимо, данные уже есть). Founder-gated.
+
+### Статус по уровням
+
+| Уровень | Цель | Статус | Что осталось |
+|---|---|---|---|
+| **L1 «не врёт»** | парсинг + корзины + гейты | 🟢 ~готов | `draft`-фактор в fit-% всегда conservative (display; hard-гейт работает отдельно) — мелочь |
+| **L2 «полезен»** | TCE+war-risk+фрахт в экономику И в score | 🟡 ядро #841 есть, проводки в score нет | port-DA, carbon, war-в-TCE, **TCE-в-ранкинг**, свежий фрахт, сужение полос |
+| **L3 «надёжен»** ← цель | passport/CII/IMSBC/чистота в score | 🟡 ветинг в fit-% есть, в score нет; данные голодают | PSC→ветинг, CII-данные, снос мёртвого паспорта, IMSBC/чистота-в-fit |
+| **L4 «pro»** | PSC-live/Baltic-live/FFA/credit | ⚪ платно, опц. | вне бесплатной планки |
+
+### Реально открытые хвосты — приоритезированы
+
+**🔧 Проводка готового (дёшево — логика/данные УЖЕ есть, надо подключить):**
+
+1. **TCE → ранжирование/fit** (L2, высший ROI) — главный список ранжировать с учётом денег; свернуть true-voyage TCE в `fitPercent` градиентом. Сейчас fit-cap бьёт только при `TCE<0` бинарно И кормится грубым `preFitTce` без ballast/canal (`fit-breakdown.ts:565`, `pair-analyzer.ts:688`).
+2. **PSC-детенции → ветинг** (L3, высший ROI) — `lib/market/psc-repository.ts` полностью построен (миграция 028 + сид + API), score его НЕ читает. Добавить 6-й суб-фактор в `computeVesselVetting`.
+3. **Port DA → TCE** (L2 «step 4») — `getPortDa` (`lib/port-da/repository.ts`) никогда не зовётся в `lib/matching/`; `daUsd=0` в каждом матче. Реальные деньги мимо. Нужен DB-handle в расчёт.
+4. **CII-данные в сид** (L3) — логика `scoreCii` живая, но `ciiRating` 0/90; `lib/imo/cii-lookup.ts` не зовётся в регене.
+5. **Carbon (ETS/FuelEU) → TCE** (L2) — `euLegPercent` / EU-флаги не прокинуты в `buildCanonicalTceInputs` → ETS=0 в матч-пути.
+6. **War-risk → per-day TCE** (L2) — сейчас только в `totalUsd` (отображение), не в `tceUsdPerDay` → даже floor его не видит.
+7. **Снести мёртвый `getVesselPassport`** (`lib/counterparty.ts` — хардкод Bahamas/DNV, зовёт только тест) — источник путаницы «passport не подключён».
+
+**🆕 Новое (нужен дизайн/данные, не проводка):**
+
+8. **Свежий фрахт** — Baltic = stale `static-seed` (price_date 2026-05-09). Live-фид = граница L4.
+9. **Сезонность / погода / ice-class** — в коде нет вообще. Низкий приоритет для L3.
+10. **Сужение golden-полос** (step 6) — когда TCE надёжен end-to-end, перепривязать TCE/distance-полосы к брокерским центрам (`verified-pairs.json`).
+
+### 🧹 Тех-долг (дивергенция регена)
+
+- **`scripts/demo-seed/real-matches.ts` + `build.ts` ОБА обходят `analyzePairs`** (6-арг `computeEstimatedTce`, без ballast/canal/floor) → дрейф от движка. **`regenerate-matches.ts` (→`analyzePairs`) = единственный канонический путь.** Карантин/снос обоих stale-скриптов (СНАЧАЛА проверить, что deploy/CI их не зовёт).
+- **Live `compute-matches.ts` пишет legacy laden-only TCE, а сид (`regenerate-matches.ts`) — true-voyage**: одна колонка `tce_usd_per_day`, два разных числа. Для демо ок (демо читает сид), но латентная нестыковка.
+
+### 📍 Рекомендуемый маршрут (порядок исполнения)
+
+1. **Прод-баг — data-миграция `sessions.db`→`demo-seed.db`** (быстро, обратимо) — оживляет L3-данные на проде, разблокирует п.PSC + RAG.
+2. **Тех-долг — свести 3 пути регена к 1 канону** (`regenerate-matches.ts`→`analyzePairs`) — снять риск ДО переделки скоринга.
+3. **🔑 Структурный шаг — рейтинг → `fitPercent`** (brainstorm → дизайн → exec) — разом включает L2 (TCE) + L3 (ветинг) в подбор. Главная работа.
+4. **Хвосты-проводки** (PSC→ветинг, port-DA/carbon→TCE, CII-данные в сид) поверх честного рейтинга.
+5. **L4** — позже, платно, по решению фаундера.
+
+---
+
 **Последний полный аудит:** 2026-05-17 (5-поточный код-аудит) + 2026-05-19 UI audit (Playwright+Chrome MCP) + **2026-05-19 ROADMAP reality audit** (claim vs prod sweep)
 **Последнее обновление:** 2026-06-05 (**ECON-CLUSTER #819/#820/#821 + BACKLOG #825/#826/#827 → прод, prod HEAD `0f185ab8`**). qa-walker нашёл 3 экономики-бага → конвейер recon→Opus-plan→exec: **#822** #820 bunker (убран жёсткий 'SGSIN'-дефолт в EconomicsTab+tce/route + race-fix; Med/BS хабы уже в `bunker_prices` via OilMonster cron); **#823** #821 laycan (`regenerate-matches --rebuild-worksheet` + persist-session-matches fail-closed recompute при laycan-disagreement); **#824** #819 TCE-знак (freight-resolver Tier-2 laden→round-trip denom fix — корень `-102k vs +774` дивергенции — + headline reads live `daily_tce_usd`). **Backlog:** **#826** (#819 cleanup — убран redundant storedTce-override + 6 canonical-tce тестов reframed под контракт list==detail/sign-agrees; freight-fix сделал live==stored convergent); **#825** (#82x cross-item worksheet rebuild по правильному item-index, DATA-affecting → prod-regen pending); **#827** (#82y detectSpot tighten — keyword AND нет concrete-date = не ложный spot). deps (qs/ws/brace/esbuild #465) уже merged 25 мая. **Prod-data-apply (Rule#22, founder-signed):** combined `regenerate-matches` + orphan-DELETE session-строк → 315→287, july_worksheets 11→0, neg_tce=125, buckets 34/193/60 целы, parity OK, health 200, backup `.bak-20260605T045322Z`. **УРОК:** #821 жил в session-UUID бакете (qa-walker session), regenerate его НЕ трогает → orphan-DELETE (как Variant B); `--dry` поймал 2 ошибки подряд (агент №1 прогнал regenerate БЕЗ `--rebuild-worksheet`→ложный GO; агент №2 нашёл session-UUID корень→NO-GO — не верь agent-GO без проверки симптома против реальности). **Предшествовало 06-04:** Variant B (broad weight-refresh 32 prod cargo, Rule22) + #814 laycan-guards + #813 polish + #816 war-risk ballast leg (все на проде). **OPEN:** #819 B(c) sibling-override `session-buckets.ts:63-67` (Tier-3, LOW — нужна convergence-recon перед удалением); #82x prod-regen (founder-signed). См. memory `project_quantika_seed_prod_apply_mechanics` (UPDATE 2026-06-05).
 **Обновление 2026-06-03:** 2026-06-03 (**4-FIX BROKER (#776) + 3 BACKLOG (#778/#779/#780) → прод, prod HEAD `d3c62d0e`, auto-deploy LIVE**). **#776** (Gate5 4-fix, main `9cfca018`): #1 табы→только «Матчи»; #2 EU-age cap≤55 «EU PSC age risk» (+ open-ended laycan «X onwards»/«From X»→forward-window); #3 даты onwards→окно (E2E 11→0 single-day); #4 порты — диакритик-фолд (`resolvePort` NFKD: Constanța/Aliağa) + 8 портов + vague→representative+amber (Вариант A). Прод-regen применён (Rule#22): main_bucket=28, visible(main∩fit≥60)=14, EU-cap 0→148, wsNULL=0. **3 backlog** (main `d3c62d0e`): **#778** ETS in/out-EU 50% coverage (intra=1/inout=0.5/extra=0 via `isEuCountry`, code-only); **#779** parse-prompt source_text exact-contiguous (re-parse корпуса = future-proofing, НЕ прогнан); **#780** distanceNm в regen (fold+`resolveVaguePort` в distance-lookup, board-NEUTRAL, nullDist_board 16→10). **Урок:** real-data verify поймал refYear-wiring баг (`real-matches` звал `computeFitBreakdown` без refYear → EU-cap молчал; unit-green пропустил) + ложную тревогу «доска 28→14» (bucket vs visible, снят 2nd-method). **🔴 OPEN — Gate5 round-2 (founder 2026-06-03), ветка `fix/gate5-eu-spot-pnl` off `d3c62d0e` (НЕ merged):** ✅ **#4-EU-by-country** (1986-судно→Monfalcone/IT показывало fit 70 без флага; `isEuropeanDischarge` детектил по region-map [пропускал named-EU, ловил non-EU Med Bejaia/DZ]; фикс = `isEuCountry(resolvePort(port).country)`; `ce468ed2`, 47/47, Dutch-Harbor guard цел); 🔄 **спот-даты** (`/cargo` показывает спот одним днём — `parseLaycan('Spot')`→today; фикс = метка «Spot» через `detectSpot`, корень `app/cargo/page.tsx:85`); 🔄 **Voyage P&L пусто** при отсутствии `cargo qty` (match 40098 weightMt пусто; фикс = «Missing: cargo quantity» в `EconomicsTab` вместо пустого блока). Доделать в новой сессии — детали `state.md` HANDOFF. FOLLOW-UPS: parse-recap.ts harden, Port-of-Call→Callao fuzzy.

--- a/scripts/demo-seed/__tests__/seed-reference-tables.test.ts
+++ b/scripts/demo-seed/__tests__/seed-reference-tables.test.ts
@@ -1,0 +1,79 @@
+/**
+ * TDD test for Phase 1: seedReferenceTables(db)
+ *
+ * Tests:
+ * 1. Against a fresh temp DB with migrations applied, all 3 tables are
+ *    populated (COUNT > 0) after one call.
+ * 2. Calling it twice does not error and counts remain the same (idempotent).
+ */
+import Database from 'better-sqlite3';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { runMigrations } from '../../../lib/migrations/runner';
+import { allMigrations } from '../../../lib/migrations/index';
+import { seedReferenceTables } from '../regenerate-matches';
+
+function makeDb(): { db: Database.Database; dbPath: string } {
+  const dbPath = path.join(
+    os.tmpdir(),
+    `ref-tables-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+  const db = new Database(dbPath);
+  runMigrations(db, allMigrations);
+  return { db, dbPath };
+}
+
+describe('seedReferenceTables', () => {
+  let db: Database.Database;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, dbPath } = makeDb());
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  });
+
+  it('populates charterers with > 0 rows', async () => {
+    await seedReferenceTables(db);
+    const { n } = db.prepare('SELECT COUNT(*) as n FROM charterers').get() as { n: number };
+    expect(n).toBeGreaterThan(0);
+  });
+
+  it('populates psc_detention_history with > 0 rows', async () => {
+    await seedReferenceTables(db);
+    const { n } = db.prepare('SELECT COUNT(*) as n FROM psc_detention_history').get() as { n: number };
+    expect(n).toBeGreaterThan(0);
+  });
+
+  it('populates port_da_estimates with > 0 rows', async () => {
+    await seedReferenceTables(db);
+    const { n } = db.prepare('SELECT COUNT(*) as n FROM port_da_estimates').get() as { n: number };
+    expect(n).toBeGreaterThan(0);
+  });
+
+  it('is idempotent — calling twice yields same counts, no error', async () => {
+    await seedReferenceTables(db);
+    const counts1 = {
+      charterers: (db.prepare('SELECT COUNT(*) as n FROM charterers').get() as { n: number }).n,
+      psc: (db.prepare('SELECT COUNT(*) as n FROM psc_detention_history').get() as { n: number }).n,
+      portDa: (db.prepare('SELECT COUNT(*) as n FROM port_da_estimates').get() as { n: number }).n,
+    };
+
+    // Second call — must not throw
+    await expect(seedReferenceTables(db)).resolves.not.toThrow();
+
+    const counts2 = {
+      charterers: (db.prepare('SELECT COUNT(*) as n FROM charterers').get() as { n: number }).n,
+      psc: (db.prepare('SELECT COUNT(*) as n FROM psc_detention_history').get() as { n: number }).n,
+      portDa: (db.prepare('SELECT COUNT(*) as n FROM port_da_estimates').get() as { n: number }).n,
+    };
+
+    expect(counts2.charterers).toBe(counts1.charterers);
+    expect(counts2.psc).toBe(counts1.psc);
+    expect(counts2.portDa).toBe(counts1.portDa);
+  });
+});

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -31,11 +31,50 @@
  */
 import Database from 'better-sqlite3';
 import path from 'node:path';
+import fs from 'node:fs';
 import { analyzePairs } from '@/lib/matching/pair-analyzer';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
 import { cfValue, type ParsedCargo, type ParsedVessel, type Match, type MatchWorksheet } from '@/lib/types';
+import { seedCharterersWithDb } from '../knowledge/seeds/seed-charterers';
+import { seedPscHistoryWithDb } from '../knowledge/seeds/seed-psc-history';
+import { seedPortDa, type BaselinePort } from '../seed-port-da';
+
+// ── Phase 1: seed reference tables into the regen's own db handle ────────────
+
+/**
+ * Populate charterers, psc_detention_history, and port_da_estimates from
+ * committed offline sources into the SAME db handle that regenerate-matches
+ * already has open. Guarantees rows land in demo-seed.db, not sessions.db.
+ *
+ * Idempotent — safe to call on each regen run (each underlying seeder is
+ * already idempotent: charterers ON CONFLICT UPDATE, psc DELETE+reinsert,
+ * port_da INSERT OR REPLACE).
+ *
+ * NOTE: port_da gap-fill via LLM is SKIPPED here (no llmCaller passed) —
+ * the noopLlmCaller never calls the real API, so the seeding is deterministic
+ * and works offline. Only the baseline JSON rows are inserted.
+ */
+export async function seedReferenceTables(db: Database.Database): Promise<void> {
+  // 1. Charterers
+  seedCharterersWithDb(db);
+
+  // 2. PSC detention history
+  seedPscHistoryWithDb(db);
+
+  // 3. Port DA estimates — baseline only (no LLM gap-fill in regen context)
+  const baselinePath = path.resolve(__dirname, '../seed-data/port-da-base.json');
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8')) as BaselinePort[];
+  // Pass a no-op LLM caller so the function never makes real API calls.
+  const noopLlmCaller = async (): Promise<never> => { throw new Error('noop'); };
+  await seedPortDa(db, baseline, noopLlmCaller);
+
+  const chartCount = (db.prepare('SELECT COUNT(*) as n FROM charterers').get() as { n: number }).n;
+  const pscCount = (db.prepare('SELECT COUNT(*) as n FROM psc_detention_history').get() as { n: number }).n;
+  const daCount = (db.prepare('SELECT COUNT(*) as n FROM port_da_estimates').get() as { n: number }).n;
+  console.log(`[regen] reference tables seeded — charterers=${chartCount} psc=${pscCount} port_da=${daCount}`);
+}
 
 // ── --rebuild-worksheet exports ───────────────────────────────────────────────
 
@@ -278,6 +317,11 @@ async function main() {
   console.log(`[regen] Opening ${dbPath}${DRY ? ' (DRY — no writes)' : ''}`);
   const db = new Database(dbPath, DRY ? { readonly: true } : {});
   if (!DRY) db.pragma('journal_mode = WAL');
+
+  // ── Step 0: seed reference tables (charterers, psc, port_da) into THIS db ──
+  if (!DRY) {
+    await seedReferenceTables(db);
+  }
 
   const frozen = (db.prepare(`SELECT frozen_date f FROM demo_seed_meta WHERE id=1`).get() as { f?: string })?.f ?? '2026-05-28';
   const today = new Date(frozen + 'T00:00:00.000Z');

--- a/scripts/knowledge/seeds/seed-charterers.ts
+++ b/scripts/knowledge/seeds/seed-charterers.ts
@@ -14,6 +14,7 @@
  */
 
 import { createHash } from 'crypto';
+import type Database from 'better-sqlite3';
 import { getStore } from '../../../lib/session-store';
 import { upsertCharterer } from '../../../lib/market/charterers-repository';
 
@@ -180,6 +181,35 @@ const DEMO_CHARTERERS: DemoCharterer[] = [
   },
 ];
 
+/**
+ * Seed charterers into an EXPLICIT db handle.
+ * Idempotent: ON CONFLICT(id) DO UPDATE (deterministic IDs from name).
+ */
+export function seedCharterersWithDb(db: Database.Database): void {
+  const byTier = { 'blue-chip': 0, second: 0, weak: 0 };
+
+  for (const c of DEMO_CHARTERERS) {
+    const id = deterministicId(c.name);
+
+    upsertCharterer(db, {
+      id,
+      name: c.name,
+      tier: c.tier,
+      payment_history: JSON.stringify(c.payment_history),
+      require_lc: c.require_lc,
+      notes: c.notes,
+    });
+
+    byTier[c.tier]++;
+  }
+
+  console.log(
+    `[seed-charterers] ${DEMO_CHARTERERS.length} charterers:` +
+    ` ${byTier['blue-chip']} blue-chip, ${byTier.second} second, ${byTier.weak} weak.`
+  );
+}
+
+/** CLI entrypoint — resolves DB via session-store (SESSIONS_DB_PATH). */
 export function seedCharterers(): void {
   const db = getStore().getDatabase();
 

--- a/scripts/knowledge/seeds/seed-psc-history.ts
+++ b/scripts/knowledge/seeds/seed-psc-history.ts
@@ -15,10 +15,31 @@
  * repeated runs converge on the same state.
  */
 
+import type Database from 'better-sqlite3';
 import { getStore } from '../../../lib/session-store';
 import { upsertInspection } from '../../../lib/market/psc-repository';
 import { PSC_FIXTURE, PSC_FIXTURE_IMOS } from '../../../lib/knowledge/sources/psc/fixture';
 
+/**
+ * Seed PSC detention history into an EXPLICIT db handle.
+ * Idempotent: DELETE-then-INSERT (converges to fixture on every call).
+ */
+export function seedPscHistoryWithDb(db: Database.Database): void {
+  const deleted = db.prepare('DELETE FROM psc_detention_history').run().changes;
+
+  for (const record of PSC_FIXTURE) {
+    upsertInspection(db, record);
+  }
+
+  const count =
+    db.prepare<[], { c: number }>('SELECT COUNT(*) as c FROM psc_detention_history').get()?.c ?? 0;
+  console.log(
+    `[seed-psc] ${PSC_FIXTURE.length} records across ${PSC_FIXTURE_IMOS.length} IMOs` +
+    ` (cleared ${deleted} old, table now ${count}).`,
+  );
+}
+
+/** CLI entrypoint — resolves DB via session-store (SESSIONS_DB_PATH). */
 export function seedPscHistory(opts: { dryRun?: boolean } = {}): void {
   const { dryRun = false } = opts;
 


### PR DESCRIPTION
## Что и зачем

**Прод-баг:** в DEMO_MODE приложение читает всё из `SESSIONS_DB_PATH=data/demo-seed.db`, но 11 reference/RAG-таблиц там **пусты** — данные осели в осиротевшем `data/sessions.db`. Корень: standalone seed-скрипты резолвят БД через `getStore().getDatabase()` / `SESSIONS_DB_PATH ?? data/sessions.db`; `deploy-vps.sh` запускает их без `SESSIONS_DB_PATH` → пишут в дефолтный `sessions.db`, не в `demo-seed.db`.

**Phase 1 (этот PR) — структурные таблицы**, durable-фикс: реген кормит сидеры **своим открытым db-хендлом** (= гарантированно `demo-seed.db`), обходя env-неоднозначность.

## Изменения
- `seed-charterers.ts` → `seedCharterersWithDb(db)` (CLI-entrypoint сохранён)
- `seed-psc-history.ts` → `seedPscHistoryWithDb(db)` (DELETE-then-INSERT, идемпотент)
- `regenerate-matches.ts` → `seedReferenceTables(db)` шаг после WAL-pragma, gated на `!DRY`; `seed-port-da` уже имел db-overload
- unit-тест `seed-reference-tables.test.ts`
- docs: §0 forward-роадмап L1→L4 (отдельный коммит)

Источники — committed/офлайн (фикстуры + `port-da-base.json`). Vertex/скрейп НЕ нужны.

## Гейты (все зелёные)
- TDD 4/4 · `npm run golden` 68/68 · regression 86 suites/1643 tests · `data-integrity-check` 6/6 (в обычном чекауте)
- `--dry` НЕ сидит (readonly) · реал-ран на временной копии: charterers=13, psc=16, port_da=94, matches intact, sessions не клоббером
- `tsc --noEmit` clean

## НЕ в этом PR
- RAG/vec0-таблицы (imsbc/igc/jwc/bimco) → **Phase 2** (Vertex-эмбеддинг + vec0-копия + web-скрейп)
- `port_distances` → отложен (graceful runtime-кэш)

## После мержа
Прод-применение под Rule#22: backup → `--dry` preview → запуск `seedReferenceTables` на live `demo-seed.db` → checkpoint → restart → health → Gate5. **Только 3 пустые таблицы, матчи/сессии не трогаются → обратимо.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)