### PR TITLE
feat(fit-canonical): fit_percent is the single user-facing metric (Wave 1 / I1)

### DIFF
--- a/__tests__/matches-fit-canonical.test.tsx
+++ b/__tests__/matches-fit-canonical.test.tsx
@@ -59,6 +59,15 @@ describe('MatchesClient.tsx — card density uses fitDisplay (I1)', () => {
     expect(result.value).toBe(72);
     expect(result.label).toBe('%');
   });
+
+  it('fitDisplay behavioral: expired laycan caps score at 70 when fit_percent is null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { fitDisplay } = require(fitDisplayPath) as { fitDisplay: (m: {score: number; fit_percent: number | null | undefined; laycan_end: number | null; laycan_start: number | null}, nowMs: number) => {value: number; label: string} };
+    const expiredEnd = Date.now() - 86_400_000; // 1 day ago
+    const result = fitDisplay({ score: 85, fit_percent: null, laycan_end: expiredEnd, laycan_start: null }, Date.now());
+    expect(result.value).toBe(70);
+    expect(result.label).toBe('%');
+  });
 });
 
 // ===== Step 2: Filter fix =====

--- a/__tests__/matches-fit-canonical.test.tsx
+++ b/__tests__/matches-fit-canonical.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * RED/GREEN tests — fit_percent canonical metric (Wave 1: FIT canonical, I1)
+ *
+ * Strategy: static JSX source analysis (testEnvironment: 'node').
+ *
+ * Step 1 — card display: card density must use fitDisplay, not raw {match.score}%
+ * Step 2 — filter fix: score80 quickFilter must use m.fit_percent ?? effectiveScore(...)
+ * Step 3 — sort parity: sort routes both 'fit' and 'score' through fit_percent
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const clientPath = path.join(ROOT, 'app/matches/MatchesClient.tsx');
+const fitDisplayPath = path.join(ROOT, 'lib/matching/fit-display.ts');
+
+function readSource(): string {
+  return fs.readFileSync(clientPath, 'utf8');
+}
+
+// ===== Step 1: Card display =====
+describe('MatchesClient.tsx — card density uses fitDisplay (I1)', () => {
+  it('card density block does NOT contain raw {match.score}%', () => {
+    const src = readSource();
+    expect(src).not.toMatch(/\{match\.score\}%/);
+  });
+
+  it('card density block references fitDisplay', () => {
+    const src = readSource();
+    expect(src).toMatch(/fitDisplay/);
+  });
+
+  it('fit-display.ts module exists and exports fitDisplay function', () => {
+    const exists = fs.existsSync(fitDisplayPath);
+    expect(exists).toBe(true);
+    const fitSrc = fs.readFileSync(fitDisplayPath, 'utf8');
+    expect(fitSrc).toMatch(/export.*function fitDisplay|export.*fitDisplay/);
+  });
+
+  it('fit-display.ts exports FitDisplay interface', () => {
+    const fitSrc = fs.readFileSync(fitDisplayPath, 'utf8');
+    expect(fitSrc).toMatch(/FitDisplay/);
+  });
+
+  // Behavioral test: fitDisplay returns fit_percent when present, fallback otherwise
+  it('fitDisplay behavioral: uses fit_percent when not null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { fitDisplay } = require(fitDisplayPath) as { fitDisplay: (m: {score: number; fit_percent: number | null | undefined; laycan_end: number | null; laycan_start: number | null}, nowMs: number) => {value: number; label: string} };
+    const result = fitDisplay({ score: 70, fit_percent: 85.4, laycan_end: null, laycan_start: null }, 0);
+    expect(result.value).toBe(85);
+    expect(result.label).toBe('% fit');
+  });
+
+  it('fitDisplay behavioral: falls back to score when fit_percent is null', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { fitDisplay } = require(fitDisplayPath) as { fitDisplay: (m: {score: number; fit_percent: number | null | undefined; laycan_end: number | null; laycan_start: number | null}, nowMs: number) => {value: number; label: string} };
+    const result = fitDisplay({ score: 72, fit_percent: null, laycan_end: null, laycan_start: null }, 0);
+    expect(result.value).toBe(72);
+    expect(result.label).toBe('%');
+  });
+});
+
+// ===== Step 2: Filter fix =====
+describe('MatchesClient.tsx — score80 quickFilter uses fit_percent (I1)', () => {
+  it('score80 predicate references m.fit_percent (not just effectiveScore)', () => {
+    const src = readSource();
+    // Must use fit_percent in score80 filter
+    expect(src).toMatch(/score80.*fit_percent|fit_percent.*score80/);
+  });
+
+  it('score80 predicate uses nullish coalescing with effectiveScore as fallback', () => {
+    const src = readSource();
+    expect(src).toMatch(/fit_percent\s*\?\?.*effectiveScore|m\.fit_percent\s*\?\?/);
+  });
+
+  it('score80 chip label is "Fit 80+" not "Score 80+"', () => {
+    const src = readSource();
+    expect(src).toMatch(/['"]Fit 80\+['"]/);
+    expect(src).not.toMatch(/['"]Score 80\+['"]/);
+  });
+});
+
+// ===== Step 3: Sort parity =====
+describe('MatchesClient.tsx — sort routes both fit and score through fit_percent (I1)', () => {
+  it('sort block uses fit_percent for both fit and score paths', () => {
+    const src = readSource();
+    // The unified sort should reference fit_percent with ?? fallback
+    expect(src).toMatch(/fit_percent\s*\?\?\s*[ab]\.(fit_percent|score)|fit_percent.*\?\?.*score/);
+  });
+
+  it('b.score - a.score is still present as tiebreaker (PI3 invariant)', () => {
+    const src = readSource();
+    expect(src).toMatch(/b\.score\s*-\s*a\.score/);
+  });
+
+  it('sort no longer has separate if(sortBy===fit) branch after unification', () => {
+    const src = readSource();
+    // The old "if (sortBy === 'fit') return (b.fit_percent ?? 0)..." pattern is replaced
+    // New pattern: fitDiff computed without a sortBy===fit conditional
+    expect(src).not.toMatch(/if\s*\(sortBy\s*===\s*['"]fit['"]\)\s*return\s*\(b\.fit_percent/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@/components/ui/toast';
 import { fmtLaycan, isLaycanExpired } from '@/lib/utils/fmt-laycan';
 import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badge';
 import { useDemoNow } from '@/lib/clock-client';
+import { fitDisplay } from '@/lib/matching/fit-display';
 
 interface Props {
   initialMatches: (StoredMatch & { laycan_display?: string | null })[];
@@ -321,14 +322,15 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
         (cargoTypes.length === 0 || cargoTypes.includes(m.cargo_type ?? '')) &&
         (quickFilter === 'all' ||
           (quickFilter === 'fresh' && isFreshMatch(m, clientNow)) ||
-          (quickFilter === 'score80' && effectiveScore(m, clientNow) >= 80) ||
+          (quickFilter === 'score80' && (m.fit_percent ?? effectiveScore(m, clientNow)) >= 80) ||
           (quickFilter === 'dwt50_60' && m.vessel_dwt != null && m.vessel_dwt >= 50000 && m.vessel_dwt <= 60000))
     )
     .sort((a, b) => {
       if (sortBy === 'freshness') return b.created_at - a.created_at;
       if (sortBy === 'tce') return (b.tce_usd_per_day ?? 0) - (a.tce_usd_per_day ?? 0);
-      if (sortBy === 'fit') return (b.fit_percent ?? 0) - (a.fit_percent ?? 0);
-      return b.score - a.score;
+      // Both 'fit' and legacy 'score' sort by fit_percent; use score as tie-break
+      const fitDiff = (b.fit_percent ?? b.score) - (a.fit_percent ?? a.score);
+      return fitDiff !== 0 ? fitDiff : b.score - a.score;
     });
 
   // Update status filter and persist to URL
@@ -431,7 +433,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                           )}
                         </div>
                         <div className="text-right flex-none">
-                          <div className="text-lg font-bold text-blue-600">{match.score}%</div>
+                          {(() => { const fd = fitDisplay(match, clientNow); return <div className="text-lg font-bold text-blue-600">{fd.value}{fd.label}</div>; })()}
                           <div className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 capitalize">
                             {match.status}
                           </div>
@@ -458,7 +460,7 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
             {([
               { id: 'all' as QuickFilter, label: 'All', count: allChipCount },
               { id: 'fresh' as QuickFilter, label: 'Fresh', count: undefined },
-              { id: 'score80' as QuickFilter, label: 'Score 80+', count: undefined },
+              { id: 'score80' as QuickFilter, label: 'Fit 80+', count: undefined },
               { id: 'dwt50_60' as QuickFilter, label: 'DWT 50–60k', count: undefined },
             ]).map(({ id, label, count }) => (
               <button

--- a/lib/matching/fit-display.ts
+++ b/lib/matching/fit-display.ts
@@ -1,0 +1,21 @@
+import { StoredMatch } from './matches-repository';
+
+function isLaycanExpired(laycan_end: number | null, laycan_start: number | null, nowMs: number): boolean {
+  // matches MatchesClient.tsx logic — expired if laycan_end is past
+  if (!laycan_end && !laycan_start) return false;
+  const end = laycan_end ?? laycan_start!;
+  return nowMs > end;
+}
+
+function effectiveScore(m: Pick<StoredMatch, 'score' | 'laycan_end' | 'laycan_start'>, nowMs: number): number {
+  if (nowMs === 0) return m.score;
+  if (isLaycanExpired(m.laycan_end, m.laycan_start, nowMs)) return Math.min(m.score, 70);
+  return m.score;
+}
+
+export interface FitDisplay { value: number; label: string; }
+
+export function fitDisplay(m: Pick<StoredMatch, 'score' | 'fit_percent' | 'laycan_end' | 'laycan_start'>, nowMs: number): FitDisplay {
+  if (m.fit_percent != null) return { value: Math.round(m.fit_percent), label: '% fit' };
+  return { value: effectiveScore(m, nowMs), label: '%' };
+}

--- a/lib/matching/fit-display.ts
+++ b/lib/matching/fit-display.ts
@@ -1,11 +1,5 @@
 import { StoredMatch } from './matches-repository';
-
-function isLaycanExpired(laycan_end: number | null, laycan_start: number | null, nowMs: number): boolean {
-  // matches MatchesClient.tsx logic — expired if laycan_end is past
-  if (!laycan_end && !laycan_start) return false;
-  const end = laycan_end ?? laycan_start!;
-  return nowMs > end;
-}
+import { isLaycanExpired } from '../utils/fmt-laycan';
 
 function effectiveScore(m: Pick<StoredMatch, 'score' | 'laycan_end' | 'laycan_start'>, nowMs: number): number {
   if (nowMs === 0) return m.score;

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -104,6 +104,7 @@ export function persistSessionMatches(
       reason: m.matchReasons[0] ?? '',
       status: 'shortlist',
       user_id: sessionId,
+      // TODO(W5): reason_structured still uses legacy scoreBreakdown; W5 refactors to fitBreakdown
       reason_structured: m.scoreBreakdown ? JSON.stringify(m.scoreBreakdown) : null,
       cargo_type: cargoTypeStr,
       load_port: loadPort,


### PR DESCRIPTION
## Summary

- **Closes I1**: `fit_percent` is now the single user-facing metric across card, table, filter, and sort surfaces
- Card density (`:434`) now uses `fitDisplay(match, clientNow)` instead of raw `{match.score}%`
- Quick-filter `score80` now applies `m.fit_percent ?? effectiveScore(m, now) >= 80`; chip relabeled "Fit 80+"
- Sort: both `'fit'` and legacy `'score'` options route through `fit_percent`; `b.score - a.score` kept as tiebreaker
- `lib/matching/fit-display.ts` introduced as the single display helper (imports `isLaycanExpired` from `lib/utils/fmt-laycan.ts` — no duplication)
- `persist-session-matches.ts:107` has `TODO(W5)` comment only; `reason_structured` consumers are >5 files (out of scope for W1)

## DoD verification blocks

**Block 1 — TypeCheck:**
```
$ NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit 2>&1 | head -15
(no output — clean)
```

**Block 2 — Affected tests:**
```
$ npx jest --findRelatedTests lib/matching/fit-display.ts app/matches/MatchesClient.tsx lib/matching/persist-session-matches.ts __tests__/matches-fit-canonical.test.tsx --maxWorkers=1 --no-coverage --ci --forceExit
Test Suites: 10 passed, 10 total
Tests:       58 passed, 58 total
```

**Block 3 — Cross-cutting grep:**
```
$ grep -rn "match\.score}%" __tests__/ app/ lib/ components/
__tests__/matches-fit-canonical.test.tsx: comment only (test description)
$ grep -rn "'Score 80+'" __tests__/ app/ lib/ components/
(no output — clean)
```

## PI3 invariants preserved
- `function effectiveScore` still in `MatchesClient.tsx` (required by `matches-556-laycan-expired.test.ts`)
- `b.score - a.score` still in sort tiebreaker (required by `matches-sort.test.tsx:62`)
- `data-testid="sort-score"` still in dropdown (required by `matches-sort.test.tsx:109`)
- No existing test expectations rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)