### PR TITLE
fix(tce): PATCH freight uses computeStoredMatchEconomics, closes I4

### DIFF
--- a/app/api/matches/[id]/__tests__/route.test.ts
+++ b/app/api/matches/[id]/__tests__/route.test.ts
@@ -370,7 +370,9 @@ describe('PATCH /api/matches/[id] — freight rate override + reset (Wave #7)', 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.freight_rate_source).toBe('estimated');
-    const est = estimateFreightRate('GRAIN', 3000, 50000);
+    // Canonical path uses port distance (NLRTM→DEHAM ≈ 250nm), not stored 3000nm.
+    // estimateFreightRate('GRAIN', 250, 50000) is the new expected rate.
+    const est = estimateFreightRate('GRAIN', 250, 50000);
     expect(body.freight_rate_usd_per_mt).toBe(est.rate);
     expect(body.freight_rate_usd_per_mt).not.toBe(99);
     expect(Number.isFinite(body.tce_usd_per_day)).toBe(true);

--- a/app/api/matches/[id]/route.ts
+++ b/app/api/matches/[id]/route.ts
@@ -9,10 +9,87 @@ import {
 } from '@/lib/matching/matches-repository';
 import { fromMatchSlug } from '@/lib/matching/match-slug';
 import type { MatchStatus } from '@/lib/matching/matches-repository';
-import { computeEstimatedTce } from '@/lib/matching/tce-calculator';
-import { resolveFreightRate } from '@/lib/matching/freight-resolver';
+import type { FreightRateSource } from '@/lib/matching/tce-calculator';
+import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+import type { StoredMatch } from '@/lib/matching/matches-repository';
 
 export const dynamic = 'force-dynamic';
+
+function buildCargoProxy(m: StoredMatch): ParsedCargo {
+  const cf = <T>(v: T | null) => (v != null ? { value: v, confidence: 'interpreted' as const } : null);
+  return {
+    emailId: m.cargo_id,
+    itemIndex: m.cargo_item_index ?? 0,
+    originPort: cf(m.load_port),
+    destinationPort: cf(m.discharge_port),
+    cargoType: (m.cargo_type ?? null) as unknown as 'BULK',
+    cargoDescription: null,
+    weightMt: null,
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    freightRateUsd: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    originCountry: null,
+    destinationCountry: null,
+  };
+}
+
+function buildVesselProxy(m: StoredMatch): ParsedVessel {
+  const cf = <T>(v: T | null) => (v != null ? { value: v, confidence: 'interpreted' as const } : null);
+  return {
+    emailId: m.vessel_id,
+    itemIndex: m.vessel_item_index ?? 0,
+    vesselName: cf(m.vessel_name),
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: cf(m.vessel_dwt),
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: null,
+    speedBallast: null,
+    consumption: null,
+    deckCapacity: null,
+    specialFeatures: [],
+  };
+}
 
 const VALID_STATUSES: MatchStatus[] = ['shortlist', 'saved', 'dismissed', 'archived'];
 
@@ -100,30 +177,20 @@ export async function PATCH(
       );
     }
 
-    // Reset-to-auto path (Wave #7): clear a sticky manual override and recompute the
-    // automatic rate from the stored match fields. Without the original email/quantity
-    // context the waterfall resolves to the estimate tier; parsed/baltic re-apply on
-    // the next full recompute.
+    // Reset-to-auto path: clear a sticky manual override and recompute via the
+    // canonical economics path (port distance, DA, canal, ETS, excludeWarRisk).
+    // Proxy cargo/vessel from stored columns — no freightOverrideUsdPerMt so
+    // resolveFreightRate falls through to estimated/baltic tier naturally.
     if (reset_freight_rate === true) {
-      const resolved = resolveFreightRate({
-        cargoType: existing.cargo_type,
-        vesselDwt: existing.vessel_dwt ?? 0,
-        quantityMt: 0,
-        distanceNm: existing.distance_nm ?? 0,
-      });
-      const tceEst = computeEstimatedTce(
-        { rate: resolved.value, source: resolved.source, confidence: resolved.confidence },
-        existing.distance_nm ?? 0,
-        existing.vessel_dwt ?? 0,
-        0,
-      );
-      const updated = updateMatchFreightRate(
+      const eco = computeStoredMatchEconomics({
+        cargo: buildCargoProxy(existing),
+        vessel: buildVesselProxy(existing),
         db,
-        id,
-        resolved.value,
-        tceEst.tce_usd_per_day,
-        resolved.source,
-      );
+      });
+      const rate = eco.freight_rate_usd_per_mt ?? existing.freight_rate_usd_per_mt ?? 0;
+      const tce = eco.tce_usd_per_day ?? existing.tce_usd_per_day ?? 0;
+      const source = (eco.freight_rate_source ?? 'estimated') as FreightRateSource;
+      const updated = updateMatchFreightRate(db, id, rate, tce, source);
       return NextResponse.json(updated, { status: 200 });
     }
 
