### PR TITLE
fix(tce): list==detail parity — distance bug, war-risk flag, live bunker (A+B+C)

### DIFF
--- a/__tests__/components/match/MatchTabs-route-distance.test.tsx
+++ b/__tests__/components/match/MatchTabs-route-distance.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ *
+ * PI2 behavioral: MatchTabs must pass storedDistanceNm (laden) to EconomicsTab,
+ * NOT readiness.distanceNm (ballast). Fix A regression guard (#fix-list-vs-detail).
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+// Capture the routeDistanceNm prop that EconomicsTab receives
+let capturedRouteDistanceNm: number | null | undefined = undefined;
+
+jest.mock('@/components/match/EconomicsTab', () => ({
+  EconomicsTab: (props: { routeDistanceNm?: number | null }) => {
+    capturedRouteDistanceNm = props.routeDistanceNm;
+    return null;
+  },
+}));
+
+jest.mock('@/components/match/VesselsTab', () => ({ VesselsTab: () => null }));
+jest.mock('@/components/match/PassportTab', () => ({ PassportTab: () => null }));
+jest.mock('@/components/match/QuoteTab', () => ({ QuoteTab: () => null }));
+jest.mock('@/lib/confidence', () => ({
+  getConfidenceColorClass: () => 'border-blue-500',
+}));
+
+import { MatchTabs } from '@/components/match/MatchTabs';
+import type { Match } from '@/lib/types';
+
+const BALLAST_DISTANCE_NM = 415;
+const LADEN_DISTANCE_NM = 254;
+
+function makeMatch(readinessDistanceNm: number | undefined): Match {
+  return {
+    cargoEmailId: 'cargo-1',
+    cargoItemIndex: 0,
+    vesselEmailId: 'vessel-1',
+    vesselItemIndex: 0,
+    score: 75,
+    matchLevel: 'good',
+    matchReasons: [],
+    issues: [],
+    readiness: readinessDistanceNm !== undefined
+      ? { distanceNm: readinessDistanceNm, openDate: null, openPosition: null }
+      : undefined,
+  } as unknown as Match;
+}
+
+function clickEconomicsTab(container: HTMLElement) {
+  const tabs = container.querySelectorAll('[role="tab"]');
+  const econ = Array.from(tabs).find(t => t.textContent === 'Economics');
+  if (econ) fireEvent.click(econ);
+}
+
+describe('MatchTabs — routeDistanceNm prop forwarding (Fix A)', () => {
+  beforeEach(() => { capturedRouteDistanceNm = undefined; });
+
+  test('uses storedDistanceNm (laden) even when readiness.distanceNm (ballast) is present', () => {
+    const match = makeMatch(BALLAST_DISTANCE_NM);
+
+    const { container } = render(
+      <MatchTabs
+        match={match}
+        storedDistanceNm={LADEN_DISTANCE_NM}
+        matchDbId={1}
+      />,
+    );
+
+    clickEconomicsTab(container);
+
+    expect(capturedRouteDistanceNm).toBe(LADEN_DISTANCE_NM);
+    expect(capturedRouteDistanceNm).not.toBe(BALLAST_DISTANCE_NM);
+  });
+
+  test('passes null when storedDistanceNm is null (no readiness fallback)', () => {
+    const match = makeMatch(BALLAST_DISTANCE_NM);
+
+    const { container } = render(
+      <MatchTabs
+        match={match}
+        storedDistanceNm={null}
+        matchDbId={1}
+      />,
+    );
+
+    clickEconomicsTab(container);
+
+    expect(capturedRouteDistanceNm).toBeNull();
+  });
+
+  test('passes null when neither storedDistanceNm nor readiness.distanceNm', () => {
+    const match = makeMatch(undefined);
+
+    const { container } = render(
+      <MatchTabs
+        match={match}
+        matchDbId={1}
+      />,
+    );
+
+    clickEconomicsTab(container);
+
+    expect(capturedRouteDistanceNm).toBeNull();
+  });
+});

--- a/__tests__/economics/list-detail-tce-parity.test.ts
+++ b/__tests__/economics/list-detail-tce-parity.test.ts
@@ -4,6 +4,8 @@
  * Root-cause verified: before Tasks 1-6, computeEstimatedTce had the correct round-trip
  * denominator BUT EconomicsTab used laden-only estimateVoyageDays → DETAIL diverged.
  * After this wave: both go through buildCanonicalTceInputs → they agree to the dollar.
+ *
+ * Extended (fix-list-vs-detail A+B+C): real ports + live bunker + war-risk-exclude row.
  */
 import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { calculateTCE } from '@/lib/economics/voyage-calculator';
@@ -81,5 +83,41 @@ describe('LIST tce_usd_per_day === DETAIL daily_tce_usd (parity, #819)', () => {
       s.distanceNm, s.vesselDwt, s.quantityMt, s.speedKts, s.consumptionMtPerDay,
     );
     expect(tce.tce_usd_per_day).toBeGreaterThan(0);
+  });
+
+  test('SEAGULL71-like Marmara→Constanta — real ports + live bunker(766) + war-risk-exclude: list==detail', () => {
+    // Acceptance row: SEAGULL71 proxy — real HRA ports, live bunker, excludeWarRisk flag on detail path.
+    // LIST path uses computeEstimatedTce with empty ports (war-risk $0) + live bunker
+    // DETAIL path uses calculateTCE with real ports + excludeWarRiskFromDailyTce=true + same live bunker
+    const LIVE_BUNKER = 766;
+    const s = { vesselDwt: 3000, speedKts: 12, consumptionMtPerDay: 8, distanceNm: 254, quantityMt: 2500 };
+    const freight = estimateFreightRate('GRAIN', s.distanceNm, s.vesselDwt);
+
+    // LIST: live bunker, empty ports (war-risk $0 by design)
+    const list = computeEstimatedTce(
+      { rate: freight.rate, source: freight.source, confidence: freight.confidence },
+      s.distanceNm, s.vesselDwt, s.quantityMt, s.speedKts, s.consumptionMtPerDay,
+      undefined, undefined, undefined, LIVE_BUNKER,
+    );
+
+    // DETAIL: real ports, same live bunker, war-risk excluded from per-day
+    const detailInputs = buildCanonicalTceInputs({
+      vesselDwt: s.vesselDwt,
+      speedKts: s.speedKts,
+      consumptionMtPerDay: s.consumptionMtPerDay,
+      distanceNm: s.distanceNm,
+      quantityMt: s.quantityMt,
+      freightRateUsdPerMt: freight.rate,
+      bunkerPriceUsdPerMt: LIVE_BUNKER,
+      originPort: 'Marmara',
+      destinationPort: 'Constanta',
+      euaPriceEur: DEFAULT_EUA_EUR,
+      vesselValueUsd: DEFAULT_VESSEL_VALUE_USD,
+    });
+    const detail = calculateTCE({ ...detailInputs, excludeWarRiskFromDailyTce: true });
+
+    expect(detail.daily_tce_usd).toBe(list.tce_usd_per_day);
+    // Sanity: war-risk IS computed and surfaced in breakdown
+    expect(detail.breakdown.war_risk_usd).toBeGreaterThanOrEqual(0);
   });
 });

