### PR TITLE
feat: L3 vetting wiring (PSC+charterer+CII) (Lane B)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-l3-vetting.md
+++ b/docs/superpowers/plans/2026-06-07-l3-vetting.md
@@ -1,0 +1,669 @@
+# L3 Vetting Wiring (PSC + Charterer + CII) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire three already-collected trust signals — PSC detention history, charterer credit tier, CII rating — into the broker-facing fit/vetting score, so roadmap level **L3 ("trustworthy")** stops ignoring data the DB already holds.
+
+**Architecture:** Three independent, surgical hooks, each respecting the existing "unknown ≠ penalty" invariant and the founder stance *"compatibility leads, trust adjusts"*:
+1. **PSC** → a 6th sub-factor *inside* `computeVesselVetting`, gated on an **optional** `detentionCount` param (resolved in `pair-analyzer` where `db` + `vessel.imo` are in scope). The vetting factor stays one component → no new fit weight.
+2. **Charterer** → a small **separate fit penalty** in `computeFitBreakdown` (mirrors the existing `sanctionsPenalty` pattern), NOT a new component and NOT inside vetting — because the charterer is the *counterparty/cargo* side, while vetting is *vessel*-side.
+3. **CII** → no scoring change at all; just **hydrate** `vessel.ciiRating` from `lookupCii(imo)` during regen so the *existing* `scoreCii` finally fires.
+
+**Tech Stack:** TypeScript, better-sqlite3, Jest (`--maxWorkers=1 --forceExit`), `tsx` for the regen script.
+
+---
+
+## ⚠️ EXECUTION ORDERING CONSTRAINT (read first)
+
+This lane (**Lane B**) edits `lib/matching/pair-analyzer.ts`, which is **also edited by Lane A (port-DA)**. The executor **MUST start this lane only AFTER Lane A has merged to `main`** and this branch has been rebased on it. Starting concurrently will produce a hard merge conflict in the `computeFitBreakdown(...)` call site (~`pair-analyzer.ts:763`). Confirm `git log --oneline -1 origin/main` shows the Lane A merge before Task 5.
+
+---
+
+## Founder calibration (DECISION REQUIRED — present before regen)
+
+Like the #846 ~18pt money weight the founder personally chose, the magnitude of each trust hit is a founder call. **Net effect on headline fit must stay MODERATE.** Defaults below; STRONGER / SOFTER variants and their expected bucket impact are in **Task 7 (measurement)**.
+
+| Signal | DEFAULT (recommended) | STRONGER | SOFTER |
+|--------|----------------------|----------|--------|
+| **PSC** (inside vetting, weight 7) | 1 detention → `caution` (share 0.65); ≥2 → `warn` (0.20); 0 → `ok`. 3-yr window. | ≥1 detention → `warn` (0.20). | only ≥2 → `caution`; single detention stays `ok`. |
+| **Charterer** weak tier | `weak` → −4 fit pts; `second`/`blue-chip` → 0. | `weak` → −8; `second` → −3. | `weak` → −2; `second` → 0. |
+| **CII** | none — already inside vetting weight 7; once hydrated, `scoreCii` fires on real `A–E` data. No new weight. | n/a (data, not weight) | n/a |
+
+**Why DEFAULT is moderate:** PSC sits inside the weight-7 vetting average over 6 sub-factors, so a lone `warn` moves the headline only ~0.9 pt; a `caution` ~0.4 pt. Charterer −4 is half the sanctions-MEDIUM −8 (credit risk is softer than a sanctions flag). CII adds no weight — it only stops the silent neutral.
+
+### ⚠️ Charterer linkage gap (must be surfaced to founder)
+
+**`ParsedCargo` carries no charterer/counterparty identity field** (verified: `lib/types.ts:181-219`). The 13 seeded charterers are *real* names (Cargill, Glencore, …) keyed by `getCharterer(db, id)` with a name-derived id; but the demo cargo emails **anonymize** charterer names to placeholders (`manifest.anonymization.charterers`, e.g. "GRAIN TRADER A"), so **no reliable cargo→charterer link exists in current data**.
+
+Consequence: the charterer **scoring + plumbing** is fully implemented and behaviorally tested (Tasks 3–5) via direct `chartererTier` injection, but the live **resolver** (`resolveChartererTier(db, cargo)`) returns `null` until a charterer identity reaches the cargo — so on a real regen today the charterer effect is **zero** (unknown → neutral). Two honest paths, founder picks one:
+
+- **(A) Recommended — ship plumbing now, defer resolution.** Land Tasks 1–8; resolver returns `null` with a documented `TODO`. A separate brief adds `cargo.chartererName` to the parser; the moment it lands, the signal activates with zero further fit-engine work. **No fabricated data.**
+- **(B) Demo-only deterministic assignment.** A toggle (`DEMO_CHARTERER_ASSIGN=1`) maps each cargo to a seeded charterer by a stable hash of `cargoEmailId`, so the founder can *see* tiers move fit in the demo. Synthetic — clearly labelled, off by default. (Implementation sketch in Task 5, Step 6; only build if founder asks.)
+
+This plan implements **(A)**. Do **not** silently fabricate the link.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `lib/sailing/vessel-vetting.ts` | Modify | Add `scorePsc` sub-factor + optional `detentionCount` in opts. Backward-compatible (absent → 5 factors). |
+| `lib/sailing/__tests__/vessel-vetting.test.ts` | Modify (additive) | New PSC behavioral tests. Existing 5-factor tests untouched. |
+| `lib/sailing/fit-breakdown.ts` | Modify | Thread `detentionCount` into `scoreVetting`; add `chartererTier` input + `chartererPenalty` (separate, like `sanctionsPenalty`). |
+| `lib/sailing/__tests__/fit-breakdown.test.ts` | Modify (additive) | New PSC-via-vetting + charterer-penalty tests. Existing `toHaveLength(10)` untouched. |
+| `lib/matching/pair-analyzer.ts` | Modify | Resolve `detentionCount` (`getDetentionCount` by `vessel.imo`) + `chartererTier` (`resolveChartererTier`), pass into `computeFitBreakdown`. |
+| `lib/matching/charterer-tier.ts` | Create | `resolveChartererTier(db, cargo)` helper (returns `null` today — documented gap). |
+| `lib/matching/__tests__/vetting-wiring.test.ts` | Create | Behavioral db-backed test: real PSC rows → lower fit on that vessel's pairs. |
+| `scripts/demo-seed/regenerate-matches.ts` | Modify | CII hydration loop: `lookupCii(imo)` → set `vessel.ciiRating` before `analyzePairs`. |
+| `scripts/demo-seed/__tests__/cii-hydration.test.ts` | Create | Behavioral test of the hydration helper against `cii.json`. |
+
+---
+
+## Recon facts (verified 2026-06-07, main `5a5d3f36`)
+
+- `computeVesselVetting(vessel, {refYear})` — 5 sub-factors, avg of `VETTING_VERDICT_SHARE`; `unknown`→0.6 (`vessel-vetting.ts:122-144`).
+- `scoreVetting(vessel, refYear?)` → one fit component, weight 7 (`fit-breakdown.ts:411`, `FIT_WEIGHTS.vetting=7`).
+- `computeFitBreakdown` builds **exactly 10 components** + applies `sanctionsPenalty` as a scalar subtraction (`fit-breakdown.ts:564-581`). Existing test asserts `components` length **10** (`fit-breakdown.test.ts:300`).
+- `getDetentionCount(db, imo, sinceDate)` → count of `detained=1` since date (`psc-repository.ts:96`). PSC fixture: 5 IMOs, **4 detentions** (`9322180`×1, `9478999`×2, `9734567`×1), same IMOs as `cii.json` (`lib/knowledge/sources/psc/fixture.ts`).
+- `getCharterer(db, id)` / `listCharterers(db, tier?)` → `ChartererRow.tier ∈ {blue-chip, second, weak}` (`charterers-repository.ts:18`).
+- `lookupCii(imo, opts?)` → `{ rating: 'A'..'E'|'unknown' }`, reads `lib/sample-data/imo/cii.json` (12 records, `imo`+`rating`) before any LLM (`cii-lookup.ts:68`). In regen we pass **no** `callLlm` and only use the dataset hit → deterministic, offline.
+- `vessel.imo: string | null`, `vessel.ciiRating?: 'A'..'E'|null` (`types.ts:227,266`).
+- `db` is in scope inside `analyzePairs` and at the `computeFitBreakdown` call (`pair-analyzer.ts:763`, `refYear` too).
+- Regen: vessels loaded into `vessels[]` array at `regenerate-matches.ts:436-441`, BEFORE `analyzePairs(...)` at `:448`. `--dry` opens **readonly** and **skips** `seedReferenceTables` (`:408`), so a dry measurement reads pre-seeded data only.
+- Test harnesses: PSC → `new Database(':memory:'); migration028.up(db)`. Charterers → `migration026.up(db)`.
+
+---
+
+## Task 1: PSC sub-factor inside `computeVesselVetting`
+
+**Files:**
+- Modify: `lib/sailing/vessel-vetting.ts`
+- Test: `lib/sailing/__tests__/vessel-vetting.test.ts`
+
+**Design:** Add `scorePsc(detentionCount)` returning a `VettingFactor` with `key: 'psc'`. Append it to `factors` **only when `opts.detentionCount` is provided** (number, incl. 0). When absent → array stays length 5 → every existing test passes unchanged (PI3: zero existing-expectation rewrites). Reuses existing `VETTING_VERDICT_SHARE` — no new constants.
+
+- [ ] **Step 1: Write the failing tests** (append to `vessel-vetting.test.ts`)
+
+```typescript
+describe('computeVesselVetting — PSC sub-factor (optional)', () => {
+  it('detentionCount omitted → still 5 factors (backward-compatible)', () => {
+    const result = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR });
+    expect(result.factors).toHaveLength(5);
+    expect(result.factors.some((f) => f.key === 'psc')).toBe(false);
+  });
+
+  it('detentionCount=0 → 6 factors, psc verdict ok, no badge', () => {
+    const result = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 0 });
+    expect(result.factors).toHaveLength(6);
+    const psc = result.factors.find((f) => f.key === 'psc');
+    expect(psc?.verdict).toBe('ok');
+    expect(result.badges.some((b) => /detention|PSC/i.test(b))).toBe(false);
+  });
+
+  it('detentionCount=1 → psc caution + badge', () => {
+    const result = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 1 });
+    const psc = result.factors.find((f) => f.key === 'psc');
+    expect(psc?.verdict).toBe('caution');
+    expect(result.badges.some((b) => /detention|PSC/i.test(b))).toBe(true);
+  });
+
+  it('detentionCount>=2 → psc warn, lower score than caution', () => {
+    const warn = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 2 });
+    const caution = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 1 });
+    const psc = warn.factors.find((f) => f.key === 'psc');
+    expect(psc?.verdict).toBe('warn');
+    expect(warn.score).toBeLessThan(caution.score);
+  });
+
+  it('a detention lowers overall vetting vs a clean PSC record', () => {
+    const clean = computeVesselVetting(makeVesselFields({ flag: 'Marshall Islands', classSociety: 'DNV', built: 2018, pandi: 'Gard', ciiRating: 'B' }), { refYear: REF_YEAR, detentionCount: 0 });
+    const detained = computeVesselVetting(makeVesselFields({ flag: 'Marshall Islands', classSociety: 'DNV', built: 2018, pandi: 'Gard', ciiRating: 'B' }), { refYear: REF_YEAR, detentionCount: 2 });
+    expect(detained.score).toBeLessThan(clean.score);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx jest lib/sailing/__tests__/vessel-vetting.test.ts -t "PSC sub-factor" --maxWorkers=1 --no-coverage`
+Expected: FAIL (`detentionCount` not handled; 5 factors not 6).
+
+- [ ] **Step 3: Implement** — in `vessel-vetting.ts`, add the scorer after `scoreCii` (before the Public API block):
+
+```typescript
+/** PSC detention history — detentions in the lookback window are the single
+ *  strongest port-state-control trust signal. 0 → clean; 1 → caution; ≥2 → warn.
+ *  Caller supplies the count (resolved from psc_detention_history by IMO upstream,
+ *  where the db handle lives) — this module stays pure / db-free. */
+function scorePsc(detentionCount: number): VettingFactor {
+  if (detentionCount <= 0) {
+    return { key: 'psc', label: 'PSC detentions', verdict: 'ok', rationale: 'No port-state-control detentions on record in the lookback window.' };
+  }
+  if (detentionCount === 1) {
+    return { key: 'psc', label: 'PSC detentions', verdict: 'caution', rationale: '1 PSC detention in the lookback window — elevated inspection risk.' };
+  }
+  return { key: 'psc', label: 'PSC detentions', verdict: 'warn', rationale: `${detentionCount} PSC detentions in the lookback window — high inspection / off-hire risk.` };
+}
+```
+
+Update the signature + factor assembly:
+
+```typescript
+export function computeVesselVetting(
+  vessel: Pick<ParsedVessel, 'flag' | 'built' | 'classSociety' | 'pandi' | 'ciiRating'>,
+  opts: { refYear: number; detentionCount?: number },
+): VesselVettingResult {
+  const { refYear, detentionCount } = opts;
+
+  const factors: VettingFactor[] = [
+    scoreFlag(vessel.flag),
+    scoreClass(vessel.classSociety),
+    scoreAge(vessel.built, refYear),
+    scorePandi(vessel.pandi),
+    scoreCii(vessel.ciiRating),
+  ];
+  // PSC is optional: only included when the caller supplies a count (db-resolved).
+  // Absent → 5 factors, preserving every existing caller's behaviour.
+  if (detentionCount != null) {
+    factors.push(scorePsc(detentionCount));
+  }
+
+  const avgShare =
+    factors.reduce((sum, f) => sum + VETTING_VERDICT_SHARE[f.verdict], 0) / factors.length;
+  // ... badges + return unchanged
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest lib/sailing/__tests__/vessel-vetting.test.ts --maxWorkers=1 --no-coverage`
+Expected: PASS — all old tests + 5 new. (Old "all null → 5 factors / 0.6" still green: no `detentionCount` passed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/sailing/vessel-vetting.ts lib/sailing/__tests__/vessel-vetting.test.ts
+git commit -m "feat(vetting): optional PSC detention sub-factor in computeVesselVetting"
+```
+
+---
+
+## Task 2: Thread `detentionCount` through `scoreVetting`
+
+**Files:**
+- Modify: `lib/sailing/fit-breakdown.ts`
+- Test: `lib/sailing/__tests__/fit-breakdown.test.ts`
+
+**Design:** `scoreVetting` gains an optional `detentionCount` param, forwarded to `computeVesselVetting`. The vetting **component count is unchanged** (still 1 of 10) → `fit-breakdown.test.ts:300` `toHaveLength(10)` stays green.
+
+- [ ] **Step 1: Write the failing test** (append to `fit-breakdown.test.ts`)
+
+```typescript
+import { scoreVetting } from '../fit-breakdown';
+import type { ParsedVessel } from '@/lib/types';
+
+function vesselFor(over: Partial<ParsedVessel> = {}): ParsedVessel {
+  // minimal ParsedVessel — only vetting-relevant fields matter here
+  return {
+    emailId: 'e', itemIndex: 0, vesselName: null, imo: '9478999',
+    flag: 'Marshall Islands', built: 2018, classSociety: 'DNV', pandi: 'Gard',
+    dwtSummer: null, dwcc: null, draftMax: null, loa: null, beam: null, grt: null,
+    nrt: null, holdsCount: null, hatchesCount: null, grainCapacity: null,
+    grainCapacityUnit: null, baleCapacity: null, holdDimensions: null,
+    hatchDimensions: null, tankTopStrength: null, geared: null, craneCapacity: null,
+    hatchType: null, vesselType: null, openPosition: null, openDate: null,
+    direction: null, restrictions: [], lastCargoes: null, speedLaden: null,
+    speedBallast: null, consumption: null, deckCapacity: null, specialFeatures: [],
+    ciiRating: 'B', ...over,
+  } as ParsedVessel;
+}
+
+describe('scoreVetting — PSC pass-through', () => {
+  it('detentions lower the vetting component score', () => {
+    const clean = scoreVetting(vesselFor(), 2026, 0);
+    const detained = scoreVetting(vesselFor(), 2026, 2);
+    expect(detained.score).toBeLessThan(clean.score);
+    expect(detained.factor).toBe('vetting');
+  });
+
+  it('omitting detentionCount preserves legacy 5-factor behaviour', () => {
+    const legacy = scoreVetting(vesselFor(), 2026);
+    const zero = scoreVetting(vesselFor(), 2026, 0);
+    // legacy (no PSC factor) scores at least as high as zero-detention (PSC ok adds a 6th 1.0 share)
+    expect(legacy.score).toBeGreaterThanOrEqual(zero.score - 0.01);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest lib/sailing/__tests__/fit-breakdown.test.ts -t "PSC pass-through" --maxWorkers=1 --no-coverage`
+Expected: FAIL (`scoreVetting` takes only 2 args).
+
+- [ ] **Step 3: Implement** — update `scoreVetting` in `fit-breakdown.ts`:
+
+```typescript
+export function scoreVetting(vessel: ParsedVessel, refYear?: number, detentionCount?: number): FitBreakdownComponent {
+  const w = FIT_WEIGHTS.vetting;
+  const effectiveVessel = refYear != null ? vessel : { ...vessel, built: null };
+  const effectiveRefYear = refYear ?? 0;
+  const result = computeVesselVetting(effectiveVessel, { refYear: effectiveRefYear, detentionCount });
+  // ... rationale + return unchanged
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest lib/sailing/__tests__/fit-breakdown.test.ts --maxWorkers=1 --no-coverage`
+Expected: PASS — incl. existing `toHaveLength(10)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/sailing/fit-breakdown.ts lib/sailing/__tests__/fit-breakdown.test.ts
+git commit -m "feat(fit): pass PSC detention count through scoreVetting"
+```
+
+---
+
+## Task 3: Charterer credit-tier penalty in `computeFitBreakdown`
+
+**Files:**
+- Modify: `lib/sailing/fit-breakdown.ts`
+- Test: `lib/sailing/__tests__/fit-breakdown.test.ts`
+
+**Design + justification:** Charterer credit is the **counterparty/cargo** side, vetting is **vessel** side — keep them separate. Implement as a scalar `chartererPenalty` subtracted from the linear sum, exactly like the existing `sanctionsPenalty` (`fit-breakdown.ts:580`). This **adds no component** → `toHaveLength(10)` stays green (PI3). DEFAULT calibration: `weak` → 4, else 0.
+
+- [ ] **Step 1: Write the failing tests** (append to `fit-breakdown.test.ts`)
+
+```typescript
+import { computeFitBreakdown } from '../fit-breakdown';
+// (reuse the test's existing makeCargo/makeVessel/baseInput helpers near the top of the file)
+
+describe('computeFitBreakdown — charterer credit-tier penalty', () => {
+  it('weak tier lowers fitPercent vs no tier (default −4)', () => {
+    const base = baseFitInput(); // existing helper producing a mid-fit pair
+    const withTier = computeFitBreakdown({ ...base, chartererTier: 'weak' });
+    const without = computeFitBreakdown({ ...base });
+    expect(withTier.fitPercent).toBeLessThan(without.fitPercent);
+    expect(without.fitPercent - withTier.fitPercent).toBeCloseTo(4, 0);
+  });
+
+  it('blue-chip / second / undefined → no penalty', () => {
+    const base = baseFitInput();
+    const blue = computeFitBreakdown({ ...base, chartererTier: 'blue-chip' });
+    const none = computeFitBreakdown({ ...base });
+    expect(blue.fitPercent).toBe(none.fitPercent);
+  });
+
+  it('still exactly 10 components (penalty is not a component)', () => {
+    const fb = computeFitBreakdown({ ...baseFitInput(), chartererTier: 'weak' });
+    expect(fb.components).toHaveLength(10);
+  });
+});
+```
+
+> If `fit-breakdown.test.ts` has no shared `baseFitInput()` helper, add a small local one mirroring the inputs used by the existing `toHaveLength(10)` test (`cargo`, `vessel`, `readiness`, `sanctions`, `hardFilters`, `refYear`). Do **not** modify the existing test.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest lib/sailing/__tests__/fit-breakdown.test.ts -t "charterer credit-tier" --maxWorkers=1 --no-coverage`
+Expected: FAIL (`chartererTier` not on `FitBreakdownInput`).
+
+- [ ] **Step 3: Implement** — in `fit-breakdown.ts`:
+
+Add the calibration constant near `FIT_WEIGHTS`:
+
+```typescript
+// Charterer credit-tier penalty (founder-calibrated; DEFAULT). Counterparty-side,
+// kept OUT of vessel vetting. weak → soft fit hit; second/blue-chip → none.
+// STRONGER: { weak: 8, second: 3 }. SOFTER: { weak: 2, second: 0 }.
+export const CHARTERER_TIER_PENALTY: Record<'blue-chip' | 'second' | 'weak', number> = {
+  'blue-chip': 0,
+  second: 0,
+  weak: 4,
+};
+```
+
+Extend `FitBreakdownInput`:
+
+```typescript
+  /** Charterer credit tier (counterparty side). Absent/null → no penalty (unknown = neutral). */
+  chartererTier?: 'blue-chip' | 'second' | 'weak' | null;
+```
+
+In `computeFitBreakdown`, destructure `chartererTier` and apply alongside the sanctions penalty:
+
+```typescript
+  const sanctionsPenalty = sanctions?.risk === 'MEDIUM' ? 8 : 0;
+  const chartererPenalty = chartererTier ? CHARTERER_TIER_PENALTY[chartererTier] : 0;
+  let fit = rawSum - sanctionsPenalty - chartererPenalty;
+```
+
+Record it on the returned breakdown (add field `chartererPenalty` next to `sanctionsPenalty` in the return object, and to the `FitBreakdown` type in `lib/types.ts` as `chartererPenalty?: number`). This keeps the breakdown self-explaining for the broker panel.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest lib/sailing/__tests__/fit-breakdown.test.ts --maxWorkers=1 --no-coverage`
+Expected: PASS — incl. existing `toHaveLength(10)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/sailing/fit-breakdown.ts lib/sailing/__tests__/fit-breakdown.test.ts lib/types.ts
+git commit -m "feat(fit): charterer credit-tier penalty (counterparty-side, separate from vetting)"
+```
+
+---
+
+## Task 4: `resolveChartererTier` helper (documented gap)
+
+**Files:**
+- Create: `lib/matching/charterer-tier.ts`
+- Test: extend `lib/matching/__tests__/vetting-wiring.test.ts` (created in Task 6) — covered there.
+
+**Design:** Encapsulate the cargo→charterer resolution behind one function so the gap is in exactly one place and the day a `cargo.chartererName` field lands, only this file changes.
+
+- [ ] **Step 1: Implement** (no separate RED — exercised by Task 6's behavioral test)
+
+```typescript
+import type Database from 'better-sqlite3';
+import type { ParsedCargo } from '@/lib/types';
+import { getCharterer, listCharterers } from '@/lib/market/charterers-repository';
+
+export type ChartererTier = 'blue-chip' | 'second' | 'weak';
+
+/**
+ * Resolve a cargo's charterer credit tier from the charterers table.
+ *
+ * GAP (2026-06-07): ParsedCargo carries no charterer identity field, and the
+ * demo corpus anonymizes charterer names in the email body. Until a
+ * `cargo.chartererName` field exists, there is no reliable key → this returns
+ * null (→ unknown → neutral fit, no penalty). The scoring path that CONSUMES
+ * this value is fully wired + tested (computeFitBreakdown.chartererTier), so
+ * activation is a one-line change here once the parser provides the name.
+ *
+ * @returns the tier, or null when no charterer can be resolved.
+ */
+export function resolveChartererTier(_db: Database.Database, _cargo: ParsedCargo): ChartererTier | null {
+  // TODO(charterer-field): once ParsedCargo gains chartererName, resolve via
+  //   getCharterer(db, deterministicId(name)) or a name lookup over
+  //   listCharterers(db), and return row.tier. Helpers imported above are the
+  //   exact functions to call — kept referenced so this stays a one-line edit.
+  void getCharterer; void listCharterers;
+  return null;
+}
+```
+
+- [ ] **Step 2: Commit** (with Task 6, or standalone)
+
+```bash
+git add lib/matching/charterer-tier.ts
+git commit -m "feat(matching): resolveChartererTier helper (resolution gap documented)"
+```
+
+---
+
+## Task 5: Wire both signals at the `computeFitBreakdown` call site
+
+**Files:**
+- Modify: `lib/matching/pair-analyzer.ts` (~`:761-771`)
+
+**⚠️ Do this only after the Lane A merge + rebase (see top constraint).**
+
+- [ ] **Step 1: Add the PSC lookback constant** near the top of `pair-analyzer.ts` (with the other module constants):
+
+```typescript
+// PSC detention lookback for the vetting signal: 3 years before refYear.
+const PSC_LOOKBACK_YEARS = 3;
+```
+
+- [ ] **Step 2: Add imports**
+
+```typescript
+import { getDetentionCount } from '@/lib/market/psc-repository';
+import { resolveChartererTier } from '@/lib/matching/charterer-tier';
+```
+
+- [ ] **Step 3: Resolve + pass at the call site** — replace the existing `computeFitBreakdown({...})` block (~`:763`) with:
+
+```typescript
+      const imo = vessel.imo;
+      const detentionCount = imo
+        ? getDetentionCount(db, imo, `${refYear - PSC_LOOKBACK_YEARS}-01-01`)
+        : undefined; // no IMO → leave PSC neutral (omit factor)
+      const chartererTier = resolveChartererTier(db, cargo);
+      const fb = computeFitBreakdown({
+        cargo,
+        vessel,
+        readiness: analysis?.readiness,
+        sanctions: analysis?.sanctions,
+        hardFilters: analysis?.hardFilters,
+        refYear,
+        tceUsdPerDay: econ?.tceUsdPerDay ?? null,
+        detentionCount,
+        chartererTier,
+      });
+```
+
+And add `detentionCount` to `FitBreakdownInput` + forward it in `computeFitBreakdown` to `scoreVetting`:
+
+In `fit-breakdown.ts` `FitBreakdownInput`:
+```typescript
+  /** PSC detentions in lookback window (resolved upstream where db is in scope). Absent → PSC factor omitted (neutral). */
+  detentionCount?: number;
+```
+In `computeFitBreakdown` body, destructure `detentionCount` and change the vetting call:
+```typescript
+    scoreVetting(vessel, refYear, detentionCount),
+```
+
+> **Guard:** `db` here is the `analyzePairs` `options.db`. It is defined in the regen path (`regenerate-matches.ts:448` passes `db`). If a future caller invokes `analyzePairs` without `db`, `getDetentionCount`/`resolveChartererTier` must be skipped — wrap in `if (db) {...}` and leave both values `undefined`/`null`. Verify `db` nullability in the `analyzePairs` signature and guard accordingly.
+
+- [ ] **Step 4: Run the full matching suite** (no expectation rewrites; these guard against regressions):
+
+Run: `npx jest lib/matching --maxWorkers=1 --no-coverage --forceExit`
+Expected: PASS. If any golden-set fit value shifts, STOP — that means a seeded vessel already has `imo` matching a PSC fixture IMO and the fit legitimately moved; confirm against Task 7 measurement, do **not** edit the golden expectation without founder sign-off (PI3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/matching/pair-analyzer.ts lib/sailing/fit-breakdown.ts
+git commit -m "feat(matching): wire PSC detentions + charterer tier into fit at pair-analyzer"
+```
+
+- [ ] **Step 6 (OPTIONAL — only if founder picks calibration path B):** demo-only charterer assignment. Behind `process.env.DEMO_CHARTERER_ASSIGN === '1'`, in `resolveChartererTier` map `cargo.emailId` → a seeded charterer via a stable hash over `listCharterers(db)` (sorted by id for determinism), return `row.tier`. Add a test asserting it is OFF by default. Do **not** build unless explicitly requested.
+
+---
+
+## Task 6: Behavioral db-backed integration test
+
+**Files:**
+- Create: `lib/matching/__tests__/vetting-wiring.test.ts`
+
+**Design:** Real in-memory db with PSC + charterer migrations, real PSC fixture rows, real `analyzePairs` → assert a vessel whose `imo` has detentions scores **lower fit** than the same vessel with a clean IMO. This is the PI2 behavioral test (real `analyzePairs`, not a string check).
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import Database from 'better-sqlite3';
+import migration026 from '@/lib/migrations/026-charterers';
+import migration028 from '@/lib/migrations/028-psc-history';
+import { PSC_FIXTURE } from '@/lib/knowledge/sources/psc/fixture';
+import { upsertInspection } from '@/lib/market/psc-repository';
+import { analyzePairs } from '@/lib/matching/pair-analyzer';
+import { getDetentionCount } from '@/lib/market/psc-repository';
+import { resolveChartererTier } from '@/lib/matching/charterer-tier';
+// reuse a minimal cargo+vessel pair factory; copy the smallest valid pair from
+// an existing matching test (e.g. distance-nm-unlocode.test.ts) so analyzePairs
+// produces ≥1 main match.
+
+describe('vetting wiring — PSC detentions lower fit (behavioral)', () => {
+  let db: Database.Database;
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration026.up(db);
+    migration028.up(db);
+    for (const rec of PSC_FIXTURE) upsertInspection(db, rec);
+  });
+  afterEach(() => db.close());
+
+  it('getDetentionCount fires on a fixture IMO within the 3yr window', () => {
+    expect(getDetentionCount(db, '9478999', '2023-01-01')).toBeGreaterThanOrEqual(2);
+    expect(getDetentionCount(db, '9156789', '2023-01-01')).toBe(0); // clean IMO
+  });
+
+  it('same vessel with a detained IMO scores lower fit than with a clean IMO', async () => {
+    const cargo = makeMatchableCargo();           // helper — see note above
+    const detainedVessel = makeMatchableVessel({ imo: '9478999' });
+    const cleanVessel = makeMatchableVessel({ imo: '9156789' });
+
+    const rDetained = await analyzePairs([cargo], [detainedVessel], async () => [], { refYear: 2026, today: new Date('2026-05-28T00:00:00Z'), db });
+    const rClean = await analyzePairs([cargo], [cleanVessel], async () => [], { refYear: 2026, today: new Date('2026-05-28T00:00:00Z'), db });
+
+    const fitDetained = rDetained.matches[0]?.fitPercent ?? rDetained.lowConfidenceMatches[0]?.fitPercent;
+    const fitClean = rClean.matches[0]?.fitPercent ?? rClean.lowConfidenceMatches[0]?.fitPercent;
+    expect(fitDetained).toBeDefined();
+    expect(fitClean).toBeDefined();
+    expect(fitDetained!).toBeLessThan(fitClean!);
+  });
+
+  it('resolveChartererTier returns null today (documented gap)', () => {
+    expect(resolveChartererTier(db, makeMatchableCargo())).toBeNull();
+  });
+});
+```
+
+> The `makeMatchableCargo/Vessel` helpers must produce a pair that clears the hard gates (matching cargo/vessel type, plausible weight/DWT, resolvable ports, valid laycan vs open date) so `analyzePairs` yields a scored match. Lift the smallest passing pair from an existing `lib/matching/__tests__` file rather than inventing one.
+
+- [ ] **Step 2: Run**
+
+Run: `npx jest lib/matching/__tests__/vetting-wiring.test.ts --maxWorkers=1 --no-coverage --forceExit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/matching/__tests__/vetting-wiring.test.ts
+git commit -m "test(matching): behavioral PSC-lowers-fit + charterer-gap integration"
+```
+
+---
+
+## Task 7: CII hydration in regen
+
+**Files:**
+- Modify: `scripts/demo-seed/regenerate-matches.ts`
+- Create: `scripts/demo-seed/__tests__/cii-hydration.test.ts`
+
+**Design:** Before `analyzePairs`, set `vessel.ciiRating` from the static dataset for every vessel with an IMO. Use `lookupCii(imo)` with **no** `callLlm` → it returns the `cii.json` hit (or `'unknown'`); map `'unknown'`→`null` (keeps `scoreCii` neutral, per invariant). Extract the loop into an exported pure-ish helper so it is testable without a full regen.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { hydrateCiiRatings } from '../regenerate-matches';
+import type { ParsedVessel } from '@/lib/types';
+
+function v(imo: string | null): ParsedVessel {
+  return { imo, ciiRating: null } as unknown as ParsedVessel;
+}
+
+describe('hydrateCiiRatings', () => {
+  it('sets ciiRating from the static cii.json dataset by IMO', async () => {
+    const vessels = [v('9322180'), v('9200648'), v('0000000'), v(null)];
+    await hydrateCiiRatings(vessels);
+    expect(vessels[0].ciiRating).toBe('D'); // 9322180 → D in cii.json
+    expect(vessels[1].ciiRating).toBe('A'); // 9200648 → A
+    expect(vessels[2].ciiRating).toBeNull(); // unknown IMO → null (neutral)
+    expect(vessels[3].ciiRating).toBeNull(); // no IMO → untouched
+  });
+
+  it('does not overwrite an already-present rating', async () => {
+    const pre = v('9322180'); (pre as ParsedVessel).ciiRating = 'A';
+    await hydrateCiiRatings([pre]);
+    expect(pre.ciiRating).toBe('A');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx jest scripts/demo-seed/__tests__/cii-hydration.test.ts --maxWorkers=1 --no-coverage`
+Expected: FAIL (`hydrateCiiRatings` not exported).
+
+- [ ] **Step 3: Implement** — in `regenerate-matches.ts`, add import + exported helper:
+
+```typescript
+import { lookupCii } from '@/lib/imo/cii-lookup';
+
+/** Hydrate vessel.ciiRating from the static cii.json dataset by IMO (offline,
+ *  no LLM). 'unknown'/no-IMO → leave null (neutral). Never overwrites an
+ *  existing rating. Mutates the vessels in place. */
+export async function hydrateCiiRatings(vessels: ParsedVessel[]): Promise<void> {
+  for (const vessel of vessels) {
+    if (vessel.ciiRating != null) continue;          // respect a parser-provided value
+    const imo = vessel.imo;
+    if (!imo) continue;
+    const { rating } = await lookupCii(imo);          // dataset hit, no callLlm
+    vessel.ciiRating = rating === 'unknown' ? null : rating;
+  }
+}
+```
+
+Call it in `main()` right after the vessels array is populated (after the load loop ending `regenerate-matches.ts:444`, before `analyzePairs` at `:448`):
+
+```typescript
+  await hydrateCiiRatings(vessels);
+  console.log(`[regen] CII hydrated for ${vessels.filter((v) => v.ciiRating != null).length}/${vessels.length} vessels`);
+```
+
+> The default `lookupCii` cache dir writes through `setCiiCached`. In a `--dry` (readonly) run this only touches the cache dir on disk, not the db — acceptable. If the offline runner forbids that write, pass `{ cacheDir: os.tmpdir() }`; otherwise leave default.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest scripts/demo-seed/__tests__/cii-hydration.test.ts --maxWorkers=1 --no-coverage`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/demo-seed/regenerate-matches.ts scripts/demo-seed/__tests__/cii-hydration.test.ts
+git commit -m "feat(seed): hydrate vessel.ciiRating from cii.json during regen"
+```
+
+---
+
+## Task 8: Before/after measurement (READ-ONLY, per calibration variant)
+
+**Goal:** Document the bucket/fit shift so the founder picks a calibration. **No prod regen, no writes.**
+
+> **Environment note:** the repo's `data/demo-seed.db` is a **0-byte placeholder** (the real seed db is built at deploy). Run the measurement where a populated `demo-seed.db` exists (the dev-VPS seed, or after running the seed build locally). If no populated db is available, record that and hand the measurement to the orchestrator for a VPS run — do **not** fabricate numbers.
+
+- [ ] **Step 1: Baseline (current main, pre-change)** — capture buckets:
+
+Run: `npx tsx scripts/demo-seed/regenerate-matches.ts --db <populated>.db --dry 2>&1 | grep -E "BUCKETS|main|review|insufficient"`
+Record: `main` count, fit min/med/max, `≥80`, `≥70`; `review`; `insufficient`.
+
+- [ ] **Step 2: With DEFAULT calibration (this branch)** — same command on the branch build; record the same fields.
+
+- [ ] **Step 3: STRONGER + SOFTER** — temporarily flip `CHARTERER_TIER_PENALTY` (Task 3) and the PSC verdict mapping (Task 1) to the STRONGER / SOFTER rows from the calibration table, re-run `--dry`, record, then `git checkout` the files (no commit of variant values).
+
+- [ ] **Step 4: Record results** in this plan under the table below and in the PR description.
+
+| Variant | main (N) | fit med | ≥80 | ≥70 | review | insufficient | Δ vs baseline |
+|---------|----------|---------|-----|-----|--------|--------------|---------------|
+| Baseline (main) | _fill_ | | | | | | — |
+| DEFAULT | _fill_ | | | | | | |
+| STRONGER | _fill_ | | | | | | |
+| SOFTER | _fill_ | | | | | | |
+
+**Expected shape (hypothesis to confirm, not a claim):** only the 5 PSC/CII fixture IMOs (`9322180`, `9478999`, `9512345`, `9156789`, `9734567`) move — and only if a seeded vessel actually carries one of those IMOs. PSC + CII hit the **same** IMOs (by fixture design), so D/E vessels with detentions take a compounded vetting dip (still bounded by weight 7). Charterer Δ is **0** under path (A) until a `chartererName` field exists. If **no** seeded vessel carries a fixture IMO, all variants equal baseline → note that the demo corpus needs a fixture-IMO vessel for the signal to be visible (a data follow-up, not a code defect).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Scope IN #1 (PSC→vetting, penalty curve) → Tasks 1,2,5. #2 (charterer tier→fit, placement justified = separate counterparty penalty) → Tasks 3,4,5. #3 (CII hydration via lookupCii by IMO from cii.json) → Task 7. Founder calibration (default+stronger+softer, bucket impact) → calibration table + Task 8. Execution-ordering constraint → top of doc. Before/after `--dry` READ-ONLY → Task 8. Scope OUT (IMSBC, seasonality, dead `getVesselPassport`, prod regen) → untouched.
+- **Placeholders:** none — every code/test step shows full code; the only deliberate "fill" cells are the measurement numbers (Task 8), which require a populated db at execution time.
+- **Type consistency:** `detentionCount?: number` and `chartererTier?: ...|null` are the same names across `computeVesselVetting` opts → `scoreVetting` → `FitBreakdownInput` → `pair-analyzer` call. `CHARTERER_TIER_PENALTY` keys match the `ChartererRow.tier` union. `hydrateCiiRatings` maps `'unknown'`→`null` consistent with `scoreCii`'s `null` branch.
+- **PI3 compliance:** zero existing-expectation rewrites. PSC factor is opt-in (existing 5-factor + 0.6 tests untouched); charterer is a scalar penalty (existing `toHaveLength(10)` untouched). Any golden-set shift in Task 5 is flagged as STOP-not-rewrite.
+- **PI2 compliance:** Task 6 is a real `analyzePairs` db-backed behavioral test; Task 7 calls the real `lookupCii` against the real `cii.json`.

--- a/lib/matching/__tests__/vetting-wiring.test.ts
+++ b/lib/matching/__tests__/vetting-wiring.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Behavioral tests — PSC detentions lower fit (L3 vetting wiring, Lane B).
+ *
+ * PI2: calls real analyzePairs with a real in-memory db seeded with PSC fixture
+ * rows — no string-match checks, full engine path exercised.
+ *
+ * Uses the same cargo/vessel pair shape from pair-analyzer-tce-into-fit.test.ts
+ * (Shanghai→Rotterdam grain, ~50kt, open Singapore) which reliably produces a
+ * scored match (clears all hard gates, has resolvable port distance).
+ */
+
+import Database from 'better-sqlite3';
+import migration026 from '@/lib/migrations/026-charterers';
+import migration028 from '@/lib/migrations/028-psc-history';
+import { PSC_FIXTURE } from '@/lib/knowledge/sources/psc/fixture';
+import { upsertInspection, getDetentionCount } from '@/lib/market/psc-repository';
+import { analyzePairs } from '@/lib/matching/pair-analyzer';
+import { resolveChartererTier } from '@/lib/matching/charterer-tier';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+
+const TODAY = new Date('2026-05-28T00:00:00Z');
+
+function makeMatchableCargo(): ParsedCargo {
+  return {
+    emailId: 'vetting-wiring-cargo',
+    itemIndex: 0,
+    originPort: { value: 'Shanghai', confidence: 'confirmed' },
+    originCountry: 'China',
+    destinationPort: { value: 'Rotterdam', confidence: 'confirmed' },
+    destinationCountry: 'Netherlands',
+    cargoDescription: { value: 'Grain', confidence: 'confirmed' },
+    weightMt: { value: 50000, confidence: 'confirmed' },
+    weightMtMin: 50000,
+    weightMtMax: 50000,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BULK',
+    containerType: null,
+    quantity: 50000,
+    incoterms: null,
+    preferredDates: null,
+    laycan: '2026-10-01 .. 2026-10-20',
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    freightRateUsd: null,
+  };
+}
+
+function makeMatchableVessel(over: Partial<ParsedVessel> = {}): ParsedVessel {
+  return {
+    emailId: 'vetting-wiring-vessel',
+    itemIndex: 0,
+    vesselName: { value: 'MV VETTING TEST', confidence: 'confirmed' },
+    imo: null,
+    flag: 'Marshall Islands',
+    built: 2015,
+    classSociety: 'DNV',
+    pandi: 'Gard',
+    dwtSummer: { value: 55000, confidence: 'confirmed' },
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: false,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: 'Bulk Carrier',
+    openPosition: { value: 'Singapore', confidence: 'confirmed' },
+    openDate: { value: '2026-09-15', confidence: 'confirmed' },
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: '14.0',
+    speedBallast: '14.5',
+    consumption: '30 mt IFO',
+    deckCapacity: null,
+    specialFeatures: [],
+    ciiRating: null,
+    verificationWarning: null,
+    ...over,
+  };
+}
+
+describe('vetting wiring — PSC detentions lower fit (behavioral)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    migration026.up(db);
+    migration028.up(db);
+    for (const rec of PSC_FIXTURE) upsertInspection(db, rec);
+  });
+
+  afterEach(() => db.close());
+
+  it('getDetentionCount fires on a fixture IMO within the 3yr window', () => {
+    expect(getDetentionCount(db, '9478999', '2023-01-01')).toBeGreaterThanOrEqual(2);
+    expect(getDetentionCount(db, '9156789', '2023-01-01')).toBe(0); // clean IMO
+  });
+
+  it('same vessel with a detained IMO scores lower fit than with a clean IMO', async () => {
+    const cargo = makeMatchableCargo();
+    const detainedVessel = makeMatchableVessel({ imo: '9478999', emailId: 'vessel-detained' });
+    const cleanVessel = makeMatchableVessel({ imo: '9156789', emailId: 'vessel-clean' });
+
+    const rDetained = await analyzePairs(
+      [cargo],
+      [detainedVessel],
+      async () => [],
+      { refYear: 2026, today: TODAY, db },
+    );
+    const rClean = await analyzePairs(
+      [{ ...cargo, emailId: 'vetting-wiring-cargo-clean' }],
+      [cleanVessel],
+      async () => [],
+      { refYear: 2026, today: TODAY, db },
+    );
+
+    const fitDetained =
+      rDetained.matches[0]?.fitPercent ?? rDetained.lowConfidenceMatches[0]?.fitPercent;
+    const fitClean =
+      rClean.matches[0]?.fitPercent ?? rClean.lowConfidenceMatches[0]?.fitPercent;
+
+    expect(fitDetained).toBeDefined();
+    expect(fitClean).toBeDefined();
+    expect(fitDetained!).toBeLessThan(fitClean!);
+  });
+
+  it('resolveChartererTier returns null today (documented gap)', () => {
+    expect(resolveChartererTier(db, makeMatchableCargo())).toBeNull();
+  });
+});

--- a/lib/matching/charterer-tier.ts
+++ b/lib/matching/charterer-tier.ts
@@ -1,0 +1,26 @@
+import type Database from 'better-sqlite3';
+import type { ParsedCargo } from '@/lib/types';
+import { getCharterer, listCharterers } from '@/lib/market/charterers-repository';
+
+export type ChartererTier = 'blue-chip' | 'second' | 'weak';
+
+/**
+ * Resolve a cargo's charterer credit tier from the charterers table.
+ *
+ * GAP (2026-06-07): ParsedCargo carries no charterer identity field, and the
+ * demo corpus anonymizes charterer names in the email body. Until a
+ * `cargo.chartererName` field exists, there is no reliable key → this returns
+ * null (→ unknown → neutral fit, no penalty). The scoring path that CONSUMES
+ * this value is fully wired + tested (computeFitBreakdown.chartererTier), so
+ * activation is a one-line change here once the parser provides the name.
+ *
+ * @returns the tier, or null when no charterer can be resolved.
+ */
+export function resolveChartererTier(_db: Database.Database, _cargo: ParsedCargo): ChartererTier | null {
+  // TODO(charterer-field): once ParsedCargo gains chartererName, resolve via
+  //   getCharterer(db, deterministicId(name)) or a name lookup over
+  //   listCharterers(db), and return row.tier. Helpers imported above are the
+  //   exact functions to call — kept referenced so this stays a one-line edit.
+  void getCharterer; void listCharterers;
+  return null;
+}

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -28,6 +28,8 @@ import { getBalticDayRate } from '@/lib/market/baltic-freight';
 import { sumMatchPortDaUsd } from '@/lib/port-da/match-da';
 import type Database from 'better-sqlite3';
 import { getPortDistance } from '@/lib/sailing/port-distances';
+import { getDetentionCount } from '@/lib/market/psc-repository';
+import { resolveChartererTier } from '@/lib/matching/charterer-tier';
 import { formatNumber } from '@/lib/utils';
 import { LLMTimeoutError } from '@/lib/openai';
 import { now } from '@/lib/clock';
@@ -65,6 +67,9 @@ export type AiScorer = (payload: {
  * (penalised, possibly weak) and ≥3-week idle is bucketed.
  */
 export const IDLE_HARD_MAX_GAP_DAYS = 21;
+
+// PSC detention lookback for the vetting signal: 3 years before refYear.
+const PSC_LOOKBACK_YEARS = 3;
 
 /** Outcome of the matching pipeline: the main "worth calling" list plus the
  *  preserved side-buckets (no pair is ever dropped — see the partition below). */
@@ -767,6 +772,11 @@ export async function analyzePairs(
       );
       const econ = computeMatchEconomicsFor(m, cargos, vessels, db, economicsCalcAt);
       if (econ) m.economics = econ;
+      const imo = vessel.imo;
+      const detentionCount = db && imo
+        ? getDetentionCount(db, imo, `${refYear - PSC_LOOKBACK_YEARS}-01-01`)
+        : undefined; // no db/IMO → leave PSC neutral (omit factor)
+      const chartererTier = db ? resolveChartererTier(db, cargo) : null;
       const fb = computeFitBreakdown({
         cargo,
         vessel,
@@ -775,6 +785,8 @@ export async function analyzePairs(
         hardFilters: analysis?.hardFilters,
         refYear,
         tceUsdPerDay: econ?.tceUsdPerDay ?? null,
+        detentionCount,
+        chartererTier,
       });
       m.fitPercent = fb.fitPercent;
       m.fitBreakdown = fb;

--- a/lib/sailing/__tests__/fit-breakdown.test.ts
+++ b/lib/sailing/__tests__/fit-breakdown.test.ts
@@ -8,6 +8,7 @@ import {
   scoreBallast,
   scoreUtilisation,
   scoreTiming,
+  scoreVetting,
 } from '../fit-breakdown';
 import type { MatchReadiness, MatchSanctions, MatchHardFilters, ParsedCargo, ParsedVessel } from '@/lib/types';
 
@@ -526,5 +527,54 @@ describe('computeFitBreakdown — economic cap (C3 #783)', () => {
     // EU-age cap (ceiling 55) should still be applied
     expect(fb.fitPercent).toBeLessThanOrEqual(55);
     expect(fb.appliedCap?.reason).toMatch(/EU discharge|EU PSC/i);
+  });
+});
+
+describe('scoreVetting — PSC pass-through', () => {
+  it('detentions lower the vetting component score', () => {
+    const vessel = makeVessel({ flag: 'Marshall Islands', classSociety: 'DNV', built: 2018, pandi: 'Gard', ciiRating: 'B' });
+    const clean = scoreVetting(vessel, 2026, 0);
+    const detained = scoreVetting(vessel, 2026, 2);
+    expect(detained.score).toBeLessThan(clean.score);
+    expect(detained.factor).toBe('vetting');
+  });
+
+  it('omitting detentionCount preserves legacy 5-factor behaviour', () => {
+    const vessel = makeVessel({ flag: 'Marshall Islands', classSociety: 'DNV', built: 2018, pandi: 'Gard', ciiRating: 'B' });
+    const legacy = scoreVetting(vessel, 2026);
+    const zero = scoreVetting(vessel, 2026, 0);
+    // legacy (no PSC factor) scores at least as high as zero-detention (PSC ok adds a 6th 1.0 share)
+    expect(legacy.score).toBeGreaterThanOrEqual(zero.score - 0.01);
+  });
+});
+
+describe('computeFitBreakdown — charterer credit-tier penalty', () => {
+  function baseFitInput() {
+    return {
+      cargo: makeCargo(),
+      vessel: makeVessel({ built: 2018, flag: 'Marshall Islands', classSociety: 'DNV', pandi: 'Gard', ciiRating: 'B' }),
+      readiness: READY_IDEAL,
+      sanctions: SANCTIONS_OK,
+      hardFilters: HF_PASS,
+      refYear: 2026,
+    };
+  }
+
+  it('weak tier lowers fitPercent vs no tier (default −4)', () => {
+    const withTier = computeFitBreakdown({ ...baseFitInput(), chartererTier: 'weak' });
+    const without = computeFitBreakdown({ ...baseFitInput() });
+    expect(withTier.fitPercent).toBeLessThan(without.fitPercent);
+    expect(without.fitPercent - withTier.fitPercent).toBeCloseTo(4, 0);
+  });
+
+  it('blue-chip / second / undefined → no penalty', () => {
+    const blue = computeFitBreakdown({ ...baseFitInput(), chartererTier: 'blue-chip' });
+    const none = computeFitBreakdown({ ...baseFitInput() });
+    expect(blue.fitPercent).toBe(none.fitPercent);
+  });
+
+  it('still exactly 10 components (penalty is not a component)', () => {
+    const fb = computeFitBreakdown({ ...baseFitInput(), chartererTier: 'weak' });
+    expect(fb.components).toHaveLength(10);
   });
 });

--- a/lib/sailing/__tests__/vessel-vetting.test.ts
+++ b/lib/sailing/__tests__/vessel-vetting.test.ts
@@ -163,3 +163,40 @@ describe('computeVesselVetting — score ordering', () => {
     expect(bad.score).toBeLessThan(unknownVessel.score);
   });
 });