@@ -136,14 +203,14 @@ export async function PATCH(
           { status: 400 }
         );
       }
-      const freightEst = { rate, source: 'manual' as const, confidence: 1.0 };
-      const tceEst = computeEstimatedTce(
-        freightEst,
-        existing.distance_nm ?? 0,
-        existing.vessel_dwt ?? 0,
-        0,
-      );
-      const updated = updateMatchFreightRate(db, id, rate, tceEst.tce_usd_per_day, 'manual');
+      const eco = computeStoredMatchEconomics({
+        cargo: buildCargoProxy(existing),
+        vessel: buildVesselProxy(existing),
+        db,
+        freightOverrideUsdPerMt: rate,
+      });
+      const tce = eco.tce_usd_per_day ?? existing.tce_usd_per_day ?? 0;
+      const updated = updateMatchFreightRate(db, id, rate, tce, 'manual');
       return NextResponse.json(updated, { status: 200 });
     }
 

--- a/app/api/matches/__tests__/patch-freight-canonical.test.ts
+++ b/app/api/matches/__tests__/patch-freight-canonical.test.ts
@@ -1,0 +1,230 @@
+/**
+ * WAVE 3 — PATCH freight path uses computeStoredMatchEconomics (canonical TCE).
+ *
+ * Key invariant: both PATCH branches (manual override + reset) must persist
+ * tce_usd_per_day from computeStoredMatchEconomics, never from the stripped
+ * computeEstimatedTce (which lacks DA, uses stale stored distance, and includes
+ * war-risk in the headline). Closes I4.
+ *
+ * Test scenario:
+ *   load_port=Piraeus, discharge_port=Rotterdam (≈2850nm in distance table).
+ *   stored distance_nm=9999 (intentionally wrong — makes old vs new measurably
+ *   different: old used stored 9999nm, new uses port-distance 2850nm).
+ */
+
+import Database from 'better-sqlite3';
+import { NextRequest } from 'next/server';
+import migration032 from '@/lib/migrations/032-matches';
+import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import migration035 from '@/lib/migrations/035-matches-tce-distance';
+import migration036 from '@/lib/migrations/036-matches-freight-rate';
+import migration042 from '@/lib/migrations/042-matches-fit';
+import migration044 from '@/lib/migrations/044-matches-item-index';
+import { computeEstimatedTce } from '@/lib/matching/tce-calculator';
+import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+import { requireSession } from '@/lib/session';
+
+let testDb: Database.Database;
+
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({
+    getDatabase: () => testDb,
+  })),
+}));
+
+jest.mock('@/lib/session', () => ({
+  requireSession: jest.fn(),
+}));
+
+const mockRequireSession = requireSession as jest.Mock;
+const SESSION_A = { session: { id: 'sess-a' }, sessionId: 'user-a' };
+
+const CARGO_ID = 'cargo-w3-001';
+const VESSEL_ID = 'vessel-w3-001';
+const LOAD_PORT = 'Piraeus';
+const DISCHARGE_PORT = 'Rotterdam';
+const VESSEL_DWT = 50_000;
+const STORED_DISTANCE = 9_999;
+
+function freshDb(): Database.Database {
+  const d = new Database(':memory:');
+  migration032.up(d);
+  migration033.up(d);
+  migration034.up(d);
+  migration035.up(d);
+  migration036.up(d);
+  migration042.up(d);
+  migration044.up(d);
+  return d;
+}
+
+function seedMatch(database: Database.Database, userId: string): number {
+  const res = database.prepare(
+    `INSERT INTO matches
+       (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at,
+        cargo_type, load_port, discharge_port, vessel_dwt, distance_nm,
+        tce_usd_per_day, freight_rate_usd_per_mt, freight_rate_source)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    CARGO_ID, VESSEL_ID, 75, '{}', 'shortlist',
+    userId, Date.now(), Date.now(),
+    'GRAIN', LOAD_PORT, DISCHARGE_PORT,
+    VESSEL_DWT, STORED_DISTANCE,
+    10_000, 15, 'estimated',
+  );
+  return res.lastInsertRowid as number;
+}
+
+async function patch(id: number, body: unknown) {
+  const { PATCH } = await import('@/app/api/matches/[id]/route');
+  const req = new NextRequest(`http://localhost/api/matches/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return PATCH(req, { params: Promise.resolve({ id: String(id) }) });
+}
+
+function makeCargoProxy(): ParsedCargo {
+  const cf = <T>(v: T | null) => (v != null ? { value: v, confidence: 'interpreted' as const } : null);
+  return {
+    emailId: CARGO_ID,
+    itemIndex: 0,
+    originPort: cf(LOAD_PORT),
+    destinationPort: cf(DISCHARGE_PORT),
+    cargoType: null as unknown as 'BULK',
+    cargoDescription: null,
+    weightMt: null,
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    freightRateUsd: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    originCountry: null,
+    destinationCountry: null,
+  };
+}
+
+function makeVesselProxy(): ParsedVessel {
+  const cf = <T>(v: T | null) => (v != null ? { value: v, confidence: 'interpreted' as const } : null);
+  return {
+    emailId: VESSEL_ID,
+    itemIndex: 0,
+    vesselName: null,
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    dwtSummer: cf(VESSEL_DWT),
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: null,
+    speedBallast: null,
+    consumption: null,
+    deckCapacity: null,
+    specialFeatures: [],
+  };
+}
+
+beforeEach(() => {
+  mockRequireSession.mockReturnValue(SESSION_A);
+});
+
+describe('WAVE 3 — PATCH uses canonical computeStoredMatchEconomics', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = freshDb();
+    testDb = db;
+    process.env.MATCHES_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    db.close();
+    delete process.env.MATCHES_ENABLED;
+  });
+
+  it('PI2-manual-override: tce_usd_per_day from PATCH matches computeStoredMatchEconomics, differs from computeEstimatedTce', async () => {
+    const id = seedMatch(db, 'user-a');
+    const res = await patch(id, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.freight_rate_source).toBe('manual');
+    expect(body.freight_rate_usd_per_mt).toBe(25);
+
+    // Canonical path (new): port-distance-based, war-risk excluded from headline
+    const canonical = computeStoredMatchEconomics({
+      cargo: makeCargoProxy(),
+      vessel: makeVesselProxy(),
+      db,
+      freightOverrideUsdPerMt: 25,
+    });
+    expect(canonical.tce_usd_per_day).not.toBeNull();
+    expect(body.tce_usd_per_day).toBeCloseTo(canonical.tce_usd_per_day!, 0);
+
+    // Old stripped path used stored distance_nm=9999 — measurably different
+    const oldTce = computeEstimatedTce(
+      { rate: 25, source: 'manual', confidence: 1 },
+      STORED_DISTANCE,
+      VESSEL_DWT,
+      0,
+    ).tce_usd_per_day;
+    expect(body.tce_usd_per_day).not.toBeCloseTo(oldTce, 0);
+  });
+
+  it('PI2-reset: reset_freight_rate recomputes via canonical path — source=estimated, finite TCE', async () => {
+    const id = seedMatch(db, 'user-a');
+    const res = await patch(id, { reset_freight_rate: true });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.freight_rate_source).toBe('estimated');
+    expect(body.freight_rate_usd_per_mt).toBeGreaterThan(0);
+    expect(Number.isFinite(body.tce_usd_per_day)).toBe(true);
+
+    // TCE from canonical (port-based 2850nm) differs from old stripped (stored 9999nm)
+    const oldEstTce = computeEstimatedTce(
+      { rate: body.freight_rate_usd_per_mt, source: 'estimated', confidence: 0.6 },
+      STORED_DISTANCE,
+      VESSEL_DWT,
+      0,
+    ).tce_usd_per_day;
+    expect(body.tce_usd_per_day).not.toBeCloseTo(oldEstTce, 0);
+  });
+});