--- a/__tests__/lib/economics/voyage-war-risk-exclude.test.ts
+++ b/__tests__/lib/economics/voyage-war-risk-exclude.test.ts
@@ -1,0 +1,59 @@
+/**
+ * PI2 behavioral — excludeWarRiskFromDailyTce flag (Fix C, #fix-list-vs-detail).
+ *
+ * When the flag is set:
+ *  - daily_tce_usd excludes war-risk premium (matches stored TCE which uses empty ports → $0)
+ *  - breakdown.war_risk_usd is still reported (breakdown line unchanged)
+ *  - total_costs_usd still includes war-risk (so total is accurate)
+ *
+ * Parity acceptance: real-port TCE with flag ON equals empty-port TCE.
+ */
+import { calculateTCE } from '@/lib/economics/voyage-calculator';
+import type { VoyageInput } from '@/lib/economics/voyage-calculator';
+
+const BASE_INPUT: VoyageInput = {
+  vessel: { dwt: 44000, valueUsd: 22_000_000, speedKts: 12, consumptionMtPerDay: 25 },
+  route: { originPort: '', destinationPort: '', distanceNm: 254 },
+  cargo: { quantityMt: 35000, freightRateUsdPerMt: 22 },
+  bunkerPriceUsdPerMt: 600,
+  euaPriceEur: 65,
+  durationDays: 3,
+};
+
+const HRA_INPUT: VoyageInput = {
+  ...BASE_INPUT,
+  route: { originPort: 'Marmara', destinationPort: 'Constanta', distanceNm: 254 },
+};
+
+describe('excludeWarRiskFromDailyTce flag (Fix C)', () => {
+  test('war_risk_usd still > 0 in breakdown when flag is set with real HRA ports', () => {
+    const result = calculateTCE({ ...HRA_INPUT, excludeWarRiskFromDailyTce: true });
+    expect(result.breakdown.war_risk_usd).toBeGreaterThan(0);
+    expect(result.breakdown.applicable.war_risk).toBe(true);
+  });
+
+  test('daily_tce_usd with real ports + flag ON equals daily_tce_usd with empty ports (no flag)', () => {
+    const withFlag = calculateTCE({ ...HRA_INPUT, excludeWarRiskFromDailyTce: true });
+    const emptyPorts = calculateTCE({ ...BASE_INPUT });
+    expect(withFlag.daily_tce_usd).toBe(emptyPorts.daily_tce_usd);
+  });
+
+  test('without flag, real ports depresses daily_tce_usd vs empty ports', () => {
+    const withoutFlag = calculateTCE({ ...HRA_INPUT });
+    const emptyPorts = calculateTCE({ ...BASE_INPUT });
+    expect(withoutFlag.daily_tce_usd).toBeLessThan(emptyPorts.daily_tce_usd);
+  });
+
+  test('total_costs_usd includes war_risk_usd regardless of flag', () => {
+    const result = calculateTCE({ ...HRA_INPUT, excludeWarRiskFromDailyTce: true });
+    const { bunker_usd, canal_usd, da_usd, war_risk_usd, ets_usd, total_costs_usd } = result.breakdown;
+    expect(total_costs_usd).toBe(bunker_usd + canal_usd + da_usd + war_risk_usd + ets_usd);
+  });
+
+  test('flag=false produces same result as omitting the flag', () => {
+    const withFalse = calculateTCE({ ...HRA_INPUT, excludeWarRiskFromDailyTce: false });
+    const withOmit = calculateTCE({ ...HRA_INPUT });
+    expect(withFalse.daily_tce_usd).toBe(withOmit.daily_tce_usd);
+    expect(withFalse.breakdown.war_risk_usd).toBe(withOmit.breakdown.war_risk_usd);
+  });
+});

