### PR TITLE
feat(tce): L2 economics wiring — ETS + Bosporus + distance fix + seed quarantine

### DIFF
--- a/__tests__/economics/list-detail-tce-parity.test.ts
+++ b/__tests__/economics/list-detail-tce-parity.test.ts
@@ -6,11 +6,11 @@
  * After this wave: both go through buildCanonicalTceInputs → they agree to the dollar.
  *
  * Extended (fix-list-vs-detail A+B+C): real ports + live bunker + war-risk-exclude row.
+ * Extended (L2): EU + BlackSea parity rows (#856 — ETS + Bosporus wiring).
  */
 import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { calculateTCE } from '@/lib/economics/voyage-calculator';
-import { computeEstimatedTce } from '@/lib/matching/tce-calculator';
-import { estimateFreightRate } from '@/lib/matching/tce-calculator';
+import { computeEstimatedTce, buildMatchEconomics, estimateFreightRate, deriveEtsCoverage, routeTransitsBosporus, quoteBosporusSafe } from '@/lib/matching/tce-calculator';
 
 interface Sample {
   name: string;
@@ -20,6 +20,19 @@ interface Sample {
   distanceNm: number;
   quantityMt: number;
   cargoType: string;
+}
+
+interface ParitySampleL2 {
+  name: string;
+  loadPort: string;
+  dischargePort: string;
+  vesselDwt: number;
+  speedKts: number;
+  consumptionMtPerDay: number;
+  distanceNm: number;
+  quantityMt: number;
+  cargoType: string;
+  euaPriceEur: number;
 }
 
 const SAMPLES: Sample[] = [
@@ -119,5 +132,70 @@ describe('LIST tce_usd_per_day === DETAIL daily_tce_usd (parity, #819)', () => {
     expect(detail.daily_tce_usd).toBe(list.tce_usd_per_day);
     // Sanity: war-risk IS computed and surfaced in breakdown
     expect(detail.breakdown.war_risk_usd).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('L2 parity: EU + BlackSea routes — list (buildMatchEconomics) == detail (route inputs)', () => {
+  const L2_SAMPLES: ParitySampleL2[] = [
+    // Intra-EU: both GR + IT → coverageFactor 1.0, no Bosporus
+    { name: 'Thisvi(GR)→Monfalcone(IT) intra-EU',
+      loadPort: 'Thisvi', dischargePort: 'Monfalcone',
+      vesselDwt: 18930, speedKts: 12, consumptionMtPerDay: 18,
+      distanceNm: 708, quantityMt: 15000, cargoType: 'GRAIN', euaPriceEur: 77 },
+    // BlackSea+EU: Reni(UA) non-EU + Constanta(RO) EU → coverageFactor 0.5, no Bosporus (intra-BS)
+    { name: 'Reni(UA)→Constanta(RO) one-EU + intra-BlackSea',
+      loadPort: 'Reni', dischargePort: 'Constanta',
+      vesselDwt: 5000, speedKts: 12, consumptionMtPerDay: 10,
+      distanceNm: 590, quantityMt: 4000, cargoType: 'GRAIN', euaPriceEur: 77 },
+    // Med→BlackSea+EU: Piraeus(GR, EU) → Constanta(RO, EU) — Bosporus transit + intra-EU coverage 1.0
+    { name: 'Piraeus(GR)→Constanta(RO) Bosporus+intra-EU',
+      loadPort: 'Piraeus', dischargePort: 'Constanta',
+      vesselDwt: 5000, speedKts: 12, consumptionMtPerDay: 10,
+      distanceNm: 650, quantityMt: 4000, cargoType: 'GRAIN', euaPriceEur: 77 },
+  ];
+
+  test.each(L2_SAMPLES)('$name — list and detail agree to the dollar', (s) => {
+    const freight = estimateFreightRate(s.cargoType, s.distanceNm, s.vesselDwt);
+
+    // LIST path: buildMatchEconomics (what pair-analyzer uses for tce_usd_per_day)
+    const list = buildMatchEconomics({
+      cargoType: s.cargoType,
+      distanceNm: s.distanceNm,
+      vesselDwt: s.vesselDwt,
+      quantityMt: s.quantityMt,
+      speedKts: s.speedKts,
+      consumptionMt: s.consumptionMtPerDay,
+      loadPort: s.loadPort,
+      dischargePort: s.dischargePort,
+      calculatedAt: '2026-06-08T00:00:00.000Z',
+      euaPriceEur: s.euaPriceEur,
+    })!;
+
+    // DETAIL path: same exported helpers → same coverage + same canal → same TCE
+    const { originEu, destEu, euLegPercent } = deriveEtsCoverage(s.loadPort, s.dischargePort);
+    const detailCanalUsd = routeTransitsBosporus(s.loadPort, s.dischargePort)
+      ? quoteBosporusSafe(s.vesselDwt)
+      : 0;
+    const detailInputs = buildCanonicalTceInputs({
+      vesselDwt: s.vesselDwt,
+      speedKts: s.speedKts,
+      consumptionMtPerDay: s.consumptionMtPerDay,
+      distanceNm: s.distanceNm,
+      quantityMt: s.quantityMt,
+      freightRateUsdPerMt: freight.rate,
+      bunkerPriceUsdPerMt: DEFAULT_BUNKER_USD_PER_MT,
+      originPort: s.loadPort,
+      destinationPort: s.dischargePort,
+      euaPriceEur: s.euaPriceEur,
+      vesselValueUsd: DEFAULT_VESSEL_VALUE_USD,
+      euLegPercent,
+      originEu,
+      destEu,
+      canalUsd: detailCanalUsd > 0 ? detailCanalUsd : undefined,
+    });
+    // excludeWarRiskFromDailyTce matches buildMatchEconomics (which uses empty ports → $0 war risk)
+    const detail = calculateTCE({ ...detailInputs, excludeWarRiskFromDailyTce: true });
+
+    expect(detail.daily_tce_usd).toBe(list.tceUsdPerDay);
   });
 });

--- a/__tests__/scripts/seed-quarantine.test.ts
+++ b/__tests__/scripts/seed-quarantine.test.ts
@@ -1,0 +1,33 @@
+import { QUARANTINE_PAIRS, isMatchQuarantined } from '@/scripts/demo-seed/regenerate-matches';
+
+describe('QUARANTINE_PAIRS — Thisvi→Monfalcone 18930 DWT thin post-ETS match', () => {
+  it('QUARANTINE_PAIRS includes Thisvi→Monfalcone in DWT range 17000-21000', () => {
+    expect(
+      QUARANTINE_PAIRS.some(
+        (q) =>
+          q.loadPort.toLowerCase() === 'thisvi' &&
+          q.dischargePort.toLowerCase() === 'monfalcone' &&
+          q.vesselDwtMin <= 18930 &&
+          q.vesselDwtMax >= 18930,
+      ),
+    ).toBe(true);
+  });
+
+  it('isMatchQuarantined returns true for Thisvi→Monfalcone 18930 DWT', () => {
+    expect(
+      isMatchQuarantined({ loadPort: 'Thisvi', dischargePort: 'Monfalcone', vesselDwt: 18930 }),
+    ).toBe(true);
+  });
+
+  it('isMatchQuarantined returns false for Thisvi→Monfalcone 9000 DWT (smaller variant stays in main)', () => {
+    expect(
+      isMatchQuarantined({ loadPort: 'Thisvi', dischargePort: 'Monfalcone', vesselDwt: 9000 }),
+    ).toBe(false);
+  });
+
+  it('isMatchQuarantined returns false for unrelated route', () => {
+    expect(
+      isMatchQuarantined({ loadPort: 'Piraeus', dischargePort: 'Constanta', vesselDwt: 18930 }),
+    ).toBe(false);
+  });
+});

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -20,6 +20,7 @@ import { getStore } from '@/lib/session-store';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { isEuCountry } from '@/lib/validation/sanctions';
+import { routeTransitsBosporus, quoteBosporusSafe } from '@/lib/matching/tce-calculator';
 
 const LOCODE_RE = /^[A-Za-z]{5}$/;
 
@@ -230,7 +231,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     approximatePorts.push({ side: 'destination', input: data.route.destinationPort, resolvedTo: destinationResolved.portName });
   }
 
-  const canalUsd = resolveCanalUsd(data);
+  let canalUsd = resolveCanalUsd(data);
+  // Auto-derive Bosporus dues when body.canalUsd is absent (parity with stored match path).
+  // Suez is left to explicit body.canalUsd / viaSuez to avoid double-charge on existing callers.
+  if (typeof data.canalUsd !== 'number' && !data.route.viaSuez && !data.route.viaCanal) {
+    if (routeTransitsBosporus(originResolved.portName, destinationResolved.portName)) {
+      canalUsd += quoteBosporusSafe(data.vessel.dwt);
+    }
+  }
   const daUsd = resolveDaUsd(data, originResolved, destinationResolved);
 
   // Resolve distance (explicit or auto-resolve if flag enabled)

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -327,6 +327,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
           cargo: core.cargo,
           durationDays: core.durationDays,
           euaPriceEur: core.euaPriceEur,
+          includeEuETS: true,   // parity: let route auto-derive EU coverage (same as stored match path)
           bunkerPort,
           bunkerGrade,
           // Only include bunkerPriceUsdPerMt when user-entered; absent → API auto-resolves

--- a/lib/__tests__/matching/economics-wiring.test.ts
+++ b/lib/__tests__/matching/economics-wiring.test.ts
@@ -75,7 +75,12 @@ jest.mock('@/lib/sailing/date-sanity', () => ({
   isLaycanValid: jest.fn().mockReturnValue({ valid: true }),
 }));
 
+// Preserve real exports (isEuCountry, EU_COUNTRIES, …) — the L2 ETS path
+// (deriveEtsCoverage → isEuCountry) is now reached via buildMatchEconomics, so a
+// bare stub would make isEuCountry undefined at runtime. Only checkSanctions is
+// overridden to keep scoring deterministic.
 jest.mock('@/lib/validation/sanctions', () => ({
+  ...jest.requireActual('@/lib/validation/sanctions'),
   checkSanctions: jest.fn().mockReturnValue({ risk: 'NONE', blocking: false }),
 }));
 

--- a/lib/economics/canonical-tce-inputs.ts
+++ b/lib/economics/canonical-tce-inputs.ts
@@ -23,6 +23,11 @@ export interface CanonicalTceInputArgs {
   canalUsd?: number;
   /** Pre-computed port disbursement total (USD) — load + discharge fixed costs. */
   daUsd?: number;
+  /** EU leg percentage (0–1). 1.0 when either endpoint is EU. coverageFactor (0.5/1.0) handled in ets.ts. */
+  euLegPercent?: number;
+  /** EU ETS endpoint flags. Passed to calculateTCE for coverageFactor derivation. */
+  originEu?: boolean;
+  destEu?: boolean;
 }
 
 export function buildCanonicalTceInputs(args: CanonicalTceInputArgs): VoyageInput {
@@ -68,5 +73,8 @@ export function buildCanonicalTceInputs(args: CanonicalTceInputArgs): VoyageInpu
     durationDays,
     canalUsd: args.canalUsd,
     daUsd: args.daUsd,
+    euLegPercent: args.euLegPercent,
+    originEu: args.originEu,
+    destEu: args.destEu,
   };
 }

--- a/lib/matching/__tests__/tce-bosporus.test.ts
+++ b/lib/matching/__tests__/tce-bosporus.test.ts
@@ -1,0 +1,34 @@
+import { buildMatchEconomics } from '@/lib/matching/tce-calculator';
+
+function econ(loadPort: string, dischargePort: string) {
+  return buildMatchEconomics({
+    loadPort,
+    dischargePort,
+    vesselDwt: 5000,
+    quantityMt: 4000,
+    speedKts: 12,
+    consumptionMt: 10,
+    cargoType: 'GRAIN',
+    calculatedAt: '2026-06-08T00:00:00.000Z',
+    freight: { rate: 22, source: 'estimate', confidence: 0.6 },
+    distanceNm: 430,
+  } as any);
+}
+
+describe('Bosporus transit detection', () => {
+  it('Med↔BlackSea route charges Bosporus dues in canal_usd', () => {
+    const r = econ('Piraeus', 'Odesa'); // Med ↔ Black Sea
+    expect(r).not.toBeNull();
+    expect(r!.breakdown.canal_usd).toBeGreaterThan(0);
+  });
+
+  it('intra-Med route charges no Bosporus', () => {
+    const r = econ('Piraeus', 'Genoa'); // both Med
+    expect(r!.breakdown.canal_usd).toBe(0);
+  });
+
+  it('intra-BlackSea route charges no Bosporus', () => {
+    const r = econ('Chornomorsk', 'Constanta'); // both Black Sea — strait not transited
+    expect(r!.breakdown.canal_usd).toBe(0);
+  });
+});

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -29,6 +29,7 @@ import {
   parseLeadingNumber,
   parseConsumption,
   buildMatchEconomics,
+  deriveEtsCoverage,
 } from '@/lib/matching/tce-calculator';
 
 describe('parseLeadingNumber', () => {
@@ -296,8 +297,16 @@ describe('buildMatchEconomics', () => {
     expect(Number.isFinite(econ!.tceUsdPerDay!)).toBe(true);
 
     const freight = estimateFreightRate(base.cargoType, base.distanceNm, base.vesselDwt);
+    // base route Rotterdam→Hamburg: both EU ports → EU-ETS applies to the full leg.
+    // buildMatchEconomics derives this coverage internally (deriveEtsCoverage); the
+    // reference must pass the SAME ETS inputs or it lags behind by the ETS cost
+    // (~$5.5k/day here: 31117 no-ETS vs 25587 with-ETS). The invariant under test is
+    // path parity, not a fixed number — so mirror the derivation, don't hardcode.
+    const ets = deriveEtsCoverage(base.loadPort, base.dischargePort);
     const tce = computeEstimatedTce(
       freight, base.distanceNm, base.vesselDwt, base.quantityMt, base.speedKts, base.consumptionMt,
+      undefined, undefined, undefined, undefined,
+      ets.euLegPercent, ets.originEu, ets.destEu,
     );
     // Per-day TCE must match the value compute-matches.ts persists to the DB column.
     expect(econ!.tceUsdPerDay).toBe(tce.tce_usd_per_day);

--- a/lib/matching/__tests__/tce-ets-wiring.test.ts
+++ b/lib/matching/__tests__/tce-ets-wiring.test.ts
@@ -1,0 +1,38 @@
+import { buildMatchEconomics } from '@/lib/matching/tce-calculator';
+
+function econ(loadPort: string, dischargePort: string, euaPriceEur = 77) {
+  return buildMatchEconomics({
+    loadPort,
+    dischargePort,
+    euaPriceEur,
+    vesselDwt: 18930,
+    quantityMt: 15000,
+    speedKts: 12,
+    consumptionMt: 18,
+    cargoType: 'GRAIN',
+    calculatedAt: '2026-06-08T00:00:00.000Z',
+    freight: { rate: 22, source: 'estimate', confidence: 0.6 },
+    distanceNm: 708,
+  } as any);
+}
+
+describe('ETS wiring via buildMatchEconomics', () => {
+  it('intra-EU route (Thisvi GR → Monfalcone IT) produces non-zero ETS', () => {
+    const r = econ('Thisvi', 'Monfalcone');
+    expect(r!.breakdown.ets_usd).toBeGreaterThan(0);
+  });
+
+  it('non-EU↔non-EU route produces zero ETS', () => {
+    const r = econ('Marmara', 'Novorossiysk'); // both non-EU
+    expect(r!.breakdown.ets_usd ?? 0).toBe(0);
+  });
+
+  it('one-EU route (non-EU → Ravenna IT) applies ~50% coverage (less than intra-EU equivalent)', () => {
+    const oneLeg = econ('Marmara', 'Ravenna')!; // TR → IT
+    const bothLeg = econ('Thisvi', 'Ravenna')!;  // GR → IT
+    const oneEts = oneLeg.breakdown.ets_usd ?? 0;
+    const bothEts = bothLeg.breakdown.ets_usd ?? 0;
+    expect(oneEts).toBeGreaterThan(0);
+    expect(oneEts).toBeLessThan(bothEts); // 0.5 vs 1.0 coverageFactor
+  });
+});

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -23,6 +23,7 @@ import { checkSanctions } from '@/lib/validation/sanctions';
 import { enrichReasons } from '@/lib/matching/reason-enricher';
 import { applyHoldCleanliness } from '@/lib/matching/hold-cleanliness';
 import { buildMatchEconomics, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
+import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 import { sumMatchPortDaUsd } from '@/lib/port-da/match-da';
@@ -308,6 +309,7 @@ function computeMatchEconomicsFor(
   // Unknown ports / no db → 0 (graceful), matching the voyage detail page.
   const daUsd = db ? sumMatchPortDaUsd([loadPort, dischargePort], ecoDwt, cargoType, db) : 0;
 
+  const liveEuaRow = db ? getLatestEuaPrice(db, 'spot') : null;
   const econ = buildMatchEconomics({
     cargoType,
     distanceNm: distanceResult.nm,
@@ -327,6 +329,7 @@ function computeMatchEconomicsFor(
     ballastDistanceNm,
     daUsd,
     bunkerPriceUsdPerMt,
+    euaPriceEur: liveEuaRow?.price_eur_per_tco2 ?? undefined,
   });
 
   return econ ?? undefined;

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -309,7 +309,18 @@ function computeMatchEconomicsFor(
   // Unknown ports / no db → 0 (graceful), matching the voyage detail page.
   const daUsd = db ? sumMatchPortDaUsd([loadPort, dischargePort], ecoDwt, cargoType, db) : 0;
 
-  const liveEuaRow = db ? getLatestEuaPrice(db, 'spot') : null;
+  // Live EUA spot for ETS costing. Missing table / query error → null (graceful),
+  // matching the daUsd + canal-quote convention above; buildMatchEconomics then
+  // falls back to its DEFAULT_EUA_EUR. Match path must not throw on a DB without
+  // the eua_prices table (test/in-memory handles, pre-seed environments).
+  let liveEuaRow: ReturnType<typeof getLatestEuaPrice> = null;
+  if (db) {
+    try {
+      liveEuaRow = getLatestEuaPrice(db, 'spot');
+    } catch {
+      liveEuaRow = null;
+    }
+  }
   const econ = buildMatchEconomics({
     cargoType,
     distanceNm: distanceResult.nm,

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -2,6 +2,9 @@ import { calculateTCE, type TCEBreakdown } from '@/lib/economics/voyage-calculat
 import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
 import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { quoteSuez } from '@/lib/economics/canals/index';
+import { quoteBosporus } from '@/lib/economics/canals/bosporus';
+import { resolvePort } from '@/lib/ports/resolve';
+import { isEuCountry } from '@/lib/validation/sanctions';
 import type { EconomicsResult } from '@/lib/types';
 
 // Ballpark base freight rates (USD/mt) per cargo class
@@ -148,6 +151,10 @@ export function computeEstimatedTce(
   canal_usd?: number,
   da_usd?: number,
   bunkerPriceUsdPerMt: number = DEFAULT_BUNKER_USD_PER_MT,
+  euLegPercent?: number,
+  originEu?: boolean,
+  destEu?: boolean,
+  euaPriceEur?: number,
 ): TceEstimate {
   const inputs = buildCanonicalTceInputs({
     vesselDwt: vessel_dwt,
@@ -159,11 +166,14 @@ export function computeEstimatedTce(
     bunkerPriceUsdPerMt,
     originPort: '',
     destinationPort: '',
-    euaPriceEur: DEFAULT_EUA_EUR,
+    euaPriceEur: euaPriceEur ?? DEFAULT_EUA_EUR,
     vesselValueUsd: DEFAULT_VESSEL_VALUE_USD,
     ballastDistanceNm: ballast_distance_nm,
     canalUsd: canal_usd,
     daUsd: da_usd,
+    euLegPercent,
+    originEu,
+    destEu,
   });
   const result = calculateTCE(inputs);
 
@@ -175,13 +185,11 @@ export function computeEstimatedTce(
   };
 }
 
-// ── Suez transit detection (overhaul step 3) ─────────────────────────────────
-// Classify a port into a geographic basin for routing decisions.
-// Returns 'indian' for Indian subcontinent / Persian Gulf / Red Sea,
-// 'eastafrica' for East African coast, 'med' for Mediterranean / Black Sea,
-// 'atlantic' for Atlantic-facing European / N-African ports, 'westafrica' for
-// West African ports (reached via Cape, not Suez), and 'unknown' otherwise.
-type _PortBasin = 'indian' | 'eastafrica' | 'med' | 'atlantic' | 'westafrica' | 'unknown';
+// ── Basin classification (Suez + Bosporus transit detection) ─────────────────
+// 'blacksea' is distinct from 'med' so Bosporus detection works: a route from
+// 'med' to 'blacksea' (or vice-versa) transits the Bosporus strait.
+// For Suez purposes, 'blacksea' is treated as 'westOfSuez' (same as 'med').
+type _PortBasin = 'indian' | 'eastafrica' | 'med' | 'blacksea' | 'atlantic' | 'westafrica' | 'unknown';
 
 function _classifyPortBasin(port: string | null | undefined): _PortBasin {
   if (!port) return 'unknown';
@@ -189,22 +197,33 @@ function _classifyPortBasin(port: string | null | undefined): _PortBasin {
   if (/kandla|mundra|mumbai|nhava|chennai|kolkata|karachi|kakinada|kochi|cochin|colombo|tuticorin|bandar.?abb?as?|dubai|abu.?dhabi|fujairah|sohar|muscat|salalah|jebel.?ali|ruwais|jeddah|yanbu|aqaba|djibouti|aden|berbera/.test(p)) return 'indian';
   if (/mtwara|mombasa|dar.?es.?salaam|tanga|nacala|beira|maputo|quelimane|zanzibar/.test(p)) return 'eastafrica';
   if (/matadi|boma|pointe.?noire|cotonou|lome|abidjan|dakar|conakry|freetown|banjul|monrovia|tema|lagos|apapa|tincan|bonny|warri|port.?harcourt|douala/.test(p)) return 'westafrica';
-  if (/ravenna|marghera|venice|trieste|genoa|la.?spezia|livorno|naples|taranto|bari|brindisi|catania|palermo|messina|augusta|trapani|pozzallo|bizerte|skikda|oran|algiers|tunis|sfax|bejaia|annaba|casablanca|jorf|safi|tangier|tanger|agadir|barcelona|valencia|algeciras|gibraltar|marseille|toulon|sete|fos|savona|vado|civitavecchia|piraeus|thessaloniki|izmir|aliaga|iskenderun|mersin|antalya|derince|izmit|istanbul|marmara|bandirma|karasu|constanta|varna|burgas|novorossiysk|odessa|odesa|chornomorsk|mykolaiv|kherson|yuzhne|suez|port.?said|alexandria|damietta|limassol|larnaca|haifa|ashdod|beirut|lattakia|tartus/.test(p)) return 'med';
+  // Black Sea ports — must precede the `med` branch (Bosporus/Dardanelles required to reach Med).
+  if (/constanta|varna|burgas|novorossiysk|novorossiisk|odessa|odesa|chornomorsk|mykolaiv|mykolayiv|kherson|sevastopol|yuzhne|yuzhny|pivdennyi|reni|izmail|poti|batumi|giurgiulest|karasu/.test(p)) return 'blacksea';
+  if (/ravenna|marghera|venice|trieste|genoa|la.?spezia|livorno|naples|taranto|bari|brindisi|catania|palermo|messina|augusta|trapani|pozzallo|bizerte|skikda|oran|algiers|tunis|sfax|bejaia|annaba|casablanca|jorf|safi|tangier|tanger|agadir|barcelona|valencia|algeciras|gibraltar|marseille|toulon|sete|fos|savona|vado|civitavecchia|piraeus|thessaloniki|izmir|aliaga|iskenderun|mersin|antalya|derince|izmit|istanbul|marmara|bandirma|suez|port.?said|alexandria|damietta|limassol|larnaca|haifa|ashdod|beirut|lattakia|tartus/.test(p)) return 'med';
   if (/rotterdam|amsterdam|antwerp|zeebrugge|ghent|dunkirk|le.?havre|rouen|brest|la.?pallice|bayonne|bilbao|santander|gijon|aviles|vigo|oporto|porto|lisbon|setubal|figueira|hamburg|bremerhaven|bremen|wilhelmshaven|emden|rostock|lubeck|gdansk|gdynia|szczecin|felixstowe|southampton|london|tilbury|teesport|sunderland|newcastle|immingham|grimsby|hull|liverpool|birkenhead|belfast|dublin|greenore|cork|oslo|gothenburg|goteborg|stavanger|bergen|haugesund|halsvik|aarhus|copenhagen|helsingborg|stockholm|helsinki|tallinn|riga|klaipeda/.test(p)) return 'atlantic';
   return 'unknown';
 }
 
 // A route transits Suez if one port is "east of Suez" (Indian Ocean / East Africa)
-// and the other is "west of Suez" (Mediterranean / Atlantic). West-Africa ports are
-// reached via Cape so they do NOT trigger Suez even when paired with East-Africa.
+// and the other is "west of Suez" (Mediterranean / Atlantic / Black Sea). West-Africa
+// ports are reached via Cape so they do NOT trigger Suez even when paired with East-Africa.
 function _routeTransitsSuez(portA: string | null | undefined, portB: string | null | undefined): boolean {
   if (!portA || !portB) return false;
   const basinA = _classifyPortBasin(portA);
   const basinB = _classifyPortBasin(portB);
   const eastOfSuez = new Set<_PortBasin>(['indian', 'eastafrica']);
-  const westOfSuez = new Set<_PortBasin>(['med', 'atlantic']);
+  // blacksea is reachable from Indian Ocean via Suez + Bosporus, so it is west-of-Suez.
+  const westOfSuez = new Set<_PortBasin>(['med', 'atlantic', 'blacksea']);
   return (eastOfSuez.has(basinA) && westOfSuez.has(basinB)) ||
          (eastOfSuez.has(basinB) && westOfSuez.has(basinA));
+}
+
+// A route transits the Bosporus if one endpoint is on the Med/Marmara side and the
+// other is on the Black Sea side. Intra-Med and intra-BlackSea routes do not transit.
+function _routeTransitsBosporus(portA: string | null | undefined, portB: string | null | undefined): boolean {
+  const a = _classifyPortBasin(portA);
+  const b = _classifyPortBasin(portB);
+  return (a === 'med' && b === 'blacksea') || (a === 'blacksea' && b === 'med');
 }
 
 // Derive approximate net tonnage from DWT (bulker convention: NT ≈ DWT × 0.65).
@@ -220,6 +239,33 @@ function _quoteSuezSafe(vesselDwt: number, laden: boolean): number {
   } catch {
     return 0;
   }
+}
+
+// Quote Bosporus dues for one transit (bulker convention). Returns 0 on any error.
+function _quoteBosporusSafe(vesselDwt: number): number {
+  try {
+    const vesselNt = Math.round(vesselDwt * NT_DWT_RATIO);
+    const q = quoteBosporus({ vesselDwt, vesselNt, vesselType: 'bulker' });
+    return Number.isFinite(q?.totalUsd) ? q.totalUsd : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// ── Exported helpers for detail-path parity (app/api/voyage/tce/route.ts) ────
+// Single source of truth: both stored (list) and detail paths use these functions.
+export const classifyPortBasin = _classifyPortBasin;
+export const routeTransitsBosporus = _routeTransitsBosporus;
+export const quoteBosporusSafe = _quoteBosporusSafe;
+
+/** Derive EU-ETS coverage flags from port names. Used by both the stored match path
+ *  and the detail route to guarantee identical euLegPercent/originEu/destEu. */
+export function deriveEtsCoverage(loadPort?: string | null, dischargePort?: string | null) {
+  const rl = loadPort ? resolvePort(loadPort) : null;
+  const rd = dischargePort ? resolvePort(dischargePort) : null;
+  const originEu = isEuCountry(rl?.country ?? null);
+  const destEu = isEuCountry(rd?.country ?? null);
+  return { originEu, destEu, euLegPercent: (originEu || destEu) ? 1.0 : 0 };
 }
 
 export interface MatchEconomicsInput {
@@ -250,6 +296,8 @@ export interface MatchEconomicsInput {
   daUsd?: number | null;
   /** Live bunker price (USD/mt). Defaults to DEFAULT_BUNKER_USD_PER_MT (600) when omitted. */
   bunkerPriceUsdPerMt?: number | null;
+  /** Live EUA spot price (EUR/tCO2). Defaults to DEFAULT_EUA_EUR (65) when omitted. */
+  euaPriceEur?: number | null;
 }
 
 /**
@@ -270,22 +318,34 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
   const freight =
     input.resolvedFreight ?? estimateFreightRate(input.cargoType, input.distanceNm, input.vesselDwt);
 
-  // ── Canal detection (overhaul step 3) ──────────────────────────────────────
-  // Detect Suez transit for laden and ballast legs using port basin geometry
-  // (no DB required). Quote dues and pass as canalUsd to calculateTCE.
+  // ── Canal detection ───────────────────────────────────────────────────────────
+  // Detect Suez and Bosporus transits using port basin geometry (no DB required).
   let canalUsd = 0;
   const ladenTransitsSuez = _routeTransitsSuez(input.loadPort, input.dischargePort);
   if (ladenTransitsSuez && input.vesselDwt > 0) {
     canalUsd += _quoteSuezSafe(input.vesselDwt, true);
   }
+  const ladenTransitsBosporus = _routeTransitsBosporus(input.loadPort, input.dischargePort);
+  if (ladenTransitsBosporus && input.vesselDwt > 0) {
+    canalUsd += _quoteBosporusSafe(input.vesselDwt);
+  }
   const ballastNm = input.ballastDistanceNm;
   const ballastOpenPos = input.vesselOpenPosition;
   if (ballastNm != null && ballastNm > 0 && ballastOpenPos && input.loadPort) {
-    const ballastTransitsSuez = _routeTransitsSuez(ballastOpenPos, input.loadPort);
-    if (ballastTransitsSuez && input.vesselDwt > 0) {
+    if (_routeTransitsSuez(ballastOpenPos, input.loadPort) && input.vesselDwt > 0) {
       canalUsd += _quoteSuezSafe(input.vesselDwt, false);
     }
+    if (_routeTransitsBosporus(ballastOpenPos, input.loadPort) && input.vesselDwt > 0) {
+      canalUsd += _quoteBosporusSafe(input.vesselDwt);
+    }
   }
+
+  // ── EU-ETS coverage derivation ────────────────────────────────────────────────
+  // Convention MUST match app/api/voyage/tce/route.ts:307-327.
+  const { originEu, destEu, euLegPercent } = deriveEtsCoverage(input.loadPort, input.dischargePort);
+  const euaPriceEur = (input.euaPriceEur != null && input.euaPriceEur > 0)
+    ? input.euaPriceEur
+    : DEFAULT_EUA_EUR;
 
   const tce = computeEstimatedTce(
     freight,
@@ -298,6 +358,10 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
     canalUsd > 0 ? canalUsd : undefined,
     input.daUsd != null && input.daUsd > 0 ? input.daUsd : undefined,
     input.bunkerPriceUsdPerMt != null ? input.bunkerPriceUsdPerMt : undefined,
+    euLegPercent,
+    originEu,
+    destEu,
+    euaPriceEur,
   );
 
   const warLaden = calculateWarRiskPremium({
@@ -324,6 +388,8 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
       bunkerPort: input.loadPort ?? '',
       euEtsAmount: tce.breakdown.ets_eur,
       euEtsApplicable: tce.breakdown.applicable.ets,
+      canal_usd: tce.breakdown.canal_usd,
+      ets_usd: tce.breakdown.ets_usd,
       // BC aliases — laden-only — unchanged meaning for existing consumers
       warRiskPremium: warLaden.premiumUsd,
       warRiskZones: warLaden.zones,

--- a/lib/sailing/__tests__/port-distances.test.ts
+++ b/lib/sailing/__tests__/port-distances.test.ts
@@ -130,6 +130,14 @@ describe('normalizePortName', () => {
   it('handles multi-port ranges by taking first', () => {
     expect(normalizePortName('Bay of Biscay (Bayonne/Bilbao range)')).toBe('Bayonne');
   });
+
+  it('"Port of Call, Ukraine (unspecified)" resolves to Odesa (vague-ukraine guard)', () => {
+    expect(normalizePortName('Port of Call, Ukraine (unspecified)')).toBe('Odesa');
+  });
+
+  it('"Port of Call, Ukraine" (no parenthetical) resolves to Odesa', () => {
+    expect(normalizePortName('Port of Call, Ukraine')).toBe('Odesa');
+  });
 });
 
 describe('getPortDistance', () => {
@@ -194,6 +202,12 @@ describe('getPortDistance', () => {
     // (No way to construct this with current 15 ports — all have coords.
     //  Phase 5 with JSON-loaded ports may have null-coord entries.)
     expect(getPortDistance('Karasu', 'Karasu')).not.toBeNull();
+  });
+
+  it('Iskenderun → "Port of Call, Ukraine (unspecified)" < 2000nm (not 7811nm Callao)', () => {
+    const d = getPortDistance('Iskenderun', 'Port of Call, Ukraine (unspecified)');
+    expect(d).not.toBeNull();
+    expect(d!.nm).toBeLessThan(2000);
   });
 });
 

--- a/lib/sailing/__tests__/port-distances.test.ts
+++ b/lib/sailing/__tests__/port-distances.test.ts
@@ -1022,3 +1022,16 @@ describe('getPortDistance — Phase D1 hand-curated corridor pairs', () => {
     });
   });
 });
+
+describe('vague Ukraine discharge resolves to Black-Sea-plausible distance', () => {
+  it('Iskenderun → "Port of Call Ukraine" resolves to a Black-Sea-plausible distance (< 1500nm), not 7811', () => {
+    const d = getPortDistance('Iskenderun', 'Port of Call Ukraine');
+    expect(d).not.toBeNull();
+    expect(d!.nm).toBeGreaterThan(400);   // real Iskenderun→Odesa ≈ 760nm
+    expect(d!.nm).toBeLessThan(1500);     // hard ceiling — 7811 is the bug
+  });
+
+  it('"Ukraine" alone resolves to a Black-Sea representative port', () => {
+    expect(normalizePortName('Ukraine')).toBe('Odesa');
+  });
+});

--- a/lib/sailing/__tests__/port-distances.test.ts
+++ b/lib/sailing/__tests__/port-distances.test.ts
@@ -1049,3 +1049,49 @@ describe('vague Ukraine discharge resolves to Black-Sea-plausible distance', () 
     expect(normalizePortName('Ukraine')).toBe('Odesa');
   });
 });
+
+describe('vague-unknown port strings do not fuzzy-match distant real ports (fix-l2-r5)', () => {
+  // Root bug: "Port of Call (unspecified)" → strips to "Call" → fuzzysort prefix-matches
+  // "callao" (Callao, Peru) → Damietta↔Callao = 7688nm in the MAIN match bucket.
+  it('normalizePortName("Port of Call (unspecified)") → null, not Callao', () => {
+    expect(normalizePortName('Port of Call (unspecified)')).toBeNull();
+  });
+
+  it('normalizePortName("Port of Call") → null, not Callao', () => {
+    expect(normalizePortName('Port of Call')).toBeNull();
+  });
+
+  // Root bug: "Greece (port unspecified)" → paren hint "port" → fuzzysort prefix-matches
+  // "portland" → getPortDistance(Iskenderun, Portland) = 5105nm.
+  it('normalizePortName("Greece (port unspecified)") → null, not Portland', () => {
+    expect(normalizePortName('Greece (port unspecified)')).toBeNull();
+  });
+
+  it('normalizePortName("Egypt (port unspecified)") → null, not Portland', () => {
+    expect(normalizePortName('Egypt (port unspecified)')).toBeNull();
+  });
+
+  // Behavioral: vague unknown discharge → getPortDistance returns null (no bogus 7000+nm distance)
+  it('getPortDistance("Damietta", "Port of Call (unspecified)") → null (was 7688nm via Callao)', () => {
+    expect(getPortDistance('Damietta', 'Port of Call (unspecified)')).toBeNull();
+  });
+
+  it('getPortDistance("Iskenderun", "Greece (port unspecified)") → not 5105nm (was Portland via paren-hint "port")', () => {
+    const d = getPortDistance('Iskenderun', 'Greece (port unspecified)');
+    // Before fix: paren hint "port" → fuzzy → Portland → 5105nm (wrong continent).
+    // After fix: "port" is noise word, hint discarded; centroid fallback gives ~600nm (correct region).
+    expect(d?.nm ?? 0).toBeLessThan(4000);
+  });
+
+  // Regression: Ukraine-specific guard still works (must come before the UNKNOWN_RE guard)
+  it('"Port of Call, Ukraine (unspecified)" still resolves to Odesa (Ukraine guard unchanged)', () => {
+    expect(normalizePortName('Port of Call, Ukraine (unspecified)')).toBe('Odesa');
+  });
+
+  // Regression: real port name lookups still work (direct alias + fuzzy not broken by new guards)
+  it('real port names with aliases still resolve correctly', () => {
+    expect(normalizePortName('Aliaga')).toBe('Aliaga');
+    expect(normalizePortName('Odessa')).toBe('Odesa');          // alias → Odesa
+    expect(normalizePortName('Novorossisk')).toBe('Novorossiysk'); // alias → Novorossiysk
+  });
+});

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -1184,13 +1184,15 @@ function fuzzyMatchPort(query: string): string | null {
 /**
  * Extract parenthetical hint tokens from a raw port name.
  * Example: "Hereke (Marmara)" → ["marmara"]; "Bay of Biscay (Bayonne/Bilbao range)" → ["bayonne", "bilbao"].
- * Filters out 2-letter country codes (e.g. "TR", "EG") and noise words ("range", "cluster", "region", "area").
+ * Filters out 2-letter country codes (e.g. "TR", "EG") and noise words ("range", "cluster", "region", "area",
+ * "port", "unspecified") — the last two appear in broker vague descriptors like "(port unspecified)" and
+ * must not be used as port-name hints (they fuzzy-match "Portland" via fuzzysort prefix matching).
  */
 function extractParenHints(raw: string): string[] {
   const hints: string[] = [];
   const pat = /\(([^)]+)\)/g;
   let m: RegExpExecArray | null;
-  const noise = /\b(range|cluster|region|area)\b/gi;
+  const noise = /\b(range|cluster|region|area|port|unspecified)\b/gi;
   while ((m = pat.exec(raw)) !== null) {
     const content = m[1].replace(noise, '').trim();
     if (!content) continue;
@@ -1227,6 +1229,11 @@ export function normalizePortName(raw: string | null | undefined): string | null
   if (lowerRaw.includes('ukraine') && /port[\s-]*of[\s-]*call|unspecified/i.test(raw)) {
     return 'Odesa';
   }
+
+  // Vague-unknown descriptor guard (mirrors resolveVaguePort UNKNOWN_RE).
+  // "Port of Call (unspecified)" strips to "Call" → fuzzysort prefix-matches "callao" → Callao (Peru).
+  // Return null here so the fuzzy path never fires; caller should use resolveVaguePort for vague strings.
+  if (/\b(port\s+of\s+call|tbs|to\s+be\s+specified|unnamed)\b/i.test(trimmedRaw)) return null;
 
   // Capture parenthetical hints BEFORE stripping (used as fallback if primary name fails)
   const parenHints = extractParenHints(raw);

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -1220,6 +1220,14 @@ export function normalizePortName(raw: string | null | undefined): string | null
     if (entry?.name) return normalizePortName(entry.name);
   }
 
+  // Early vague-Ukraine guard: "Port of Call, Ukraine (unspecified)" is a broker
+  // shorthand that stripCountry/stripPortPrefix degrades to 'Call' → Callao (Peru).
+  // Catch it here before stripping removes the country token.
+  const lowerRaw = trimmedRaw.toLowerCase();
+  if (lowerRaw.includes('ukraine') && /port[\s-]*of[\s-]*call|unspecified/i.test(raw)) {
+    return 'Odesa';
+  }
+
   // Capture parenthetical hints BEFORE stripping (used as fallback if primary name fails)
   const parenHints = extractParenHints(raw);
   let s = stripCountry(stripParenthetical(raw)).trim();

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -110,6 +110,10 @@ const PORT_ALIASES: Record<string, KnownPort> = {
   'reni': 'Izmail',             // Reni is a nearby Danube port, use Izmail as proxy
   'izmail / reni': 'Izmail',
   'izmayil': 'Izmail',
+  // Vague country/region discharge labels → representative Black Sea port (avoids fuzzy mis-resolution).
+  // "Port of Call Ukraine" → stripPortPrefix → "Call Ukraine" → parts → 'ukraine' → Odesa.
+  'ukraine': 'Odesa',
+  'call ukraine': 'Odesa',
   'yuzhny': 'Yuzhny',
   'pivdennyi': 'Yuzhny',        // Ukrainian name for Yuzhny port
   'pivdenniy': 'Yuzhny',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -65,6 +65,10 @@ export interface EconomicsBreakdown {
   warRiskZonesBallast?: string[];
   /** Laden + ballast totalPremiumUsd. Reflected in EconomicsResult.totalUsd. */
   warRiskTotalCombined?: number;
+  /** Canal dues (Suez + Bosporus combined, USD). Zero if no canal transit. */
+  canal_usd?: number;
+  /** EU ETS cost in USD (converted from EUR). Zero if non-EU route. */
+  ets_usd?: number;
 }
 
 export interface EconomicsResult {

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -417,6 +417,26 @@ function cargoTypeStr(cargo: ParsedCargo): string | null {
   return (t as string) ?? null;
 }
 
+// ── Quarantine list ───────────────────────────────────────────────────────────
+// Matches in this list are moved to the review bucket regardless of fit score.
+// Thin post-ETS matches that would show implausibly low ($100-300/day) TCE to
+// a client, signalling a broken calc rather than honest economics.
+export const QUARANTINE_PAIRS: Array<{ loadPort: string; dischargePort: string; vesselDwtMin: number; vesselDwtMax: number }> = [
+  // Thisvi(GR)→Monfalcone(IT) 18930 DWT: post-ETS TCE ~$277/day — thin to the point of
+  // looking broken. Smaller-DWT variants (8100-9220 DWT) are viable and remain in main.
+  { loadPort: 'Thisvi', dischargePort: 'Monfalcone', vesselDwtMin: 17000, vesselDwtMax: 21000 },
+];
+
+export function isMatchQuarantined(m: Pick<Match, 'loadPort' | 'dischargePort' | 'vesselDwt'>): boolean {
+  return QUARANTINE_PAIRS.some(
+    (q) =>
+      m.loadPort?.toLowerCase() === q.loadPort.toLowerCase() &&
+      m.dischargePort?.toLowerCase() === q.dischargePort.toLowerCase() &&
+      (m.vesselDwt ?? 0) >= q.vesselDwtMin &&
+      (m.vesselDwt ?? 0) <= q.vesselDwtMax,
+  );
+}
+
 async function main() {
   // --rebuild-worksheet / --dry-rebuild-worksheet: targeted worksheet rebuild mode.
   // Does NOT re-run analyzePairs — only patches worksheet_json for seed matches
@@ -578,8 +598,8 @@ async function main() {
   const MAIN_FIT_FLOOR = Number(arg('--fit-floor') ?? 60);
   const INSUF_CAP = Number(arg('--insuf-cap') ?? 60);
   const mainAll = dedup(result.matches.filter((m) => m.confidence?.blockSend !== true));
-  const mainClean = mainAll.filter((m) => (m.fitPercent ?? 0) >= MAIN_FIT_FLOOR);
-  const demoted = mainAll.filter((m) => (m.fitPercent ?? 0) < MAIN_FIT_FLOOR);
+  const mainClean = mainAll.filter((m) => (m.fitPercent ?? 0) >= MAIN_FIT_FLOOR && !isMatchQuarantined(m));
+  const demoted = mainAll.filter((m) => (m.fitPercent ?? 0) < MAIN_FIT_FLOOR || isMatchQuarantined(m));
   const review = dedup([...result.lowConfidenceMatches, ...demoted]);
   const insufficient = dedup(result.insufficientData)
     .sort((a, b) => b.score - a.score)

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -427,7 +427,7 @@ export const QUARANTINE_PAIRS: Array<{ loadPort: string; dischargePort: string; 
   { loadPort: 'Thisvi', dischargePort: 'Monfalcone', vesselDwtMin: 17000, vesselDwtMax: 21000 },
 ];
 
-export function isMatchQuarantined(m: Pick<Match, 'loadPort' | 'dischargePort' | 'vesselDwt'>): boolean {
+export function isMatchQuarantined(m: { loadPort: string | null; dischargePort: string | null; vesselDwt: number | null }): boolean {
   return QUARANTINE_PAIRS.some(
     (q) =>
       m.loadPort?.toLowerCase() === q.loadPort.toLowerCase() &&
@@ -435,6 +435,14 @@ export function isMatchQuarantined(m: Pick<Match, 'loadPort' | 'dischargePort' |
       (m.vesselDwt ?? 0) >= q.vesselDwtMin &&
       (m.vesselDwt ?? 0) <= q.vesselDwtMax,
   );
+}
+
+function matchToQuarantineInput(m: Match) {
+  return {
+    loadPort: m.worksheet?.cargo.loadPort ?? null,
+    dischargePort: m.worksheet?.cargo.dischargePort ?? null,
+    vesselDwt: m.worksheet?.vessel.dwtSummer ?? null,
+  };
 }
 
 async function main() {
@@ -598,8 +606,8 @@ async function main() {
   const MAIN_FIT_FLOOR = Number(arg('--fit-floor') ?? 60);
   const INSUF_CAP = Number(arg('--insuf-cap') ?? 60);
   const mainAll = dedup(result.matches.filter((m) => m.confidence?.blockSend !== true));
-  const mainClean = mainAll.filter((m) => (m.fitPercent ?? 0) >= MAIN_FIT_FLOOR && !isMatchQuarantined(m));
-  const demoted = mainAll.filter((m) => (m.fitPercent ?? 0) < MAIN_FIT_FLOOR || isMatchQuarantined(m));
+  const mainClean = mainAll.filter((m) => (m.fitPercent ?? 0) >= MAIN_FIT_FLOOR && !isMatchQuarantined(matchToQuarantineInput(m)));
+  const demoted = mainAll.filter((m) => (m.fitPercent ?? 0) < MAIN_FIT_FLOOR || isMatchQuarantined(matchToQuarantineInput(m)));
   const review = dedup([...result.lowConfidenceMatches, ...demoted]);
   const insufficient = dedup(result.insufficientData)
     .sort((a, b) => b.score - a.score)


### PR DESCRIPTION
## Summary

- **Bosporus detection**: Add `blacksea` basin to port classifier; Med↔BlackSea routes now charge Bosporus dues (~$6-8k) in `canal_usd`. Exports `routeTransitsBosporus`/`quoteBosporusSafe` for reuse.
- **EU-ETS wiring**: `buildMatchEconomics` now resolves EU endpoint flags via `resolvePort`+`isEuCountry`, derives `euLegPercent`/`coverageFactor`, passes live EUA price from DB. Exports `deriveEtsCoverage`.
- **list==detail parity held**: `EconomicsTab` POSTs `includeEuETS:true`; `route.ts` auto-derives Bosporus canal when `body.canalUsd` absent — both use the same exported helpers.
- **Distance fix**: `PORT_ALIASES['ukraine']→'Odesa'`, `PORT_ALIASES['call ukraine']→'Odesa'` — `'Port of Call Ukraine'` discharge no longer fuzzy-matches to 7811nm.
- **Seed quarantine**: Thisvi→Monfalcone 18930 DWT moved to `__demo_review__` (post-ETS ~$277/day looks broken); smaller-DWT variants stay in main.

## Test plan

- [ ] `npx jest tce-bosporus` — 3 Bosporus detection tests green
- [ ] `npx jest tce-ets-wiring` — 3 ETS wiring tests green
- [ ] `npx jest list-detail-tce-parity` — 10 parity tests green (7 existing + 3 new L2 samples)
- [ ] `npx jest port-distances.test.ts` — 202 tests green incl. Ukraine distance fix
- [ ] `npx jest seed-quarantine` — 4 quarantine tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)