### PR TITLE
fix(w10.1): CII cache source-preservation + appliedCap nullish guard

### DIFF
--- a/__tests__/cii-cache-source-preservation.test.ts
+++ b/__tests__/cii-cache-source-preservation.test.ts
@@ -1,0 +1,49 @@
+/**
+ * FIX 1 — W10.1: CII cache hit must preserve original source so CiiRatingBadge
+ * keeps showing the "Estimated by AI" asterisk on every revisit.
+ *
+ * Root: cii-lookup.ts line 78 previously returned { ...cached, source: 'cache' },
+ * overwriting the stored 'llm-fallback' → isEstimated=false → asterisk gone.
+ */
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { lookupCii } from '@/lib/imo/cii-lookup';
+
+const ABSENT_IMO = '9800001'; // not in static dataset
+
+describe('CII cache source-preservation', () => {
+  it('cache hit returns original source (llm-fallback) — badge disclosure stays on revisit', async () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cii-w10-'));
+
+    const first = await lookupCii(ABSENT_IMO, { callLlm: async () => 'D', cacheDir });
+    expect(first.source).toBe('llm-fallback');
+    expect(first.rating).toBe('D');
+
+    // Second call — must serve from cache with original source intact
+    const second = await lookupCii(ABSENT_IMO, { callLlm: async () => 'D', cacheDir });
+    expect(second.source).toBe('llm-fallback'); // NOT 'cache'
+    expect(second.rating).toBe('D');
+
+    // Simulate CiiRatingBadge logic
+    const isEstimated = second.source === 'llm-fallback';
+    expect(isEstimated).toBe(true);
+  });
+
+  it('first call (no cache) returns llm-fallback for absent IMO', async () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cii-w10-nc-'));
+    const res = await lookupCii(ABSENT_IMO, { callLlm: async () => 'E', cacheDir });
+    expect(res.source).toBe('llm-fallback');
+    expect(res.rating).toBe('E');
+  });
+
+  it('imo-public source is also preserved through cache on revisit', async () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cii-w10-pub-'));
+    // 9322180 is in the static dataset → source: 'imo-public'
+    const first = await lookupCii('9322180', { cacheDir });
+    expect(first.source).toBe('imo-public');
+
+    const second = await lookupCii('9322180', { cacheDir });
+    expect(second.source).toBe('imo-public'); // must not change to 'cache' on hit
+  });
+});

--- a/__tests__/components/vessel/CiiRatingBadge-llm-fallback.test.tsx
+++ b/__tests__/components/vessel/CiiRatingBadge-llm-fallback.test.tsx
@@ -29,12 +29,6 @@ describe('CiiRatingBadge — llm-fallback asterisk', () => {
     expect(badge.textContent).toBe('CII D');
   });
 
