### PR TITLE
fix(#865): use nominal cargo weight in Source-Attribution + fit-breakdown scorers

### DIFF
--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -312,7 +312,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   <SourceAttributionSection
                     fields={[
                       ...(cargo.cargoDescription ? [{ label: 'Cargo', value: cargo.cargoDescription }] : []),
-                      ...(cargo.weightMt ? [{ label: 'Weight', value: { ...cargo.weightMt, value: cargo.weightMtMax ?? cfValue(cargo.weightMt) } }] : []),
+                      ...(cargo.weightMt ? [{ label: 'Weight', value: cargo.weightMt }] : []),
                       ...(cargo.originPort ? [{ label: 'Load Port', value: cargo.originPort }] : []),
                       ...(cargo.destinationPort ? [{ label: 'Discharge Port', value: cargo.destinationPort }] : []),
                       ...(laycanDisplay

--- a/lib/sailing/__tests__/fit-breakdown.test.ts
+++ b/lib/sailing/__tests__/fit-breakdown.test.ts
@@ -578,3 +578,57 @@ describe('computeFitBreakdown — charterer credit-tier penalty', () => {
     expect(fb.components).toHaveLength(10);
   });
 });
+
+describe('#865 — fit-breakdown uses nominal cargo weight for display scoring', () => {
+  function cargoWithRange(nominal: number, max: number): ParsedCargo {
+    return makeCargo({
+      weightMt: { value: nominal, confidence: 'confirmed' },
+      weightMtMin: Math.round(nominal * 0.98),
+      weightMtMax: max,
+    });
+  }
+
+  it('class-fit rationale shows nominal weight (2720), not weightMtMax (2774)', () => {
+    const input = {
+      cargo: cargoWithRange(2720, 2774),
+      vessel: makeVessel({ dwtSummer: { value: 3178, confidence: 'confirmed' }, dwcc: null, grainCapacity: 7000 }),
+      readiness: READY_IDEAL,
+      sanctions: SANCTIONS_OK,
+      hardFilters: HF_PASS,
+      refYear: 2026,
+    };
+    const fit = computeFitBreakdown(input);
+    const classFit = fit.components.find(c => c.factor === 'classFit');
+    expect(classFit?.rationale).toContain('2720');
+    expect(classFit?.rationale).not.toContain('2774');
+  });
+
+  it('divergence tracks per-match option % (10% case): nominal 2800 not 3080', () => {
+    const input = {
+      cargo: cargoWithRange(2800, 3080),
+      // Vessel DWT 3200 so the vessel-dwt number never collides with the max weight (3080)
+      vessel: makeVessel({ dwtSummer: { value: 3200, confidence: 'confirmed' }, dwcc: null, grainCapacity: 7000 }),
+      readiness: READY_IDEAL,
+      sanctions: SANCTIONS_OK,
+      hardFilters: HF_PASS,
+      refYear: 2026,
+    };
+    const fit = computeFitBreakdown(input);
+    const classFit = fit.components.find(c => c.factor === 'classFit');
+    expect(classFit?.rationale).toContain('cargo 2800 mt');
+    expect(classFit?.rationale).not.toContain('cargo 3080 mt');
+  });
+
+  it('keeps worst-case in inputs.cargoWtMax for transparency', () => {
+    const input = {
+      cargo: cargoWithRange(2720, 2774),
+      vessel: makeVessel({ dwtSummer: { value: 3178, confidence: 'confirmed' }, dwcc: null, grainCapacity: 7000 }),
+      readiness: READY_IDEAL,
+      sanctions: SANCTIONS_OK,
+      hardFilters: HF_PASS,
+      refYear: 2026,
+    };
+    const fit = computeFitBreakdown(input);
+    expect(fit.inputs.cargoWtMax).toBe(2774);
+  });
+});

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -569,19 +569,20 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
   const desc = cfValue(cargo.cargoDescription);
   const partCargo = isPartCargo(desc);
 
-  const cargoWtMax = resolveCargoWeight(cargo);
+  const cargoWtMax = resolveCargoWeight(cargo);                  // worst-case: caps + overload gate (#792) + transparency
+  const cargoWtNominal = cfValue(cargo.weightMt) ?? cargoWtMax;  // nominal: display-facing scoring (#865)
   const dwt = cfValue(vessel.dwtSummer);
   const dwcc = cfValue(vessel.dwcc);
   const capacity = dwcc != null && dwcc > 0 ? dwcc : dwt;
 
   const components: FitBreakdownComponent[] = [
-    scoreUtilisation(cargoWtMax, capacity, partCargo),
+    scoreUtilisation(cargoWtNominal, capacity, partCargo),
     scoreTiming(readiness),
     scoreBallast(readiness?.distanceNm ?? null, dwt),
-    scoreClassFit(cargoWtMax, dwt, partCargo),
+    scoreClassFit(cargoWtNominal, dwt, partCargo),
     scoreCargoTypeQuality(cargo.cargoType, vessel.vesselType, vessel.lastCargoes),
     scoreCranes(vessel.geared, cfValue(cargo.originPort)),
-    scoreVolume(cargoWtMax, desc, vessel.grainCapacity, cargo.stowageFactor),
+    scoreVolume(cargoWtNominal, desc, vessel.grainCapacity, cargo.stowageFactor),
     scoreDraft(hardFilters),
     scoreVetting(vessel, refYear, detentionCount),
     scoreEconomics(tceUsdPerDay, dwt),


### PR DESCRIPTION
## Summary

- `page.tsx:315` — Source-Attribution Weight field now passes `cargo.weightMt` directly (nominal 2720 mt) instead of the override `cargo.weightMtMax ?? cfValue(cargo.weightMt)` which was substituting the MOLCHOPT worst-case upper bound (2774 mt)
- `fit-breakdown.ts` — `computeFitBreakdown` adds `cargoWtNominal = cfValue(cargo.weightMt) ?? cargoWtMax` and threads it into `scoreUtilisation`, `scoreClassFit`, and `scoreVolume`; `cargoWtMax` is kept for the utilisation gating cap, `inputs.cargoWtMax` transparency field, and the deadfreight cap check (preserves #792 overload gate)
- 3 new tests in `describe('#865 ...')` block at end of `fit-breakdown.test.ts` covering the 2% (CONTACT29: 2720/2774) and 10% (2800/3080) option-percentage cases plus `inputs.cargoWtMax` preservation

## Acceptance

| Issue | Criterion | Status | Evidence |
|-------|-----------|--------|----------|
| #865 | Source-Attribution shows 2720 not 2774 | ✓ | `app/match/[id]/page.tsx:315` → `value: cargo.weightMt` |
| #865 | Class-fit/util/volume rationale show nominal weight | ✓ | fit-breakdown.test.ts `#865` (3/3 green) |
| #865 | Worst-case preserved for overload gate (#792) | ✓ | `cargoWtMax` kept in gating cap + `inputs.cargoWtMax` |
| #865 | Param table (`MatchWorksheet.tsx:68`) unchanged | ✓ | not touched |

## Test plan

- [ ] `npm test -- lib/sailing/__tests__/fit-breakdown.test.ts` — 3/3 new tests green
- [ ] Source-Attribution dialog on `/match/51704` (CONTACT29) shows Weight = 2,720 mt (not 2,774 mt)
- [ ] Class-fit rationale reads "cargo 2720 mt" (not 2774)

## Notes

- `data/demo-seed.db` is gitignored — VPS re-seed required: `npx tsx scripts/demo-seed/patch-fit.ts` on the deploy host
- DO NOT MERGE — orchestrator runs cold test-skill + VALUE_CHECK then merges

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)