--- a/__tests__/lib/matching/tce-bunker-param.test.ts
+++ b/__tests__/lib/matching/tce-bunker-param.test.ts
@@ -1,0 +1,55 @@
+/**
+ * PI2 behavioral — bunkerPriceUsdPerMt parameter threading (Fix B, #fix-list-vs-detail).
+ *
+ * computeEstimatedTce and buildMatchEconomics must accept a live bunker price
+ * and produce a TCE that reflects that price in the breakdown.
+ */
+import { computeEstimatedTce, estimateFreightRate, buildMatchEconomics } from '@/lib/matching/tce-calculator';
+
+const FREIGHT = estimateFreightRate('GRAIN', 254, 44000);
+
+describe('computeEstimatedTce — bunkerPriceUsdPerMt param (Fix B)', () => {
+  test('higher bunker price yields lower TCE', () => {
+    const low = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
+    const high = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 766);
+    expect(high.tce_usd_per_day).toBeLessThan(low.tce_usd_per_day);
+  });
+
+  test('breakdown.bunker_usd reflects the passed bunker price', () => {
+    const result = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 766);
+    // durationDays for 254nm at 12kts ≈ 254/(12*24) ≈ 0.882 days round-trip
+    // bunker_usd = consumption * duration * price ≈ 25 * roundtrip * 766
+    // Just check the ratio: bunker_usd(766) / bunker_usd(600) ≈ 766/600
+    const base = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
+    const ratio = result.breakdown.bunker_usd / base.breakdown.bunker_usd;
+    expect(ratio).toBeCloseTo(766 / 600, 1);
+  });
+
+  test('omitting bunkerPriceUsdPerMt uses the 600 default', () => {
+    const withDefault = computeEstimatedTce(FREIGHT, 254, 44000, 35000);
+    const with600 = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
+    expect(withDefault.tce_usd_per_day).toBe(with600.tce_usd_per_day);
+  });
+});
+
+describe('buildMatchEconomics — bunkerPriceUsdPerMt propagation (Fix B)', () => {
+  const BASE = {
+    cargoType: 'GRAIN',
+    distanceNm: 254,
+    vesselDwt: 44000,
+    quantityMt: 35000,
+    speedKts: 12,
+    consumptionMt: 25,
+    loadPort: null,
+    dischargePort: null,
+    calculatedAt: '2026-06-07T00:00:00Z',
+  };
+
+  test('bunkerPriceUsdPerMt=766 produces lower tceUsdPerDay than default', () => {
+    const live = buildMatchEconomics({ ...BASE, bunkerPriceUsdPerMt: 766 });
+    const def = buildMatchEconomics({ ...BASE });
+    expect(live).not.toBeNull();
+    expect(def).not.toBeNull();
+    expect(live!.tceUsdPerDay ?? 0).toBeLessThan(def!.tceUsdPerDay ?? 0);
+  });
+});

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -362,6 +362,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     daysInHra: data.daysInHra,
     canalUsd,
     daUsd,
