### PR TITLE
fix(tce): full list↔detail parity — bunker/canal/ETS/consumption/bunker-reco

### DIFF
--- a/__tests__/components/match/EconomicsTab-bunker-null.test.tsx
+++ b/__tests__/components/match/EconomicsTab-bunker-null.test.tsx
@@ -1,14 +1,19 @@
 /**
  * @jest-environment jsdom
  *
- * A2.1 RTL behavioral tests — bunkerPort default-state and recommendation-driven override.
+ * A2.1 RTL behavioral tests — bunkerPort default-state and recommendation handling.
+ *
+ * CONTRACT CHANGE (PR #863, list↔detail parity): the bunker recommendation is now
+ * ADVISORY — it shows a savings note/comparison but no longer overrides the headline
+ * bunker port. The headline voyage TCE always computes at the baseline NLRTM/VLSFO so it
+ * matches the stored LIST TCE (which is fixed at NLRTM). Previously the recommendation
+ * auto-overrode the port to GIGIB/sgsin — that silent override made detail≠list.
  *
  * PI2 behavioral: renders EconomicsTab via RTL, asserts against DOM + captured fetch calls.
- * Real value shapes per task fix: bunkerPort initializes to 'NLRTM' instead of null.
  *  - Initial render (bunkerPort='NLRTM'): P&L fires immediately with default Rotterdam
- *  - Recommendation returns GIGIB: P&L fires with bunkerPort='GIGIB' (API overrides default)
- *  - Recommendation fallback (port=null): P&L still fires with 'NLRTM' (fallback to default)
- *  - bunkerPort='sgsin' lowercase from recommendation: P&L fires with 'sgsin' (API normalises)
+ *  - Recommendation returns GIGIB: headline STAYS 'NLRTM' (advisory, no override)
+ *  - Recommendation fallback (port=null): P&L still fires with 'NLRTM'
+ *  - Recommendation lowercase 'sgsin': headline STAYS 'NLRTM' (no override)
  */
 import '@testing-library/jest-dom';
 import { render, screen, act, waitFor } from '@testing-library/react';
