### PR TITLE
fix(waterfall): M1 duration 1dp, M2 TCE-basis reconcile, L1 negative-zero (cold-QA #861)

### DIFF
--- a/__tests__/components/economics/CalculationWaterfall.test.tsx
+++ b/__tests__/components/economics/CalculationWaterfall.test.tsx
@@ -69,3 +69,51 @@ describe('CalculationWaterfall — DA DataQualityBadge (W6a)', () => {
     expect(badge).toBeInTheDocument();
   });
 });
+
+describe('CalculationWaterfall — qafix M1/M2/L1', () => {
+  it('M1: duration_days renders with one decimal place, not raw float', () => {
+    // 12.133333 → toFixed(1) = "12.1" (unambiguous rounding)
+    const bd = makeBreakdown({ duration_days: 12.133333333333333 });
+    render(<CalculationWaterfall breakdown={bd} />);
+    const durationEl = screen.getByTestId('duration-days');
+    expect(durationEl).not.toHaveTextContent('12.133');
+    expect(durationEl).toHaveTextContent('12.1');
+  });
+
+  it('M1: bunker caption shows duration with one decimal', () => {
+    const bd = makeBreakdown({ duration_days: 12.133333333333333 });
+    render(<CalculationWaterfall breakdown={bd} />);
+    const caption = screen.getByTestId('bunker-caption');
+    expect(caption).not.toHaveTextContent('12.133');
+    expect(caption).toHaveTextContent('12.1');
+  });
+
+  it('M2: tce-basis row present and shows net+warRisk when war_risk_usd>0', () => {
+    // daily_tce = (net_voyage + war_risk) / duration = (122000 + 10000) / 15 = 8800
+    const bd = makeBreakdown({
+      war_risk_usd: 10000,
+      net_voyage_usd: 122000,
+      daily_tce_usd: 8800,
+      total_costs_usd: 78000,
+      duration_days: 15,
+    });
+    render(<CalculationWaterfall breakdown={bd} />);
+    const tceBasis = screen.getByTestId('tce-basis');
+    expect(tceBasis).toHaveTextContent('$132,000');
+    // final daily TCE must match
+    expect(screen.getByTestId('daily-tce')).toHaveTextContent('$8,800');
+  });
+
+  it('M2: no tce-basis row when war_risk_usd=0 (math already reconciles)', () => {
+    const bd = makeBreakdown({ war_risk_usd: 0, net_voyage_usd: 132000, daily_tce_usd: 8800, duration_days: 15 });
+    render(<CalculationWaterfall breakdown={bd} />);
+    expect(screen.queryByTestId('tce-basis')).toBeNull();
+  });
+
+  it('L1: war_risk_usd=0 does not render negative-zero display', () => {
+    render(<CalculationWaterfall breakdown={makeBreakdown({ war_risk_usd: 0 })} />);
+    const warRiskRow = screen.getByTestId('cost-war-risk');
+    expect(warRiskRow).not.toHaveTextContent('$-0');
+    expect(warRiskRow).not.toHaveTextContent('-$0');
+  });
+});

--- a/components/economics/CalculationWaterfall.tsx
+++ b/components/economics/CalculationWaterfall.tsx
@@ -19,6 +19,7 @@ interface Props {
 
 /** Broker convention: negatives render as `-$X`, not `$-X` (matches VoyageBreakdownChart). */
 function fmtUsd(n: number): string {
+  if (n === 0) return '$0'; // guards both 0 and -0
   return n < 0
     ? `-$${Math.abs(n).toLocaleString('en-US')}`
     : `$${n.toLocaleString('en-US')}`;
@@ -87,7 +88,7 @@ export function CalculationWaterfall({ breakdown }: Props) {
             className="text-xs text-gray-400 pl-4"
             data-testid="bunker-caption"
           >
-            расход {bunker_consumption_mt_per_day} т/день · {duration_days} дн · цена ${bunker_price_usd_per_mt}/т
+            расход {bunker_consumption_mt_per_day} т/день · {duration_days.toFixed(1)} дн · цена ${bunker_price_usd_per_mt}/т
           </div>
         </div>
 
@@ -165,10 +166,24 @@ export function CalculationWaterfall({ breakdown }: Props) {
         <span data-testid="net-voyage">{fmtUsd(net_voyage_usd)}</span>
       </div>
 
+      {/* ── TCE BASIS (war-risk add-back when excluded from TCE) ─── */}
+      {war_risk_usd > 0 && (
+        <>
+          <div className="flex justify-between text-gray-600 text-xs" data-testid="tce-basis-addback">
+            <span>+ Военный риск возвращён в базу TCE</span>
+            <span>{fmtUsd(war_risk_usd)}</span>
+          </div>
+          <div className="flex justify-between font-semibold" data-testid="tce-basis">
+            <span>= Чистыми для TCE</span>
+            <span>{fmtUsd(net_voyage_usd + war_risk_usd)}</span>
+          </div>
+        </>
+      )}
+
       {/* ── ДЛИНА РЕЙСА ──────────────────────────────────── */}
       <div className="flex justify-between text-gray-600" data-testid="duration-days">
         <span>÷ Длина рейса</span>
-        <span>{duration_days} дней</span>
+        <span>{duration_days.toFixed(1)} дней</span>
       </div>
 
       {/* ── ЗАРАБОТОК В ДЕНЬ (TCE) ───────────────────────── */}


### PR DESCRIPTION
## Summary

Cold-QA findings on `CalculationWaterfall.tsx` (shipped in PR #861):

- **M1** `duration_days` was rendered as raw float (`12.953...`) — now `.toFixed(1)` in duration row and bunker caption
- **M2** When war_risk excluded from TCE the visible math `net_voyage ÷ days ≠ daily_tce` — added "Чистыми для TCE" intermediate row (net + war_risk add-back) so arithmetic is readable end-to-end
- **L1** `fmtUsd(-0)` rendered `$-0` — added `n === 0` guard in `fmtUsd` (covers both 0 and −0)

## Test plan

- [ ] `npx jest "__tests__/components/economics/CalculationWaterfall" --forceExit` → 10/10 pass
- [ ] `NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit` → clean
- [ ] Duration row shows e.g. `15.0 дней` (not `15 дней`) for integer durations; `12.1 дней` for floats
- [ ] When a match has war_risk > 0, "Показать расчёт" panel shows an extra "Чистыми для TCE" row with the correct add-back
- [ ] War-risk $0 line shows `$0` not `$-0`

## Acceptance criteria (issue #861)

| Issue | Criterion | Status | Evidence |
|-------|-----------|--------|----------|
| #861 (cold-QA) | M1: duration renders 1 decimal | ✓ | `CalculationWaterfall.tsx:91,173` `.toFixed(1)` |
| #861 (cold-QA) | M2: divide-row math reconciles for reader | ✓ | `tce-basis` row added at line ~172, testid `tce-basis` |
| #861 (cold-QA) | L1: no `$-0` when war_risk=0 | ✓ | `fmtUsd` line 22 `n===0` guard |
| #861 (cold-QA) | Component test covers all three | ✓ | 5 new tests, 10 total green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)