### PR TITLE
fix(w10): PATCH fit_percent stale + dashboard fit pill + CII disclosure (W10 B/M1/M2)

### DIFF
--- a/__tests__/api/freight-rate-override.test.ts
+++ b/__tests__/api/freight-rate-override.test.ts
@@ -19,7 +19,15 @@ import migration033 from '@/lib/migrations/033-matches-score-breakdown';
 import migration034 from '@/lib/migrations/034-matches-unique-constraint';
 import migration035 from '@/lib/migrations/035-matches-tce-distance';
 import migration036 from '@/lib/migrations/036-matches-freight-rate';
+import migration037 from '@/lib/migrations/037-add-user-preferred-mode';
+import migration038 from '@/lib/migrations/038-jobs-progress';
+import migration039 from '@/lib/migrations/039-demo-seed-meta';
+import migration040 from '@/lib/migrations/040-counter-offers';
+import migration041 from '@/lib/migrations/041-matches-vessel-name';
+import migration042 from '@/lib/migrations/042-matches-fit';
 import { createMatch } from '@/lib/matching/matches-repository';
+import { patchEconomicsComponent } from '@/lib/matching/persist-session-matches';
+import type { FitBreakdown } from '@/lib/types';
 import { requireSession } from '@/lib/session';
 
 let testDb: Database.Database;
@@ -46,6 +54,12 @@ function freshDb(): Database.Database {
   migration034.up(db);
   migration035.up(db);
   migration036.up(db);
+  migration037.up(db);
+  migration038.up(db);
+  migration039.up(db);
+  migration040.up(db);
+  migration041.up(db);
+  migration042.up(db);
   return db;
 }
 
@@ -156,5 +170,44 @@ describe('PATCH /api/matches/[id] — freight rate override', () => {
     const match = seedMatch(testDb);
     const res = await doPatch(match.id, { freight_rate_usd_per_mt: 25 });
     expect(res.status).toBe(503);
+  });
+
+  it('PATCH freight override recomputes fit_percent via canonical patchEconomicsComponent', async () => {
+    const db = testDb;
+    const fb: FitBreakdown = {
+      fitPercent: 70,
+      components: [
+        { factor: 'economics', score: 9, weight: 18, rationale: 'seed', tier: 'neutral' },
+        { factor: 'timing', score: 20, weight: 20, rationale: 'seed', tier: 'good' },
+      ],
+      sanctionsPenalty: 0,
+      chartererPenalty: 0,
+      appliedCap: null,
+    } as unknown as FitBreakdown;
+
+    const match = createMatch(db, {
+      cargo_id: 'cargo-test',
+      vessel_id: 'vessel-test-fit',
+      score: 80,
+      reason: 'r',
+      user_id: SESSION_ID,
+      distance_nm: 3000,
+      vessel_dwt: 50000,
+      load_port: 'UAODS',
+      discharge_port: 'NLRTM',
+      fit_percent: 70,
+      fit_breakdown: JSON.stringify(fb),
+    });
+
+    mockRequireSession.mockReturnValue({ sessionId: SESSION_ID });
+    const res = await doPatch(match.id, { freight_rate_usd_per_mt: 25 });
+    expect(res.status).toBe(200);
+
+    const row = db
+      .prepare('SELECT fit_percent, fit_breakdown, tce_usd_per_day FROM matches WHERE id = ?')
+      .get(match.id) as { fit_percent: number; fit_breakdown: string; tce_usd_per_day: number };
+    const expected = patchEconomicsComponent(fb, row.tce_usd_per_day, 50000).fitPercent;
+    expect(row.fit_percent).toBeCloseTo(expected, 5);
+    expect(row.fit_breakdown).not.toBeNull();
   });
 });

--- a/__tests__/pages/dashboard-fresh-fit.test.tsx
+++ b/__tests__/pages/dashboard-fresh-fit.test.tsx
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DashboardFreshMatches } from '@/components/dashboard/DashboardFreshMatches';
+
+it('renders fit_percent as "N% fit" when present (matches list rule)', () => {
+  render(<DashboardFreshMatches matches={[
+    { id: 1, score: 88, fit_percent: 73.4, matchLevel: 'good', matchReasons: ['r'] },
+  ]} />);
+  expect(screen.getByText('73% fit')).toBeInTheDocument();
+  expect(screen.queryByText('88')).not.toBeInTheDocument();
+});
+
+it('falls back to raw score when fit_percent is null', () => {
+  render(<DashboardFreshMatches matches={[
+    { id: 2, score: 88, fit_percent: null, matchLevel: 'good', matchReasons: ['r'] },
+  ]} />);
+  expect(screen.getByText('88')).toBeInTheDocument();
+});

