### PR TITLE
feat(ballast): persist ballast_distance_nm + align freight sizing (I5, I6)

### DIFF
--- a/__tests__/match-worksheet-migration.test.ts
+++ b/__tests__/match-worksheet-migration.test.ts
@@ -34,9 +34,11 @@ describe('migration 045 — worksheet_json column', () => {
     expect(row.worksheet_json).toBeNull();
   });
 
-  it('migration 046 version is 46 and is the last in allMigrations', () => {
+  it('migration 046 (consumption-estimated) and 047 (ballast-distance) both in allMigrations; 047 is last', () => {
+    const m46 = allMigrations.find((m) => m.version === 46);
+    expect(m46?.name).toBe('matches-consumption-estimated');
     const last = allMigrations[allMigrations.length - 1];
-    expect(last.version).toBe(46);
-    expect(last.name).toBe('matches-consumption-estimated');
+    expect(last.version).toBe(47);
+    expect(last.name).toBe('matches-ballast-distance');
   });
 });

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -119,12 +119,14 @@ export default async function MatchDetailPage({ params }: Props) {
   };
 
   // Ballast reposition distance: open position → load port (nm).
-  // Mirrors stored-match-economics.ts so DETAIL uses the same single-voyage
-  // duration as LIST (fixes SEAGULL-41: list $9,084 ≠ detail $4,473 bug).
+  // Stored-first: prefer the persisted value so detail TCE matches list TCE even
+  // after session expiry (I5 fix). Falls back to session re-derivation for legacy
+  // rows written before migration 047 that have null stored value.
   const ballastDistanceNm =
-    vessel && cargo
+    storedMatch.ballast_distance_nm ??
+    (vessel && cargo
       ? (getPortDistance(cfValue(vessel.openPosition) ?? '', cfValue(cargo.originPort) ?? '')?.nm ?? null)
-      : null;
+      : null);
 
   return (
     <main className="min-h-screen bg-ds-bg">

--- a/lib/economics/__tests__/canonical-tce-inputs.test.ts
+++ b/lib/economics/__tests__/canonical-tce-inputs.test.ts
@@ -50,6 +50,26 @@ describe('buildCanonicalTceInputs', () => {
     const out = buildCanonicalTceInputs(baseInput);
     expect(out.daUsd).toBeUndefined();
   });
+
+  test('ballastDistanceNm known: uses ballast+laden+2 not round-trip', () => {
+    // Piraeus→Odessa ballast ≈ 800nm, Odessa→Rotterdam laden ≈ 2900nm, speed 13kts
+    const ballastNm = 800;
+    const ladenNm = 2900;
+    const speedKts = 13;
+    const out = buildCanonicalTceInputs({
+      ...baseInput,
+      distanceNm: ladenNm,
+      speedKts,
+      ballastDistanceNm: ballastNm,
+    });
+    const ballastDays = ballastNm / (speedKts * 24);
+    const ladenDays = ladenNm / (speedKts * 24);
+    const expected = ballastDays + ladenDays + 2;
+    expect(out.durationDays).toBeCloseTo(expected, 2);
+    // Confirm it's NOT the round-trip
+    const roundTrip = ladenDays * 2 + 2;
+    expect(out.durationDays).not.toBeCloseTo(roundTrip, 1);
+  });
 });
 
 test('buildMatchEconomics with zero consumption on 28k-DWT vessel: consumptionEstimated=true, TCE uses class-aware ~14', () => {

--- a/lib/matching/__tests__/freight-resolver.test.ts
+++ b/lib/matching/__tests__/freight-resolver.test.ts
@@ -128,3 +128,37 @@ describe('resolveFreightRate — tier-2 math gives sane $/mt', () => {
     expect(r.source).toBe('estimated');
   });
 });
