### PR TITLE
fix(port-da): recalibrate DA to realistic values + fix list↔detail DA parity

### DIFF
--- a/lib/port-da/__tests__/match-da.test.ts
+++ b/lib/port-da/__tests__/match-da.test.ts
@@ -3,6 +3,13 @@ import { sumMatchPortDaUsd } from '@/lib/port-da/match-da';
 
 // Minimal in-memory port_da_estimates fixture mirroring the seed schema.
 // port codes confirmed: resolvePort('constanta')→ROCND, resolvePort('marmara')→TRMAR
+//
+// RC1 note (2026-06-08): the fixture was previously seeded with cargo_type='bulk'.
+// The old test was verifying a code path (passing lowercase cargoType → DB lookup)
+// that returned 0 rows against the real 'general'-only seed data, which is the
+// exact parity bug.  The fixture is now corrected to cargo_type='general' (matching
+// port-da-base.json), and cargoType is passed to sumMatchPortDaUsd but is deliberately
+// ignored inside (port infra costs are cargo-agnostic — see match-da.ts comment).
 function makeDb(): Database.Database {
   const db = new Database(':memory:');
   db.exec(`
@@ -15,16 +22,20 @@ function makeDb(): Database.Database {
   const ins = db.prepare(`INSERT INTO port_da_estimates
     (port_code,vessel_dwt_min,vessel_dwt_max,port_dues_usd,pilotage_usd,tugs_usd,
      stevedoring_usd_per_mt,cargo_type,confidence,source) VALUES (?,?,?,?,?,?,?,?,?,?)`);
-  // Constanta (ROCND): 10k + 5k + 3k = 18k fixed (cargo_type='bulk' matches lower-cased 'BULK')
-  ins.run('ROCND', 0, 100000, 10000, 5000, 3000, 2, 'bulk', 'verified', 'seed');
+  // Constanta (ROCND): 10k + 5k + 3k = 18k fixed (cargo_type='general' — the only
+  // type in the real seed; sumMatchPortDaUsd ignores the cargoType argument and
+  // resolves against 'general' for parity with the detail route).
+  ins.run('ROCND', 0, 100000, 10000, 5000, 3000, 2, 'general', 'verified', 'seed');
   // Marmara (TRMAR): 8k + 4k + 2k = 14k fixed
-  ins.run('TRMAR', 0, 100000, 8000, 4000, 2000, 2, 'bulk', 'verified', 'seed');
+  ins.run('TRMAR', 0, 100000, 8000, 4000, 2000, 2, 'general', 'verified', 'seed');
   return db;
 }
 
 describe('sumMatchPortDaUsd', () => {
   test('sums totalFixedUsd across both resolvable ports', () => {
     const db = makeDb();
+    // cargoType='bulk' is accepted in the signature but ignored inside — DA resolves
+    // against 'general' rows regardless, matching the detail-route behaviour.
     const total = sumMatchPortDaUsd(['constanta', 'marmara'], 30000, 'bulk', db);
     expect(total).toBe(18000 + 14000);
     db.close();

--- a/lib/port-da/match-da.ts
+++ b/lib/port-da/match-da.ts
@@ -10,15 +10,25 @@ import { resolvePort } from '@/lib/ports/resolve';
  * (port dues + pilotage + tugs) for the load and discharge ports, and both treat a
  * missing/unresolvable port as a 0 contribution rather than crashing or inventing a number.
  *
+ * Port infrastructure costs (dues, pilotage, tugs) are cargo-agnostic — the same
+ * pilot and tug service is rendered regardless of whether the vessel carries bulk,
+ * general cargo, or containers.  The seed data is 'general'-only, so passing the
+ * cargo-specific type (e.g. 'bulk') was silently returning 0 rows and dropping DA
+ * from the list TCE entirely.  We always resolve against the 'general' tariff row
+ * (getPortDa default), matching exactly what resolveDaUsd in the detail route does
+ * (it passes cargoType from the optional request field, which is absent in the
+ * standard TCE call-path and therefore also falls through to 'general').
+ *
  * @param portNames  free-text port names (load, discharge); null/empty entries skipped
  * @param vesselDwt  vessel DWT for the DA band lookup
- * @param cargoType  free-text cargo class; getPortDa maps unknown → 'general'
+ * @param _cargoType unused — kept in the signature for call-site compatibility;
+ *                   DA lookup is always cargo-agnostic ('general' default)
  * @param db         match-path db handle (port_da_estimates lives in demo-seed.db)
  */
 export function sumMatchPortDaUsd(
   portNames: Array<string | null | undefined>,
   vesselDwt: number,
-  cargoType: string | null | undefined,
+  _cargoType: string | null | undefined,
   db: Database.Database,
 ): number {
   let total = 0;
@@ -27,10 +37,10 @@ export function sumMatchPortDaUsd(
     try {
       const resolved = resolvePort(name);
       if (!resolved) continue;
-      const da = getPortDa(
-        { port: resolved, vesselDwt, cargoType: cargoType?.toLowerCase() },
-        db,
-      );
+      // Pass cargoType=undefined → getPortDa resolves to 'general' (the only seed
+      // cargo type).  This mirrors resolveDaUsd in the detail route and guarantees
+      // list DA == detail DA for the same (port, dwt) pair.
+      const da = getPortDa({ port: resolved, vesselDwt }, db);
       if (da) total += da.totalFixedUsd;
     } catch {
       // Unresolvable port / lookup failure → 0 contribution (matches detail page).

--- a/scripts/diag/recalibrate-port-da.ts
+++ b/scripts/diag/recalibrate-port-da.ts
@@ -1,0 +1,162 @@
+/**
+ * recalibrate-port-da.ts
+ *
+ * De-inflates port-da-base.json by applying web-researched divisors
+ * (VDA / DPWorld / Marlo benchmarks 2026-06-08):
+ *
+ *   port_dues_usd  ÷ 2
+ *   pilotage_usd   ÷ 6
+ *   tugs_usd       ÷ 2.5
+ *
+ * Each result is rounded to the nearest $100.
+ * stevedoring_usd_per_mt, DWT bands, cargo_type, vessel codes are untouched.
+ * source is updated to reflect the recalibration event.
+ * confidence stays 'estimated'.
+ *
+ * Usage:
+ *   npx tsx scripts/diag/recalibrate-port-da.ts
+ *
+ * Prints a before/after table for TRISK, ROCND, NLRTM, GBLIV, TRALI
+ * plus min/median/max across all 54 ports for the 1000-9999 DWT bracket,
+ * then writes the result back to scripts/seed-data/port-da-base.json.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BASE_PATH = path.join(__dirname, '..', 'seed-data', 'port-da-base.json');
+const NEW_SOURCE = 'recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)';
+
+interface Bracket {
+  vessel_dwt_min: number;
+  vessel_dwt_max: number;
+  port_dues_usd: number;
+  pilotage_usd: number;
+  tugs_usd: number;
+  stevedoring_usd_per_mt: number;
+  cargo_type: string;
+  confidence: string;
+  source: string;
+}
+
+interface PortEntry {
+  port_code: string;
+  port_name: string;
+  brackets: Bracket[];
+}
+
+function round100(v: number): number {
+  return Math.round(v / 100) * 100;
+}
+
+function recalibrateBracket(b: Bracket): Bracket {
+  return {
+    ...b,
+    port_dues_usd: round100(b.port_dues_usd / 2),
+    pilotage_usd: round100(b.pilotage_usd / 6),
+    tugs_usd: round100(b.tugs_usd / 2.5),
+    source: NEW_SOURCE,
+  };
+}
+
+function main(): void {
+  const raw = fs.readFileSync(BASE_PATH, 'utf8');
+  const data: PortEntry[] = JSON.parse(raw);
+
+  // -------------------------------------------------------------------------
+  // Spot-check report: TRISK, ROCND, NLRTM, GBLIV, TRALI (1000-9999 bracket)
+  // -------------------------------------------------------------------------
+  const REPORT_CODES = ['TRISK', 'ROCND', 'NLRTM', 'GBLIV', 'TRALI'];
+  const SMALL_DWT_TEST = 5000; // falls in 1000-9999
+
+  console.log('\n=== Before/After for key ports (lowest DWT bracket) ===\n');
+  console.log(
+    'Port     DWT-band          BEFORE total    AFTER total   (dues/pilot/tugs)\n' +
+    '-'.repeat(78),
+  );
+
+  for (const port of data) {
+    if (!REPORT_CODES.includes(port.port_code)) continue;
+    for (const b of port.brackets) {
+      if (!(b.vessel_dwt_min <= SMALL_DWT_TEST && b.vessel_dwt_max >= SMALL_DWT_TEST)) continue;
+      const oldTotal = b.port_dues_usd + b.pilotage_usd + b.tugs_usd;
+      const nb = recalibrateBracket(b);
+      const newTotal = nb.port_dues_usd + nb.pilotage_usd + nb.tugs_usd;
+      console.log(
+        `${port.port_code.padEnd(8)} ` +
+        `${String(b.vessel_dwt_min).padStart(5)}-${String(b.vessel_dwt_max).padEnd(7)} ` +
+        `$${String(oldTotal).padStart(8)} → $${String(newTotal).padStart(8)}  ` +
+        `(${nb.port_dues_usd}/${nb.pilotage_usd}/${nb.tugs_usd})`,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Min/median/max for the 1000-9999 bracket across all 54 ports
+  // -------------------------------------------------------------------------
+  const oldTotals: number[] = [];
+  const newTotals: number[] = [];
+
+  for (const port of data) {
+    for (const b of port.brackets) {
+      if (!(b.vessel_dwt_min <= SMALL_DWT_TEST && b.vessel_dwt_max >= SMALL_DWT_TEST)) continue;
+      const nb = recalibrateBracket(b);
+      oldTotals.push(b.port_dues_usd + b.pilotage_usd + b.tugs_usd);
+      newTotals.push(nb.port_dues_usd + nb.pilotage_usd + nb.tugs_usd);
+    }
+  }
+
+  function median(arr: number[]): number {
+    const s = [...arr].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+  }
+
+  console.log('\n=== Min/median/max across all 54 ports (1 000-9 999 DWT bracket) ===\n');
+  console.log(`  OLD: min=$${Math.min(...oldTotals).toLocaleString()}  median=$${median(oldTotals).toLocaleString()}  max=$${Math.max(...oldTotals).toLocaleString()}`);
+  console.log(`  NEW: min=$${Math.min(...newTotals).toLocaleString()}  median=$${median(newTotals).toLocaleString()}  max=$${Math.max(...newTotals).toLocaleString()}`);
+
+  // -------------------------------------------------------------------------
+  // Validate web-research targets for TRISK and ROCND
+  // -------------------------------------------------------------------------
+  const targetRanges: Record<string, [number, number]> = {
+    TRISK: [10_000, 14_000], // research range $10-14k
+    ROCND: [12_000, 20_000], // research range $12-20k
+  };
+
+  let allInRange = true;
+  for (const port of data) {
+    const range = targetRanges[port.port_code];
+    if (!range) continue;
+    for (const b of port.brackets) {
+      if (!(b.vessel_dwt_min <= SMALL_DWT_TEST && b.vessel_dwt_max >= SMALL_DWT_TEST)) continue;
+      const nb = recalibrateBracket(b);
+      const newTotal = nb.port_dues_usd + nb.pilotage_usd + nb.tugs_usd;
+      const [lo, hi] = range;
+      if (newTotal < lo || newTotal > hi) {
+        console.warn(
+          `\nWARN: ${port.port_code} new total $${newTotal.toLocaleString()} outside research range $${lo.toLocaleString()}-$${hi.toLocaleString()} — divisors still applied uniformly`,
+        );
+        allInRange = false;
+      } else {
+        console.log(`\nOK: ${port.port_code} new total $${newTotal.toLocaleString()} is within research range $${lo.toLocaleString()}-$${hi.toLocaleString()}`);
+      }
+    }
+  }
+  if (allInRange) {
+    console.log('\nAll validated ports are within web-research ranges. ✓');
+  }
+
+  // -------------------------------------------------------------------------
+  // Apply recalibration to all brackets and write output
+  // -------------------------------------------------------------------------
+  const recalibrated: PortEntry[] = data.map((port) => ({
+    ...port,
+    brackets: port.brackets.map(recalibrateBracket),
+  }));
+
+  fs.writeFileSync(BASE_PATH, JSON.stringify(recalibrated, null, 2) + '\n', 'utf8');
+  console.log(`\nWrote recalibrated data to ${BASE_PATH}\n`);
+}
+
+main();

--- a/scripts/diag/verify-port-da-recalibration.ts
+++ b/scripts/diag/verify-port-da-recalibration.ts
@@ -1,0 +1,192 @@
+/**
+ * verify-port-da-recalibration.ts
+ *
+ * Part C verification: builds an in-memory SQLite DB, seeds port_da_estimates
+ * from the recalibrated port-da-base.json using the REAL seedPortDa function,
+ * then verifies for the SEAGULL 71 Iskenderun→Constanța scenario (DWT 8100, BULK):
+ *
+ *   (1) DA is now realistic (combined ≈ $24-32k, NOT the old $65.6k)
+ *   (2) LIST DA == DETAIL DA (parity, delta 0) — the parity bug is fixed
+ *   (3) LIST TCE == DETAIL TCE (delta 0)
+ *
+ * Usage:
+ *   npx tsx scripts/diag/verify-port-da-recalibration.ts
+ */
+
+import Database from 'better-sqlite3';
+import * as path from 'path';
+import * as fs from 'fs';
+import { runMigrations } from '../../lib/migrations/runner';
+import { allMigrations } from '../../lib/migrations/index';
+import { seedPortDa, type BaselinePort, type LlmCaller, type LlmGapBracket } from '../seed-port-da';
+import { getPortDa } from '../../lib/port-da/repository';
+import { sumMatchPortDaUsd } from '../../lib/port-da/match-da';
+import { computeEstimatedTce, estimateFreightRate, deriveEtsCoverage, routeTransitsBosporus, quoteBosporusSafe } from '../../lib/matching/tce-calculator';
+import { buildCanonicalTceInputs } from '../../lib/economics/canonical-tce-inputs';
+import { calculateTCE } from '../../lib/economics/voyage-calculator';
+
+// ─── Scenario: SEAGULL 71 ───────────────────────────────────────────────────
+const VESSEL_DWT = 8100;
+const CARGO_TYPE = 'BULK'; // as passed from matching layer
+const LOAD_PORT = 'Iskenderun';
+const DISCHARGE_PORT = 'Constanta';
+const SPEED_KTS = 12;
+const CONSUMPTION_MT_PER_DAY = 14;
+const DISTANCE_NM = 590; // Iskenderun → Constanța via Bosporus
+
+// Default economic parameters (same as computeEstimatedTce defaults in tce-calculator.ts)
+const BUNKER_USD_MT = 600;
+const EUA_EUR = 65;
+const VESSEL_VALUE_USD = 22_000_000;
+
+// No-op LLM caller (we only care about baseline brackets, not gap-fill)
+const noopLlmCaller: LlmCaller = async (
+  _model, _portCode, _portName, _bracketName, dwtMin, dwtMax,
+): Promise<LlmGapBracket> => ({
+  vessel_dwt_min: dwtMin,
+  vessel_dwt_max: dwtMax,
+  port_dues_usd: 20000,
+  pilotage_usd: 5000,
+  tugs_usd: 8000,
+  stevedoring_usd_per_mt: 5.0,
+  confidence: 'estimated',
+});
+
+async function main(): Promise<void> {
+  // ── Build in-memory DB and seed from recalibrated JSON ─────────────────────
+  const db = new Database(':memory:');
+  runMigrations(db, allMigrations);
+
+  const baselinePath = path.join(__dirname, '..', 'seed-data', 'port-da-base.json');
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8')) as BaselinePort[];
+  await seedPortDa(db, baseline, noopLlmCaller);
+
+  const { count: daRows } = db.prepare<[], { count: number }>(
+    'SELECT COUNT(*) AS count FROM port_da_estimates',
+  ).get()!;
+  console.log(`\nSeeded ${daRows} port_da_estimates rows from recalibrated JSON.`);
+
+  // ── Verify individual port DA values ────────────────────────────────────────
+  const iskDA = getPortDa({ portCode: 'TRISK', vesselDwt: VESSEL_DWT }, db);
+  const cndDA = getPortDa({ portCode: 'ROCND', vesselDwt: VESSEL_DWT }, db);
+
+  console.log('\n=== DA lookup for DWT ' + VESSEL_DWT + ' ===');
+  console.log(`TRISK (Iskenderun): ${iskDA ? `$${iskDA.totalFixedUsd.toLocaleString()} (dues=${iskDA.portDuesUsd} pilot=${iskDA.pilotageUsd} tugs=${iskDA.tugsUsd})` : 'NULL'}`);
+  console.log(`ROCND (Constanța):  ${cndDA ? `$${cndDA.totalFixedUsd.toLocaleString()} (dues=${cndDA.portDuesUsd} pilot=${cndDA.pilotageUsd} tugs=${cndDA.tugsUsd})` : 'NULL'}`);
+
+  const combinedDA = (iskDA?.totalFixedUsd ?? 0) + (cndDA?.totalFixedUsd ?? 0);
+  console.log(`\nCombined DA (both ports): $${combinedDA.toLocaleString()}`);
+
+  // ── Check (1): DA is realistic ───────────────────────────────────────────────
+  const DA_MIN = 20_000;
+  const DA_MAX = 36_000;
+  console.log(`\n(1) DA realistic? Range $${DA_MIN.toLocaleString()}–$${DA_MAX.toLocaleString()}:`);
+  if (combinedDA >= DA_MIN && combinedDA <= DA_MAX) {
+    console.log(`    PASS ✓  Combined DA $${combinedDA.toLocaleString()} is within $${DA_MIN.toLocaleString()}–$${DA_MAX.toLocaleString()}`);
+    console.log(`            (OLD inflated value was ~$65,600)`);
+  } else {
+    console.error(`    FAIL ✗  Combined DA $${combinedDA.toLocaleString()} outside expected range!`);
+    process.exit(1);
+  }
+
+  // ── Compute DA via LIST path (sumMatchPortDaUsd) ────────────────────────────
+  const listDA = sumMatchPortDaUsd([LOAD_PORT, DISCHARGE_PORT], VESSEL_DWT, CARGO_TYPE, db);
+
+  // ── Compute DA via DETAIL path (getPortDa per port, 'general' default) ──────
+  const iskResolved = db.prepare<[string, number, number, string], { port_dues_usd: number; pilotage_usd: number; tugs_usd: number }>(
+    'SELECT port_dues_usd, pilotage_usd, tugs_usd FROM port_da_estimates WHERE port_code = ? AND vessel_dwt_min <= ? AND vessel_dwt_max >= ? AND cargo_type = ? ORDER BY confidence DESC LIMIT 1',
+  ).get('TRISK', VESSEL_DWT, VESSEL_DWT, 'general');
+  const cndResolved = db.prepare<[string, number, number, string], { port_dues_usd: number; pilotage_usd: number; tugs_usd: number }>(
+    'SELECT port_dues_usd, pilotage_usd, tugs_usd FROM port_da_estimates WHERE port_code = ? AND vessel_dwt_min <= ? AND vessel_dwt_max >= ? AND cargo_type = ? ORDER BY confidence DESC LIMIT 1',
+  ).get('ROCND', VESSEL_DWT, VESSEL_DWT, 'general');
+  const detailDA = ((iskResolved?.port_dues_usd ?? 0) + (iskResolved?.pilotage_usd ?? 0) + (iskResolved?.tugs_usd ?? 0)) +
+                   ((cndResolved?.port_dues_usd ?? 0) + (cndResolved?.pilotage_usd ?? 0) + (cndResolved?.tugs_usd ?? 0));
+
+  console.log('\n=== DA parity: LIST vs DETAIL ===');
+  console.log(`LIST  DA (sumMatchPortDaUsd): $${listDA.toLocaleString()}`);
+  console.log(`DETAIL DA (getPortDa/general): $${detailDA.toLocaleString()}`);
+  console.log(`Delta: $${Math.abs(listDA - detailDA)}`);
+
+  // ── Check (2): LIST DA == DETAIL DA ─────────────────────────────────────────
+  console.log('\n(2) LIST DA == DETAIL DA?');
+  if (listDA === detailDA) {
+    console.log(`    PASS ✓  Both paths produce $${listDA.toLocaleString()} (delta 0)`);
+  } else {
+    console.error(`    FAIL ✗  LIST DA $${listDA.toLocaleString()} ≠ DETAIL DA $${detailDA.toLocaleString()} (delta $${Math.abs(listDA - detailDA)})`);
+    process.exit(1);
+  }
+
+  // ── Compute TCE via LIST path (computeEstimatedTce / buildMatchEconomics) ───
+  const freight = estimateFreightRate(CARGO_TYPE, DISTANCE_NM, VESSEL_DWT);
+  const { euLegPercent, originEu, destEu } = deriveEtsCoverage(LOAD_PORT, DISCHARGE_PORT);
+  const bosporusUsd = routeTransitsBosporus(LOAD_PORT, DISCHARGE_PORT)
+    ? quoteBosporusSafe(VESSEL_DWT)
+    : 0;
+
+  const listTce = computeEstimatedTce(
+    { rate: freight.rate, source: freight.source, confidence: freight.confidence },
+    DISTANCE_NM,
+    VESSEL_DWT,
+    Math.min(VESSEL_DWT * 0.9, VESSEL_DWT),
+    SPEED_KTS,
+    CONSUMPTION_MT_PER_DAY,
+    undefined,           // ballastDistanceNm
+    bosporusUsd > 0 ? bosporusUsd : undefined, // canal
+    listDA > 0 ? listDA : undefined,
+    BUNKER_USD_MT,
+    euLegPercent,
+    originEu,
+    destEu,
+    EUA_EUR,
+    true, // excludeWarRiskFromDailyTce
+  );
+
+  // ── Compute TCE via DETAIL path (calculateTCE) ───────────────────────────────
+  const canonicalInputs = buildCanonicalTceInputs({
+    vesselDwt: VESSEL_DWT,
+    speedKts: SPEED_KTS,
+    consumptionMtPerDay: CONSUMPTION_MT_PER_DAY,
+    distanceNm: DISTANCE_NM,
+    quantityMt: Math.min(VESSEL_DWT * 0.9, VESSEL_DWT),
+    freightRateUsdPerMt: freight.rate,
+    bunkerPriceUsdPerMt: BUNKER_USD_MT,
+    originPort: LOAD_PORT,
+    destinationPort: DISCHARGE_PORT,
+    euaPriceEur: EUA_EUR,
+    vesselValueUsd: VESSEL_VALUE_USD,
+    canalUsd: bosporusUsd > 0 ? bosporusUsd : undefined,
+    daUsd: detailDA > 0 ? detailDA : undefined,
+    euLegPercent,
+    originEu,
+    destEu,
+  });
+  const detailResult = calculateTCE({ ...canonicalInputs, excludeWarRiskFromDailyTce: true });
+
+  console.log('\n=== TCE parity: LIST vs DETAIL ===');
+  console.log(`Scenario: ${LOAD_PORT} → ${DISCHARGE_PORT}, DWT=${VESSEL_DWT}, dist=${DISTANCE_NM}nm`);
+  console.log(`Freight rate: $${freight.rate}/mt (${freight.source})`);
+  console.log(`Canal (Bosporus): $${bosporusUsd.toLocaleString()}`);
+  console.log(`LIST  DA: $${listDA.toLocaleString()}`);
+  console.log(`DETAIL DA: $${detailDA.toLocaleString()}`);
+  console.log(`LIST  TCE: $${listTce.tce_usd_per_day.toFixed(0)}/day`);
+  console.log(`DETAIL TCE: $${detailResult.daily_tce_usd.toFixed(0)}/day`);
+  console.log(`Delta: $${Math.abs(listTce.tce_usd_per_day - detailResult.daily_tce_usd).toFixed(2)}`);
+
+  // ── Check (3): LIST TCE == DETAIL TCE ───────────────────────────────────────
+  const tceDelta = Math.abs(listTce.tce_usd_per_day - detailResult.daily_tce_usd);
+  console.log('\n(3) LIST TCE == DETAIL TCE (±$1)?');
+  if (tceDelta <= 1) {
+    console.log(`    PASS ✓  Delta $${tceDelta.toFixed(2)} ≤ $1`);
+  } else {
+    console.error(`    FAIL ✗  TCE delta $${tceDelta.toFixed(2)} > $1 — parity broken!`);
+    process.exit(1);
+  }
+
+  console.log('\n══ ALL 3 CHECKS PASSED ══\n');
+  db.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/seed-data/port-da-base.json
+++ b/scripts/seed-data/port-da-base.json
@@ -6,35 +6,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 27500,
-        "pilotage_usd": 14900,
-        "tugs_usd": 12700,
-        "stevedoring_usd_per_mt": 9.0,
+        "port_dues_usd": 13800,
+        "pilotage_usd": 2500,
+        "tugs_usd": 5100,
+        "stevedoring_usd_per_mt": 9,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 50000,
-        "pilotage_usd": 27000,
-        "tugs_usd": 23000,
-        "stevedoring_usd_per_mt": 9.0,
+        "port_dues_usd": 25000,
+        "pilotage_usd": 4500,
+        "tugs_usd": 9200,
+        "stevedoring_usd_per_mt": 9,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 75000,
-        "pilotage_usd": 40500,
-        "tugs_usd": 34500,
+        "port_dues_usd": 37500,
+        "pilotage_usd": 6800,
+        "tugs_usd": 13800,
         "stevedoring_usd_per_mt": 8.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -45,35 +45,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 15100,
-        "pilotage_usd": 8200,
-        "tugs_usd": 6900,
+        "port_dues_usd": 7600,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2800,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 27500,
-        "pilotage_usd": 14900,
-        "tugs_usd": 12600,
+        "port_dues_usd": 13800,
+        "pilotage_usd": 2500,
+        "tugs_usd": 5000,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 41200,
-        "pilotage_usd": 22300,
-        "tugs_usd": 19000,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 20600,
+        "pilotage_usd": 3700,
+        "tugs_usd": 7600,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -84,68 +84,68 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 21400,
-        "pilotage_usd": 11600,
-        "tugs_usd": 9800,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 10700,
+        "pilotage_usd": 1900,
+        "tugs_usd": 3900,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 39000,
-        "pilotage_usd": 21100,
-        "tugs_usd": 17900,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 19500,
+        "pilotage_usd": 3500,
+        "tugs_usd": 7200,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 58500,
-        "pilotage_usd": 31600,
-        "tugs_usd": 26900,
+        "port_dues_usd": 29300,
+        "pilotage_usd": 5300,
+        "tugs_usd": 10800,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 65001,
         "vessel_dwt_max": 90000,
-        "port_dues_usd": 88000,
-        "pilotage_usd": 47000,
-        "tugs_usd": 40000,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 44000,
+        "pilotage_usd": 7800,
+        "tugs_usd": 16000,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 90001,
         "vessel_dwt_max": 150000,
-        "port_dues_usd": 116000,
-        "pilotage_usd": 62000,
-        "tugs_usd": 53000,
+        "port_dues_usd": 58000,
+        "pilotage_usd": 10300,
+        "tugs_usd": 21200,
         "stevedoring_usd_per_mt": 4.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 150001,
         "vessel_dwt_max": 200000,
-        "port_dues_usd": 148000,
-        "pilotage_usd": 80000,
-        "tugs_usd": 68000,
-        "stevedoring_usd_per_mt": 4.0,
+        "port_dues_usd": 74000,
+        "pilotage_usd": 13300,
+        "tugs_usd": 27200,
+        "stevedoring_usd_per_mt": 4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -156,35 +156,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 19800,
-        "pilotage_usd": 10700,
-        "tugs_usd": 9100,
+        "port_dues_usd": 9900,
+        "pilotage_usd": 1800,
+        "tugs_usd": 3600,
         "stevedoring_usd_per_mt": 5.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 36000,
-        "pilotage_usd": 19400,
-        "tugs_usd": 16600,
+        "port_dues_usd": 18000,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6600,
         "stevedoring_usd_per_mt": 5.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 54000,
-        "pilotage_usd": 29200,
-        "tugs_usd": 24800,
+        "port_dues_usd": 27000,
+        "pilotage_usd": 4900,
+        "tugs_usd": 9900,
         "stevedoring_usd_per_mt": 5.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -195,68 +195,68 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 18700,
-        "pilotage_usd": 10100,
-        "tugs_usd": 8600,
+        "port_dues_usd": 9400,
+        "pilotage_usd": 1700,
+        "tugs_usd": 3400,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 34000,
-        "pilotage_usd": 18400,
-        "tugs_usd": 15600,
+        "port_dues_usd": 17000,
+        "pilotage_usd": 3100,
+        "tugs_usd": 6200,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 51000,
-        "pilotage_usd": 27500,
-        "tugs_usd": 23500,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 25500,
+        "pilotage_usd": 4600,
+        "tugs_usd": 9400,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 65001,
         "vessel_dwt_max": 90000,
-        "port_dues_usd": 82000,
-        "pilotage_usd": 44000,
-        "tugs_usd": 38000,
+        "port_dues_usd": 41000,
+        "pilotage_usd": 7300,
+        "tugs_usd": 15200,
         "stevedoring_usd_per_mt": 5.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 90001,
         "vessel_dwt_max": 150000,
-        "port_dues_usd": 108000,
-        "pilotage_usd": 58000,
-        "tugs_usd": 49000,
+        "port_dues_usd": 54000,
+        "pilotage_usd": 9700,
+        "tugs_usd": 19600,
         "stevedoring_usd_per_mt": 4.7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 150001,
         "vessel_dwt_max": 200000,
-        "port_dues_usd": 138000,
-        "pilotage_usd": 74000,
-        "tugs_usd": 63000,
+        "port_dues_usd": 69000,
+        "pilotage_usd": 12300,
+        "tugs_usd": 25200,
         "stevedoring_usd_per_mt": 4.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -267,35 +267,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17000,
-        "pilotage_usd": 9200,
-        "tugs_usd": 7900,
+        "port_dues_usd": 8500,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3200,
         "stevedoring_usd_per_mt": 5.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 31000,
-        "pilotage_usd": 16700,
-        "tugs_usd": 14300,
+        "port_dues_usd": 15500,
+        "pilotage_usd": 2800,
+        "tugs_usd": 5700,
         "stevedoring_usd_per_mt": 5.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 46500,
-        "pilotage_usd": 25100,
-        "tugs_usd": 21400,
+        "port_dues_usd": 23300,
+        "pilotage_usd": 4200,
+        "tugs_usd": 8600,
         "stevedoring_usd_per_mt": 4.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -306,35 +306,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 16000,
-        "pilotage_usd": 8600,
-        "tugs_usd": 7300,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 8000,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2900,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 29000,
-        "pilotage_usd": 15700,
-        "tugs_usd": 13300,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 14500,
+        "pilotage_usd": 2600,
+        "tugs_usd": 5300,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 43500,
-        "pilotage_usd": 23500,
-        "tugs_usd": 20000,
+        "port_dues_usd": 21800,
+        "pilotage_usd": 3900,
+        "tugs_usd": 8000,
         "stevedoring_usd_per_mt": 4.6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -345,35 +345,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 15100,
-        "pilotage_usd": 8200,
-        "tugs_usd": 6900,
+        "port_dues_usd": 7600,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2800,
         "stevedoring_usd_per_mt": 4.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 27500,
-        "pilotage_usd": 14900,
-        "tugs_usd": 12600,
+        "port_dues_usd": 13800,
+        "pilotage_usd": 2500,
+        "tugs_usd": 5000,
         "stevedoring_usd_per_mt": 4.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 41200,
-        "pilotage_usd": 22300,
-        "tugs_usd": 19000,
+        "port_dues_usd": 20600,
+        "pilotage_usd": 3700,
+        "tugs_usd": 7600,
         "stevedoring_usd_per_mt": 4.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -384,35 +384,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 13800,
-        "pilotage_usd": 7400,
-        "tugs_usd": 6300,
+        "port_dues_usd": 6900,
+        "pilotage_usd": 1200,
+        "tugs_usd": 2500,
         "stevedoring_usd_per_mt": 4.6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 25000,
-        "pilotage_usd": 13500,
-        "tugs_usd": 11500,
+        "port_dues_usd": 12500,
+        "pilotage_usd": 2300,
+        "tugs_usd": 4600,
         "stevedoring_usd_per_mt": 4.6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 37500,
-        "pilotage_usd": 20200,
-        "tugs_usd": 17300,
+        "port_dues_usd": 18800,
+        "pilotage_usd": 3400,
+        "tugs_usd": 6900,
         "stevedoring_usd_per_mt": 4.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -423,35 +423,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 15100,
-        "pilotage_usd": 8200,
-        "tugs_usd": 6900,
+        "port_dues_usd": 7600,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2800,
         "stevedoring_usd_per_mt": 4.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 27500,
-        "pilotage_usd": 14900,
-        "tugs_usd": 12600,
+        "port_dues_usd": 13800,
+        "pilotage_usd": 2500,
+        "tugs_usd": 5000,
         "stevedoring_usd_per_mt": 4.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 41200,
-        "pilotage_usd": 22300,
-        "tugs_usd": 19000,
-        "stevedoring_usd_per_mt": 4.0,
+        "port_dues_usd": 20600,
+        "pilotage_usd": 3700,
+        "tugs_usd": 7600,
+        "stevedoring_usd_per_mt": 4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -462,35 +462,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 14300,
-        "pilotage_usd": 7700,
-        "tugs_usd": 6600,
+        "port_dues_usd": 7200,
+        "pilotage_usd": 1300,
+        "tugs_usd": 2600,
         "stevedoring_usd_per_mt": 4.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 26000,
-        "pilotage_usd": 14000,
-        "tugs_usd": 12000,
+        "port_dues_usd": 13000,
+        "pilotage_usd": 2300,
+        "tugs_usd": 4800,
         "stevedoring_usd_per_mt": 4.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 39000,
-        "pilotage_usd": 21100,
-        "tugs_usd": 17900,
+        "port_dues_usd": 19500,
+        "pilotage_usd": 3500,
+        "tugs_usd": 7200,
         "stevedoring_usd_per_mt": 4.1,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -501,35 +501,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 13200,
-        "pilotage_usd": 7200,
-        "tugs_usd": 6100,
+        "port_dues_usd": 6600,
+        "pilotage_usd": 1200,
+        "tugs_usd": 2400,
         "stevedoring_usd_per_mt": 4.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 24000,
-        "pilotage_usd": 13000,
-        "tugs_usd": 11000,
+        "port_dues_usd": 12000,
+        "pilotage_usd": 2200,
+        "tugs_usd": 4400,
         "stevedoring_usd_per_mt": 4.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 36000,
-        "pilotage_usd": 19400,
-        "tugs_usd": 16600,
+        "port_dues_usd": 18000,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6600,
         "stevedoring_usd_per_mt": 3.9,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -540,35 +540,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 19200,
-        "pilotage_usd": 10400,
-        "tugs_usd": 8900,
+        "port_dues_usd": 9600,
+        "pilotage_usd": 1700,
+        "tugs_usd": 3600,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 35000,
-        "pilotage_usd": 18900,
-        "tugs_usd": 16100,
+        "port_dues_usd": 17500,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6400,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 52500,
-        "pilotage_usd": 28400,
-        "tugs_usd": 24100,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 26300,
+        "pilotage_usd": 4700,
+        "tugs_usd": 9600,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -579,35 +579,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 26100,
-        "pilotage_usd": 14100,
-        "tugs_usd": 12000,
+        "port_dues_usd": 13100,
+        "pilotage_usd": 2400,
+        "tugs_usd": 4800,
         "stevedoring_usd_per_mt": 8.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 47500,
-        "pilotage_usd": 25600,
-        "tugs_usd": 21900,
+        "port_dues_usd": 23800,
+        "pilotage_usd": 4300,
+        "tugs_usd": 8800,
         "stevedoring_usd_per_mt": 8.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 71200,
-        "pilotage_usd": 38500,
-        "tugs_usd": 32800,
+        "port_dues_usd": 35600,
+        "pilotage_usd": 6400,
+        "tugs_usd": 13100,
         "stevedoring_usd_per_mt": 8.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -618,35 +618,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17900,
-        "pilotage_usd": 9700,
-        "tugs_usd": 8200,
+        "port_dues_usd": 9000,
+        "pilotage_usd": 1600,
+        "tugs_usd": 3300,
         "stevedoring_usd_per_mt": 6.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 32500,
-        "pilotage_usd": 17600,
-        "tugs_usd": 14900,
+        "port_dues_usd": 16300,
+        "pilotage_usd": 2900,
+        "tugs_usd": 6000,
         "stevedoring_usd_per_mt": 6.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 48800,
-        "pilotage_usd": 26300,
-        "tugs_usd": 22400,
+        "port_dues_usd": 24400,
+        "pilotage_usd": 4400,
+        "tugs_usd": 9000,
         "stevedoring_usd_per_mt": 5.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -657,35 +657,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17000,
-        "pilotage_usd": 9200,
-        "tugs_usd": 7900,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 8500,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3200,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 31000,
-        "pilotage_usd": 16700,
-        "tugs_usd": 14300,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 15500,
+        "pilotage_usd": 2800,
+        "tugs_usd": 5700,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 46500,
-        "pilotage_usd": 25100,
-        "tugs_usd": 21400,
+        "port_dues_usd": 23300,
+        "pilotage_usd": 4200,
+        "tugs_usd": 8600,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -696,35 +696,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17900,
-        "pilotage_usd": 9700,
-        "tugs_usd": 8200,
+        "port_dues_usd": 9000,
+        "pilotage_usd": 1600,
+        "tugs_usd": 3300,
         "stevedoring_usd_per_mt": 6.1,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 32500,
-        "pilotage_usd": 17600,
-        "tugs_usd": 14900,
+        "port_dues_usd": 16300,
+        "pilotage_usd": 2900,
+        "tugs_usd": 6000,
         "stevedoring_usd_per_mt": 6.1,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 48800,
-        "pilotage_usd": 26300,
-        "tugs_usd": 22400,
+        "port_dues_usd": 24400,
+        "pilotage_usd": 4400,
+        "tugs_usd": 9000,
         "stevedoring_usd_per_mt": 5.6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -735,35 +735,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 19200,
-        "pilotage_usd": 10400,
-        "tugs_usd": 8900,
+        "port_dues_usd": 9600,
+        "pilotage_usd": 1700,
+        "tugs_usd": 3600,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 35000,
-        "pilotage_usd": 18900,
-        "tugs_usd": 16100,
+        "port_dues_usd": 17500,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6400,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 52500,
-        "pilotage_usd": 28400,
-        "tugs_usd": 24100,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 26300,
+        "pilotage_usd": 4700,
+        "tugs_usd": 9600,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -774,35 +774,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 21400,
-        "pilotage_usd": 11600,
-        "tugs_usd": 9800,
+        "port_dues_usd": 10700,
+        "pilotage_usd": 1900,
+        "tugs_usd": 3900,
         "stevedoring_usd_per_mt": 7.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 39000,
-        "pilotage_usd": 21100,
-        "tugs_usd": 17900,
+        "port_dues_usd": 19500,
+        "pilotage_usd": 3500,
+        "tugs_usd": 7200,
         "stevedoring_usd_per_mt": 7.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 58500,
-        "pilotage_usd": 31600,
-        "tugs_usd": 26900,
+        "port_dues_usd": 29300,
+        "pilotage_usd": 5300,
+        "tugs_usd": 10800,
         "stevedoring_usd_per_mt": 6.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -813,35 +813,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 15100,
-        "pilotage_usd": 8200,
-        "tugs_usd": 6900,
+        "port_dues_usd": 7600,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2800,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 27500,
-        "pilotage_usd": 14900,
-        "tugs_usd": 12600,
+        "port_dues_usd": 13800,
+        "pilotage_usd": 2500,
+        "tugs_usd": 5000,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 41200,
-        "pilotage_usd": 22300,
-        "tugs_usd": 19000,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 20600,
+        "pilotage_usd": 3700,
+        "tugs_usd": 7600,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -852,35 +852,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 19800,
-        "pilotage_usd": 10700,
-        "tugs_usd": 9100,
-        "stevedoring_usd_per_mt": 7.0,
+        "port_dues_usd": 9900,
+        "pilotage_usd": 1800,
+        "tugs_usd": 3600,
+        "stevedoring_usd_per_mt": 7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 36000,
-        "pilotage_usd": 19400,
-        "tugs_usd": 16600,
-        "stevedoring_usd_per_mt": 7.0,
+        "port_dues_usd": 18000,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6600,
+        "stevedoring_usd_per_mt": 7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 54000,
-        "pilotage_usd": 29200,
-        "tugs_usd": 24800,
+        "port_dues_usd": 27000,
+        "pilotage_usd": 4900,
+        "tugs_usd": 9900,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -891,35 +891,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 25300,
-        "pilotage_usd": 13600,
-        "tugs_usd": 11700,
-        "stevedoring_usd_per_mt": 8.0,
+        "port_dues_usd": 12700,
+        "pilotage_usd": 2300,
+        "tugs_usd": 4700,
+        "stevedoring_usd_per_mt": 8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 46000,
-        "pilotage_usd": 24800,
-        "tugs_usd": 21200,
-        "stevedoring_usd_per_mt": 8.0,
+        "port_dues_usd": 23000,
+        "pilotage_usd": 4100,
+        "tugs_usd": 8500,
+        "stevedoring_usd_per_mt": 8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 69000,
-        "pilotage_usd": 37300,
-        "tugs_usd": 31700,
+        "port_dues_usd": 34500,
+        "pilotage_usd": 6200,
+        "tugs_usd": 12700,
         "stevedoring_usd_per_mt": 7.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -930,35 +930,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 22600,
-        "pilotage_usd": 12200,
-        "tugs_usd": 10400,
+        "port_dues_usd": 11300,
+        "pilotage_usd": 2000,
+        "tugs_usd": 4200,
         "stevedoring_usd_per_mt": 7.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 41000,
-        "pilotage_usd": 22100,
-        "tugs_usd": 18900,
+        "port_dues_usd": 20500,
+        "pilotage_usd": 3700,
+        "tugs_usd": 7600,
         "stevedoring_usd_per_mt": 7.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 61500,
-        "pilotage_usd": 33200,
-        "tugs_usd": 28300,
-        "stevedoring_usd_per_mt": 7.0,
+        "port_dues_usd": 30800,
+        "pilotage_usd": 5500,
+        "tugs_usd": 11300,
+        "stevedoring_usd_per_mt": 7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -969,35 +969,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 21400,
-        "pilotage_usd": 11600,
-        "tugs_usd": 9800,
+        "port_dues_usd": 10700,
+        "pilotage_usd": 1900,
+        "tugs_usd": 3900,
         "stevedoring_usd_per_mt": 7.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 39000,
-        "pilotage_usd": 21100,
-        "tugs_usd": 17900,
+        "port_dues_usd": 19500,
+        "pilotage_usd": 3500,
+        "tugs_usd": 7200,
         "stevedoring_usd_per_mt": 7.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 58500,
-        "pilotage_usd": 31600,
-        "tugs_usd": 26900,
+        "port_dues_usd": 29300,
+        "pilotage_usd": 5300,
+        "tugs_usd": 10800,
         "stevedoring_usd_per_mt": 6.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1008,35 +1008,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 23400,
-        "pilotage_usd": 12700,
-        "tugs_usd": 10700,
+        "port_dues_usd": 11700,
+        "pilotage_usd": 2100,
+        "tugs_usd": 4300,
         "stevedoring_usd_per_mt": 7.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 42500,
-        "pilotage_usd": 23000,
-        "tugs_usd": 19500,
+        "port_dues_usd": 21300,
+        "pilotage_usd": 3800,
+        "tugs_usd": 7800,
         "stevedoring_usd_per_mt": 7.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 63800,
-        "pilotage_usd": 34400,
-        "tugs_usd": 29300,
+        "port_dues_usd": 31900,
+        "pilotage_usd": 5700,
+        "tugs_usd": 11700,
         "stevedoring_usd_per_mt": 7.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1047,35 +1047,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 24200,
-        "pilotage_usd": 13100,
-        "tugs_usd": 11100,
-        "stevedoring_usd_per_mt": 8.0,
+        "port_dues_usd": 12100,
+        "pilotage_usd": 2200,
+        "tugs_usd": 4400,
+        "stevedoring_usd_per_mt": 8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 44000,
-        "pilotage_usd": 23800,
-        "tugs_usd": 20200,
-        "stevedoring_usd_per_mt": 8.0,
+        "port_dues_usd": 22000,
+        "pilotage_usd": 4000,
+        "tugs_usd": 8100,
+        "stevedoring_usd_per_mt": 8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 66000,
-        "pilotage_usd": 35600,
-        "tugs_usd": 30400,
+        "port_dues_usd": 33000,
+        "pilotage_usd": 5900,
+        "tugs_usd": 12200,
         "stevedoring_usd_per_mt": 7.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1086,35 +1086,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 24800,
-        "pilotage_usd": 13400,
-        "tugs_usd": 11400,
+        "port_dues_usd": 12400,
+        "pilotage_usd": 2200,
+        "tugs_usd": 4600,
         "stevedoring_usd_per_mt": 8.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 45000,
-        "pilotage_usd": 24300,
-        "tugs_usd": 20700,
+        "port_dues_usd": 22500,
+        "pilotage_usd": 4100,
+        "tugs_usd": 8300,
         "stevedoring_usd_per_mt": 8.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 67500,
-        "pilotage_usd": 36400,
-        "tugs_usd": 31100,
+        "port_dues_usd": 33800,
+        "pilotage_usd": 6100,
+        "tugs_usd": 12400,
         "stevedoring_usd_per_mt": 7.7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1125,35 +1125,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 23400,
-        "pilotage_usd": 12700,
-        "tugs_usd": 10700,
+        "port_dues_usd": 11700,
+        "pilotage_usd": 2100,
+        "tugs_usd": 4300,
         "stevedoring_usd_per_mt": 7.9,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 42500,
-        "pilotage_usd": 23000,
-        "tugs_usd": 19500,
+        "port_dues_usd": 21300,
+        "pilotage_usd": 3800,
+        "tugs_usd": 7800,
         "stevedoring_usd_per_mt": 7.9,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 63800,
-        "pilotage_usd": 34400,
-        "tugs_usd": 29300,
+        "port_dues_usd": 31900,
+        "pilotage_usd": 5700,
+        "tugs_usd": 11700,
         "stevedoring_usd_per_mt": 7.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1164,35 +1164,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17000,
-        "pilotage_usd": 9200,
-        "tugs_usd": 7900,
+        "port_dues_usd": 8500,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3200,
         "stevedoring_usd_per_mt": 6.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 31000,
-        "pilotage_usd": 16700,
-        "tugs_usd": 14300,
+        "port_dues_usd": 15500,
+        "pilotage_usd": 2800,
+        "tugs_usd": 5700,
         "stevedoring_usd_per_mt": 6.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 46500,
-        "pilotage_usd": 25100,
-        "tugs_usd": 21400,
+        "port_dues_usd": 23300,
+        "pilotage_usd": 4200,
+        "tugs_usd": 8600,
         "stevedoring_usd_per_mt": 5.7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1203,35 +1203,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 16500,
-        "pilotage_usd": 8900,
-        "tugs_usd": 7600,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 8300,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3000,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 30000,
-        "pilotage_usd": 16200,
-        "tugs_usd": 13800,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 15000,
+        "pilotage_usd": 2700,
+        "tugs_usd": 5500,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 45000,
-        "pilotage_usd": 24300,
-        "tugs_usd": 20700,
+        "port_dues_usd": 22500,
+        "pilotage_usd": 4100,
+        "tugs_usd": 8300,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1242,68 +1242,68 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 24800,
-        "pilotage_usd": 13400,
-        "tugs_usd": 11400,
+        "port_dues_usd": 12400,
+        "pilotage_usd": 2200,
+        "tugs_usd": 4600,
         "stevedoring_usd_per_mt": 7.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 45000,
-        "pilotage_usd": 24300,
-        "tugs_usd": 20700,
+        "port_dues_usd": 22500,
+        "pilotage_usd": 4100,
+        "tugs_usd": 8300,
         "stevedoring_usd_per_mt": 7.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 67500,
-        "pilotage_usd": 36400,
-        "tugs_usd": 31100,
-        "stevedoring_usd_per_mt": 7.0,
+        "port_dues_usd": 33800,
+        "pilotage_usd": 6100,
+        "tugs_usd": 12400,
+        "stevedoring_usd_per_mt": 7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 65001,
         "vessel_dwt_max": 90000,
-        "port_dues_usd": 110000,
-        "pilotage_usd": 60000,
-        "tugs_usd": 50000,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 55000,
+        "pilotage_usd": 10000,
+        "tugs_usd": 20000,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 90001,
         "vessel_dwt_max": 150000,
-        "port_dues_usd": 145000,
-        "pilotage_usd": 78000,
-        "tugs_usd": 67000,
+        "port_dues_usd": 72500,
+        "pilotage_usd": 13000,
+        "tugs_usd": 26800,
         "stevedoring_usd_per_mt": 4.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 150001,
         "vessel_dwt_max": 200000,
-        "port_dues_usd": 185000,
-        "pilotage_usd": 100000,
-        "tugs_usd": 86000,
-        "stevedoring_usd_per_mt": 4.0,
+        "port_dues_usd": 92500,
+        "pilotage_usd": 16700,
+        "tugs_usd": 34400,
+        "stevedoring_usd_per_mt": 4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1314,68 +1314,68 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 23400,
-        "pilotage_usd": 12700,
-        "tugs_usd": 10700,
+        "port_dues_usd": 11700,
+        "pilotage_usd": 2100,
+        "tugs_usd": 4300,
         "stevedoring_usd_per_mt": 7.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 42500,
-        "pilotage_usd": 23000,
-        "tugs_usd": 19500,
+        "port_dues_usd": 21300,
+        "pilotage_usd": 3800,
+        "tugs_usd": 7800,
         "stevedoring_usd_per_mt": 7.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 63800,
-        "pilotage_usd": 34400,
-        "tugs_usd": 29300,
+        "port_dues_usd": 31900,
+        "pilotage_usd": 5700,
+        "tugs_usd": 11700,
         "stevedoring_usd_per_mt": 6.9,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 65001,
         "vessel_dwt_max": 90000,
-        "port_dues_usd": 105000,
-        "pilotage_usd": 57000,
-        "tugs_usd": 49000,
+        "port_dues_usd": 52500,
+        "pilotage_usd": 9500,
+        "tugs_usd": 19600,
         "stevedoring_usd_per_mt": 5.2,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 90001,
         "vessel_dwt_max": 150000,
-        "port_dues_usd": 140000,
-        "pilotage_usd": 75000,
-        "tugs_usd": 64000,
+        "port_dues_usd": 70000,
+        "pilotage_usd": 12500,
+        "tugs_usd": 25600,
         "stevedoring_usd_per_mt": 4.6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 150001,
         "vessel_dwt_max": 200000,
-        "port_dues_usd": 178000,
-        "pilotage_usd": 96000,
-        "tugs_usd": 82000,
+        "port_dues_usd": 89000,
+        "pilotage_usd": 16000,
+        "tugs_usd": 32800,
         "stevedoring_usd_per_mt": 4.1,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1386,35 +1386,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 20600,
-        "pilotage_usd": 11100,
-        "tugs_usd": 9500,
+        "port_dues_usd": 10300,
+        "pilotage_usd": 1900,
+        "tugs_usd": 3800,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 37500,
-        "pilotage_usd": 20200,
-        "tugs_usd": 17300,
+        "port_dues_usd": 18800,
+        "pilotage_usd": 3400,
+        "tugs_usd": 6900,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 56200,
-        "pilotage_usd": 30400,
-        "tugs_usd": 25900,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 28100,
+        "pilotage_usd": 5100,
+        "tugs_usd": 10400,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1425,68 +1425,68 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 19200,
-        "pilotage_usd": 10400,
-        "tugs_usd": 8900,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 9600,
+        "pilotage_usd": 1700,
+        "tugs_usd": 3600,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 35000,
-        "pilotage_usd": 18900,
-        "tugs_usd": 16100,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 17500,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6400,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 52500,
-        "pilotage_usd": 28400,
-        "tugs_usd": 24100,
+        "port_dues_usd": 26300,
+        "pilotage_usd": 4700,
+        "tugs_usd": 9600,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 65001,
         "vessel_dwt_max": 90000,
-        "port_dues_usd": 95000,
-        "pilotage_usd": 51000,
-        "tugs_usd": 44000,
+        "port_dues_usd": 47500,
+        "pilotage_usd": 8500,
+        "tugs_usd": 17600,
         "stevedoring_usd_per_mt": 4.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 90001,
         "vessel_dwt_max": 150000,
-        "port_dues_usd": 125000,
-        "pilotage_usd": 67000,
-        "tugs_usd": 57000,
+        "port_dues_usd": 62500,
+        "pilotage_usd": 11200,
+        "tugs_usd": 22800,
         "stevedoring_usd_per_mt": 4.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 150001,
         "vessel_dwt_max": 200000,
-        "port_dues_usd": 160000,
-        "pilotage_usd": 86000,
-        "tugs_usd": 73000,
+        "port_dues_usd": 80000,
+        "pilotage_usd": 14300,
+        "tugs_usd": 29200,
         "stevedoring_usd_per_mt": 3.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1497,35 +1497,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 13800,
-        "pilotage_usd": 7400,
-        "tugs_usd": 6300,
+        "port_dues_usd": 6900,
+        "pilotage_usd": 1200,
+        "tugs_usd": 2500,
         "stevedoring_usd_per_mt": 4.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 25000,
-        "pilotage_usd": 13500,
-        "tugs_usd": 11500,
+        "port_dues_usd": 12500,
+        "pilotage_usd": 2300,
+        "tugs_usd": 4600,
         "stevedoring_usd_per_mt": 4.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 37500,
-        "pilotage_usd": 20200,
-        "tugs_usd": 17300,
+        "port_dues_usd": 18800,
+        "pilotage_usd": 3400,
+        "tugs_usd": 6900,
         "stevedoring_usd_per_mt": 4.1,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1536,35 +1536,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 16500,
-        "pilotage_usd": 8900,
-        "tugs_usd": 7600,
+        "port_dues_usd": 8300,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3000,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 30000,
-        "pilotage_usd": 16200,
-        "tugs_usd": 13800,
+        "port_dues_usd": 15000,
+        "pilotage_usd": 2700,
+        "tugs_usd": 5500,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 45000,
-        "pilotage_usd": 24300,
-        "tugs_usd": 20700,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 22500,
+        "pilotage_usd": 4100,
+        "tugs_usd": 8300,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1575,35 +1575,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 12400,
-        "pilotage_usd": 6700,
-        "tugs_usd": 5700,
+        "port_dues_usd": 6200,
+        "pilotage_usd": 1100,
+        "tugs_usd": 2300,
         "stevedoring_usd_per_mt": 4.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 22500,
-        "pilotage_usd": 12200,
-        "tugs_usd": 10300,
+        "port_dues_usd": 11300,
+        "pilotage_usd": 2000,
+        "tugs_usd": 4100,
         "stevedoring_usd_per_mt": 4.4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 33800,
-        "pilotage_usd": 18200,
-        "tugs_usd": 15500,
-        "stevedoring_usd_per_mt": 4.0,
+        "port_dues_usd": 16900,
+        "pilotage_usd": 3000,
+        "tugs_usd": 6200,
+        "stevedoring_usd_per_mt": 4,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1614,35 +1614,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 16500,
-        "pilotage_usd": 8900,
-        "tugs_usd": 7600,
+        "port_dues_usd": 8300,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3000,
         "stevedoring_usd_per_mt": 5.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 30000,
-        "pilotage_usd": 16200,
-        "tugs_usd": 13800,
+        "port_dues_usd": 15000,
+        "pilotage_usd": 2700,
+        "tugs_usd": 5500,
         "stevedoring_usd_per_mt": 5.8,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 45000,
-        "pilotage_usd": 24300,
-        "tugs_usd": 20700,
+        "port_dues_usd": 22500,
+        "pilotage_usd": 4100,
+        "tugs_usd": 8300,
         "stevedoring_usd_per_mt": 5.3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1653,46 +1653,46 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 49500,
-        "pilotage_usd": 26400,
-        "tugs_usd": 22600,
+        "port_dues_usd": 24800,
+        "pilotage_usd": 4400,
+        "tugs_usd": 9000,
         "stevedoring_usd_per_mt": 3.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 65001,
         "vessel_dwt_max": 90000,
-        "port_dues_usd": 90000,
-        "pilotage_usd": 48000,
-        "tugs_usd": 41000,
+        "port_dues_usd": 45000,
+        "pilotage_usd": 8000,
+        "tugs_usd": 16400,
         "stevedoring_usd_per_mt": 3.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 90001,
         "vessel_dwt_max": 150000,
-        "port_dues_usd": 118000,
-        "pilotage_usd": 63000,
-        "tugs_usd": 54000,
-        "stevedoring_usd_per_mt": 3.0,
+        "port_dues_usd": 59000,
+        "pilotage_usd": 10500,
+        "tugs_usd": 21600,
+        "stevedoring_usd_per_mt": 3,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 150001,
         "vessel_dwt_max": 200000,
-        "port_dues_usd": 150000,
-        "pilotage_usd": 81000,
-        "tugs_usd": 69000,
+        "port_dues_usd": 75000,
+        "pilotage_usd": 13500,
+        "tugs_usd": 27600,
         "stevedoring_usd_per_mt": 2.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "broker-research-2026-05"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1703,35 +1703,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 15400,
-        "pilotage_usd": 8300,
-        "tugs_usd": 7100,
+        "port_dues_usd": 7700,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2800,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 28000,
-        "pilotage_usd": 15100,
-        "tugs_usd": 12900,
+        "port_dues_usd": 14000,
+        "pilotage_usd": 2500,
+        "tugs_usd": 5200,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 42000,
-        "pilotage_usd": 22600,
-        "tugs_usd": 19400,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 21000,
+        "pilotage_usd": 3800,
+        "tugs_usd": 7800,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1742,35 +1742,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 16000,
-        "pilotage_usd": 8600,
-        "tugs_usd": 7300,
+        "port_dues_usd": 8000,
+        "pilotage_usd": 1400,
+        "tugs_usd": 2900,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 29000,
-        "pilotage_usd": 15700,
-        "tugs_usd": 13300,
+        "port_dues_usd": 14500,
+        "pilotage_usd": 2600,
+        "tugs_usd": 5300,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 43500,
-        "pilotage_usd": 23600,
-        "tugs_usd": 20000,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 21800,
+        "pilotage_usd": 3900,
+        "tugs_usd": 8000,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1781,35 +1781,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 18200,
-        "pilotage_usd": 9800,
-        "tugs_usd": 8400,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 9100,
+        "pilotage_usd": 1600,
+        "tugs_usd": 3400,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 33000,
-        "pilotage_usd": 17800,
-        "tugs_usd": 15200,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 16500,
+        "pilotage_usd": 3000,
+        "tugs_usd": 6100,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 49500,
-        "pilotage_usd": 26700,
-        "tugs_usd": 22800,
+        "port_dues_usd": 24800,
+        "pilotage_usd": 4500,
+        "tugs_usd": 9100,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1820,35 +1820,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 19800,
-        "pilotage_usd": 10700,
-        "tugs_usd": 9100,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 9900,
+        "pilotage_usd": 1800,
+        "tugs_usd": 3600,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 36000,
-        "pilotage_usd": 19400,
-        "tugs_usd": 16600,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 18000,
+        "pilotage_usd": 3200,
+        "tugs_usd": 6600,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 54000,
-        "pilotage_usd": 29100,
-        "tugs_usd": 24900,
+        "port_dues_usd": 27000,
+        "pilotage_usd": 4900,
+        "tugs_usd": 10000,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1859,35 +1859,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 22000,
-        "pilotage_usd": 11900,
-        "tugs_usd": 10100,
+        "port_dues_usd": 11000,
+        "pilotage_usd": 2000,
+        "tugs_usd": 4000,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 40000,
-        "pilotage_usd": 21600,
-        "tugs_usd": 18400,
+        "port_dues_usd": 20000,
+        "pilotage_usd": 3600,
+        "tugs_usd": 7400,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 60000,
-        "pilotage_usd": 32400,
-        "tugs_usd": 27600,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 30000,
+        "pilotage_usd": 5400,
+        "tugs_usd": 11000,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1898,35 +1898,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 14600,
-        "pilotage_usd": 7900,
-        "tugs_usd": 6700,
+        "port_dues_usd": 7300,
+        "pilotage_usd": 1300,
+        "tugs_usd": 2700,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 26500,
-        "pilotage_usd": 14300,
-        "tugs_usd": 12200,
+        "port_dues_usd": 13300,
+        "pilotage_usd": 2400,
+        "tugs_usd": 4900,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 39800,
-        "pilotage_usd": 21400,
-        "tugs_usd": 18300,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 19900,
+        "pilotage_usd": 3600,
+        "tugs_usd": 7300,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1937,35 +1937,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 9900,
-        "pilotage_usd": 5300,
-        "tugs_usd": 4600,
+        "port_dues_usd": 5000,
+        "pilotage_usd": 900,
+        "tugs_usd": 1800,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 18000,
-        "pilotage_usd": 9700,
-        "tugs_usd": 8300,
+        "port_dues_usd": 9000,
+        "pilotage_usd": 1600,
+        "tugs_usd": 3300,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 27000,
-        "pilotage_usd": 14600,
-        "tugs_usd": 12400,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 13500,
+        "pilotage_usd": 2400,
+        "tugs_usd": 5000,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -1976,35 +1976,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 13200,
-        "pilotage_usd": 7200,
-        "tugs_usd": 6100,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 6600,
+        "pilotage_usd": 1200,
+        "tugs_usd": 2400,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 24000,
-        "pilotage_usd": 13000,
-        "tugs_usd": 11000,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 12000,
+        "pilotage_usd": 2200,
+        "tugs_usd": 4400,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 36000,
-        "pilotage_usd": 19500,
-        "tugs_usd": 16500,
+        "port_dues_usd": 18000,
+        "pilotage_usd": 3300,
+        "tugs_usd": 6600,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2015,35 +2015,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 9600,
-        "pilotage_usd": 5200,
-        "tugs_usd": 4400,
+        "port_dues_usd": 4800,
+        "pilotage_usd": 900,
+        "tugs_usd": 1800,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 17500,
-        "pilotage_usd": 9500,
-        "tugs_usd": 8000,
+        "port_dues_usd": 8800,
+        "pilotage_usd": 1600,
+        "tugs_usd": 3200,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 26200,
-        "pilotage_usd": 14200,
-        "tugs_usd": 12000,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 13100,
+        "pilotage_usd": 2400,
+        "tugs_usd": 4800,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2054,35 +2054,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17000,
-        "pilotage_usd": 9200,
-        "tugs_usd": 7900,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 8500,
+        "pilotage_usd": 1500,
+        "tugs_usd": 3200,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 31000,
-        "pilotage_usd": 16700,
-        "tugs_usd": 14300,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 15500,
+        "pilotage_usd": 2800,
+        "tugs_usd": 5700,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 46500,
-        "pilotage_usd": 25000,
-        "tugs_usd": 21400,
+        "port_dues_usd": 23300,
+        "pilotage_usd": 4200,
+        "tugs_usd": 8600,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2093,35 +2093,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 17600,
-        "pilotage_usd": 9500,
-        "tugs_usd": 8100,
+        "port_dues_usd": 8800,
+        "pilotage_usd": 1600,
+        "tugs_usd": 3200,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 32000,
-        "pilotage_usd": 17300,
-        "tugs_usd": 14700,
+        "port_dues_usd": 16000,
+        "pilotage_usd": 2900,
+        "tugs_usd": 5900,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 48000,
-        "pilotage_usd": 26000,
-        "tugs_usd": 22000,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 24000,
+        "pilotage_usd": 4300,
+        "tugs_usd": 8800,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2132,35 +2132,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 23700,
-        "pilotage_usd": 12800,
-        "tugs_usd": 10900,
-        "stevedoring_usd_per_mt": 7.0,
+        "port_dues_usd": 11900,
+        "pilotage_usd": 2100,
+        "tugs_usd": 4400,
+        "stevedoring_usd_per_mt": 7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 43000,
-        "pilotage_usd": 23200,
-        "tugs_usd": 19800,
-        "stevedoring_usd_per_mt": 7.0,
+        "port_dues_usd": 21500,
+        "pilotage_usd": 3900,
+        "tugs_usd": 7900,
+        "stevedoring_usd_per_mt": 7,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 64500,
-        "pilotage_usd": 34800,
-        "tugs_usd": 29700,
+        "port_dues_usd": 32300,
+        "pilotage_usd": 5800,
+        "tugs_usd": 11900,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2171,35 +2171,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 22600,
-        "pilotage_usd": 12200,
-        "tugs_usd": 10400,
+        "port_dues_usd": 11300,
+        "pilotage_usd": 2000,
+        "tugs_usd": 4200,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 41000,
-        "pilotage_usd": 22100,
-        "tugs_usd": 18900,
+        "port_dues_usd": 20500,
+        "pilotage_usd": 3700,
+        "tugs_usd": 7600,
         "stevedoring_usd_per_mt": 6.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 61500,
-        "pilotage_usd": 33200,
-        "tugs_usd": 28400,
-        "stevedoring_usd_per_mt": 6.0,
+        "port_dues_usd": 30800,
+        "pilotage_usd": 5500,
+        "tugs_usd": 11400,
+        "stevedoring_usd_per_mt": 6,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2210,35 +2210,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 13800,
-        "pilotage_usd": 7400,
-        "tugs_usd": 6300,
+        "port_dues_usd": 6900,
+        "pilotage_usd": 1200,
+        "tugs_usd": 2500,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 25000,
-        "pilotage_usd": 13500,
-        "tugs_usd": 11500,
+        "port_dues_usd": 12500,
+        "pilotage_usd": 2300,
+        "tugs_usd": 4600,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 37500,
-        "pilotage_usd": 20200,
-        "tugs_usd": 17200,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 18800,
+        "pilotage_usd": 3400,
+        "tugs_usd": 6900,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   },
@@ -2249,35 +2249,35 @@
       {
         "vessel_dwt_min": 1000,
         "vessel_dwt_max": 9999,
-        "port_dues_usd": 14300,
-        "pilotage_usd": 7700,
-        "tugs_usd": 6600,
+        "port_dues_usd": 7200,
+        "pilotage_usd": 1300,
+        "tugs_usd": 2600,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 10000,
         "vessel_dwt_max": 40000,
-        "port_dues_usd": 26000,
-        "pilotage_usd": 14000,
-        "tugs_usd": 12000,
+        "port_dues_usd": 13000,
+        "pilotage_usd": 2300,
+        "tugs_usd": 4800,
         "stevedoring_usd_per_mt": 5.5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       },
       {
         "vessel_dwt_min": 40001,
         "vessel_dwt_max": 65000,
-        "port_dues_usd": 39000,
-        "pilotage_usd": 21000,
-        "tugs_usd": 18000,
-        "stevedoring_usd_per_mt": 5.0,
+        "port_dues_usd": 19500,
+        "pilotage_usd": 3500,
+        "tugs_usd": 7200,
+        "stevedoring_usd_per_mt": 5,
         "cargo_type": "general",
         "confidence": "estimated",
-        "source": "manual-2026-06"
+        "source": "recalibrated-2026-06-08 (VDA/DPWorld/Marlo benchmarks)"
       }
     ]
   }

--- a/tests/unit/port-da/seed-values.test.ts
+++ b/tests/unit/port-da/seed-values.test.ts
@@ -39,66 +39,71 @@ describe('spec-betafix-03 — Port DA seed acceptance', () => {
     await seedPortDa(db, baseline, mockLlmCaller);
   });
 
-  it('Lagos NGAPP DA for 30k DWT is >= $90k and <= $150k', () => {
+  // RC1 note (2026-06-08 recalibration): thresholds below reflect de-inflated values
+  // (port_dues÷2, pilotage÷6, tugs÷2.5).  The old thresholds encoded the LLM-fabricated
+  // 2-3× inflation.  The new floors are set ~10% below each port's actual recalibrated
+  // total for robustness against future fine-tuning while still guarding against
+  // accidentally zeroing out a port or regressing to the old inflated data.
+  it('Lagos NGAPP DA for 30k DWT is >= $32k and <= $60k', () => {
     const r = getPortDa({ portCode: 'NGAPP', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(90_000);
-    expect(r!.totalFixedUsd).toBeLessThanOrEqual(150_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(32_000);
+    expect(r!.totalFixedUsd).toBeLessThanOrEqual(60_000);
   });
 
-  it('Rotterdam NLRTM DA for 35k DWT is >= $80k', () => {
+  it('Rotterdam NLRTM DA for 35k DWT is >= $28k', () => {
     const r = getPortDa({ portCode: 'NLRTM', vesselDwt: 35000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(80_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(28_000);
   });
 
-  it('Antwerp BEANR DA for 30k DWT is >= $75k', () => {
+  it('Antwerp BEANR DA for 30k DWT is >= $26k', () => {
     const r = getPortDa({ portCode: 'BEANR', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(75_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(26_000);
   });
 
-  it('Singapore SGSIN DA for 35k DWT is between $60k and $90k', () => {
+  it('Singapore SGSIN DA for 35k DWT is between $20k and $40k', () => {
     const r = getPortDa({ portCode: 'SGSIN', vesselDwt: 35000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(60_000);
-    expect(r!.totalFixedUsd).toBeLessThanOrEqual(90_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(20_000);
+    expect(r!.totalFixedUsd).toBeLessThanOrEqual(40_000);
   });
 
-  it('Durban ZADUR DA for 30k DWT is >= $65k', () => {
+  it('Durban ZADUR DA for 30k DWT is >= $23k', () => {
     const r = getPortDa({ portCode: 'ZADUR', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(65_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(23_000);
   });
 
-  it('Suez EGSUZ DA for 30k DWT is >= $40k', () => {
+  it('Suez EGSUZ DA for 30k DWT is >= $15k', () => {
     const r = getPortDa({ portCode: 'EGSUZ', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(40_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(15_000);
   });
 
-  it('Dubai AEDXB DA for 30k DWT is >= $50k', () => {
+  it('Dubai AEDXB DA for 30k DWT is >= $18k', () => {
     const r = getPortDa({ portCode: 'AEDXB', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(50_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(18_000);
   });
 
-  it('Mersin TRMER DA for 30k DWT is >= $45k', () => {
+  it('Mersin TRMER DA for 30k DWT is >= $17k', () => {
     const r = getPortDa({ portCode: 'TRMER', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(45_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(17_000);
   });
 
-  it('Aqaba JOAQB DA for 30k DWT is >= $40k', () => {
+  it('Aqaba JOAQB DA for 30k DWT is >= $14k', () => {
     const r = getPortDa({ portCode: 'JOAQB', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(40_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(14_000);
   });
 
-  it('Misurata LYMRA DA for 30k DWT is >= $50k', () => {
+  it('Misurata LYMRA DA for 30k DWT is >= $18k', () => {
     const r = getPortDa({ portCode: 'LYMRA', vesselDwt: 30000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(50_000);
+    expect(r!.totalFixedUsd).toBeGreaterThanOrEqual(18_000);
   });
 
   it('Unknown UNLOCODE returns null fallback (not a thrown error)', () => {
@@ -156,22 +161,24 @@ describe('wave4-portda — 15 new demo ports + small-vessel bracket coverage', (
 
   afterAll(() => db.close());
 
-  it('TRALI at 8 000 DWT hits small-vessel bracket with total ~30 800', () => {
+  // RC1 note (2026-06-08 recalibration): exact totals updated to reflect de-inflated
+  // values (port_dues÷2, pilotage÷6, tugs÷2.5, rounded to nearest $100).
+  it('TRALI at 8 000 DWT hits small-vessel bracket with total 11 900', () => {
     const r = getPortDa({ portCode: 'TRALI', vesselDwt: 8000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBe(30_800);
+    expect(r!.totalFixedUsd).toBe(11_900);
   });
 
-  it('ROCND at 25 000 DWT hits handysize bracket with total 66 000', () => {
+  it('ROCND at 25 000 DWT hits handysize bracket with total 25 600', () => {
     const r = getPortDa({ portCode: 'ROCND', vesselDwt: 25000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBe(66_000);
+    expect(r!.totalFixedUsd).toBe(25_600);
   });
 
-  it('GBLIV at 50 000 DWT hits large bracket with total 129 000', () => {
+  it('GBLIV at 50 000 DWT hits large bracket with total 50 000', () => {
     const r = getPortDa({ portCode: 'GBLIV', vesselDwt: 50000 }, db);
     expect(r).not.toBeNull();
-    expect(r!.totalFixedUsd).toBe(129_000);
+    expect(r!.totalFixedUsd).toBe(50_000);
   });
 
   it('seeded DB has 54 distinct port_codes after adding 15 new ports', () => {


### PR DESCRIPTION
## Проблема (прод, match 51414 SEAGULL 71 Iskenderun→Constanța)
Список TCE/day **+\$2.7k** vs калькулятор **−\$9,481** на одном матче. Два корня в портовых сборах (DA):

1. **Паритет-баг:** список (`sumMatchPortDaUsd`) спрашивал DA с `cargo_type='bulk'` → 0 строк (таблица только `'general'`) → DA \$0. Калькулятор (`resolveDaUsd`→`getPortDa`) тип не шлёт → `'general'` → DA \$65,600. → список молча обнулял сборы.
2. **Данные:** портсборы в `port-da-base.json` LLM-выдуманы (все `confidence:'estimated'`, нет реального источника) и завышены ~2-3× (лоцман 5-10×). Веб-ресёрч по тарифам VDA/DP World/Marlo.

## Фикс
- **Паритет** (`lib/port-da/match-da.ts`): DA считается cargo-agnostic (`'general'`, как калькулятор) → list DA == detail DA структурно.
- **Рекалибровка** (`port-da-base.json`, все 54 порта × все DWT-классы): port_dues ÷2, pilotage ÷6, tugs ÷2.5. Iskenderun \$29.2k→\$11.3k, Constanța \$36.4k→\$14.1k (в диапазонах ресёрча \$10-14k / \$12-20k).

## Проверка (на DA-заполненной БД — локальная demo-seed пустая по DA!)
- list DA == detail DA (delta 0), list TCE == detail TCE (delta 0); DA реалистичный \$25.4k (было \$65.6k).
- tsc clean; jest 80/80 (port-da + matching + parity).

## Деплой
port_da_estimates сидится из port-da-base.json через `regenerate-matches.ts → seedReferenceTables` (НЕ в demo-seed.db at rest). Прод-применение = re-seed port_da на проде (special-case #22: --dry → backup → write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)