--- a/__tests__/pages/match-cii-source.test.ts
+++ b/__tests__/pages/match-cii-source.test.ts
@@ -1,0 +1,18 @@
+import { lookupCii } from '@/lib/imo/cii-lookup';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+it('lookupCii with stub LLM returns llm-fallback for an IMO absent from the dataset', async () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cii-w10-'));
+  const res = await lookupCii('0000001', { callLlm: async () => 'unknown', cacheDir });
+  expect(res.source).toBe('llm-fallback');
+});
+
+it('lookupCii returns imo-public for an IMO present in the static dataset', async () => {
+  const ds = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'lib/sample-data/imo/cii.json'), 'utf-8'));
+  const knownImo = ds.records[0].imo;
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cii-w10-'));
+  const res = await lookupCii(knownImo, { callLlm: async () => 'unknown', cacheDir });
+  expect(res.source).toBe('imo-public');
+});

--- a/app/api/matches/[id]/route.ts
+++ b/app/api/matches/[id]/route.ts
@@ -11,8 +11,9 @@ import { fromMatchSlug } from '@/lib/matching/match-slug';
 import type { MatchStatus } from '@/lib/matching/matches-repository';
 import type { FreightRateSource } from '@/lib/matching/tce-calculator';
 import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
-import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+import type { ParsedCargo, ParsedVessel, FitBreakdown } from '@/lib/types';
 import type { StoredMatch } from '@/lib/matching/matches-repository';
+import { patchEconomicsComponent } from '@/lib/matching/persist-session-matches';
 
 export const dynamic = 'force-dynamic';
 
@@ -89,6 +90,14 @@ function buildVesselProxy(m: StoredMatch): ParsedVessel {
     deckCapacity: null,
     specialFeatures: [],
   };
+}
+
+function recomputeFit(existing: StoredMatch, tce: number | null): { fit_percent: number; fit_breakdown: string } | null {
+  if (tce == null || !Number.isFinite(tce) || !existing.fit_breakdown) return null;
+  let parsed: FitBreakdown;
+  try { parsed = JSON.parse(existing.fit_breakdown) as FitBreakdown; } catch { return null; }
+  const patched = patchEconomicsComponent(parsed, tce, existing.vessel_dwt ?? 0);
+  return { fit_percent: patched.fitPercent, fit_breakdown: JSON.stringify(patched) };
 }
 
 const VALID_STATUSES: MatchStatus[] = ['shortlist', 'saved', 'dismissed', 'archived'];
@@ -190,7 +199,8 @@ export async function PATCH(
       const rate = eco.freight_rate_usd_per_mt ?? existing.freight_rate_usd_per_mt ?? 0;
       const tce = eco.tce_usd_per_day ?? existing.tce_usd_per_day ?? 0;
       const source = (eco.freight_rate_source ?? 'estimated') as FreightRateSource;
-      const updated = updateMatchFreightRate(db, id, rate, tce, source);
+      const fit = recomputeFit(existing, eco.tce_usd_per_day ?? null);
+      const updated = updateMatchFreightRate(db, id, rate, tce, source, fit);
       return NextResponse.json(updated, { status: 200 });
     }
 
@@ -210,7 +220,8 @@ export async function PATCH(
         freightOverrideUsdPerMt: rate,
       });
       const tce = eco.tce_usd_per_day ?? existing.tce_usd_per_day ?? 0;
-      const updated = updateMatchFreightRate(db, id, rate, tce, 'manual');
+      const fit = recomputeFit(existing, eco.tce_usd_per_day ?? null);
+      const updated = updateMatchFreightRate(db, id, rate, tce, 'manual', fit);
       return NextResponse.json(updated, { status: 200 });
     }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -83,6 +83,7 @@ export default async function DashboardPage() {
   }
   const storedMatches = listMatches(db, { user_id: sessionId!, sortBy: 'score', sortDir: 'desc' });
   const matchIdMap = new Map(storedMatches.map((sm) => [`${sm.cargo_id}|${sm.vessel_id}`, sm.id]));
