### PR TITLE
fix: CII hydration offline-only in regen (no LLM)

### DIFF
--- a/scripts/demo-seed/__tests__/cii-hydration.test.ts
+++ b/scripts/demo-seed/__tests__/cii-hydration.test.ts
@@ -1,9 +1,28 @@
 /**
  * Behavioral tests — hydrateCiiRatings (Task 7, Lane B CII hydration).
  *
- * PI2: calls the real lookupCii against the real cii.json dataset — no mocks.
+ * PI2: calls the real lookupCii against the real cii.json dataset — no mocks of the impl.
+ * The jest.mock factory wraps lookupCii to enforce the callLlm guard is passed (offline
+ * determinism): any call without opts.callLlm throws, so tests would fail before the fix.
  * Verifies the helper sets ratings by IMO, maps unknown → null, skips pre-set ratings.
  */
+
+// Guard: real lookupCii still runs, but throws if called without the callLlm opt.
+// This makes every test in this file a determinism test — without the fix they'd all fail.
+jest.mock('@/lib/imo/cii-lookup', () => {
+  const actual = jest.requireActual<typeof import('@/lib/imo/cii-lookup')>('@/lib/imo/cii-lookup');
+  return {
+    ...actual,
+    lookupCii: jest.fn((imo: string, opts?: { callLlm?: () => Promise<string> }) => {
+      if (!opts?.callLlm) {
+        throw new Error(
+          `lookupCii("${imo}") called without callLlm guard — would hit network in offline regen`,
+        );
+      }
+      return actual.lookupCii(imo, opts);
+    }),
+  };
+});
 
 import { hydrateCiiRatings } from '../regenerate-matches';
 import type { ParsedVessel } from '@/lib/types';
@@ -26,5 +45,13 @@ describe('hydrateCiiRatings', () => {
     const pre = v('9322180', 'A');
     await hydrateCiiRatings([pre]);
     expect(pre.ciiRating).toBe('A'); // pre-set 'A' stays, not overwritten with 'D'
+  });
+
+  it('passes callLlm guard — offline determinism: absent IMO stays null without hitting LLM', async () => {
+    // The module mock above throws if lookupCii is called without callLlm —
+    // this test would throw before the fix (no guard was passed).
+    const vessel = v('0000000');
+    await hydrateCiiRatings([vessel]);
+    expect(vessel.ciiRating).toBeNull();
   });
 });

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -53,7 +53,7 @@ export async function hydrateCiiRatings(vessels: ParsedVessel[]): Promise<void> 
     if (vessel.ciiRating != null) continue;
     const imo = vessel.imo;
     if (!imo) continue;
-    const { rating } = await lookupCii(imo);
+    const { rating } = await lookupCii(imo, { callLlm: async () => 'unknown' });
     vessel.ciiRating = rating === 'unknown' ? null : rating;
   }
 }


### PR DESCRIPTION
## Summary
- `hydrateCiiRatings` in `scripts/demo-seed/regenerate-matches.ts` called `lookupCii(imo)` without the no-LLM guard, making seed regen non-deterministic and failing offline (115 ECONNREFUSED on dev)
- Fix: pass `{ callLlm: async () => 'unknown' }` — mirrors the existing guard at `lib/vessel/registry.ts:144`, reads cache + static `cii.json` only
- Vessels absent from `cii.json` stay null (neutral), matching the docstring

## Test plan
- [ ] `jest.mock` guard in `cii-hydration.test.ts` throws if `lookupCii` is called without `callLlm` — proves fix is required (all 3 tests in file would fail before the fix)
- [ ] 3/3 tests green: rating by IMO, no-overwrite, offline-determinism
- [ ] 29/29 findRelatedTests green
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)