### PR TITLE
fix(demo): compute war-risk premium from seeded ports+dwt in hydrate stub

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
@@ -1,6 +1,8 @@
 import Database from 'better-sqlite3';
 import { buildDemoSessionBlob } from '../hydrate-demo-session';
 import { logger } from '@/lib/logger';
+import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
+import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 
 function makeSeedDb(): Database.Database {
   const db = new Database(':memory:');
@@ -103,6 +105,90 @@ describe('buildDemoSessionBlob', () => {
       vesselEmailId: 'e2', vesselItemIndex: 1,
       score: 77, fitPercent: 72.5,
     });
+    db.close();
+  });
+
+  it('#883: HRA route (Nemrut Bay → Berbera) yields warRiskPremium matching oracle', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE emails (
+        account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+        from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+        body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+      );
+      CREATE TABLE parsed_results (
+        account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+        result_json TEXT, parsed_at INTEGER
+      );
+      CREATE TABLE matches (
+        id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+        reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+        reason_structured TEXT,
+        tce_usd_per_day REAL, load_port TEXT, discharge_port TEXT, vessel_dwt INTEGER
+      );
+    `);
+    db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+      VALUES ('demo','e1','t1','a@demo.local','me@demo.local','Cargo','2026-05-20','b','s','[]',0)`).run();
+    db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+      VALUES ('demo','e2','t2','b@demo.local','me@demo.local','Vessel','2026-05-21','b','s','[]',0)`).run();
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e1','cargo','v1','[{"emailId":"e1","itemIndex":0}]',0)`).run();
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e2','vessel','v1','[{"emailId":"e2","itemIndex":0}]',0)`).run();
+    db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured, tce_usd_per_day, load_port, discharge_port, vessel_dwt)
+      VALUES ('e1','e2',90,'HRA route','shortlist',NULL,0,0,NULL,12000,'Nemrut Bay','Berbera',3176)`).run();
+
+    const blob = buildDemoSessionBlob(db);
+    const oracle = calculateWarRiskPremium({
+      route: { fromPort: 'Nemrut Bay', toPort: 'Berbera' },
+      vesselValueUsd: estimateVesselValueUsd(3176),
+    });
+
+    // UI rounds 666.96 → "$667"; test parity with exact oracle value
+    expect(oracle.premiumUsd).toBeCloseTo(667, 0);
+    const bd = blob.matches[0].economics!.breakdown;
+    expect(bd.warRiskPremium).toBe(oracle.premiumUsd);
+    expect(bd.warRiskZones).toEqual(expect.arrayContaining(['Red Sea / Bab al-Mandeb HRA']));
+    expect(bd.warRiskBreakdown).toBeDefined();
+    expect(bd.warRiskBreakdown!.hullPremiumUsd).toBe(oracle.premiumUsd);
+    db.close();
+  });
+
+  it('#883: non-HRA route (Rotterdam → Hamburg) yields warRiskPremium 0 + no breakdown', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE emails (
+        account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+        from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+        body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+      );
+      CREATE TABLE parsed_results (
+        account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+        result_json TEXT, parsed_at INTEGER
+      );
+      CREATE TABLE matches (
+        id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+        reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+        reason_structured TEXT,
+        tce_usd_per_day REAL, load_port TEXT, discharge_port TEXT, vessel_dwt INTEGER
+      );
+    `);
+    db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+      VALUES ('demo','e1','t1','a@demo.local','me@demo.local','Cargo','2026-05-20','b','s','[]',0)`).run();
+    db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+      VALUES ('demo','e2','t2','b@demo.local','me@demo.local','Vessel','2026-05-21','b','s','[]',0)`).run();
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e1','cargo','v1','[{"emailId":"e1","itemIndex":0}]',0)`).run();
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e2','vessel','v1','[{"emailId":"e2","itemIndex":0}]',0)`).run();
+    db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured, tce_usd_per_day, load_port, discharge_port, vessel_dwt)
+      VALUES ('e1','e2',85,'Non-HRA route','shortlist',NULL,0,0,NULL,10000,'Rotterdam','Hamburg',50000)`).run();
+
+    const blob = buildDemoSessionBlob(db);
+    const bd = blob.matches[0].economics!.breakdown;
+    expect(bd.warRiskPremium).toBe(0);
+    expect(bd.warRiskZones).toEqual([]);
+    expect(bd.warRiskBreakdown).toBeUndefined();
     db.close();
   });
 

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -5,6 +5,8 @@ import { buildProcessedEmails } from '@/lib/classification-service';
 import { deriveMatchLevel } from '@/lib/sailing/match-scoring';
 import { deleteOrphanSessionMatches } from '@/lib/matching/matches-repository';
 import { logger } from '@/lib/logger';
+import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
+import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import type {
   Email, Classification, ParsedCargo, ParsedVessel, ParsedFixtureRecap, Match, ScoreBreakdown, SessionData,
 } from '@/lib/types';
@@ -29,6 +31,9 @@ interface MatchRow {
   cargo_item_index: number | null; vessel_item_index: number | null;
   worksheet_json: string | null;
   tce_usd_per_day: number | null;
+  load_port: string | null;
+  discharge_port: string | null;
+  vessel_dwt: number | null;
 }
 
 function safeJsonArray<T>(json: string, ctx: string): T[] {
@@ -98,7 +103,11 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
     ? 'worksheet_json'
     : 'NULL as worksheet_json';
   const tceCol = colNames.has('tce_usd_per_day') ? 'tce_usd_per_day' : 'NULL as tce_usd_per_day';
-  const selectCols = `cargo_id, vessel_id, score, reason, reason_structured, ${fitCols}, ${idxCols}, ${worksheetCol}, ${tceCol}`;
+  const portCols = colNames.has('load_port')
+    ? 'load_port, discharge_port'
+    : 'NULL as load_port, NULL as discharge_port';
+  const dwtCol = colNames.has('vessel_dwt') ? 'vessel_dwt' : 'NULL as vessel_dwt';
+  const selectCols = `cargo_id, vessel_id, score, reason, reason_structured, ${fitCols}, ${idxCols}, ${worksheetCol}, ${tceCol}, ${portCols}, ${dwtCol}`;
 
   // Only the seeded snapshot rows (user_id IS NULL). Per-session copies that
   // persistSessionMatches writes (user_id = sessionId) must NOT be re-read here,
@@ -120,6 +129,16 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   function rowsToMatches(rows: MatchRow[]): Match[] {
     return rows.map((r) => {
       const tce = r.tce_usd_per_day;
+      // #883: compute demo war-risk from seeded ports + dwt, mirroring the live
+      // /api/voyage/tce path (estimateVesselValueUsd(dwt), NOT DEFAULT 22M) so the
+      // banner premium matches the P&L line. calculateWarRiskPremium is pure/sync.
+      const warRisk =
+        r.load_port && r.discharge_port
+          ? calculateWarRiskPremium({
+              route: { fromPort: r.load_port, toPort: r.discharge_port },
+              vesselValueUsd: estimateVesselValueUsd(r.vessel_dwt ?? 0),
+            })
+          : null;
       // Carry the seed-computed TCE into economics.tceUsdPerDay so
       // persistSessionMatches can prefer it over a live recompute.
       const economics: import('@/lib/types').EconomicsResult | undefined =
@@ -127,7 +146,11 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
           ? {
               breakdown: {
                 bunkerCost: 0, bunkerPort: '', euEtsAmount: 0,
-                euEtsApplicable: false, warRiskPremium: 0, warRiskZones: [],
+                euEtsApplicable: false,
+                warRiskPremium: warRisk?.premiumUsd ?? 0,
+                warRiskZones: warRisk?.zones ?? [],
+                warRiskBreakdown: warRisk?.applicable ? warRisk.breakdown : undefined,
+                warRiskTotal: warRisk?.breakdown?.totalPremiumUsd,
               },
               totalUsd: 0,
               calculatedAt: new Date(0).toISOString(),


### PR DESCRIPTION
## Summary

- `lib/demo-mode/hydrate-demo-session.ts` banner was hardcoding `warRiskPremium: 0, warRiskZones: []` regardless of route — causing "No JWC war risk zones" on Nemrut Bay → Berbera while P&L showed War Risk: $667
- Now calls `calculateWarRiskPremium({ route: { fromPort: load_port, toPort: discharge_port }, vesselValueUsd: estimateVesselValueUsd(vessel_dwt) })` — mirrors the live `/api/voyage/tce` path exactly so **banner premium == P&L premium**
- Extends `MatchRow` with `load_port / discharge_port / vessel_dwt` + `colNames.has()` guards for backward-compat with in-memory test DBs lacking these columns
- Sets `warRiskBreakdown` so `EconomicsTab` warrisk-section guard fires

## Test plan

- [ ] `npx jest --findRelatedTests lib/demo-mode/hydrate-demo-session.ts` → 50/50 green
- [ ] New test: HRA route (Nemrut Bay → Berbera, dwt=3176) → `warRiskPremium ≈ 667`, zone chip "Red Sea / Bab al-Mandeb HRA", `warRiskBreakdown` defined
- [ ] New test: non-HRA route (Rotterdam → Hamburg) → `warRiskPremium = 0`, `warRiskZones = []`, `warRiskBreakdown = undefined`
- [ ] Existing tests unmodified (PI3 ✓)

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)