-  it('does NOT add asterisk for cache source', () => {
-    render(<CiiRatingBadge rating="C" year={2025} source="cache" />);
-    const badge = screen.getByTestId('cii-rating-badge');
-    expect(badge.textContent).toBe('CII C');
-  });
-
   it('tooltip contains "Estimated by AI" for llm-fallback', () => {
     render(<CiiRatingBadge rating="D" year={2025} source="llm-fallback" />);
     const badge = screen.getByTestId('cii-rating-badge');

--- a/__tests__/persist-session-matches-applied-cap.test.ts
+++ b/__tests__/persist-session-matches-applied-cap.test.ts
@@ -1,0 +1,54 @@
+/**
+ * FIX 2 — W10.1: patchEconomicsComponent must not crash when appliedCap is undefined
+ * (legacy fit_breakdown JSON written before the field was added).
+ *
+ * Root: persist-session-matches.ts:31 used `!== null`, which is false for undefined,
+ * then accessed undefined.ceiling → TypeError → PATCH 500.
+ */
+import { patchEconomicsComponent } from '@/lib/matching/persist-session-matches';
+import type { FitBreakdown } from '@/lib/types';
+
+function baseFb(overrides: Partial<FitBreakdown> = {}): FitBreakdown {
+  return {
+    fitPercent: 70,
+    components: [
+      { factor: 'economics', score: 9, weight: 18, rationale: 'seed', label: 'Economics (TCE)' },
+      { factor: 'timing', score: 15, weight: 15, rationale: 'seed', label: 'Timing' },
+    ],
+    totalWeight: 100,
+    partCargo: false,
+    vesselClass: 'handymax',
+    sanctionsPenalty: 0,
+    chartererPenalty: 0,
+    appliedCap: null,
+    inputs: { distanceNm: 3000, gapDays: 2, verdict: 'spot', utilisation: 0.8, vesselDwt: 50000 },
+    ...overrides,
+  } as unknown as FitBreakdown;
+}
+
+describe('patchEconomicsComponent — appliedCap guard', () => {
+  it('does NOT crash when appliedCap is undefined (legacy JSON without the field)', () => {
+    const fb = baseFb({ appliedCap: undefined as unknown as null });
+    expect(() => patchEconomicsComponent(fb, 8000, 50000)).not.toThrow();
+    const result = patchEconomicsComponent(fb, 8000, 50000);
+    expect(result.fitPercent).toBeGreaterThanOrEqual(0);
+    expect(result.fitPercent).toBeLessThanOrEqual(100);
+  });
+
+  it('still applies cap correctly when appliedCap is a real object', () => {
+    const fb = baseFb({
+      appliedCap: { ceiling: 50, reason: 'PSC detention' } as unknown as null,
+    });
+    // economics score + timing = likely >50 → cap should apply
+    const result = patchEconomicsComponent(fb, 50000, 50000);
+    expect(result.fitPercent).toBeLessThanOrEqual(50);
+  });
+
+  it('no cap applied when appliedCap is null', () => {
+    const fb = baseFb({ appliedCap: null });
+    // Should compute normally without cap
+    expect(() => patchEconomicsComponent(fb, 8000, 50000)).not.toThrow();
+    const result = patchEconomicsComponent(fb, 8000, 50000);
+    expect(result.fitPercent).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/__tests__/persist-session-matches-applied-cap.test.ts
+++ b/__tests__/persist-session-matches-applied-cap.test.ts
@@ -35,13 +35,23 @@ describe('patchEconomicsComponent — appliedCap guard', () => {
     expect(result.fitPercent).toBeLessThanOrEqual(100);
   });
 
-  it('still applies cap correctly when appliedCap is a real object', () => {
+  it('cap fires and clamps to ceiling when rawSum > ceiling', () => {
+    // scoreEconomics(50000 tce, 50000 dwt) = 18; timing score = 15; rawSum = 33
+    // ceiling 20 < 33 → cap fires → fitPercent must be exactly 20
     const fb = baseFb({
-      appliedCap: { ceiling: 50, reason: 'PSC detention' } as unknown as null,
+      appliedCap: { ceiling: 20, reason: 'PSC detention' } as unknown as null,
     });
-    // economics score + timing = likely >50 → cap should apply
     const result = patchEconomicsComponent(fb, 50000, 50000);
-    expect(result.fitPercent).toBeLessThanOrEqual(50);
+    expect(result.fitPercent).toBe(20);
+  });
+
+  it('cap present but does NOT fire when rawSum < ceiling', () => {
+    // rawSum = 33; ceiling 40 > 33 → cap does not clamp → fitPercent must be exactly 33
+    const fb = baseFb({
+      appliedCap: { ceiling: 40, reason: 'PSC detention' } as unknown as null,
+    });
+    const result = patchEconomicsComponent(fb, 50000, 50000);
+    expect(result.fitPercent).toBe(33);
   });
 
   it('no cap applied when appliedCap is null', () => {

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -145,7 +145,7 @@ export default async function MatchDetailPage({ params }: Props) {
   // Resolve source WITHOUT a live LLM call (stub returns 'unknown' — we use only .source,
   // the badge rating comes from restrictions). Dataset hit → imo-public; miss → llm-fallback.
   const hasCiiDorE = !!vessel?.restrictions?.some((r) => typeof r === 'string' && /\bCII\s+rating\s+[DE]\b/i.test(r));
-  let ciiSource: 'imo-public' | 'llm-fallback' | 'cache' | undefined;
+  let ciiSource: 'imo-public' | 'llm-fallback' | undefined;
   if (vessel?.imo && hasCiiDorE) {
     ciiSource = (await lookupCii(vessel.imo, { callLlm: async () => 'unknown' })).source;
   }

--- a/components/vessel/CiiRatingBadge.tsx
+++ b/components/vessel/CiiRatingBadge.tsx
@@ -3,7 +3,7 @@ import type { CiiRating } from '@/lib/imo/cii-lookup';
 interface CiiRatingBadgeProps {
   rating: CiiRating;
   year: number;
-  source: 'imo-public' | 'llm-fallback' | 'cache';
+  source: 'imo-public' | 'llm-fallback';
   size?: 'small' | 'medium';
 }
 

--- a/components/vessel/__tests__/CiiRatingBadge.test.tsx
+++ b/components/vessel/__tests__/CiiRatingBadge.test.tsx
@@ -32,9 +32,9 @@ describe('CiiRatingBadge', () => {
     expect(badge).toHaveClass('bg-gray-400');
   });
 
-  it('has tooltip with year and source', () => {
-    render(<CiiRatingBadge rating="C" year={2025} source="cache" />);
+  it('has tooltip with year and source for imo-public', () => {
+    render(<CiiRatingBadge rating="C" year={2025} source="imo-public" />);
     const badge = screen.getByTestId('cii-rating-badge');
-    expect(badge).toHaveAttribute('title', 'CII rating C (2025, source: cache)');
+    expect(badge).toHaveAttribute('title', 'CII rating C (2025, source: imo-public)');
   });
 });

--- a/lib/imo/cii-lookup.ts
+++ b/lib/imo/cii-lookup.ts
@@ -73,9 +73,10 @@ export async function lookupCii(imo: string, opts: LookupOpts = {}): Promise<Cii
     return { imo, rating: 'unknown', year: 2025, source: 'imo-public', fetchedAt: new Date().toISOString() };
   }
 
-  // Cache hit
+  // Cache hit — return stored result with its original source intact (preserves 'llm-fallback'
+  // so CiiRatingBadge.isEstimated stays true for AI-estimated ratings on revisit).
   const cached = getCiiCached(imo, cacheDir);
-  if (cached) return { ...cached, source: 'cache' };
+  if (cached) return cached;
 
   // Static dataset
   const datasetRating = lookupInDataset(imo);

--- a/lib/imo/cii-lookup.ts
+++ b/lib/imo/cii-lookup.ts
@@ -8,7 +8,7 @@ export interface CiiResult {
   imo: string;
   rating: CiiRating;
   year: number;
-  source: 'imo-public' | 'llm-fallback' | 'cache';
+  source: 'imo-public' | 'llm-fallback';
   fetchedAt: string;
 }
 

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -28,7 +28,7 @@ export function patchEconomicsComponent(
   const sanctionsPenalty = breakdown.sanctionsPenalty ?? 0;
   const chartererPenalty = breakdown.chartererPenalty ?? 0;
   let fit = rawSum - sanctionsPenalty - chartererPenalty;
-  if (breakdown.appliedCap !== null && fit > breakdown.appliedCap.ceiling) {
+  if (breakdown.appliedCap != null && fit > breakdown.appliedCap.ceiling) {
     fit = breakdown.appliedCap.ceiling;
   }
   const fitPercent = Math.max(0, Math.min(100, Math.round(fit * 10) / 10));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -274,7 +274,7 @@ export interface ParsedVessel {
    */
   ciiRating?: 'A' | 'B' | 'C' | 'D' | 'E' | null;
   /** Source of the CII rating — set when lookup was performed. */
-  ciiSource?: 'imo-public' | 'llm-fallback' | 'cache' | null;
+  ciiSource?: 'imo-public' | 'llm-fallback' | null;
   /**
    * Human-readable warning about external-registry verification — e.g.
    * "Name mismatch: Equasis says X, email says Y" or "IMO not found in Equasis registry".

--- a/tests/imo/cii-lookup.test.ts
+++ b/tests/imo/cii-lookup.test.ts
@@ -46,7 +46,7 @@ describe('lookupCii — cache', () => {
     // Second call — must come from cache
     const second = await lookupCii(DEMO_IMO, { cacheDir, callLlm });
 
-    expect(second.source).toBe('cache');
+    expect(second.source).toBe('imo-public'); // original source preserved; not overwritten to 'cache'
     expect(second.rating).toBe('D');
     expect(llmCalls).toBe(0); // LLM never called since dataset hit
   });
@@ -84,9 +84,9 @@ describe('lookupCii — LLM fallback', () => {
     expect(result.source).toBe('llm-fallback');
     expect(llmCalls).toBe(1);
 
-    // Second call should hit cache, not LLM
+    // Second call should hit cache, not LLM — original source preserved
     const cached = await lookupCii(UNKNOWN_IMO, { cacheDir, callLlm });
-    expect(cached.source).toBe('cache');
+    expect(cached.source).toBe('llm-fallback'); // not 'cache' — badge disclosure stays on revisit
     expect(llmCalls).toBe(1);
   });
 


### PR DESCRIPTION
## Summary

Two surgical fixes from cold adversarial QA (testskill-880 findings 1+2):

- **FIX 1** (`lib/imo/cii-lookup.ts:78`): cache hit now preserves the original `source` field (`llm-fallback` / `imo-public`) instead of overwriting it to `'cache'`. `CiiRatingBadge.isEstimated` was returning `false` on every revisit of an AI-estimated rating, silently dropping the asterisk and "Estimated by AI" tooltip.
- **FIX 2** (`lib/matching/persist-session-matches.ts:31`): changed `!== null` to `!= null` so `appliedCap: undefined` (legacy `fit_breakdown` JSON written before the field existed) no longer causes `TypeError: Cannot read properties of undefined (reading 'ceiling')` → PATCH 500.

## Test plan

- [ ] `__tests__/cii-cache-source-preservation.test.ts` — 3 tests: llm-fallback preserved through cache, imo-public preserved, first-call baseline
- [ ] `__tests__/persist-session-matches-applied-cap.test.ts` — 3 tests: undefined cap no throw, real cap still applied, null cap no throw
- [ ] Updated `tests/imo/cii-lookup.test.ts` expectations (2 lines) to reflect fixed behaviour
- [ ] `npx jest --findRelatedTests` → 149/149 passed
- [ ] `tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)