### PR TITLE
feat(w5): data_quality channel infra (ROOT A) — types/derive/badge + consumption wiring

### DIFF
--- a/components/data-quality/DataQualityBadge.tsx
+++ b/components/data-quality/DataQualityBadge.tsx
@@ -1,0 +1,40 @@
+'use client';
+import type { DataTier } from '@/lib/data-quality/types';
+
+interface Props {
+  tier: DataTier;
+  asOf?: string;
+}
+
+function formatDayMonth(asOf: string): string {
+  const d = new Date(asOf);
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${dd}-${mm}`;
+}
+
+export function DataQualityBadge({ tier, asOf }: Props) {
+  if (tier === 'live') return null;
+
+  if (tier === 'estimated') {
+    return (
+      <span
+        data-testid="data-quality-badge"
+        className="text-xs text-amber-600"
+      >
+        (est.)
+      </span>
+    );
+  }
+
+  // stale
+  const dateStr = asOf ? ` · ${formatDayMonth(asOf)}` : '';
+  return (
+    <span
+      data-testid="data-quality-badge"
+      className="text-xs text-red-600"
+    >
+      {`(stale${dateStr})`}
+    </span>
+  );
+}

--- a/components/data-quality/__tests__/DataQualityBadge.test.tsx
+++ b/components/data-quality/__tests__/DataQualityBadge.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { DataQualityBadge } from '../DataQualityBadge';
+
+test('DataQualityBadge: tier=estimated renders (est.)', () => {
+  const { container } = render(<DataQualityBadge tier="estimated" />);
+  expect(container).toHaveTextContent('(est.)');
+});
+
+test('DataQualityBadge: tier=stale renders stale with dd-mm date', () => {
+  render(<DataQualityBadge tier="stale" asOf="2026-05-09" />);
+  expect(screen.getByTestId('data-quality-badge')).toHaveTextContent('stale');
+  expect(screen.getByTestId('data-quality-badge')).toHaveTextContent('09-05');
+});
+
+test('DataQualityBadge: tier=live renders nothing', () => {
+  const { container } = render(<DataQualityBadge tier="live" />);
+  expect(container.firstChild).toBeNull();
+});

--- a/lib/data-quality/__tests__/channel-consumption.test.ts
+++ b/lib/data-quality/__tests__/channel-consumption.test.ts
@@ -1,0 +1,40 @@
+/**
+ * W5 refactor: EconomicsResult.dataQuality.consumption maps W2 consumptionEstimated boolean
+ * into the unified data-quality channel.
+ */
+import { buildMatchEconomics } from '@/lib/matching/tce-calculator';
+
+test('buildMatchEconomics with zero consumption populates dataQuality.consumption.tier=estimated', () => {
+  const result = buildMatchEconomics({
+    cargoType: 'GRAIN',
+    distanceNm: 3000,
+    vesselDwt: 28000,
+    quantityMt: 18000,
+    speedKts: 12,
+    consumptionMt: 0,
+    loadPort: 'NLRTM',
+    dischargePort: 'EGPSD',
+    calculatedAt: new Date().toISOString(),
+    excludeWarRiskFromDailyTce: true,
+  });
+  expect(result).not.toBeNull();
+  expect(result!.dataQuality?.consumption?.tier).toBe('estimated');
+});
+
+test('buildMatchEconomics with explicit consumption: no dataQuality.consumption entry or tier=live', () => {
+  const result = buildMatchEconomics({
+    cargoType: 'GRAIN',
+    distanceNm: 3000,
+    vesselDwt: 28000,
+    quantityMt: 18000,
+    speedKts: 12,
+    consumptionMt: 22,
+    loadPort: 'NLRTM',
+    dischargePort: 'EGPSD',
+    calculatedAt: new Date().toISOString(),
+    excludeWarRiskFromDailyTce: true,
+  });
+  expect(result).not.toBeNull();
+  const tier = result!.dataQuality?.consumption?.tier;
+  expect(tier === undefined || tier === 'live').toBe(true);
+});

--- a/lib/data-quality/__tests__/derive.test.ts
+++ b/lib/data-quality/__tests__/derive.test.ts
@@ -1,0 +1,21 @@
+import { deriveTier } from '../derive';
+
+test('deriveTier: static-seed with asOf 30 days ago and staleAfterDays:14 → stale', () => {
+  expect(deriveTier({ source: 'static-seed', asOf: '2026-05-09', staleAfterDays: 14 })).toBe('stale');
+});
+
+test('deriveTier: source=estimated with no verifiedSources → estimated', () => {
+  expect(deriveTier({ source: 'estimated' })).toBe('estimated');
+});
+
+test('deriveTier: source=eex in verifiedSources → live', () => {
+  expect(deriveTier({ source: 'eex', verifiedSources: ['eex'] })).toBe('live');
+});
+
+test('deriveTier: stale check wins over verified source when asOf is old', () => {
+  expect(deriveTier({ source: 'eex', verifiedSources: ['eex'], asOf: '2026-05-01', staleAfterDays: 7 })).toBe('stale');
+});
+
+test('deriveTier: no source no asOf → live', () => {
+  expect(deriveTier({})).toBe('live');
+});

--- a/lib/data-quality/derive.ts
+++ b/lib/data-quality/derive.ts
@@ -1,0 +1,26 @@
+import type { DataTier } from './types';
+
+interface DeriveTierInput {
+  source?: string;
+  asOf?: string;
+  staleAfterDays?: number;
+  verifiedSources?: string[];
+}
+
+function ageInDays(asOf: string): number {
+  const ms = Date.now() - new Date(asOf).getTime();
+  return Math.floor(ms / (1000 * 60 * 60 * 24));
+}
+
+export function deriveTier(input: DeriveTierInput): DataTier {
+  if (input.asOf && input.staleAfterDays != null && ageInDays(input.asOf) > input.staleAfterDays) {
+    return 'stale';
+  }
+  if (input.source && input.verifiedSources?.includes(input.source)) {
+    return 'live';
+  }
+  if (!input.source) {
+    return 'live';
+  }
+  return 'estimated';
+}

--- a/lib/data-quality/types.ts
+++ b/lib/data-quality/types.ts
@@ -1,0 +1,8 @@
+export type DataTier = 'live' | 'estimated' | 'stale';
+
+export interface DataQuality {
+  tier: DataTier;
+  source?: string;
+  asOf?: string;
+  note?: string;
+}

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -388,5 +388,8 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
     freightRateSource: tce.freight_rate_source,
     consumptionEstimated: input.consumptionMt <= 0 ? true : undefined,
     qtyEstimated: input.quantityMt <= 0 ? true : undefined,
+    dataQuality: input.consumptionMt <= 0
+      ? { consumption: { tier: 'estimated' as const, source: 'class-estimate' } }
+      : undefined,
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -99,6 +99,8 @@ export interface EconomicsResult {
   consumptionEstimated?: boolean;
   /** Set when cargo quantity was absent/zero and DWT×0.65 fallback fired. */
   qtyEstimated?: boolean;
+  /** Data-quality channel — per-field provenance (W5). Map key = field name. */
+  dataQuality?: Record<string, import('./data-quality/types').DataQuality>;
 }
 
 // ── FuelEU Maritime (Spec γ-11) ──


### PR DESCRIPTION
## Wave 5 — Data-Quality Channel Infrastructure (ROOT A)

Closes the infra wave for Disease A. Builds the typed channel that W6+ will thread through every estimation/staleness surface.

### What ships

| File | What |
|------|------|
| `lib/data-quality/types.ts` | `DataTier = 'live'\|'estimated'\|'stale'`; `DataQuality{tier,source?,asOf?,note?}` |
| `lib/data-quality/derive.ts` | `deriveTier({source,asOf,staleAfterDays,verifiedSources})` — stale > estimated > live |
| `components/data-quality/DataQualityBadge.tsx` | Renders `(est.)` / `(stale · dd-mm)` / nothing |
| `lib/types.ts` | `EconomicsResult.dataQuality?: Record<string, DataQuality>` |
| `lib/matching/tce-calculator.ts` | Populates `dataQuality.consumption={tier:'estimated'}` when `consumptionMt<=0` |

### Design decisions
- **W2's `consumptionEstimated` boolean is kept** — too many callers to change in one wave (17 refs). Channel is additive; `consumptionEstimated` stays as a backward-compat alias. W6 will thread the channel to the UI.
- **DB column `consumption_estimated` unchanged** — the channel is a read-model over it. No migration.
- **`deriveTier` logic**: stale check first (asOf age > staleAfterDays) → live check (source in verifiedSources) → estimated fallback.

### DoD blocks

**Block 1 — TypeCheck:**
```
$ NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit 2>&1 | head -10
(no output — clean)
```

**Block 2 — Affected tests:**
```
$ npx jest --findRelatedTests lib/data-quality/__tests__/derive.test.ts lib/data-quality/__tests__/channel-consumption.test.ts components/data-quality/__tests__/DataQualityBadge.test.tsx lib/matching/__tests__/stored-match-economics-consumption.test.ts lib/economics/__tests__/canonical-tce-inputs.test.ts __tests__/components/match/EconomicsTab-consumption-estimate.test.tsx --maxWorkers=1 --no-coverage 2>&1 | tail -5
Test Suites: 6 passed, 6 total
Tests:       21 passed, 21 total
```

**Block 3 — Cross-cutting grep:**
N/A — no literal strings changed in this diff.

### PI checks
- **PI3**: 0 existing test expectations modified (all 8 new tests are additions)
- **PI2**: ≥1 behavioral test — `channel-consumption.test.ts` calls real `buildMatchEconomics()` and asserts `dataQuality.consumption.tier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)