### PR TITLE
feat(ports): add Monrovia + Ras el Khair to port-master; alias Puerto Limón/Koh Sri Chang (portgap)

### DIFF
--- a/data/ports/port-master.json
+++ b/data/ports/port-master.json
@@ -9778,5 +9778,7 @@
     "aliases": [
       "Yarımca"
     ]
-  }
+  },
+  { "unlocode": "LRMRV", "name": "Monrovia", "country": "LR", "lat": 6.317, "lon": -10.8, "maxDraftM": 11.0, "hasShoreCranes": true, "berthType": "deep-sea", "note": "Liberia, Freeport of Monrovia (portgap)" },
+  { "unlocode": "SARSK", "name": "Ras el Khair", "country": "SA", "lat": 27.033, "lon": 49.083, "maxDraftM": 18.0, "hasShoreCranes": true, "berthType": "terminal", "note": "Saudi Arabian Gulf industrial port (portgap)" }
 ]

--- a/lib/sailing/__tests__/port-distances.test.ts
+++ b/lib/sailing/__tests__/port-distances.test.ts
@@ -1,4 +1,5 @@
 import { getPortDistance, normalizePortName, KNOWN_PORTS } from '../port-distances';
+import { getPortMaster } from '../port-master';
 
 describe('normalizePortName — fuzzy length-ratio guard (Phase B)', () => {
   it('"Vasto" resolves to canonical Vasto, NOT Vladivostok (Phase C1)', () => {
@@ -1093,5 +1094,23 @@ describe('vague-unknown port strings do not fuzzy-match distant real ports (fix-
     expect(normalizePortName('Aliaga')).toBe('Aliaga');
     expect(normalizePortName('Odessa')).toBe('Odesa');          // alias → Odesa
     expect(normalizePortName('Novorossisk')).toBe('Novorossiysk'); // alias → Novorossiysk
+  });
+});
+
+describe('portgap: absent/aliased ports resolve to non-null distance', () => {
+  it('Monrovia resolves via new JSON entry', () => {
+    expect(getPortMaster('Monrovia')).not.toBeNull();
+    expect(getPortDistance('Kakinada Anchorage', 'Monrovia')?.nm).toBeGreaterThan(0);
+  });
+  it('Ras el Khair resolves via new JSON entry', () => {
+    expect(getPortMaster('Ras el Khair')).not.toBeNull();
+    expect(getPortDistance('Ras el Khair', 'Shuaiba')?.nm).toBeGreaterThan(0);
+  });
+  it('Puerto Limon (no accent) resolves to existing CRLIO via alias', () => {
+    expect(normalizePortName('Puerto Limon')).toBe('Puerto Limón');
+    expect(getPortDistance('Karasu', 'Puerto Limon')?.nm).toBeGreaterThan(0);
+  });
+  it('Koh Sri Chang resolves via Bangkok alias', () => {
+    expect(getPortDistance('Koh Sri Chang', 'Conakry')?.nm).toBeGreaterThan(0);
   });
 });

--- a/lib/sailing/port-distances.ts
+++ b/lib/sailing/port-distances.ts
@@ -77,9 +77,9 @@ export type KnownPort = typeof KNOWN_PORTS[number];
 
 /**
  * Aliases map alternative spellings / former names / range phrasing to canonical.
- * Keys must be lowercase; values must be elements of KNOWN_PORTS.
+ * Keys must be lowercase; values are canonical port names (KNOWN_PORTS or port-master.json names).
  */
-const PORT_ALIASES: Record<string, KnownPort> = {
+const PORT_ALIASES: Record<string, string> = {
   // Black Sea
   'karasu': 'Karasu',
   'istanbul': 'Istanbul',
@@ -327,6 +327,9 @@ const PORT_ALIASES: Record<string, KnownPort> = {
   'koh sichang': 'Bangkok',     // Ko Si Chang anchorage — Gulf of Thailand, Bangkok proxy
   'ko sichang': 'Bangkok',
   'ko si chang': 'Bangkok',
+  'koh sri chang': 'Bangkok',   // variant spelling — Gulf of Thailand, Bangkok proxy (portgap)
+  'puerto limon': 'Puerto Limón',   // accent-less broker spelling → existing CRLIO entry (portgap)
+  'puerto limón': 'Puerto Limón',   // self-alias: deterministic round-trip for getPortMaster (portgap)
   // East Asia
   'hong kong': 'HongKong',
   'hongkong': 'HongKong',


### PR DESCRIPTION
## Summary

- Adds 2 new port-master JSON entries: **Monrovia** (LRMRV, Liberia) and **Ras el Khair** (SARSK, Saudi Arabia) — both absent from port-master.json, causing 10 demo matches to show gray `$0.0k` (null distance)
- Adds 3 `PORT_ALIASES` keys: `koh sri chang → Bangkok`, `puerto limon → Puerto Limón`, `puerto limón → Puerto Limón` (diacritic round-trip fix for existing CRLIO entry)
- Widens `PORT_ALIASES` type to `Record<string, string>` — previously `Record<string, KnownPort>` blocked port-master-only canonical names as values
- Part of portgap fix-wave: recovers ~10 absent-port null-distance matches so the broker list shows real TCE instead of gray `$0.0k`
- **Part A (data regen)** runs separately on main after this merges

## Test plan

- [x] 4 new behavioral tests: `getPortMaster('Monrovia') !== null`, `getPortDistance('Kakinada Anchorage', 'Monrovia')?.nm > 0`, same for Ras el Khair, Puerto Limon alias, Koh Sri Chang alias
- [x] All 333 port-related tests pass (8 suites)
- [x] `tsc --noEmit` clean
- [x] Baseline 207 prior tests unaffected (211 total = 207 + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)