### PR TITLE
fix(demo-seed): invalidate stale sessions on regen (Lane #1)

### DIFF
--- a/scripts/demo-seed/__tests__/invalidate-live-sessions.test.ts
+++ b/scripts/demo-seed/__tests__/invalidate-live-sessions.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Behavioral tests — invalidateLiveSessions (Lane #1 stale-session durable fix).
+ *
+ * PI2: runs the real helper against a real in-memory better-sqlite3 DB. No impl mocks.
+ * Proves a regen wipes per-session match copies + all sessions, while leaving the
+ * fresh master (NULL) and sentinel buckets intact, so the next login re-hydrates clean.
+ */
+import Database from 'better-sqlite3';
+import type { Database as DB } from 'better-sqlite3';
+import { invalidateLiveSessions } from '../regenerate-matches';
+import { buildDemoSessionBlob } from '@/lib/demo-mode/hydrate-demo-session';
+
+function makeDb(): DB {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cargo_id TEXT, vessel_id TEXT, user_id TEXT,
+      score REAL, reason TEXT, reason_structured TEXT,
+      tce_usd_per_day REAL
+    );
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, access_token TEXT NOT NULL,
+      created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL, data TEXT NOT NULL
+    );
+    CREATE TABLE emails (
+      gmail_message_id TEXT, thread_id TEXT, from_addr TEXT, from_name TEXT,
+      from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+      body TEXT, snippet TEXT, label_ids TEXT
+    );
+    CREATE TABLE parsed_results (parse_type TEXT, result_json TEXT);
+  `);
+  const ins = db.prepare(
+    `INSERT INTO matches (cargo_id, vessel_id, user_id, score, reason, reason_structured, tce_usd_per_day)
+     VALUES (?,?,?,?,?,?,?)`,
+  );
+  // master (NULL) — fresh, must survive
+  ins.run('c1', 'v1', null, 0.85, null, null, 9586);
+  ins.run('c2', 'v2', null, 0.80, null, null, 9000);
+  // sentinels — must survive
+  ins.run('c3', 'v3', '__demo_review__', 0.5, null, null, 2977);
+  ins.run('c4', 'v4', '__demo_insufficient__', 0.3, null, null, 3906);
+  // per-session UUID copies — must be deleted
+  ins.run('c1', 'v1', 'sess-aaaa', 0.85, null, null, -308);
+  ins.run('c2', 'v2', 'sess-bbbb', 0.80, null, null, -943);
+  // sessions rows — must be deleted
+  const sIns = db.prepare(
+    `INSERT INTO sessions (id, access_token, created_at, expires_at, data) VALUES (?,?,?,?,?)`,
+  );
+  sIns.run('sess-aaaa', 'tok', 1, 9_999_999_999_999, '{}');
+  sIns.run('sess-bbbb', 'tok', 1, 9_999_999_999_999, '{}');
+  return db;
+}
+
+describe('invalidateLiveSessions', () => {
+  it('deletes per-session UUID match copies, keeps master (NULL) + sentinels', () => {
+    const db = makeDb();
+    invalidateLiveSessions(db);
+
+    const nullCount = db
+      .prepare(`SELECT COUNT(*) n FROM matches WHERE user_id IS NULL`)
+      .get() as { n: number };
+    const sentinels = db
+      .prepare(
+        `SELECT COUNT(*) n FROM matches WHERE user_id IN ('__demo_review__','__demo_insufficient__')`,
+      )
+      .get() as { n: number };
+    const sessionCopies = db
+      .prepare(
+        `SELECT COUNT(*) n FROM matches WHERE user_id IS NOT NULL
+           AND user_id NOT IN ('__demo_review__','__demo_insufficient__')`,
+      )
+      .get() as { n: number };
+
+    expect(nullCount.n).toBe(2);
+    expect(sentinels.n).toBe(2);
+    expect(sessionCopies.n).toBe(0);
+  });
+
+  it('empties the sessions table (force re-hydration on next login)', () => {
+    const db = makeDb();
+    invalidateLiveSessions(db);
+    const sess = db.prepare(`SELECT COUNT(*) n FROM sessions`).get() as { n: number };
+    expect(sess.n).toBe(0);
+  });
+
+  it('is a no-op-safe second call (idempotent — re-running regen is fine)', () => {
+    const db = makeDb();
+    invalidateLiveSessions(db);
+    expect(() => invalidateLiveSessions(db)).not.toThrow();
+    const sess = db.prepare(`SELECT COUNT(*) n FROM sessions`).get() as { n: number };
+    expect(sess.n).toBe(0);
+  });
+
+  it('after invalidation, buildDemoSessionBlob still returns the fresh master (no empty state)', () => {
+    const db = makeDb();
+    invalidateLiveSessions(db);
+
+    const blob = buildDemoSessionBlob(db);
+    expect(blob.matches.length).toBe(2);
+    expect(blob.matches.every((m) => (m.economics?.tceUsdPerDay ?? 0) > 0)).toBe(true);
+  });
+});

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -58,6 +58,31 @@ export async function hydrateCiiRatings(vessels: ParsedVessel[]): Promise<void> 
   }
 }
 
+// ── Lane #1: invalidate stale demo sessions after regen ──────────────────────
+
+/**
+ * After a regen replaces the master/sentinel buckets, the pre-regen per-session
+ * copies + their session blobs are stale. Wipe both so the next login re-hydrates
+ * from the fresh NULL bucket (buildDemoSessionBlob reads only `WHERE user_id IS NULL`).
+ * deleteOrphanSessionMatches can't help — demo sessions have a ~30-day TTL, so they're
+ * never "orphans" during the regen window.
+ *
+ * Founder decision: invalidate ALL sessions. demo-seed.db (== SESSIONS_DB_PATH in
+ * DEMO_MODE) holds only demo sessions; no real/non-demo sessions live here.
+ */
+export function invalidateLiveSessions(db: Database.Database): void {
+  const matchDel = db
+    .prepare(
+      `DELETE FROM matches WHERE user_id IS NOT NULL
+         AND user_id NOT IN ('__demo_review__','__demo_insufficient__')`,
+    )
+    .run();
+  const sessionDel = db.prepare(`DELETE FROM sessions`).run();
+  console.log(
+    `[regen] invalidated stale demo state · cleared ${matchDel.changes} session match copies · expired ${sessionDel.changes} sessions`,
+  );
+}
+
 // ── Phase 1: seed reference tables into the regen's own db handle ────────────
 
 /**
@@ -667,6 +692,10 @@ async function main() {
     console.log(`[regen] deleted ${del.changes} old seed rows · wrote main=${a} review=${b} insufficient=${c}`);
   });
   tx();
+
+  // Lane #1: wipe stale per-session copies + session blobs so the next login
+  // re-hydrates from the fresh master bucket just written above.
+  invalidateLiveSessions(db);
 
   // verify
   const v = db.prepare(`SELECT COUNT(*) n, SUM(fit_percent IS NOT NULL) withfit FROM matches WHERE user_id IS NULL`).get() as { n: number; withfit: number };


### PR DESCRIPTION
## Summary
- Exports `invalidateLiveSessions(db)` from `regenerate-matches.ts`, called after `tx()` commits the fresh master/sentinel buckets
- Deletes per-session UUID match copies + empties `sessions` table on every regen, forcing the next login to re-hydrate from the clean NULL bucket via `buildDemoSessionBlob`
- Fixes root cause: `deleteOrphanSessionMatches` only prunes dead-session copies; ~30-day TTL sessions were never "orphans" during a regen window, so stale `sessions.data` blobs persisted

## Test plan
- [ ] `npx jest scripts/demo-seed/__tests__/invalidate-live-sessions.test.ts --maxWorkers=1 --no-coverage` → 4/4 green
  - session UUID match copies wiped, master(NULL)+sentinels intact
  - `sessions` table emptied
  - idempotent second call
  - `buildDemoSessionBlob` returns fresh master after invalidation (PI2, real in-memory DB)
- [ ] Existing `scripts/demo-seed/__tests__/` suite: 17 suites / 110 tests green, no regressions

## Notes
- Lane #3 (FixB live-bunker) edits `regenerate-matches.ts` in the `writeBucket` region (~line 639). This PR touches only the new helper block (after line 59) and the post-`tx()` call site — no conflict expected.
- `DELETE FROM sessions` is safe: `demo-seed.db` (≡ `SESSIONS_DB_PATH` in DEMO_MODE) holds only demo sessions per confirmed `lib/session-store.ts:15-16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)