--- a/lib/matching/stored-match-economics.ts
+++ b/lib/matching/stored-match-economics.ts
@@ -38,6 +38,13 @@ export interface StoredMatchEconomicsInput {
   db?: Database.Database;
   calculatedAt?: Date;
   bunkerPriceUsdPerMt?: number;
+  /**
+   * Sticky manual freight rate override ($/mt). When set, passed as tier-0
+   * manualRateUsdPerMt to resolveFreightRate — wins over all other tiers.
+   * Used by PATCH /api/matches/[id] so freight edits go through the canonical
+   * economics path (not the stripped computeEstimatedTce). Closes I4.
+   */
+  freightOverrideUsdPerMt?: number | null;
 }
 
 export interface StoredMatchEconomicsResult {
@@ -96,6 +103,7 @@ export function computeStoredMatchEconomics(
     distanceNm: distanceResult.nm,
     speedKts: ecoSpeed,
     balticDayRate: db ? getBalticDayRate(db, ecoDwt) : null,
+    manualRateUsdPerMt: input.freightOverrideUsdPerMt ?? undefined,
   });
 
   // Ballast reposition distance: open position → load port.


### PR DESCRIPTION
## Summary

- Both PATCH branches (manual override + reset) now call `computeStoredMatchEconomics` instead of the stripped `computeEstimatedTce`
- Adds `freightOverrideUsdPerMt` to `StoredMatchEconomicsInput` (tier-0 manual override) so freight edits go through canonical economics
- Proxy cargo/vessel built from stored match columns (`load_port`, `discharge_port`, `vessel_dwt`) when full session data is unavailable
- `computeEstimatedTce` NOT deleted — still used in `session-buckets.ts` and `tce-calculator` internals