+
+describe('resolveFreightRate — tier-2 ballast-aware duration', () => {
+  it('uses ballastDays+ladenDays+2 when ballastDistanceNm provided', () => {
+    const ballastNm = 800;
+    const r = resolveFreightRate({
+      ...base,
+      balticDayRate: balticInput,
+      ballastDistanceNm: ballastNm,
+    });
+    expect(r.source).toBe('baltic');
+    const safeSpeed = base.speedKts!;
+    const ladenDays = estimateVoyageDays(base.distanceNm, safeSpeed);
+    const ballastDays = ballastNm / (safeSpeed * 24);
+    const expectedDays = ballastDays + ladenDays + 2;
+    const expectedRate = Math.round((balticInput.usdPerDay * expectedDays) / base.quantityMt * 100) / 100;
+    expect(r.value).toBeCloseTo(expectedRate, 2);
+    // Confirm it differs from round-trip
+    const roundTripDays = ladenDays * 2 + 2;
+    const roundTripRate = Math.round((balticInput.usdPerDay * roundTripDays) / base.quantityMt * 100) / 100;
+    expect(r.value).not.toBeCloseTo(roundTripRate, 2);
+  });
+
+  it('falls back to round-trip when ballastDistanceNm is null', () => {
+    const r = resolveFreightRate({
+      ...base,
+      balticDayRate: balticInput,
+      ballastDistanceNm: null,
+    });
+    const ladenDays = estimateVoyageDays(base.distanceNm, base.speedKts);
+    const days = ladenDays * 2 + 2;
+    const expectedRate = Math.round((balticInput.usdPerDay * days) / base.quantityMt * 100) / 100;
+    expect(r.value).toBeCloseTo(expectedRate, 2);
+  });
+});

--- a/lib/matching/__tests__/stored-match-economics.test.ts
+++ b/lib/matching/__tests__/stored-match-economics.test.ts
@@ -108,6 +108,27 @@ describe('computeStoredMatchEconomics — single source of truth', () => {
     expect(result.tce_breakdown).toBeNull();
   });
 
