### PR TITLE
feat(constants): centralize bunker + ETS fallback constants (W7, closes I8+I9)

### DIFF
--- a/__tests__/economics/list-detail-tce-parity.test.ts
+++ b/__tests__/economics/list-detail-tce-parity.test.ts
@@ -12,6 +12,7 @@
  *   via sumMatchPortDaUsd so a DA bug in the helper would be caught (not circular).
  */
 import Database from 'better-sqlite3';
+import { DEFAULT_BUNKER_USD_PER_MT as _DEFAULT_BUNKER, FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
 import { buildCanonicalTceInputs } from '@/lib/economics/canonical-tce-inputs';
 import { calculateTCE } from '@/lib/economics/voyage-calculator';
 import { computeEstimatedTce, buildMatchEconomics, estimateFreightRate, deriveEtsCoverage, routeTransitsBosporus, quoteBosporusSafe, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
@@ -52,9 +53,9 @@ const SAMPLES: Sample[] = [
   { name: 'Long-haul Santos→Qingdao',   vesselDwt: 82000, speedKts: 14, consumptionMtPerDay: 32, distanceNm: 11200, quantityMt: 75000, cargoType: 'GRAIN' },
 ];
 
-// Constants matching computeEstimatedTce defaults (see tce-calculator.ts)
-const DEFAULT_BUNKER_USD_PER_MT = 600;
-const DEFAULT_EUA_EUR = 65;
+// Constants matching computeEstimatedTce defaults — imported from lib/constants (W7)
+const DEFAULT_BUNKER_USD_PER_MT = _DEFAULT_BUNKER;  // 600
+const DEFAULT_EUA_EUR = FALLBACK_EUA_EUR_PER_TCO2;  // 87.5 (was 65, unified W7)
 const DEFAULT_VESSEL_VALUE_USD = 22_000_000;
 
 describe('LIST tce_usd_per_day === DETAIL daily_tce_usd (parity, #819)', () => {
@@ -369,7 +370,7 @@ describe('Workstream A5: stored list TCE ↔ live detail TCE parity (CI guard)',
       bunkerPriceUsdPerMt: 600, // DEFAULT_BUNKER_USD_PER_MT (matches helper default)
       originPort: loadPort,
       destinationPort: dischargePort,
-      euaPriceEur: 65, // DEFAULT_EUA_EUR
+      euaPriceEur: FALLBACK_EUA_EUR_PER_TCO2, // 87.5 — was 65, unified W7
       vesselValueUsd: 22_000_000, // DEFAULT_VESSEL_VALUE_USD
       ballastDistanceNm,
       canalUsd: canalUsd > 0 ? canalUsd : undefined,
@@ -518,7 +519,7 @@ describe('A5-ballast: openPosition ≠ loadPort — stored LIST ↔ detail TCE p
       bunkerPriceUsdPerMt: 600, // DEFAULT_BUNKER_USD_PER_MT
       originPort: loadPort,
       destinationPort: dischargePort,
-      euaPriceEur: 65,          // DEFAULT_EUA_EUR
+      euaPriceEur: FALLBACK_EUA_EUR_PER_TCO2, // 87.5 — was 65, unified W7
       vesselValueUsd: 22_000_000,
       ballastDistanceNm,        // ← THE FIX: single-voyage duration
     });
@@ -560,7 +561,7 @@ describe('A5-ballast: openPosition ≠ loadPort — stored LIST ↔ detail TCE p
       bunkerPriceUsdPerMt: 600,
       originPort: loadPort,
       destinationPort: dischargePort,
-      euaPriceEur: 65,
+      euaPriceEur: FALLBACK_EUA_EUR_PER_TCO2, // 87.5 — was 65, unified W7
       vesselValueUsd: 22_000_000,
       // ballastDistanceNm intentionally omitted
     });

--- a/__tests__/lib/constants.test.ts
+++ b/__tests__/lib/constants.test.ts
@@ -1,0 +1,46 @@
+/**
+ * W7: centralized bunker + ETS fallback constants (closes I8, I9).
+ * RED first — these exports don't exist until GREEN phase.
+ */
+import { DEFAULT_BUNKER_USD_PER_MT, FALLBACK_EUA_EUR_PER_TCO2, BUNKER_DEFAULTS } from '@/lib/constants';
+
+describe('centralized constants (W7)', () => {
+  it('exports DEFAULT_BUNKER_USD_PER_MT = 600', () => {
+    expect(DEFAULT_BUNKER_USD_PER_MT).toBe(600);
+  });
+
+  it('exports FALLBACK_EUA_EUR_PER_TCO2 = 87.5', () => {
+    expect(FALLBACK_EUA_EUR_PER_TCO2).toBe(87.5);
+  });
+
+  it('BUNKER_DEFAULTS.bunkerPrice all equal DEFAULT_BUNKER_USD_PER_MT', () => {
+    for (const cls of Object.keys(BUNKER_DEFAULTS) as Array<keyof typeof BUNKER_DEFAULTS>) {
+      expect(BUNKER_DEFAULTS[cls].bunkerPrice).toBe(DEFAULT_BUNKER_USD_PER_MT);
+    }
+  });
+});
+
+// PI2 behavioral: prove fallback parity — no default value drift between modules
+describe('fallback parity — PI2 behavioral (W7)', () => {
+  it('computeEstimatedTce with no bunkerPriceUsdPerMt == with DEFAULT_BUNKER_USD_PER_MT', async () => {
+    // Dynamic import to avoid pulling server deps at compile time
+    const { computeEstimatedTce } = await import('@/lib/matching/tce-calculator');
+    const freight = { rate: 20, source: 'estimated' as const, confidence: 0.5 };
+    const withDefault = computeEstimatedTce(freight, 3000, 50000, 45000);
+    const withExplicit = computeEstimatedTce(
+      freight, 3000, 50000, 45000,
+      12, 25, undefined, undefined, undefined,
+      DEFAULT_BUNKER_USD_PER_MT,
+    );
+    expect(withDefault.tce_usd_per_day).toBe(withExplicit.tce_usd_per_day);
+  });
+
+  it('RouteCompareModal DEFAULT_MARKET bunker == DEFAULT_BUNKER_USD_PER_MT (source code grep)', async () => {
+    const fs = await import('fs');
+    const src = fs.readFileSync(
+      require.resolve('@/components/economics/RouteCompareModal'),
+    ).toString();
+    // After W7: DEFAULT_MARKET must not hardcode 620 or any literal other than the imported constant
+    expect(src).not.toMatch(/bunkerPriceUsdPerMt:\s*620/);
+  });
+});

--- a/__tests__/lib/matching/persist-session-matches-canonical-tce.test.ts
+++ b/__tests__/lib/matching/persist-session-matches-canonical-tce.test.ts
@@ -20,6 +20,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
 import migration032 from '@/lib/migrations/032-matches';
 import migration033 from '@/lib/migrations/033-matches-score-breakdown';
 import migration034 from '@/lib/migrations/034-matches-unique-constraint';
@@ -195,7 +196,7 @@ function expectedLive(
     bunkerPriceUsdPerMt: 600, // DEFAULT_BUNKER_USD_PER_MT (matches helper default)
     originPort: loadPort,
     destinationPort: dischargePort,
-    euaPriceEur: 65, // DEFAULT_EUA_EUR
+    euaPriceEur: FALLBACK_EUA_EUR_PER_TCO2, // 87.5 — was 65, unified W7
     vesselValueUsd: 22_000_000, // DEFAULT_VESSEL_VALUE_USD
     ballastDistanceNm,
     canalUsd: canalUsd > 0 ? canalUsd : undefined,

--- a/components/economics/RouteCompareModal.tsx
+++ b/components/economics/RouteCompareModal.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import type { RouteCompareResult } from '@/lib/economics/route-decision';
 import { PriceSourceBadge } from '@/components/economics/PriceSourceBadge';
+import { DEFAULT_BUNKER_USD_PER_MT, FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
 
 type PriceSource = {
   value: number;
@@ -41,7 +42,7 @@ interface Props {
   bunkerPriceManual?: number;
 }
 
-const DEFAULT_MARKET = { bunkerPriceUsdPerMt: 620, euaPriceEur: 75 };
+const DEFAULT_MARKET = { bunkerPriceUsdPerMt: DEFAULT_BUNKER_USD_PER_MT, euaPriceEur: FALLBACK_EUA_EUR_PER_TCO2 };
 
 function fmtUsd(n: number): string {
   return `$${Math.round(n).toLocaleString('en-US')}`;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -109,15 +109,24 @@ export const STATUS_CONFIG: Record<string, { label: string; color: string; emoji
 
 export const CALENDLY_URL = 'https://wa.me/971528429812';
 
+// ── W7: Canonical fallback constants (closes I8, I9) ──
+// Single source of truth; all modules import from here. Live DB fetch unchanged.
+
+/** Bunker price fallback when no live feed value is available (USD/MT). Canonical = 600. */
+export const DEFAULT_BUNKER_USD_PER_MT = 600;
+
+/** EUA price fallback when EEX fetch fails (EUR/tCO2). ets.ts is module-of-record → 87.5. */
+export const FALLBACK_EUA_EUR_PER_TCO2 = 87.5;
+
 // ── TZ-015: Bunker Defaults by Vessel Class ──
 
 export type VesselClassName = "handysize" | "supramax" | "panamax" | "capesize";
 
 export const BUNKER_DEFAULTS: Record<VesselClassName, { speed: number; consumption: number; bunkerPrice: number }> = {
-  handysize:  { speed: 12.5, consumption: 22, bunkerPrice: 550 },
-  supramax:   { speed: 13.5, consumption: 28, bunkerPrice: 550 },
-  panamax:    { speed: 14.0, consumption: 32, bunkerPrice: 550 },
-  capesize:   { speed: 14.5, consumption: 45, bunkerPrice: 550 },
+  handysize:  { speed: 12.5, consumption: 22, bunkerPrice: DEFAULT_BUNKER_USD_PER_MT },
+  supramax:   { speed: 13.5, consumption: 28, bunkerPrice: DEFAULT_BUNKER_USD_PER_MT },
+  panamax:    { speed: 14.0, consumption: 32, bunkerPrice: DEFAULT_BUNKER_USD_PER_MT },
+  capesize:   { speed: 14.5, consumption: 45, bunkerPrice: DEFAULT_BUNKER_USD_PER_MT },
 };
 
 export const VESSEL_CLASS: Record<VesselClassName, { minDwt: number; maxDwt: number }> = {

--- a/lib/economics/ets.ts
+++ b/lib/economics/ets.ts
@@ -1,3 +1,5 @@
+import { FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
+
 // IMO/BIMCO emission factors tCO2/t fuel — Fourth IMO GHG Study 2020 + BIMCO Allowance Clause 2022
 // DEMO: interim values for demonstration purposes; production use requires verified source data.
 const CF_BY_FUEL: Record<string, number> = {
@@ -24,7 +26,7 @@ export function phaseIn(year: number): number {
   return 1.0;
 }
 
-const FALLBACK_EUA_PRICE = 87.5; // EUR/tCO2
+// FALLBACK_EUA_EUR_PER_TCO2 imported from lib/constants — single source of truth (W7).
 
 export interface EuEtsInput {
   distanceNm: number;
@@ -100,5 +102,5 @@ export async function fetchEuaPrice(): Promise<EuaPriceResult> {
   } catch {
     // fallthrough to constant
   }
-  return { price: FALLBACK_EUA_PRICE, fetched_at: new Date().toISOString() };
+  return { price: FALLBACK_EUA_EUR_PER_TCO2, fetched_at: new Date().toISOString() };
 }

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -8,6 +8,7 @@ import { resolveVaguePort } from '@/lib/ports/resolve-vague';
 import { isEuCountry } from '@/lib/validation/sanctions';
 import type { EconomicsResult } from '@/lib/types';
 import { parseLeadingNumber, parseConsumption, DEFAULT_CONSUMPTION_MT_PER_DAY } from './parse-vessel-fields';
+import { DEFAULT_BUNKER_USD_PER_MT, FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
 
 // Re-export pure parsers for existing server callers (e.g. session-buckets.ts).
 // They live in parse-vessel-fields.ts (no server deps) so client components can
@@ -34,8 +35,6 @@ const BASE_RATES: Record<string, number> = {
 };
 
 const BASE_RATE_FALLBACK = 22;
-const DEFAULT_BUNKER_USD_PER_MT = 600;
-const DEFAULT_EUA_EUR = 65;
 const DEFAULT_SPEED_KTS = 12;
 const DEFAULT_VESSEL_VALUE_USD = 22_000_000;
 
@@ -122,7 +121,7 @@ export function computeEstimatedTce(
     bunkerPriceUsdPerMt,
     originPort: '',
     destinationPort: '',
-    euaPriceEur: euaPriceEur ?? DEFAULT_EUA_EUR,
+    euaPriceEur: euaPriceEur ?? FALLBACK_EUA_EUR_PER_TCO2,
     vesselValueUsd: DEFAULT_VESSEL_VALUE_USD,
     ballastDistanceNm: ballast_distance_nm,
     canalUsd: canal_usd,
@@ -266,7 +265,7 @@ export interface MatchEconomicsInput {
   daUsd?: number | null;
   /** Live bunker price (USD/mt). Defaults to DEFAULT_BUNKER_USD_PER_MT (600) when omitted. */
   bunkerPriceUsdPerMt?: number | null;
-  /** Live EUA spot price (EUR/tCO2). Defaults to DEFAULT_EUA_EUR (65) when omitted. */
+  /** Live EUA spot price (EUR/tCO2). Defaults to FALLBACK_EUA_EUR_PER_TCO2 (87.5) when omitted. */
   euaPriceEur?: number | null;
   /** When true, war-risk premium is excluded from the per-day TCE numerator.
    *  The detail page sets this true (app/api/voyage/tce/route.ts:373) so that
@@ -319,7 +318,7 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
   const { originEu, destEu, euLegPercent } = deriveEtsCoverage(input.loadPort, input.dischargePort);
   const euaPriceEur = (input.euaPriceEur != null && input.euaPriceEur > 0)
     ? input.euaPriceEur
-    : DEFAULT_EUA_EUR;
+    : FALLBACK_EUA_EUR_PER_TCO2;
 
   const tce = computeEstimatedTce(
     freight,


### PR DESCRIPTION
## Summary

Wave 7 of the root-cure plan — closes **I8** (bunker 550/600/620 three-way split) and **I9** (ETS fallback 87.5 vs 65).

### What changed

Single `DEFAULT_BUNKER_USD_PER_MT = 600` and `FALLBACK_EUA_EUR_PER_TCO2 = 87.5` exported from `lib/constants.ts`. All modules import from there. Live DB fetch unchanged — only the fallback path is unified.

| Location | Before | After |
|---|---|---|
| `lib/constants.ts` BUNKER_DEFAULTS.bunkerPrice | 550 | `DEFAULT_BUNKER_USD_PER_MT` (600) |
| `lib/matching/tce-calculator.ts` | local `600` / `65` | imported constants |
| `lib/economics/ets.ts` | local `87.5` | imported `FALLBACK_EUA_EUR_PER_TCO2` |
| `components/economics/RouteCompareModal.tsx` DEFAULT_MARKET | `620` / `75` | `600` / `87.5` |

### Value decisions (founder-authorized per dispatch)

- **Bunker** = 600 (tce-calculator was the canonical computation path)
- **ETS** = 87.5 (ets.ts is module-of-record; old tce-calculator fallback was 65 — dropped)
- RouteCompareModal's `euaPriceEur: 75` → 87.5 (was an outlier, now aligned)

### Test updates (not PI3-prohibited)

2 test helpers that mirrored the old 65 EUA fallback updated to `FALLBACK_EUA_EUR_PER_TCO2`:
- `__tests__/economics/list-detail-tce-parity.test.ts` — local `DEFAULT_EUA_EUR` constant
- `__tests__/lib/matching/persist-session-matches-canonical-tce.test.ts` — `expectedLive()` helper

These are helper functions that mirror the production fallback to compute expected values, NOT assertions masking a bug (PI3 intent). Total: 2 file edits, well under the PI3 >5 threshold.

## DoD blocks

**Block 1 — TypeCheck:**
```
$ NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit 2>&1 | head -10
(no output)
```

**Block 2 — Affected tests:**
```
$ npx jest lib/matching/__tests__/tce-calculator.test.ts lib/economics/__tests__/ets.test.ts __tests__/lib/constants.test.ts __tests__/economics/list-detail-tce-parity.test.ts __tests__/lib/matching/persist-session-matches-canonical-tce.test.ts __tests__/components/economics/RouteCompareModal-price-sources.test.tsx lib/matching/__tests__/tce-ets-wiring.test.ts lib/matching/__tests__/tce-bosporus.test.ts --maxWorkers=1 --no-coverage --forceExit 2>&1 | tail -10
Test Suites: 8 passed, 8 total
Tests:       96 passed, 96 total
```

**Block 3 — Cross-cutting grep:**
```
$ grep -rn "FALLBACK_EUA_PRICE\b\|DEFAULT_EUA_EUR\b" __tests__/ app/ lib/ components/ --include="*.ts" --include="*.tsx" | grep -v "\.test\."
(no output — both removed from source)

$ grep -rn "bunkerPriceUsdPerMt:\s*620" __tests__/ app/ lib/ components/
__tests__/api/voyage/tce-missing-bunker-port.test.ts:101: (manual override test — passes 620 explicitly as an API param, not a fallback)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)