**Closes I4** (PATCH freight path corrupts stored TCE)

## DoD blocks

### Block 1 — TypeScript
```
$ npx tsc --noEmit 2>&1 | head -10
(no output)
```

### Block 2 — Affected tests
```
$ npx jest "patch-freight-canonical|route.test|persist-session-matches-canonical|matches-tce" --maxWorkers=1 --no-coverage 2>&1 | tail -5
Test Suites: 18 passed, 18 total
Tests:       167 passed, 167 total
Snapshots:   0 total
Time:        36.063 s
```

### Block 3 — Literal strings grep
N/A — no literal strings changed in this diff.

## Pre-removal grep (computeEstimatedTce)
```
lib/matching/session-buckets.ts:58      → legit caller, NOT changed
lib/matching/tce-calculator.ts:98,324  → definition + internal caller, NOT changed
lib/matching/stored-match-economics.ts:165 → breakdown re-derivation, NOT changed
app/api/matches/[id]/route.ts          → import REMOVED (no longer needed)
```

## PI3 count
1 existing test expectation updated (route.test.ts:374 — `estimateFreightRate` distance arg 3000→250 matching new canonical path). Within ≤5 limit.

## Test plan
- [ ] PATCH `/api/matches/[id]` with `freight_rate_usd_per_mt` → `freight_rate_source=manual`, `tce_usd_per_day` from port-distance-based formula
- [ ] PATCH with `reset_freight_rate:true` → `freight_rate_source=estimated`, canonical TCE
- [ ] Status PATCH still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)