+  it('returns ballast_distance_nm in the result for open=Piraeus/load=Odessa/laden=Rotterdam', () => {
+    const result = computeStoredMatchEconomics({
+      cargo: {
+        emailId: 'c4', itemIndex: 0,
+        originPort: { value: 'Odessa', confidence: 'confirmed', source_text: 'Odessa' },
+        destinationPort: { value: 'Rotterdam', confidence: 'confirmed', source_text: 'Rotterdam' },
+        cargoType: 'GRAIN', freightRateUsd: 30,
+        weightMt: { value: 50000, confidence: 'confirmed', source_text: '50000' },
+      } as any,
+      vessel: {
+        emailId: 'v4', itemIndex: 0,
+        dwtSummer: { value: 50000, confidence: 'confirmed', source_text: '50000' },
+        speedLaden: '13',
+        consumption: '26',
+        openPosition: { value: 'Piraeus', confidence: 'confirmed', source_text: 'Piraeus' },
+      } as any,
+    });
+    expect(result.ballast_distance_nm).not.toBeNull();
+    expect(result.ballast_distance_nm).toBeGreaterThan(0);
+  });
+
   it('works without db (gracefully degrades to zero DA)', () => {
     const result = computeStoredMatchEconomics({
       cargo: {

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -85,7 +85,7 @@ export async function computeAndPersistMatches(
     // (excludeWarRiskFromDailyTce:true) so stored TCE matches the detail page.
     const eco = cargo && vessel
       ? computeStoredMatchEconomics({ cargo, vessel, db, bunkerPriceUsdPerMt })
-      : { tce_usd_per_day: null, freight_rate_usd_per_mt: null, freight_rate_source: null, consumption_estimated: false };
+      : { tce_usd_per_day: null, freight_rate_usd_per_mt: null, freight_rate_source: null, consumption_estimated: false, ballast_distance_nm: null };
     const tce_usd_per_day = eco.tce_usd_per_day;
     const freight_rate_usd_per_mt = eco.freight_rate_usd_per_mt;
     const freight_rate_source = eco.freight_rate_source;
@@ -112,6 +112,7 @@ export async function computeAndPersistMatches(
       vessel_name: vessel ? (cfValue(vessel.vesselName) || null) : null,
       cargo_ref: cargo ? (cfValue(cargo.cargoDescription) || null) : null,
       consumption_estimated,
+      ballast_distance_nm: eco.ballast_distance_nm ?? null,
     });
   }
 

--- a/lib/matching/freight-resolver.ts
+++ b/lib/matching/freight-resolver.ts
@@ -20,6 +20,12 @@ export interface ResolveFreightInput {
    * caller from `baltic_indices` (keeps this function pure / DB-free). null → skip tier.
    */
   balticDayRate?: { usdPerDay: number; date: string; indexCode: string } | null;
+  /**
+   * Ballast reposition distance (open position → load port, nm). When provided, tier-2
+   * uses single-voyage span (ballastDays + ladenDays + 2) instead of round-trip, keeping
+   * the freight denominator consistent with the TCE formula (I6 fix).
+   */
+  ballastDistanceNm?: number | null;
 }
 
 export interface ResolvedFreightRate {
@@ -55,16 +61,22 @@ export function resolveFreightRate(input: ResolveFreightInput): ResolvedFreightR
     return { value: round2(input.parsedFreightRateUsdPerMt), source: 'parsed', confidence: PARSED_CONFIDENCE };
   }
 
-  // Tier 2 — Baltic market: $/mt = ($/day × ROUND-TRIP days) ÷ tonnes.
-  // Round-trip (laden + ballast + 2 port days) matches the duration model used
-  // downstream in computeEstimatedTce, so freight revenue and bunker cost share
-  // a consistent voyage span. Using laden-only days here while costs ran over
-  // round-trip under-stated freight ~7× and drove the −$102k vs +$774 divergence
-  // the persist-session-matches override was hiding (#819 Phase B(b)).
+  // Tier 2 — Baltic market: $/mt = ($/day × voyage days) ÷ tonnes.
+  // When ballastDistanceNm is known, uses single-voyage span (ballastDays + ladenDays + 2
+  // port days) so the freight denominator matches the TCE formula denominator (I6 fix).
+  // Without ballastDistanceNm, falls back to round-trip (laden*2 + 2) which keeps
+  // parity with the pre-ballast TCE model (#819 Phase B(b)).
   const baltic = input.balticDayRate;
   if (baltic && isPositive(baltic.usdPerDay) && input.distanceNm > 0 && input.quantityMt > 0) {
     const ladenDays = estimateVoyageDays(input.distanceNm, input.speedKts);
-    const days = ladenDays > 0 ? ladenDays * 2 + 2 : 0;
+    let days: number;
+    if (ladenDays > 0 && input.ballastDistanceNm != null && input.ballastDistanceNm > 0) {
+      const safeSpeed = input.speedKts != null && input.speedKts > 0 ? input.speedKts : 12;
+      const ballastDays = input.ballastDistanceNm / (safeSpeed * 24);
+      days = ballastDays + ladenDays + 2;
+    } else {
+      days = ladenDays > 0 ? ladenDays * 2 + 2 : 0;
+    }
     if (days > 0) {
       const value = round2((baltic.usdPerDay * days) / input.quantityMt);
       if (value > 0) {

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -32,6 +32,7 @@ export interface StoredMatch {
   vessel_item_index?: number | null;
   worksheet_json?: string | null;
   consumption_estimated?: number | null;
+  ballast_distance_nm?: number | null;
   /** Per-cargo rank by fit_percent desc (present only when listMatches called with topPerCargo). */
   cargo_rank?: number;
 }
@@ -62,6 +63,7 @@ export interface CreateMatchInput {
   vessel_item_index?: number | null;
   worksheet_json?: string | null;
   consumption_estimated?: number | null;
+  ballast_distance_nm?: number | null;
 }
 
 export interface ListMatchesOptions {
@@ -129,6 +131,11 @@ function hasConsumptionEstimatedColumn(db: Database.Database): boolean {
   return cols.some((c) => c.name === 'consumption_estimated');
 }
 
+function hasBallastDistanceColumn(db: Database.Database): boolean {
+  const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+  return cols.some((c) => c.name === 'ballast_distance_nm');
+}
+
 export function createMatch(db: Database.Database, input: CreateMatchInput): StoredMatch {
   const now = Date.now();
   const status: MatchStatus = input.status ?? 'shortlist';
@@ -163,6 +170,9 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
     // Consumption estimated column (migration 046) — conditional for same reason.
     const withConsEst = hasConsumptionEstimatedColumn(db);
     const consumption_estimated = input.consumption_estimated ?? null;
+    // Ballast distance column (migration 047) — conditional for same reason.
+    const withBallast = hasBallastDistanceColumn(db);
+    const ballast_distance_nm = input.ballast_distance_nm ?? null;
 
     const stmt = db.prepare(
       `INSERT OR IGNORE INTO matches
@@ -170,8 +180,8 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
           reason_structured, cargo_type, load_port, discharge_port,
           laycan_start, laycan_end, vessel_dwt, tce_usd_per_day, distance_nm,
           freight_rate_usd_per_mt, freight_rate_source, vessel_name, cargo_ref,
-          fit_percent, fit_breakdown${withIdx ? ', cargo_item_index, vessel_item_index' : ''}${withWorksheet ? ', worksheet_json' : ''}${withConsEst ? ', consumption_estimated' : ''})
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${withIdx ? ', ?, ?' : ''}${withWorksheet ? ', ?' : ''}${withConsEst ? ', ?' : ''})`
+          fit_percent, fit_breakdown${withIdx ? ', cargo_item_index, vessel_item_index' : ''}${withWorksheet ? ', worksheet_json' : ''}${withConsEst ? ', consumption_estimated' : ''}${withBallast ? ', ballast_distance_nm' : ''})
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${withIdx ? ', ?, ?' : ''}${withWorksheet ? ', ?' : ''}${withConsEst ? ', ?' : ''}${withBallast ? ', ?' : ''})`
     );
     const args: Array<string | number | null> = [
       input.cargo_id,
@@ -201,6 +211,7 @@ export function createMatch(db: Database.Database, input: CreateMatchInput): Sto
     if (withIdx) args.push(cargo_item_index, vessel_item_index);
     if (withWorksheet) args.push(worksheet_json);
     if (withConsEst) args.push(consumption_estimated);
+    if (withBallast) args.push(ballast_distance_nm);
     result = stmt.run(...args);
   } else if (hasVesselNameColumns(db)) {
     const reason_structured = input.reason_structured ?? null;

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -48,7 +48,7 @@ export function persistSessionMatches(
     // (excludeWarRiskFromDailyTce:true) so stored TCE matches the detail page.
     const eco = cargo && vessel
       ? computeStoredMatchEconomics({ cargo, vessel, db, bunkerPriceUsdPerMt })
-      : { tce_usd_per_day: null, freight_rate_usd_per_mt: null, freight_rate_source: null, consumption_estimated: false };
+      : { tce_usd_per_day: null, freight_rate_usd_per_mt: null, freight_rate_source: null, consumption_estimated: false, ballast_distance_nm: null };
     const tce_usd_per_day = eco.tce_usd_per_day;
     const freight_rate_usd_per_mt = eco.freight_rate_usd_per_mt;
     const freight_rate_source = eco.freight_rate_source;
@@ -125,6 +125,7 @@ export function persistSessionMatches(
       vessel_item_index: m.vesselItemIndex,
       worksheet_json: worksheetJson,
       consumption_estimated,
+      ballast_distance_nm: eco.ballast_distance_nm ?? null,
     });
   }
 }

--- a/lib/matching/stored-match-economics.ts
+++ b/lib/matching/stored-match-economics.ts
@@ -57,6 +57,8 @@ export interface StoredMatchEconomicsResult {
   tce_breakdown: TCEBreakdown | null;
   /** True when vessel consumption was absent and class-aware fallback fired. */
   consumption_estimated: boolean;
+  /** Ballast reposition distance (open position → load port, nm). Persisted so detail reads stored value on session expiry. */
+  ballast_distance_nm: number | null;
 }
 
 /**
@@ -80,6 +82,7 @@ export function computeStoredMatchEconomics(
     economics: null,
     tce_breakdown: null,
     consumption_estimated: false,
+    ballast_distance_nm: null,
   };
 
   const loadPort = cfValue(cargo.originPort);
@@ -98,6 +101,15 @@ export function computeStoredMatchEconomics(
   const ecoDwt = cfValue(vessel.dwtSummer) ?? 0;
   const ecoQty = resolveCargoWeight(cargo) ?? 0;
   const ecoSpeed = parseLeadingNumber(vessel.speedLaden);
+
+  // Ballast reposition distance: open position → load port.
+  // Computed before resolveFreightRate so tier-2 Baltic conversion uses the same
+  // single-voyage denominator as the TCE formula (I6 fix).
+  const openPosition = cfValue(vessel.openPosition);
+  const ballastResult =
+    openPosition && loadPort ? getPortDistance(openPosition, loadPort) : null;
+  const ballastDistanceNm = ballastResult?.nm ?? null;
+
   const resolvedFreight = resolveFreightRate({
     cargoType,
     parsedFreightRateUsdPerMt: cargo.freightRateUsd ?? null,
@@ -107,13 +119,8 @@ export function computeStoredMatchEconomics(
     speedKts: ecoSpeed,
     balticDayRate: db ? getBalticDayRate(db, ecoDwt) : null,
     manualRateUsdPerMt: input.freightOverrideUsdPerMt ?? undefined,
+    ballastDistanceNm,
   });
-
-  // Ballast reposition distance: open position → load port.
-  const openPosition = cfValue(vessel.openPosition);
-  const ballastResult =
-    openPosition && loadPort ? getPortDistance(openPosition, loadPort) : null;
-  const ballastDistanceNm = ballastResult?.nm ?? null;
 
   // Port disbursement (DA): load + discharge fixed costs.
   const daUsd = db
@@ -213,5 +220,6 @@ export function computeStoredMatchEconomics(
     economics: econ,
     tce_breakdown,
     consumption_estimated: consumptionEstimated,
+    ballast_distance_nm: ballastDistanceNm,
   };
 }

--- a/lib/migrations/047-matches-ballast-distance.ts
+++ b/lib/migrations/047-matches-ballast-distance.ts
@@ -1,0 +1,18 @@
+import type { Migration } from './types';
+
+const migration047: Migration = {
+  version: 47,
+  name: 'matches-ballast-distance',
+  up(db) {
+    const cols = db.prepare(`PRAGMA table_info(matches)`).all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    if (!names.has('ballast_distance_nm')) {
+      db.exec(`ALTER TABLE matches ADD COLUMN ballast_distance_nm REAL`);
+    }
+  },
+  down(db) {
+    void db;
+  },
+};
+
+export default migration047;

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -44,6 +44,7 @@ import migration043 from './043-baltic-tc-dayrates-seed';
 import migration044 from './044-matches-item-index';
 import migration045 from './045-matches-worksheet';
 import migration046 from './046-matches-consumption-estimated';
+import migration047 from './047-matches-ballast-distance';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043, migration044, migration045, migration046];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043, migration044, migration045, migration046, migration047];


### PR DESCRIPTION
## Summary

- **I5 (detail≠list on session expiry):** Migration 047 adds `ballast_distance_nm REAL` to matches table. `computeStoredMatchEconomics` now returns + persists it. `app/match/[id]/page.tsx` reads `storedMatch.ballast_distance_nm` (session-derived fallback for legacy null rows). On session expiry, detail uses stored value → same single-voyage duration as list.
- **I6 (Baltic tier-2 sized round-trip, TCE denom single-voyage):** `ResolveFreightInput` gains `ballastDistanceNm?`. Tier-2 uses `ballastDays + ladenDays + 2` when ballast known; round-trip fallback when null. `ballastDistanceNm` threaded from `computeStoredMatchEconomics` into `resolveFreightRate`.

## Pre-PASS Verification

**Block 1 — TypeCheck:**
```
$ NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit 2>&1 | head -10
(no output)
```

**Block 2 — Affected tests:**
```
$ npx jest --findRelatedTests lib/migrations/047-matches-ballast-distance.ts lib/matching/stored-match-economics.ts lib/matching/freight-resolver.ts lib/economics/canonical-tce-inputs.ts __tests__/match-worksheet-migration.test.ts --maxWorkers=1 --no-coverage --ci --forceExit 2>&1 | tail -5
Test Suites: 310 passed, 310 total
Tests:       6 skipped, 2742 passed, 2748 total
```

**Block 3 — Cross-cutting grep:**
N/A — no literal strings changed in this diff.

## Files changed (13)
| File | Change |
|------|--------|
| `lib/migrations/047-matches-ballast-distance.ts` | NEW — `ALTER TABLE matches ADD COLUMN ballast_distance_nm REAL` |
| `lib/migrations/index.ts` | Register migration047 |
| `lib/matching/stored-match-economics.ts` | Return `ballast_distance_nm`; move ballast compute before `resolveFreightRate`; pass `ballastDistanceNm` to resolver |
| `lib/matching/matches-repository.ts` | `StoredMatch` + `CreateMatchInput` + `hasBallastDistanceColumn` + conditional INSERT |
| `lib/matching/compute-matches.ts` | Pass `ballast_distance_nm` from eco result |
| `lib/matching/persist-session-matches.ts` | Pass `ballast_distance_nm` from eco result |
| `lib/matching/freight-resolver.ts` | `ballastDistanceNm?` on input; ballast-aware tier-2 branch |
| `app/match/[id]/page.tsx` | Stored-first: `storedMatch.ballast_distance_nm ?? session fallback` |
| `lib/matching/__tests__/stored-match-economics.test.ts` | RED→GREEN: `ballast_distance_nm` in result |
| `lib/economics/__tests__/canonical-tce-inputs.test.ts` | Documents ballast-aware duration |
| `lib/matching/__tests__/freight-resolver.test.ts` | RED→GREEN: tier-2 ballast-aware + null fallback |
| `__tests__/match-worksheet-migration.test.ts` | Update last-migration assertion (was 45, now 47) |

## Risk
- NULL `ballast_distance_nm` on legacy rows → round-trip fallback (not assume 0). See `canonical-tce-inputs.ts` existing guard.
- R3 (two distance engines) out of scope per plan. `KNOWLEDGE_LAYER_DISTANCES_ENABLED=off`.
- W2's migration 046 (`consumption_estimated`) is on a separate branch; migration runner sorts by version so both will apply in order after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)