+  const storedByKey = new Map(storedMatches.map((sm) => [`${sm.cargo_id}|${sm.vessel_id}`, sm]));
   const openMatchCount = countQualifyingMatches(db, { user_id: sessionId! });
 
   const priorityCards = goodMatches
@@ -103,10 +104,11 @@ export default async function DashboardPage() {
   const freshMatchesData = goodMatches
     .filter((m) => matchIdMap.get(`${m.cargoEmailId}|${m.vesselEmailId}`) != null)
     .map((m) => ({
+      id: matchIdMap.get(`${m.cargoEmailId}|${m.vesselEmailId}`)!,
       score: m.score,
+      fit_percent: storedByKey.get(`${m.cargoEmailId}|${m.vesselEmailId}`)?.fit_percent ?? null,
       matchLevel: m.matchLevel,
       matchReasons: m.matchReasons,
-      id: matchIdMap.get(`${m.cargoEmailId}|${m.vesselEmailId}`)!,
     }));
 
   const rawName = session.accountId?.split('@')[0] ?? '';

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -19,6 +19,7 @@ import { cfValue } from '@/lib/types';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { effectiveScore } from '@/lib/utils/effective-score';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
+import { lookupCii } from '@/lib/imo/cii-lookup';
 
 interface Props { params: Promise<{ id: string }>; }
 
@@ -138,6 +139,17 @@ export default async function MatchDetailPage({ params }: Props) {
   const balticRateAsOf = storedMatch.freight_rate_source === 'baltic' && vessel
     ? (getBalticDayRate(db, cfValue(vessel.dwtSummer) ?? 0)?.date ?? null)
     : null;
+
+  // CII provenance for the disclosure asterisk: the badge only renders for a D/E
+  // restriction, and only an llm-fallback source should show "Estimated by AI".
+  // Resolve source WITHOUT a live LLM call (stub returns 'unknown' — we use only .source,
+  // the badge rating comes from restrictions). Dataset hit → imo-public; miss → llm-fallback.
+  const hasCiiDorE = !!vessel?.restrictions?.some((r) => typeof r === 'string' && /\bCII\s+rating\s+[DE]\b/i.test(r));
+  let ciiSource: 'imo-public' | 'llm-fallback' | 'cache' | undefined;
+  if (vessel?.imo && hasCiiDorE) {
+    ciiSource = (await lookupCii(vessel.imo, { callLlm: async () => 'unknown' })).source;
+  }
+  const vesselWithCii = vessel && ciiSource ? { ...vessel, ciiSource } : vessel;
 
   return (
     <main className="min-h-screen bg-ds-bg">
@@ -283,7 +295,7 @@ export default async function MatchDetailPage({ params }: Props) {
 
                 <MatchTabs
                   match={sessionMatch}
-                  vessel={vessel}
+                  vessel={vesselWithCii}
                   cargo={cargo}
                   cargoEmailId={effectiveCargoEmailId}
                   matchDbId={storedMatch.id}

--- a/components/dashboard/DashboardFreshMatches.tsx
+++ b/components/dashboard/DashboardFreshMatches.tsx
@@ -3,6 +3,7 @@ import { Card, Pill } from '@/design-system/primitives';
 
 export interface FreshMatchItem {
   score: number;
+  fit_percent?: number | null;
   matchLevel: string;
   matchReasons: string[];
   id: number;
@@ -57,10 +58,10 @@ export function DashboardFreshMatches({ matches }: DashboardFreshMatchesProps) {
                 <Card padding="sm" interactive>
                   <div className="flex items-center gap-3">
                     <Pill
-                      variant={scoreToPillVariant(match.score)}
+                      variant={scoreToPillVariant(match.fit_percent ?? match.score)}
                       className="shrink-0 tabular-nums"
                     >
-                      {match.score}
+                      {match.fit_percent != null ? `${Math.round(match.fit_percent)}% fit` : match.score}
                     </Pill>
                     <p className="text-sm text-ds-text truncate flex-1">{reason}</p>
                     <span className="text-ds-text-subtle text-sm shrink-0" aria-hidden>

--- a/lib/matching/matches-repository.ts
+++ b/lib/matching/matches-repository.ts
@@ -586,14 +586,21 @@ export function updateMatchFreightRate(
   freight_rate_usd_per_mt: number,
   tce_usd_per_day: number,
   source: FreightRateSource = 'manual',
+  fit?: { fit_percent: number; fit_breakdown: string } | null,
 ): StoredMatch {
   const existing = getMatch(db, id);
   if (!existing) throw new Error(`Match not found: ${id}`);
 
   const now = Date.now();
-  db.prepare(
-    `UPDATE matches SET freight_rate_usd_per_mt = ?, freight_rate_source = ?, tce_usd_per_day = ?, updated_at = ? WHERE id = ?`
-  ).run(freight_rate_usd_per_mt, source, tce_usd_per_day, now, id);
+  if (fit != null) {
+    db.prepare(
+      `UPDATE matches SET freight_rate_usd_per_mt = ?, freight_rate_source = ?, tce_usd_per_day = ?, fit_percent = ?, fit_breakdown = ?, updated_at = ? WHERE id = ?`
+    ).run(freight_rate_usd_per_mt, source, tce_usd_per_day, fit.fit_percent, fit.fit_breakdown, now, id);
+  } else {
+    db.prepare(
+      `UPDATE matches SET freight_rate_usd_per_mt = ?, freight_rate_source = ?, tce_usd_per_day = ?, updated_at = ? WHERE id = ?`
+    ).run(freight_rate_usd_per_mt, source, tce_usd_per_day, now, id);
+  }
 
   return getMatch(db, id) as StoredMatch;
 }

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -15,7 +15,7 @@ import { scoreEconomics } from '@/lib/sailing/fit-breakdown';
  * Other components (timing, utilisation, etc.) and penalties/caps from the seed are
  * kept intact — only the economics contribution is updated.
  */
-function patchEconomicsComponent(
+export function patchEconomicsComponent(
   breakdown: FitBreakdown,
   liveTce: number | null,
   vesselDwt: number,


### PR DESCRIPTION
## Summary

- **B (BLOCKER):** `PATCH /api/matches/[id]` (freight rate edit) left `fit_percent`/`fit_breakdown` stale after recomputing TCE. Fixed by exporting `patchEconomicsComponent` from `persist-session-matches.ts`, extending `updateMatchFreightRate` with optional `fit` param, and wiring both PATCH paths (reset-to-auto + manual override) to call the canonical recompute helper.
- **M1 (MAJOR):** Dashboard "Fresh Matches" widget showed raw `score` (0–100) instead of `fit_percent`. Fixed by adding `fit_percent` to `FreshMatchItem` interface and populating from stored match (same DB column as list/detail) — dashboard pill now mirrors `MatchesClient` display rule.
- **M2 (MAJOR):** CII "Estimated by AI" disclosure badge never fired in production because `page.tsx` never set `ciiSource` on the vessel passed to `MatchTabs`. Fixed by calling `lookupCii` with a stub LLM (dataset hit → `imo-public`, miss → `llm-fallback`) gated on vessel IMO + D/E restriction presence.

## Files changed

- `lib/matching/persist-session-matches.ts` — export `patchEconomicsComponent`
- `lib/matching/matches-repository.ts` — extend `updateMatchFreightRate` with optional `fit` param
- `app/api/matches/[id]/route.ts` — `recomputeFit` helper + wire both PATCH paths
- `components/dashboard/DashboardFreshMatches.tsx` — `fit_percent` interface + pill render
- `app/dashboard/page.tsx` — `storedByKey` map + populate `fit_percent` from DB
- `app/match/[id]/page.tsx` — `lookupCii` import + CII provenance block + `vesselWithCii` prop
- `__tests__/api/freight-rate-override.test.ts` — internal-consistency oracle (PATCH fit == canonical recompute)
- `__tests__/pages/dashboard-fresh-fit.test.tsx` — new behavioral tests
- `__tests__/pages/match-cii-source.test.ts` — new behavioral tests

## Test plan

- [ ] `npx jest --findRelatedTests app/api/matches/\[id\]/route.ts --maxWorkers=1` → all pass, new test green (internal-consistency oracle)
- [ ] `npx jest __tests__/pages/dashboard-fresh-fit.test.tsx` → "73% fit" renders, null falls back to score
- [ ] `npx jest __tests__/pages/match-cii-source.test.ts` → llm-fallback for absent IMO, imo-public for known IMO
- [ ] `tsc --noEmit` → clean

Closes: W10 B, M1, M2

🤖 Generated with [Claude Code](https://claude.com/claude-code)