+    excludeWarRiskFromDailyTce: true,
   };
 
   const result = calculateTCE(tceInput);

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -75,7 +75,7 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, store
             commissionPercent={cargo?.commissionPercent}
             vessel={vessel}
             cargo={cargo}
-            routeDistanceNm={match.readiness?.distanceNm ?? storedDistanceNm ?? null}
+            routeDistanceNm={storedDistanceNm ?? null}
             matchDbId={matchDbId}
             storedFreightRate={storedFreightRate}
             freightRateSource={freightRateSource}

--- a/lib/economics/voyage-calculator.ts
+++ b/lib/economics/voyage-calculator.ts
@@ -69,6 +69,9 @@ export interface VoyageInput {
   daUsd?: number;
   /** ECA zones for bunker split calculation. If undefined, no ECA split. */
   ecaZones?: EcaZone[];
+  /** When true, war-risk premium is excluded from per-day TCE but still reported in breakdown.
+   *  Use on the detail path to match stored TCE (which uses empty ports → $0 war risk). */
+  excludeWarRiskFromDailyTce?: boolean;
 }
 
 export interface TCEBreakdown {
@@ -200,7 +203,12 @@ export function calculateTCE(input: VoyageInput): TCEResult {
   const totalCosts = bunkerUsd + canalUsd + daUsd + warRiskUsd + etsUsd;
   const netVoyage = grossFreight - totalCosts;
   const safeDuration = duration > 0 ? duration : ESTIMATED_DAYS_FALLBACK;
-  const dailyTce = duration > 0 ? Math.round(netVoyage / safeDuration) : 0;
+  // When excludeWarRiskFromDailyTce is set, omit war-risk from the per-day numerator
+  // so stored (empty ports → $0) and detail (real ports) produce the same TCE.
+  const dailyNetVoyage = input.excludeWarRiskFromDailyTce
+    ? grossFreight - (bunkerUsd + canalUsd + daUsd + etsUsd)
+    : netVoyage;
+  const dailyTce = duration > 0 ? Math.round(dailyNetVoyage / safeDuration) : 0;
 
   const breakdown: TCEBreakdown = {
     bunker_usd: bunkerUsd,

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -261,6 +261,7 @@ function computeMatchEconomicsFor(
   vessels: readonly ParsedVessel[],
   db: Database.Database | null | undefined,
   calcAt: string,
+  bunkerPriceUsdPerMt?: number,
 ): EconomicsResult | undefined {
   const cargo = cargos.find(
     (c) => c.emailId === m.cargoEmailId && c.itemIndex === m.cargoItemIndex,
@@ -325,6 +326,7 @@ function computeMatchEconomicsFor(
     },
     ballastDistanceNm,
     daUsd,
+    bunkerPriceUsdPerMt,
   });
 
   return econ ?? undefined;
@@ -338,7 +340,7 @@ export async function analyzePairs(
   cargos: ParsedCargo[],
   vessels: ParsedVessel[],
   aiScorer: AiScorer,
-  options?: { refYear?: number; today?: Date; db?: Database.Database },
+  options?: { refYear?: number; today?: Date; db?: Database.Database; bunkerPriceUsdPerMt?: number },
 ): Promise<AnalyzePairsResult> {
   if (cargos.length === 0 || vessels.length === 0) {
     return { matches: [], lowConfidenceMatches: [], insufficientData: [], blockedMatches: [] };
@@ -348,6 +350,7 @@ export async function analyzePairs(
   const currentYear = today.getUTCFullYear();
   const refYear = options?.refYear ?? currentYear;
   const db = options?.db;
+  const bunkerPriceUsdPerMt = options?.bunkerPriceUsdPerMt;
 
   // O(n²) pair analysis loop
   const analyses: PairAnalysis[] = [];
@@ -770,7 +773,7 @@ export async function analyzePairs(
       const analysis = analysisMap.get(
         pairKey(m.cargoEmailId, m.cargoItemIndex, m.vesselEmailId, m.vesselItemIndex),
       );
-      const econ = computeMatchEconomicsFor(m, cargos, vessels, db, economicsCalcAt);
+      const econ = computeMatchEconomicsFor(m, cargos, vessels, db, economicsCalcAt, bunkerPriceUsdPerMt);
       if (econ) m.economics = econ;
       const imo = vessel.imo;
       const detentionCount = db && imo

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -147,6 +147,7 @@ export function computeEstimatedTce(
   ballast_distance_nm?: number,
   canal_usd?: number,
   da_usd?: number,
+  bunkerPriceUsdPerMt: number = DEFAULT_BUNKER_USD_PER_MT,
 ): TceEstimate {
   const inputs = buildCanonicalTceInputs({
     vesselDwt: vessel_dwt,
@@ -155,7 +156,7 @@ export function computeEstimatedTce(
     distanceNm: distance_nm,
     quantityMt: quantity_mt,
     freightRateUsdPerMt: freightRate.rate,
-    bunkerPriceUsdPerMt: DEFAULT_BUNKER_USD_PER_MT,
+    bunkerPriceUsdPerMt,
     originPort: '',
     destinationPort: '',
     euaPriceEur: DEFAULT_EUA_EUR,
@@ -247,6 +248,8 @@ export interface MatchEconomicsInput {
   ballastDistanceNm?: number | null;
   /** Pre-resolved port disbursement total (USD), load + discharge. Unknown/zero → omitted. */
   daUsd?: number | null;
+  /** Live bunker price (USD/mt). Defaults to DEFAULT_BUNKER_USD_PER_MT (600) when omitted. */
+  bunkerPriceUsdPerMt?: number | null;
 }
 
 /**
@@ -294,6 +297,7 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
     ballastNm ?? undefined,
     canalUsd > 0 ? canalUsd : undefined,
     input.daUsd != null && input.daUsd > 0 ? input.daUsd : undefined,
+    input.bunkerPriceUsdPerMt != null ? input.bunkerPriceUsdPerMt : undefined,
   );
 
   const warLaden = calculateWarRiskPremium({

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -42,6 +42,7 @@ import { seedCharterersWithDb } from '../knowledge/seeds/seed-charterers';
 import { seedPscHistoryWithDb } from '../knowledge/seeds/seed-psc-history';
 import { seedPortDa, type BaselinePort } from '../seed-port-da';
 import { lookupCii } from '@/lib/imo/cii-lookup';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 
 // ── CII hydration helper ──────────────────────────────────────────────────────
 
@@ -489,7 +490,10 @@ async function main() {
   console.log(`[regen] CII hydrated for ${vessels.filter((v) => v.ciiRating != null).length}/${vessels.length} vessels`);
 
   // ── 2. Run the real engine (no LLM — deterministic gates + sweep + fit) ──
-  const result = await analyzePairs(cargos, vessels, async () => [], { refYear, today, db });
+  const bunkerRow = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
+  const bunkerPriceUsdPerMt = bunkerRow?.price_usd_per_mt ?? 600;
+  console.log(`[regen] bunker price: ${bunkerPriceUsdPerMt} USD/mt (${bunkerRow ? 'live' : 'fallback'})`);
+  const result = await analyzePairs(cargos, vessels, async () => [], { refYear, today, db, bunkerPriceUsdPerMt });
 
   // ── 3. Dedup each bucket to one match per (cargo email, vessel email) pair,
   //        keeping the highest fit (then score). Drop cleanliness blockSend from main.


### PR DESCRIPTION
## Summary

- **A**: `MatchTabs.tsx:78` — drop `readiness.distanceNm` (ballast) shadowing `storedDistanceNm` (laden); EconomicsTab now always gets laden distance
- **C**: `voyage-calculator.ts` — add `excludeWarRiskFromDailyTce` opt-in flag; `route.ts` sets it so detail per-day TCE excludes war-risk (parity with stored which uses empty ports → $0 war risk, breakdown line unchanged)
- **B**: Thread `bunkerPriceUsdPerMt` param through `computeEstimatedTce` → `buildMatchEconomics` → `analyzePairs`; `regenerate-matches.ts` resolves live bunker (NLRTM/VLSFO, fallback 600) before regen

Root cause: 3 additive mismatches between list TCE (stored at regen) and detail TCE (recalculated on card open) totaling ~$2641/day delta for SEAGULL71 Marmara→Constanța.

## Test plan

- [ ] `__tests__/components/match/MatchTabs-route-distance.test.tsx` — Fix A regression guard (3 tests)
- [ ] `__tests__/lib/economics/voyage-war-risk-exclude.test.ts` — Fix C flag behavior (5 tests)
- [ ] `__tests__/lib/matching/tce-bunker-param.test.ts` — Fix B param threading (4 tests)
- [ ] `__tests__/economics/list-detail-tce-parity.test.ts` — extended with real-ports+live-bunker+exclude row (7 tests total)
- [ ] 84/84 suites green, 684 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)