@@ -73,7 +78,7 @@ function makeGlobalFetch(recoPort: string | null, recoPriceUsdPerMt: number | nu
 
 afterEach(() => jest.restoreAllMocks());
 
-test('P&L fires immediately with default NLRTM, then updates to recommendation GIGIB', async () => {
+test('headline stays NLRTM even when recommendation returns GIGIB (advisory only, parity with list)', async () => {
   global.fetch = makeGlobalFetch('GIGIB');
   await act(async () => {
     render(
@@ -91,14 +96,10 @@ test('P&L fires immediately with default NLRTM, then updates to recommendation G
   const tceCalls = allCalls.filter(([u]: [string]) => (u as string).includes('/api/voyage/tce'));
   expect(tceCalls.length).toBeGreaterThanOrEqual(1);
 
-  // First TCE call uses default NLRTM (bunkerPort initializes to NLRTM)
-  const firstBody = JSON.parse(tceCalls[0][1].body);
-  expect(firstBody.bunkerPort).toBe('NLRTM');
-
-  // After recommendation resolves, final TCE call uses GIGIB (API overrides)
-  if (tceCalls.length > 1) {
-    const finalBody = JSON.parse(tceCalls[tceCalls.length - 1][1].body);
-    expect(finalBody.bunkerPort).toBe('GIGIB');
+  // EVERY TCE call uses the baseline NLRTM. The GIGIB recommendation is advisory and must
+  // NOT override the headline bunker port (else detail TCE ≠ list TCE). (PR #863 parity.)
+  for (const call of tceCalls) {
+    expect(JSON.parse(call[1].body).bunkerPort).toBe('NLRTM');
   }
 });
 
@@ -129,7 +130,7 @@ test('P&L fires with default NLRTM even when recommendation returns fallback (po
   expect(body.bunkerPort).toBe('NLRTM');
 });
 
-test('P&L updates to lowercase recommendation port as-sent (API normalises)', async () => {
+test('recommendation port (lowercase sgsin) does not override headline — stays NLRTM (parity)', async () => {
   global.fetch = makeGlobalFetch('sgsin'); // lowercase from recommendation
   await act(async () => {
     render(
@@ -147,13 +148,8 @@ test('P&L updates to lowercase recommendation port as-sent (API normalises)', as
   const tceCalls = allCalls.filter(([u]: [string]) => (u as string).includes('/api/voyage/tce'));
   expect(tceCalls.length).toBeGreaterThanOrEqual(1);
 
-  // First TCE call uses default NLRTM
-  const firstBody = JSON.parse(tceCalls[0][1].body);
-  expect(firstBody.bunkerPort).toBe('NLRTM');
-
-  // After recommendation resolves with lowercase sgsin, subsequent call uses sgsin
-  if (tceCalls.length > 1) {
-    const finalBody = JSON.parse(tceCalls[tceCalls.length - 1][1].body);
-    expect(finalBody.bunkerPort).toBe('sgsin');
+  // The recommendation (even a lowercase port) is advisory — the headline stays NLRTM.
+  for (const call of tceCalls) {
+    expect(JSON.parse(call[1].body).bunkerPort).toBe('NLRTM');
   }
 });

--- a/__tests__/components/match/attack-econTab-state.test.tsx
+++ b/__tests__/components/match/attack-econTab-state.test.tsx
@@ -30,7 +30,7 @@ const FULL_CARGO = {
   weightMt: { value: 45_000, confidence: 'confirmed' as const },
 };
 
-test('Attack 11: manual port selection prevents recommendation override', async () => {
+test('Attack 11: recommendation is advisory — headline port not auto-overridden; manual selection persists', async () => {
   let recoCallCount = 0;
   const fetchMock = jest.fn((url: string | Request) => {
     const u = typeof url === 'string' ? url : url.toString();
@@ -65,27 +65,25 @@ test('Attack 11: manual port selection prevents recommendation override', async 
     );
   });
 
-  // Wait for recommendation to fire and set GIGIB
-  await waitFor(() => {
-    const portSelect = screen.getByLabelText('Bunker port') as HTMLSelectElement;
-    expect(portSelect.value).toBe('GIGIB');
-  });
-
-  // User manually selects NLRTM
+  // Recommendation returns GIGIB, but the headline bunker port STAYS at the NLRTM baseline:
+  // the recommendation is advisory and must NOT auto-override the headline (PR #863 parity).
+  await waitFor(() => expect(screen.getByLabelText('Bunker port')).toBeInTheDocument());
   const portSelect = screen.getByLabelText('Bunker port') as HTMLSelectElement;
-  await act(async () => {
-    fireEvent.change(portSelect, { target: { value: 'NLRTM' } });
-  });
   expect(portSelect.value).toBe('NLRTM');
 
-  // Even if recommendation fires again (grade change triggers re-fetch), NLRTM should persist
+  // User can still manually select a different port (manual control preserved).
+  await act(async () => {
+    fireEvent.change(portSelect, { target: { value: 'GIGIB' } });
+  });
+  expect(portSelect.value).toBe('GIGIB');
+
+  // Grade change re-fires the recommendation, but it never overrides the user's manual choice.
   const gradeSelect = screen.getByLabelText('Bunker grade') as HTMLSelectElement;
   await act(async () => {
     fireEvent.change(gradeSelect, { target: { value: 'MGO' } });
   });
-  // After grade change, recommendation re-fires but bunkerPortManual=true → should not override NLRTM
   await waitFor(() => {
     const ps = screen.getByLabelText('Bunker port') as HTMLSelectElement;
-    expect(ps.value).toBe('NLRTM');
+    expect(ps.value).toBe('GIGIB');
   });
 });

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -20,7 +20,7 @@ import { getStore } from '@/lib/session-store';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { isEuCountry } from '@/lib/validation/sanctions';
-import { routeTransitsBosporus, quoteBosporusSafe } from '@/lib/matching/tce-calculator';
+import { routeTransitsBosporus, quoteBosporusSafe, routeTransitsSuez, quoteSuezSafe } from '@/lib/matching/tce-calculator';
 
 const LOCODE_RE = /^[A-Za-z]{5}$/;
 
@@ -63,6 +63,8 @@ const VoyageInputSchema = z.object({
         z.enum(['bulker', 'tanker', 'container', 'general', 'mpp']),
       )
       .optional(),
+    /** Open position for ballast-leg canal detection. Optional — absent means no ballast canal. */
+    openPosition: z.string().optional(),
   }),
   route: z.object({
     originPort: z.string(),
@@ -237,6 +239,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (typeof data.canalUsd !== 'number' && !data.route.viaSuez && !data.route.viaCanal) {
     if (routeTransitsBosporus(originResolved.portName, destinationResolved.portName)) {
       canalUsd += quoteBosporusSafe(data.vessel.dwt);
+    }
+    if (routeTransitsSuez(originResolved.portName, destinationResolved.portName)) {
+      canalUsd += quoteSuezSafe(data.vessel.dwt, true);
+    }
+    // Ballast leg canal: open position → load port (parity with stored-match path).
+    const openPosition = data.vessel.openPosition;
+    if (openPosition) {
+      const openR = resolvePortOrPassthrough(openPosition);
+      const openName = openR?.port.portName ?? openPosition;
+      if (routeTransitsBosporus(openName, originResolved.portName)) {
+        canalUsd += quoteBosporusSafe(data.vessel.dwt);
+      }
+      if (routeTransitsSuez(openName, originResolved.portName)) {
+        canalUsd += quoteSuezSafe(data.vessel.dwt, false); // ballast = unladen
+      }
     }
   }
   const daUsd = resolveDaUsd(data, originResolved, destinationResolved);

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -21,6 +21,7 @@ import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { isEuCountry } from '@/lib/validation/sanctions';
 import { routeTransitsBosporus, quoteBosporusSafe, routeTransitsSuez, quoteSuezSafe } from '@/lib/matching/tce-calculator';
+import { getPortDistance } from '@/lib/sailing/port-distances';
 
 const LOCODE_RE = /^[A-Za-z]{5}$/;
 
@@ -234,8 +235,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   let canalUsd = resolveCanalUsd(data);
-  // Auto-derive Bosporus dues when body.canalUsd is absent (parity with stored match path).
-  // Suez is left to explicit body.canalUsd / viaSuez to avoid double-charge on existing callers.
+  // Auto-derive Bosporus + Suez dues (laden and ballast legs) when no explicit canal inputs are
+  // provided — parity with the stored-match path. Explicit canalUsd/viaSuez/viaCanal skip this
+  // block (no double-charge).
   if (typeof data.canalUsd !== 'number' && !data.route.viaSuez && !data.route.viaCanal) {
     if (routeTransitsBosporus(originResolved.portName, destinationResolved.portName)) {
       canalUsd += quoteBosporusSafe(data.vessel.dwt);
@@ -244,15 +246,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       canalUsd += quoteSuezSafe(data.vessel.dwt, true);
     }
     // Ballast leg canal: open position → load port (parity with stored-match path).
+    // Guard on a resolvable ballast distance > 0 and dwt > 0, mirroring buildMatchEconomics.
     const openPosition = data.vessel.openPosition;
-    if (openPosition) {
+    if (openPosition && data.vessel.dwt > 0) {
       const openR = resolvePortOrPassthrough(openPosition);
       const openName = openR?.port.portName ?? openPosition;
-      if (routeTransitsBosporus(openName, originResolved.portName)) {
-        canalUsd += quoteBosporusSafe(data.vessel.dwt);
-      }
-      if (routeTransitsSuez(openName, originResolved.portName)) {
-        canalUsd += quoteSuezSafe(data.vessel.dwt, false); // ballast = unladen
+      const ballastLeg = getPortDistance(openName, originResolved.portName);
+      if (ballastLeg && ballastLeg.nm > 0) {
+        if (routeTransitsBosporus(openName, originResolved.portName)) {
+          canalUsd += quoteBosporusSafe(data.vessel.dwt);
+        }
+        if (routeTransitsSuez(openName, originResolved.portName)) {
+          canalUsd += quoteSuezSafe(data.vessel.dwt, false); // ballast = unladen
+        }
       }
     }
   }

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -158,14 +158,16 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
                 }
               : null,
           );
-          if (!bunkerPortManual) {
-            setBunkerPort(data.port);
-          }
+          // NOTE: We intentionally do NOT auto-set bunkerPort here.
+          // The headline voyage TCE must stay on the baseline port (NLRTM/VLSFO) so it
+          // matches the stored LIST TCE (which is always computed at NLRTM). The
+          // recommendation is advisory — shown as savings + comparison table — and the
+          // user can still switch the bunker port manually via the dropdown.
         }
       })
       .catch(() => {});
     return () => { cancelled = true; };
-  }, [recoFrom, recoTo, bunkerGrade, bunkerPortManual, recoDwt, recoSpeed, recoCons, recoVoyageDays]);
+  }, [recoFrom, recoTo, bunkerGrade, recoDwt, recoSpeed, recoCons, recoVoyageDays]);
 
   const handleOverrideSubmit = useCallback(async () => {
     if (!matchDbId) return;

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -81,7 +81,6 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const [resetting, setResetting] = useState(false);
   const [bunkerPort, setBunkerPort] = useState<BunkerPort | null>('NLRTM');
   const [bunkerGrade, setBunkerGrade] = useState<BunkerGrade>('VLSFO');
-  const [bunkerPortManual, setBunkerPortManual] = useState(false);
   const [bunkerReco, setBunkerReco] = useState<{ port: string; priceUsdPerMt: number; recommendation: string } | null>(null);
   const [bunkerFallback, setBunkerFallback] = useState<string | null>(null);
   const [bunkerCandidates, setBunkerCandidates] = useState<BunkerCandidateResult[]>([]);
@@ -495,7 +494,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
         <div className="flex gap-2 mt-2">
           <select
             value={bunkerPort ?? ''}
-            onChange={(e) => { setBunkerPort(e.target.value); setBunkerPortManual(true); }}
+            onChange={(e) => { setBunkerPort(e.target.value); }}
             aria-label="Bunker port"
             className="flex-1 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:border-blue-400"
           >

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -12,7 +12,7 @@ import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import { resolveConsMtPerDay } from '@/lib/economics/vessel-consumption';
-import { parseConsumption } from '@/lib/matching/tce-calculator';
+import { parseConsumption } from '@/lib/matching/parse-vessel-fields';
 import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
 import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -115,7 +115,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const recoTo = cargo?.destinationPort?.value;
   const recoDwt = vessel?.dwtSummer?.value ?? 0;
   const recoSpeed = parseLeadingNumber(vessel?.speedLaden);
-  const recoCons = resolveConsMtPerDay(parseConsumption(vessel?.consumption), recoDwt);
+  const recoCons = resolveConsMtPerDay(parseConsumption(vessel?.consumption, 0), recoDwt);
   const recoVoyageDays = useMemo(
     () => estimateVoyageDays(routeDistanceNm, recoSpeed),
     [routeDistanceNm, recoSpeed],
@@ -234,7 +234,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const destination = cargo?.destinationPort?.value ?? '';
     const dwt = vessel?.dwtSummer?.value ?? 0;
     const speedKts = parseLeadingNumber(vessel?.speedLaden);
-    const rawConsumption = parseConsumption(vessel?.consumption);
+    const rawConsumption = parseConsumption(vessel?.consumption, 0);
     const consumption = resolveConsMtPerDay(rawConsumption, dwt);
     const quantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
 
@@ -284,7 +284,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const voyageInputData = useMemo(() => {
     const dwt = vessel?.dwtSummer?.value ?? 0;
     const speedKts = parseLeadingNumber(vessel?.speedLaden);
-    const rawConsumptionMtPerDay = parseConsumption(vessel?.consumption);
+    const rawConsumptionMtPerDay = parseConsumption(vessel?.consumption, 0);
     const consumptionMtPerDay = resolveConsMtPerDay(rawConsumptionMtPerDay, dwt);
     const originPort = cargo?.originPort?.value ?? '';
     const destinationPort = cargo?.destinationPort?.value ?? '';

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -12,6 +12,7 @@ import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import { resolveConsMtPerDay } from '@/lib/economics/vessel-consumption';
+import { parseConsumption } from '@/lib/matching/tce-calculator';
 import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
 import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';
@@ -115,7 +116,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const recoTo = cargo?.destinationPort?.value;
   const recoDwt = vessel?.dwtSummer?.value ?? 0;
   const recoSpeed = parseLeadingNumber(vessel?.speedLaden);
-  const recoCons = resolveConsMtPerDay(parseLeadingNumber(vessel?.consumption), recoDwt);
+  const recoCons = resolveConsMtPerDay(parseConsumption(vessel?.consumption), recoDwt);
   const recoVoyageDays = useMemo(
     () => estimateVoyageDays(routeDistanceNm, recoSpeed),
     [routeDistanceNm, recoSpeed],
@@ -232,7 +233,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const destination = cargo?.destinationPort?.value ?? '';
     const dwt = vessel?.dwtSummer?.value ?? 0;
     const speedKts = parseLeadingNumber(vessel?.speedLaden);
-    const rawConsumption = parseLeadingNumber(vessel?.consumption);
+    const rawConsumption = parseConsumption(vessel?.consumption);
     const consumption = resolveConsMtPerDay(rawConsumption, dwt);
     const quantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
 
@@ -282,7 +283,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
   const voyageInputData = useMemo(() => {
     const dwt = vessel?.dwtSummer?.value ?? 0;
     const speedKts = parseLeadingNumber(vessel?.speedLaden);
-    const rawConsumptionMtPerDay = parseLeadingNumber(vessel?.consumption);
+    const rawConsumptionMtPerDay = parseConsumption(vessel?.consumption);
     const consumptionMtPerDay = resolveConsMtPerDay(rawConsumptionMtPerDay, dwt);
     const originPort = cargo?.originPort?.value ?? '';
     const destinationPort = cargo?.destinationPort?.value ?? '';
@@ -329,9 +330,14 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
         })
       : null;
 
+    const openPosition = vessel?.openPosition?.value ?? undefined;
     const input = core
       ? {
-          vessel: core.vessel,
+          vessel: {
+            ...core.vessel,
+            // Pass open position for ballast-leg canal detection (parity with stored-match path).
+            ...(openPosition ? { openPosition } : {}),
+          },
           route: core.route,
           cargo: core.cargo,
           durationDays: core.durationDays,

--- a/components/match/__tests__/EconomicsTab.bunker-baseline.test.tsx
+++ b/components/match/__tests__/EconomicsTab.bunker-baseline.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression test: headline TCE must use the BASELINE bunker port (NLRTM)
+ * even when the bunker-recommendation API returns a different port (GIGIB).
+ *
+ * Oracle: the POST body sent to /api/voyage/tce must contain bunkerPort==='NLRTM',
+ * NOT the recommended port. The recommendation is advisory only.
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EconomicsTab } from '../EconomicsTab';
+import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';
+import type { ParsedVessel, ParsedCargo, ConfidenceField } from '@/lib/types';
+
+// ── Silence console.error from expected missing prop warnings ──
+const consoleError = console.error;
+beforeAll(() => { console.error = jest.fn(); });
+afterAll(() => { console.error = consoleError; });
+
+// ── Mock complex sub-components that make their own fetch calls ──
+jest.mock('@/components/economics/RouteCompareModal', () => ({
+  RouteCompareModal: () => <div data-testid="route-compare-modal-mock" />,
+}));
+
+jest.mock('@/components/economics/BunkerComparisonTable', () => ({
+  BunkerComparisonTable: () => <div data-testid="bunker-comparison-table-mock" />,
+}));
+
+// ── Minimal valid TCEBreakdown ──
+const FIXTURE_BREAKDOWN: TCEBreakdown = {
+  freight_rate_usd_per_mt: 28,
+  quantity_mt: 50000,
+  duration_days: 18,
+  bunker_consumption_mt_per_day: 26,
+  bunker_price_usd_per_mt: 791,
+  gross_freight_usd: 1_400_000,
+  bunker_usd: 252_720,
+  canal_usd: 0,
+  da_usd: 55_000,
+  war_risk_usd: 0,
+  ets_eur: 0,
+  ets_usd: 0,
+  total_costs_usd: 307_720,
+  net_voyage_usd: 1_092_280,
+  daily_tce_usd: 60_682,
+  applicable: {
+    bunker: true,
+    canal: false,
+    da: true,
+    war_risk: false,
+    ets: false,
+  },
+};
+
+// ── Helper to create a ConfidenceField<T> ──
+function cf<T>(value: T): ConfidenceField<T> {
+  return { value, confidence: 'confirmed' };
+}
+
+// ── Vessel and cargo fixtures — same shape as toggle test ──
+const vessel: ParsedVessel = {
+  dwtSummer: cf(55000),
+  speedLaden: '14 kn' as unknown as ConfidenceField<string>,
+  consumption: '26 mt/day' as unknown as ConfidenceField<string>,
+  vesselName: null,
+  dwcc: null,
+  draftMax: null,
+  openPosition: cf('Nemrut Bay'),
+  openDate: null,
+  flag: null,
+  built: null,
+  imoNumber: null,
+  mmsi: null,
+  vesselType: null,
+  grainCubicM: null,
+  bale: null,
+  tpc: null,
+  gearDescription: null,
+  cranes: null,
+  loa: null,
+  beam: null,
+  holdCount: null,
+  hatchCount: null,
+  hatchType: null,
+  ssFitted: null,
+  tcFitted: null,
+  p1: null,
+  owners: null,
+  speedBallast: null,
+  consumptionBallast: null,
+  consumptionPort: null,
+  charterPartyTrade: null,
+  speedFull: null,
+} as unknown as ParsedVessel;
+
+// Mediterranean route that would normally trigger a GIGIB recommendation
+const cargo: ParsedCargo = {
+  originPort: cf('Nemrut Bay'),
+  destinationPort: cf('Liverpool'),
+  weightMt: cf(50000),
+  weightMtMax: undefined,
+  cargoType: cf('GRAIN'),
+  cargoDescription: null,
+  preferredDates: null,
+  laycanStart: null,
+  laycanEnd: null,
+  laycan: null,
+  commissionPct: null,
+  freightRate: null,
+} as unknown as ParsedCargo;
+
+describe('EconomicsTab — bunker baseline oracle (list↔detail TCE parity)', () => {
+  it('sends bunkerPort=NLRTM in the /api/voyage/tce POST even when recommendation returns GIGIB', async () => {
+    // Capture the POST body sent to /api/voyage/tce
+    let capturedBody: Record<string, unknown> | null = null;
+
+    const mockFetch = jest.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/market/benchmark?indicator=EUA') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ value: 65, period: '2026-06' }),
+        });
+      }
+      if (String(url).includes('/api/voyage/bunker-recommendation')) {
+        // Simulate Mediterranean route: recommendation returns GIGIB at $771
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            fallback: false,
+            message: null,
+            port: 'GIGIB',
+            priceUsdPerMt: 771,
+            recommendation: 'Bunker at GIGIB (Gibraltar) — saves ~$5,000',
+            savingsUsd: 5000,
+            candidates: [],
+          }),
+        });
+      }
+      if (url === '/api/voyage/tce') {
+        // Capture the request body for assertion
+        if (init?.body) {
+          capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ breakdown: FIXTURE_BREAKDOWN }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    });
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    render(
+      <EconomicsTab
+        vessel={vessel}
+        cargo={cargo}
+        routeDistanceNm={4500}
+        storedFreightRate={28}
+      />
+    );
+
+    // Wait until /api/voyage/tce was called at least once
+    await waitFor(
+      () => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/voyage/tce',
+          expect.objectContaining({ method: 'POST' }),
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    // Oracle: the POST body must use the NLRTM baseline, NOT the GIGIB recommendation.
+    // This is the invariant that guarantees LIST TCE === DETAIL headline TCE.
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.bunkerPort).toBe('NLRTM');
+    expect(capturedBody!.bunkerPort).not.toBe('GIGIB');
+  });
+});

--- a/data/ports/port-master.json
+++ b/data/ports/port-master.json
@@ -9739,7 +9739,8 @@
     "berthType": "river",
     "note": "Danube/Prut, Moldova free port",
     "aliases": [
-      "Giurgiulești"
+      "Giurgiulești",
+      "Giurgiuleshti"
     ]
   },
   {

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -9,6 +9,7 @@ import { endpointLlmTimeout } from '@/lib/openai-helpers';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 
 /**
  * Compute matches for a session and persist them to the DB.
@@ -56,6 +57,9 @@ export async function computeAndPersistMatches(
   const cargoMap = new Map(cargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselMap = new Map(vessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
 
+  const bunkerRow = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
+  const bunkerPriceUsdPerMt = bunkerRow?.price_usd_per_mt;
+
   for (const m of matches) {
     const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);
     const vessel = vesselMap.get(`${m.vesselEmailId}|${m.vesselItemIndex}`);
@@ -74,7 +78,7 @@ export async function computeAndPersistMatches(
     // Economics via shared helper — includes port-DA, canal, and war-risk convention
     // (excludeWarRiskFromDailyTce:true) so stored TCE matches the detail page.
     const eco = cargo && vessel
-      ? computeStoredMatchEconomics({ cargo, vessel, db })
+      ? computeStoredMatchEconomics({ cargo, vessel, db, bunkerPriceUsdPerMt })
       : { tce_usd_per_day: null, freight_rate_usd_per_mt: null, freight_rate_source: null };
     const tce_usd_per_day = eco.tce_usd_per_day;
     const freight_rate_usd_per_mt = eco.freight_rate_usd_per_mt;

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -57,8 +57,14 @@ export async function computeAndPersistMatches(
   const cargoMap = new Map(cargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselMap = new Map(vessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
 
-  const bunkerRow = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
-  const bunkerPriceUsdPerMt = bunkerRow?.price_usd_per_mt;
+  // Live bunker price (NLRTM/VLSFO) for list↔detail parity. Resilient to a missing
+  // bunker_prices table (e.g. minimal test DBs) — falls through to the helper default.
+  let bunkerPriceUsdPerMt: number | undefined;
+  try {
+    bunkerPriceUsdPerMt = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO')?.price_usd_per_mt;
+  } catch {
+    bunkerPriceUsdPerMt = undefined;
+  }
 
   for (const m of matches) {
     const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);

--- a/lib/matching/parse-vessel-fields.ts
+++ b/lib/matching/parse-vessel-fields.ts
@@ -37,17 +37,23 @@ const FUEL_GRADE_RE = /\b(?:IFO|VLSFO|LSMGO|MGO|HFO|HSFO)\s*\d+(?:\/\d+)?\b|M\/E
  * (e.g. 180 from "IFO 180 M/E 3.7MT/D") rather than the actual MT/day figure.
  * This function looks for an explicit MT/D unit first; if absent it strips grade
  * tokens before falling back to a leading-number heuristic. Strings with no
- * recoverable consumption figure return DEFAULT_CONSUMPTION_MT_PER_DAY.
+ * recoverable consumption figure return `fallback` (default
+ * DEFAULT_CONSUMPTION_MT_PER_DAY for server estimation; callers that need to
+ * DETECT absence — e.g. the detail page's "missing fuel consumption" hint —
+ * pass fallback=0 so an absent figure is falsy rather than a fabricated default).
  */
-export function parseConsumption(s: unknown): number {
-  if (s == null) return DEFAULT_CONSUMPTION_MT_PER_DAY;
-  if (typeof s === 'number') return Number.isFinite(s) && s > 0 ? s : DEFAULT_CONSUMPTION_MT_PER_DAY;
+export function parseConsumption(
+  s: unknown,
+  fallback: number = DEFAULT_CONSUMPTION_MT_PER_DAY,
+): number {
+  if (s == null) return fallback;
+  if (typeof s === 'number') return Number.isFinite(s) && s > 0 ? s : fallback;
   if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
-    return parseConsumption((s as { value: unknown }).value);
+    return parseConsumption((s as { value: unknown }).value, fallback);
   }
-  if (typeof s !== 'string') return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  if (typeof s !== 'string') return fallback;
   const str = s.trim();
-  if (!str) return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  if (!str) return fallback;
 
   const mtd = str.match(MT_PER_DAY_RE);
   if (mtd) return Number(mtd[1]);
@@ -57,5 +63,5 @@ export function parseConsumption(s: unknown): number {
   const m = stripped.match(/(\d+(?:\.\d+)?)/);
   if (m) return Number(m[1]);
 
-  return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  return fallback;
 }

--- a/lib/matching/parse-vessel-fields.ts
+++ b/lib/matching/parse-vessel-fields.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure parsers for vessel speed/consumption fields — NO server imports.
+ *
+ * Extracted from tce-calculator.ts (which transitively pulls better-sqlite3 via
+ * the canal modules) so client components (e.g. components/match/EconomicsTab.tsx)
+ * can reuse the EXACT same parsing without dragging server-only deps into the
+ * client bundle. tce-calculator re-exports these for existing server callers.
+ */
+
+export const DEFAULT_CONSUMPTION_MT_PER_DAY = 25;
+
+// Parse a leading number from strings like "12.5 knots", "25 mt/day", a raw
+// number (LLM-parsed fields can arrive as numbers, not strings), or a
+// ConfidenceField object ({ value, confidence, source_text }). Real/demo parsed
+// data stores speed/consumption as any of these despite the string typing, so
+// tolerate all rather than throw on `.match`.
+export function parseLeadingNumber(s: unknown): number {
+  if (s == null) return 0;
+  if (typeof s === 'number') return Number.isFinite(s) ? s : 0;
+  if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
+    return parseLeadingNumber((s as { value: unknown }).value);
+  }
+  if (typeof s !== 'string') return 0;
+  const m = s.match(/(\d+(?:\.\d+)?)/);
+  return m ? Number(m[1]) : 0;
+}
+
+// Matches an explicit MT/D unit: "3.7MT/D", "14 mt/day", "25 t/day"
+const MT_PER_DAY_RE = /(\d+(?:\.\d+)?)\s*(?:MT\/?D|mt\/?day|t\/day)/i;
+// Fuel-grade tokens that appear before the actual consumption figure
+const FUEL_GRADE_RE = /\b(?:IFO|VLSFO|LSMGO|MGO|HFO|HSFO)\s*\d+(?:\/\d+)?\b|M\/E|A\/E/gi;
+
+/**
+ * Parse a fuel-consumption field, skipping fuel-grade tokens like "IFO 180".
+ *
+ * parseLeadingNumber grabs the first digit sequence, which is the grade number
+ * (e.g. 180 from "IFO 180 M/E 3.7MT/D") rather than the actual MT/day figure.
+ * This function looks for an explicit MT/D unit first; if absent it strips grade
+ * tokens before falling back to a leading-number heuristic. Strings with no
+ * recoverable consumption figure return DEFAULT_CONSUMPTION_MT_PER_DAY.
+ */
+export function parseConsumption(s: unknown): number {
+  if (s == null) return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  if (typeof s === 'number') return Number.isFinite(s) && s > 0 ? s : DEFAULT_CONSUMPTION_MT_PER_DAY;
+  if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
+    return parseConsumption((s as { value: unknown }).value);
+  }
+  if (typeof s !== 'string') return DEFAULT_CONSUMPTION_MT_PER_DAY;
+  const str = s.trim();
+  if (!str) return DEFAULT_CONSUMPTION_MT_PER_DAY;
+
+  const mtd = str.match(MT_PER_DAY_RE);
+  if (mtd) return Number(mtd[1]);
+
+  // Strip fuel-grade tokens then try a plain leading number
+  const stripped = str.replace(FUEL_GRADE_RE, ' ').replace(/\s+/g, ' ').trim();
+  const m = stripped.match(/(\d+(?:\.\d+)?)/);
+  if (m) return Number(m[1]);
+
+  return DEFAULT_CONSUMPTION_MT_PER_DAY;
+}

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -6,6 +6,7 @@ import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
 import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 
 export function persistSessionMatches(
   db: Database.Database,
@@ -16,6 +17,9 @@ export function persistSessionMatches(
 ): void {
   const cargoMap = new Map(parsedCargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselMap = new Map(parsedVessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
+
+  const bunkerRow = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
+  const bunkerPriceUsdPerMt = bunkerRow?.price_usd_per_mt;
 
   for (const m of sessionMatches) {
     const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);
@@ -36,7 +40,7 @@ export function persistSessionMatches(
     // Economics via shared helper — includes port-DA, canal, and war-risk convention
     // (excludeWarRiskFromDailyTce:true) so stored TCE matches the detail page.
     const eco = cargo && vessel
-      ? computeStoredMatchEconomics({ cargo, vessel, db })
+      ? computeStoredMatchEconomics({ cargo, vessel, db, bunkerPriceUsdPerMt })
       : { tce_usd_per_day: null, freight_rate_usd_per_mt: null, freight_rate_source: null };
     const tce_usd_per_day = eco.tce_usd_per_day;
     const freight_rate_usd_per_mt = eco.freight_rate_usd_per_mt;

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -18,8 +18,15 @@ export function persistSessionMatches(
   const cargoMap = new Map(parsedCargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselMap = new Map(parsedVessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
 
-  const bunkerRow = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
-  const bunkerPriceUsdPerMt = bunkerRow?.price_usd_per_mt;
+  // Live bunker price (NLRTM/VLSFO) so the stored list TCE matches the detail page,
+  // which auto-resolves the same baseline. Resilient to a missing bunker_prices table
+  // (e.g. minimal test DBs) — falls through to the helper's default rather than throwing.
+  let bunkerPriceUsdPerMt: number | undefined;
+  try {
+    bunkerPriceUsdPerMt = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO')?.price_usd_per_mt;
+  } catch {
+    bunkerPriceUsdPerMt = undefined;
+  }
 
   for (const m of sessionMatches) {
     const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -4,6 +4,7 @@ import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { quoteSuez } from '@/lib/economics/canals/index';
 import { quoteBosporus } from '@/lib/economics/canals/bosporus';
 import { resolvePort } from '@/lib/ports/resolve';
+import { resolveVaguePort } from '@/lib/ports/resolve-vague';
 import { isEuCountry } from '@/lib/validation/sanctions';
 import type { EconomicsResult } from '@/lib/types';
 
@@ -202,6 +203,18 @@ function _classifyPortBasin(port: string | null | undefined): _PortBasin {
   if (/constanta|varna|burgas|novorossiysk|novorossiisk|odessa|odesa|chornomorsk|mykolaiv|mykolayiv|kherson|sevastopol|yuzhne|yuzhny|pivdennyi|reni|izmail|poti|batumi|giurgiulest|karasu/.test(p)) return 'blacksea';
   if (/ravenna|marghera|venice|trieste|genoa|la.?spezia|livorno|naples|taranto|bari|brindisi|catania|palermo|messina|augusta|trapani|pozzallo|bizerte|skikda|oran|algiers|tunis|sfax|bejaia|annaba|casablanca|jorf|safi|tangier|tanger|agadir|barcelona|valencia|algeciras|gibraltar|marseille|toulon|sete|fos|savona|vado|civitavecchia|piraeus|thessaloniki|izmir|aliaga|iskenderun|mersin|antalya|derince|izmit|istanbul|marmara|bandirma|suez|port.?said|alexandria|damietta|limassol|larnaca|haifa|ashdod|beirut|lattakia|tartus/.test(p)) return 'med';
   if (/rotterdam|amsterdam|antwerp|zeebrugge|ghent|dunkirk|le.?havre|rouen|brest|la.?pallice|bayonne|bilbao|santander|gijon|aviles|vigo|oporto|porto|lisbon|setubal|figueira|hamburg|bremerhaven|bremen|wilhelmshaven|emden|rostock|lubeck|gdansk|gdynia|szczecin|felixstowe|southampton|london|tilbury|teesport|sunderland|newcastle|immingham|grimsby|hull|liverpool|birkenhead|belfast|dublin|greenore|cork|oslo|gothenburg|goteborg|stavanger|bergen|haugesund|halsvik|aarhus|copenhagen|helsingborg|stockholm|helsinki|tallinn|riga|klaipeda/.test(p)) return 'atlantic';
+  // Fallback: try resolving the port name to its canonical name and re-classify.
+  // This handles aliases like "Nemrut Bay" → resolves to "Aliaga" (med),
+  // "Hereke" → "Marmara" (med), so canal detection works on vague port strings.
+  const resolved = resolvePort(port);
+  if (resolved && resolved.portName !== port) {
+    return _classifyPortBasin(resolved.portName);
+  }
+  // Second fallback: try vague descriptor resolution ("Eastern Central Greece" → Piraeus).
+  const vague = resolveVaguePort(port);
+  if (vague && vague.portName !== port) {
+    return _classifyPortBasin(vague.portName);
+  }
   return 'unknown';
 }
 
@@ -258,12 +271,14 @@ function _quoteBosporusSafe(vesselDwt: number): number {
 export const classifyPortBasin = _classifyPortBasin;
 export const routeTransitsBosporus = _routeTransitsBosporus;
 export const quoteBosporusSafe = _quoteBosporusSafe;
+export const routeTransitsSuez = _routeTransitsSuez;
+export const quoteSuezSafe = _quoteSuezSafe;
 
 /** Derive EU-ETS coverage flags from port names. Used by both the stored match path
  *  and the detail route to guarantee identical euLegPercent/originEu/destEu. */
 export function deriveEtsCoverage(loadPort?: string | null, dischargePort?: string | null) {
-  const rl = loadPort ? resolvePort(loadPort) : null;
-  const rd = dischargePort ? resolvePort(dischargePort) : null;
+  const rl = loadPort ? (resolvePort(loadPort) ?? resolveVaguePort(loadPort)) : null;
+  const rd = dischargePort ? (resolvePort(dischargePort) ?? resolveVaguePort(dischargePort)) : null;
   const originEu = isEuCountry(rl?.country ?? null);
   const destEu = isEuCountry(rd?.country ?? null);
   return { originEu, destEu, euLegPercent: (originEu || destEu) ? 1.0 : 0 };

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -7,6 +7,12 @@ import { resolvePort } from '@/lib/ports/resolve';
 import { resolveVaguePort } from '@/lib/ports/resolve-vague';
 import { isEuCountry } from '@/lib/validation/sanctions';
 import type { EconomicsResult } from '@/lib/types';
+import { parseLeadingNumber, parseConsumption, DEFAULT_CONSUMPTION_MT_PER_DAY } from './parse-vessel-fields';
+
+// Re-export pure parsers for existing server callers (e.g. session-buckets.ts).
+// They live in parse-vessel-fields.ts (no server deps) so client components can
+// import them without pulling better-sqlite3 into the client bundle.
+export { parseLeadingNumber, parseConsumption };
 
 // Ballpark base freight rates (USD/mt) per cargo class
 const BASE_RATES: Record<string, number> = {
@@ -31,7 +37,6 @@ const BASE_RATE_FALLBACK = 22;
 const DEFAULT_BUNKER_USD_PER_MT = 600;
 const DEFAULT_EUA_EUR = 65;
 const DEFAULT_SPEED_KTS = 12;
-const DEFAULT_CONSUMPTION_MT_PER_DAY = 25;
 const DEFAULT_VESSEL_VALUE_USD = 22_000_000;
 
 /**
@@ -54,57 +59,6 @@ export interface TceEstimate {
   freight_rate_source: FreightRateSource;
   /** Full deterministic voyage breakdown (additive, spec L2 #5). */
   breakdown: TCEBreakdown;
-}
-
-// Parse a leading number from strings like "12.5 knots", "25 mt/day", a raw
-// number (LLM-parsed fields can arrive as numbers, not strings), or a
-// ConfidenceField object ({ value, confidence, source_text }). Real/demo parsed
-// data stores speed/consumption as any of these despite the string typing, so
-// tolerate all rather than throw on `.match`.
-export function parseLeadingNumber(s: unknown): number {
-  if (s == null) return 0;
-  if (typeof s === 'number') return Number.isFinite(s) ? s : 0;
-  if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
-    return parseLeadingNumber((s as { value: unknown }).value);
-  }
-  if (typeof s !== 'string') return 0;
-  const m = s.match(/(\d+(?:\.\d+)?)/);
-  return m ? Number(m[1]) : 0;
-}
-
-// Matches an explicit MT/D unit: "3.7MT/D", "14 mt/day", "25 t/day"
-const MT_PER_DAY_RE = /(\d+(?:\.\d+)?)\s*(?:MT\/?D|mt\/?day|t\/day)/i;
-// Fuel-grade tokens that appear before the actual consumption figure
-const FUEL_GRADE_RE = /\b(?:IFO|VLSFO|LSMGO|MGO|HFO|HSFO)\s*\d+(?:\/\d+)?\b|M\/E|A\/E/gi;
-
-/**
- * Parse a fuel-consumption field, skipping fuel-grade tokens like "IFO 180".
- *
- * parseLeadingNumber grabs the first digit sequence, which is the grade number
- * (e.g. 180 from "IFO 180 M/E 3.7MT/D") rather than the actual MT/day figure.
- * This function looks for an explicit MT/D unit first; if absent it strips grade
- * tokens before falling back to a leading-number heuristic. Strings with no
- * recoverable consumption figure return DEFAULT_CONSUMPTION_MT_PER_DAY.
- */
-export function parseConsumption(s: unknown): number {
-  if (s == null) return DEFAULT_CONSUMPTION_MT_PER_DAY;
-  if (typeof s === 'number') return Number.isFinite(s) && s > 0 ? s : DEFAULT_CONSUMPTION_MT_PER_DAY;
-  if (typeof s === 'object' && 'value' in (s as Record<string, unknown>)) {
-    return parseConsumption((s as { value: unknown }).value);
-  }
-  if (typeof s !== 'string') return DEFAULT_CONSUMPTION_MT_PER_DAY;
-  const str = s.trim();
-  if (!str) return DEFAULT_CONSUMPTION_MT_PER_DAY;
-
-  const mtd = str.match(MT_PER_DAY_RE);
-  if (mtd) return Number(mtd[1]);
-
-  // Strip fuel-grade tokens then try a plain leading number
-  const stripped = str.replace(FUEL_GRADE_RE, ' ').replace(/\s+/g, ' ').trim();
-  const m = stripped.match(/(\d+(?:\.\d+)?)/);
-  if (m) return Number(m[1]);
-
-  return DEFAULT_CONSUMPTION_MT_PER_DAY;
 }
 
 // Distance multiplier for Tier-3 fallback. Short coastal routes (<1000nm) firmed


### PR DESCRIPTION
## Проблема
TCE/день на странице **списка матчей** не совпадал с **«Daily TCE»** на странице деталей (`/match/[id]`, калькулятор) — на ~98% матчей. Корень: **два независимых живых движка** TCE расходятся по входам (список: `computeStoredMatchEconomics`→`buildMatchEconomics`; деталь: `/api/voyage/tce`→`calculateTCE`).

## Замер (ground-truth, скрипт-эталон по всем 244 измеримым демо-матчам)
- **До:** 0/244 совпадали, 233 (97.5%) расходились >5%.
- **После:** **244/244 совпадают до доллара**, 0 расхождений.

## 6 причин и фиксы (все — выравнивание на РЕАЛЬНЫЕ рыночные входы)
1. **Бункер (79% разрыва, все матчи)** — список считал по заглушке $600/т, деталь — по живой цене из БД (~$791). `persist-session-matches.ts` + `compute-matches.ts` теперь передают живую `getLatestBunkerPrice(db,'NLRTM','VLSFO')` в общий хелпер (он уже принимал параметр).
2. **Канал Суэц (15%)** — список добавлял Суэц, деталь нет. Экспортированы `routeTransitsSuez/quoteSuezSafe`; route авто-определяет Суэц (laden + ballast) внутри существующего guard'а (без двойного списания на явный `canalUsd/viaSuez`).
3. **EU ETS (6%)** — `deriveEtsCoverage` теперь резолвит размытые брокерские порты (`resolvePort ?? resolveVaguePort`), как деталь → корректный ETS на внутри-ЕС маршрутах.
4. **Распознавание портов** — алиас «Giurgiuleshti» (реальный молдавский порт MDGIU) → деталь больше не отвергает порт, который принимает список.
5. **Потребление топлива** — `EconomicsTab` использует `parseConsumption` вместо `parseLeadingNumber` (на «IFO 180 ME 3.7 MT/D» старый парсер брал 180 т/сут вместо 3.7); шлёт `openPosition` для канала на балласте.
6. **Рекомендация бункера** — больше не перебивает молча порт headline'а (Med-маршруты уходили на GIGIB $771 vs список NLRTM $791). Рекомендация остаётся **подсказкой** «сэкономь $X», headline — на базовом порту = как список. Regression-тест пинит `bunkerPort==='NLRTM'`.

Длительность рейса и фрахт уже совпадали (#862). DA совпадает.

## Проверки
- `scripts/diag` эталон-аудит: **244/244 exact, diverging=0** (свой прогон).
- `npx tsc --noEmit`: clean.
- `npx jest` (parity + economics-tab + voyage routes): **219/219**.
- Independent review: SHIP (после правок ballast-guard + dead-code).

## Деплой
Реген НЕ нужен — список пересчитывается на лету при каждом заходе (`persistSessionMatches`), деталь тоже живая. После деплоя оба берут реальные рыночные входы автоматически. Следствие: TCE/день в демо станет ниже на топливоёмких рейсах (реальная цена топлива выше заглушки) — согласовано с фаундером.

🤖 Generated with [Claude Code](https://claude.com/claude-code)