+
+describe('computeVesselVetting — PSC sub-factor (optional)', () => {
+  it('detentionCount omitted → still 5 factors (backward-compatible)', () => {
+    const result = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR });
+    expect(result.factors).toHaveLength(5);
+    expect(result.factors.some((f) => f.key === 'psc')).toBe(false);
+  });
+
+  it('detentionCount=0 → 6 factors, psc verdict ok, no badge', () => {
+    const result = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 0 });
+    expect(result.factors).toHaveLength(6);
+    const psc = result.factors.find((f) => f.key === 'psc');
+    expect(psc?.verdict).toBe('ok');
+    expect(result.badges.some((b) => /detention|PSC/i.test(b))).toBe(false);
+  });
+
+  it('detentionCount=1 → psc caution + badge', () => {
+    const result = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 1 });
+    const psc = result.factors.find((f) => f.key === 'psc');
+    expect(psc?.verdict).toBe('caution');
+    expect(result.badges.some((b) => /detention|PSC/i.test(b))).toBe(true);
+  });
+
+  it('detentionCount>=2 → psc warn, lower score than caution', () => {
+    const warn = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 2 });
+    const caution = computeVesselVetting(makeVesselFields(), { refYear: REF_YEAR, detentionCount: 1 });
+    const psc = warn.factors.find((f) => f.key === 'psc');
+    expect(psc?.verdict).toBe('warn');
+    expect(warn.score).toBeLessThan(caution.score);
+  });
+
+  it('a detention lowers overall vetting vs a clean PSC record', () => {
+    const clean = computeVesselVetting(makeVesselFields({ flag: 'Marshall Islands', classSociety: 'DNV', built: 2018, pandi: 'Gard', ciiRating: 'B' }), { refYear: REF_YEAR, detentionCount: 0 });
+    const detained = computeVesselVetting(makeVesselFields({ flag: 'Marshall Islands', classSociety: 'DNV', built: 2018, pandi: 'Gard', ciiRating: 'B' }), { refYear: REF_YEAR, detentionCount: 2 });
+    expect(detained.score).toBeLessThan(clean.score);
+  });
+});

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -62,6 +62,15 @@ export const FIT_WEIGHTS: Record<FitFactor, number> = {
 
 const TOTAL_WEIGHT = Object.values(FIT_WEIGHTS).reduce((a, b) => a + b, 0);
 
+// Charterer credit-tier penalty (founder-calibrated; DEFAULT). Counterparty-side,
+// kept OUT of vessel vetting. weak → soft fit hit; second/blue-chip → none.
+// STRONGER: { weak: 8, second: 3 }. SOFTER: { weak: 2, second: 0 }.
+export const CHARTERER_TIER_PENALTY: Record<'blue-chip' | 'second' | 'weak', number> = {
+  'blue-chip': 0,
+  second: 0,
+  weak: 4,
+};
+
 // ────────────────────────────────────────────────────────────────────────────
 // Component scorers — each returns score normalised to [0, weight].
 // Conservative on missing data: returns 60% of weight + "unknown" rationale.
@@ -408,14 +417,14 @@ export function scoreDraft(hardFilters: MatchHardFilters | undefined): FitBreakd
  *  When refYear is absent and built is set, age falls back to unknown (neutral).
  *  unknown ≠ penalty — consistent with UNKNOWN_SHARE pattern above.
  */
-export function scoreVetting(vessel: ParsedVessel, refYear?: number): FitBreakdownComponent {
+export function scoreVetting(vessel: ParsedVessel, refYear?: number, detentionCount?: number): FitBreakdownComponent {
   const w = FIT_WEIGHTS.vetting;
   // If refYear not provided, treat age as unknown by zeroing built temporarily.
   const effectiveVessel = refYear != null
     ? vessel
     : { ...vessel, built: null };
   const effectiveRefYear = refYear ?? 0;
-  const result = computeVesselVetting(effectiveVessel, { refYear: effectiveRefYear });
+  const result = computeVesselVetting(effectiveVessel, { refYear: effectiveRefYear, detentionCount });
   const rationale = result.badges.length > 0
     ? `Items to confirm before fixing: ${result.badges.join(', ')}.`
     : result.factors.every((f) => f.verdict === 'unknown')
@@ -549,10 +558,14 @@ export interface FitBreakdownInput {
   refYear?: number;
   /** Pre-computed TCE $/day fed into the economics gradient factor. Absent/undefined → no cap (conservative). */
   tceUsdPerDay?: number | null;
+  /** PSC detentions in lookback window (resolved upstream where db is in scope). Absent → PSC factor omitted (neutral). */
+  detentionCount?: number;
+  /** Charterer credit tier (counterparty side). Absent/null → no penalty (unknown = neutral). */
+  chartererTier?: 'blue-chip' | 'second' | 'weak' | null;
 }
 
 export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
-  const { cargo, vessel, readiness, sanctions, hardFilters, refYear, tceUsdPerDay } = input;
+  const { cargo, vessel, readiness, sanctions, hardFilters, refYear, tceUsdPerDay, detentionCount, chartererTier } = input;
   const desc = cfValue(cargo.cargoDescription);
   const partCargo = isPartCargo(desc);
 
@@ -570,7 +583,7 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
     scoreCranes(vessel.geared, cfValue(cargo.originPort)),
     scoreVolume(cargoWtMax, desc, vessel.grainCapacity, cargo.stowageFactor),
     scoreDraft(hardFilters),
-    scoreVetting(vessel, refYear),
+    scoreVetting(vessel, refYear, detentionCount),
     scoreEconomics(tceUsdPerDay, dwt),
   ];
 
@@ -578,7 +591,8 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
   // Sanctions adjustment — MEDIUM trims 8 pts off (matches legacy -10 from
   // scoreBreakdown, scaled to the smaller dynamic range broker views).
   const sanctionsPenalty = sanctions?.risk === 'MEDIUM' ? 8 : 0;
-  let fit = rawSum - sanctionsPenalty;
+  const chartererPenalty = chartererTier ? CHARTERER_TIER_PENALTY[chartererTier] : 0;
+  let fit = rawSum - sanctionsPenalty - chartererPenalty;
 
   // ── Gating caps — broker-reality overrides the linear sum. ────────────────
   // A single killing factor (late, gross under-util, uneconomic ballast) makes
@@ -639,6 +653,7 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
     partCargo,
     vesselClass: classifyVesselByDwt(dwt),
     sanctionsPenalty,
+    chartererPenalty,
     appliedCap,
     inputs: {
       distanceNm: readiness?.distanceNm ?? null,

--- a/lib/sailing/vessel-vetting.ts
+++ b/lib/sailing/vessel-vetting.ts
@@ -97,6 +97,20 @@ function scorePandi(pandi: string | null): VettingFactor {
   return { key: 'pandi', label: 'P&I insurance', verdict: 'caution', rationale: `${pandi} — not an IG P&I club` };
 }
 
+/** PSC detention history — detentions in the lookback window are the single
+ *  strongest port-state-control trust signal. 0 → clean; 1 → caution; ≥2 → warn.
+ *  Caller supplies the count (resolved from psc_detention_history by IMO upstream,
+ *  where the db handle lives) — this module stays pure / db-free. */
+function scorePsc(detentionCount: number): VettingFactor {
+  if (detentionCount <= 0) {
+    return { key: 'psc', label: 'PSC detentions', verdict: 'ok', rationale: 'No port-state-control detentions on record in the lookback window.' };
+  }
+  if (detentionCount === 1) {
+    return { key: 'psc', label: 'PSC detentions', verdict: 'caution', rationale: '1 PSC detention in the lookback window — elevated inspection risk.' };
+  }
+  return { key: 'psc', label: 'PSC detentions', verdict: 'warn', rationale: `${detentionCount} PSC detentions in the lookback window — high inspection / off-hire risk.` };
+}
+
 function scoreCii(ciiRating: 'A' | 'B' | 'C' | 'D' | 'E' | null | undefined): VettingFactor {
   if (ciiRating == null) {
     return { key: 'cii', label: 'CII rating', verdict: 'unknown', rationale: 'CII rating not recorded' };
@@ -121,9 +135,9 @@ function scoreCii(ciiRating: 'A' | 'B' | 'C' | 'D' | 'E' | null | undefined): Ve
  */
 export function computeVesselVetting(
   vessel: Pick<ParsedVessel, 'flag' | 'built' | 'classSociety' | 'pandi' | 'ciiRating'>,
-  opts: { refYear: number },
+  opts: { refYear: number; detentionCount?: number },
 ): VesselVettingResult {
-  const { refYear } = opts;
+  const { refYear, detentionCount } = opts;
 
   const factors: VettingFactor[] = [
     scoreFlag(vessel.flag),
@@ -132,6 +146,11 @@ export function computeVesselVetting(
     scorePandi(vessel.pandi),
     scoreCii(vessel.ciiRating),
   ];
+  // PSC is optional: only included when the caller supplies a count (db-resolved).
+  // Absent → 5 factors, preserving every existing caller's behaviour.
+  if (detentionCount != null) {
+    factors.push(scorePsc(detentionCount));
+  }
 
   const avgShare =
     factors.reduce((sum, f) => sum + VETTING_VERDICT_SHARE[f.verdict], 0) / factors.length;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -545,6 +545,8 @@ export interface FitBreakdown {
   vesselClass: string;
   /** Pts deducted for MEDIUM sanctions risk (HIGH/blocking is filtered upstream). */
   sanctionsPenalty: number;
+  /** Pts deducted for weak charterer credit tier (counterparty-side penalty). */
+  chartererPenalty?: number;
   /** Killing-factor cap that lowered the headline fitPercent below the linear sum
    *  (e.g. 'late' verdict → cap 38). Null when no cap applied. */
   appliedCap: { reason: string; ceiling: number } | null;

--- a/scripts/demo-seed/__tests__/cii-hydration.test.ts
+++ b/scripts/demo-seed/__tests__/cii-hydration.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Behavioral tests — hydrateCiiRatings (Task 7, Lane B CII hydration).
+ *
+ * PI2: calls the real lookupCii against the real cii.json dataset — no mocks.
+ * Verifies the helper sets ratings by IMO, maps unknown → null, skips pre-set ratings.
+ */
+
+import { hydrateCiiRatings } from '../regenerate-matches';
+import type { ParsedVessel } from '@/lib/types';
+
+function v(imo: string | null, ciiRating: ParsedVessel['ciiRating'] = null): ParsedVessel {
+  return { imo, ciiRating } as unknown as ParsedVessel;
+}
+
+describe('hydrateCiiRatings', () => {
+  it('sets ciiRating from the static cii.json dataset by IMO', async () => {
+    const vessels = [v('9322180'), v('9200648'), v('0000000'), v(null)];
+    await hydrateCiiRatings(vessels);
+    expect(vessels[0].ciiRating).toBe('D'); // 9322180 → D in cii.json
+    expect(vessels[1].ciiRating).toBe('A'); // 9200648 → A
+    expect(vessels[2].ciiRating).toBeNull(); // unknown IMO → null (neutral)
+    expect(vessels[3].ciiRating).toBeNull(); // no IMO → untouched
+  });
+
+  it('does not overwrite an already-present rating', async () => {
+    const pre = v('9322180', 'A');
+    await hydrateCiiRatings([pre]);
+    expect(pre.ciiRating).toBe('A'); // pre-set 'A' stays, not overwritten with 'D'
+  });
+});

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -41,6 +41,22 @@ import { cfValue, type ParsedCargo, type ParsedVessel, type Match, type MatchWor
 import { seedCharterersWithDb } from '../knowledge/seeds/seed-charterers';
 import { seedPscHistoryWithDb } from '../knowledge/seeds/seed-psc-history';
 import { seedPortDa, type BaselinePort } from '../seed-port-da';
+import { lookupCii } from '@/lib/imo/cii-lookup';
+
+// ── CII hydration helper ──────────────────────────────────────────────────────
+
+/** Hydrate vessel.ciiRating from the static cii.json dataset by IMO (offline,
+ *  no LLM). 'unknown'/no-IMO → leave null (neutral). Never overwrites an
+ *  existing rating. Mutates the vessels in place. */
+export async function hydrateCiiRatings(vessels: ParsedVessel[]): Promise<void> {
+  for (const vessel of vessels) {
+    if (vessel.ciiRating != null) continue;
+    const imo = vessel.imo;
+    if (!imo) continue;
+    const { rating } = await lookupCii(imo);
+    vessel.ciiRating = rating === 'unknown' ? null : rating;
+  }
+}
 
 // ── Phase 1: seed reference tables into the regen's own db handle ────────────
 
@@ -443,6 +459,9 @@ async function main() {
     if (changed && !DRY) { updateParsed.run(JSON.stringify(items), r.id, r.parse_type); normalizedRows++; }
   }
   console.log(`[regen] frozen=${frozen} refYear=${refYear} · cargos=${cargos.length} vessels=${vessels.length} · normalized parsed rows=${normalizedRows}`);
+
+  await hydrateCiiRatings(vessels);
+  console.log(`[regen] CII hydrated for ${vessels.filter((v) => v.ciiRating != null).length}/${vessels.length} vessels`);
 
   // ── 2. Run the real engine (no LLM — deterministic gates + sweep + fit) ──
   const result = await analyzePairs(cargos, vessels, async () => [], { refYear, today, db });


### PR DESCRIPTION
## What this wires

Three already-collected trust signals → broker fit/vetting score (roadmap L3 — "trustworthy"):

- **PSC detentions** → optional 6th sub-factor inside `computeVesselVetting` (gated on `detentionCount`, resolved in pair-analyzer where `db`+`vessel.imo` live). Weight-7 vetting component; no new fit weight.
- **Charterer credit tier** → separate scalar penalty in `computeFitBreakdown` (mirrors `sanctionsPenalty`, kept counterparty-side OUT of vessel vetting). `weak` → −4 fit pts; `second`/`blue-chip` → 0.
- **CII** → no scoring change; hydrate `vessel.ciiRating` from `lookupCii(imo)` during regen so existing `scoreCii` finally fires on real A–E data.

## Calibration (DEFAULT — founder-approved)

| Signal | DEFAULT |
|--------|---------|
| PSC | 1 detention → `caution` (0.65 share); ≥2 → `warn` (0.20); 0 → `ok`. 3yr window. |
| Charterer weak tier | −4 fit pts; second/blue-chip → 0. |
| CII | Hydration only — no new weight. |

## Task 8 — Before/After Measurement (DEFAULT variant)

> **Note:** `data/demo-seed.db` is a 0-byte placeholder in this repo. Measurement run against a populated seed db from another worktree (cargos=3, vessels=0). No vessel data available in this environment to produce a non-trivial bucket comparison.
>
> **Result:** 0 vessels in seed → all bucket counts are 0 across all variants. This confirms the plan hypothesis: "If no seeded vessel carries a fixture IMO, all variants equal baseline." The demo corpus needs a fixture-IMO vessel for the signal to be visible in buckets — a data follow-up (seed more vessels), not a code defect.
>
> Measurement will be re-run by orchestrator on dev-VPS after a full seed rebuild with vessels carrying fixture IMOs.

| Variant | main (N) | fit med | ≥80 | ≥70 | review | insufficient | Δ vs baseline |
|---------|----------|---------|-----|-----|--------|--------------|---------------|
| Baseline (main) | 0 | — | — | — | 0 | 0 | — |
| DEFAULT | 0 | — | — | — | 0 | 0 | no change (no vessel IMOs match fixture) |

## PI3 / PI2 compliance

- **PI3**: zero existing-expectation rewrites. PSC factor is opt-in → existing 5-factor/0.6 tests untouched. Charterer is a scalar penalty → existing `toHaveLength(10)` untouched.
- **PI2**: `vetting-wiring.test.ts` calls real `analyzePairs` with a real in-memory db seeded with PSC fixture rows; `cii-hydration.test.ts` calls real `lookupCii` against real `cii.json`.

## ⚠️ Surfaced: Charterer linkage gap

`ParsedCargo` has no charterer identity field; demo emails anonymize charterer names. Resolver returns `null` (unknown → neutral fit, no penalty) until `cargo.chartererName` lands. PATH A (ship plumbing now, defer resolution) implemented — no fabricated data.

## Files changed

| File | Change |
|------|--------|
| `lib/sailing/vessel-vetting.ts` | +`scorePsc`, optional `detentionCount` in opts |
| `lib/sailing/fit-breakdown.ts` | Thread `detentionCount` → `scoreVetting`; add `chartererTier` + `chartererPenalty` |
| `lib/types.ts` | Add `chartererPenalty?: number` to `FitBreakdown` |
| `lib/matching/charterer-tier.ts` | New: `resolveChartererTier` (documented gap) |
| `lib/matching/pair-analyzer.ts` | Resolve PSC + charterer at call site, pass to `computeFitBreakdown` |
| `scripts/demo-seed/regenerate-matches.ts` | +`hydrateCiiRatings`, called before `analyzePairs` |
| `lib/sailing/__tests__/vessel-vetting.test.ts` | +5 PSC behavioral tests |
| `lib/sailing/__tests__/fit-breakdown.test.ts` | +PSC pass-through + charterer penalty tests |
| `lib/matching/__tests__/vetting-wiring.test.ts` | New: behavioral db-backed integration test |
| `scripts/demo-seed/__tests__/cii-hydration.test.ts` | New: behavioral cii.json hydration test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)