### PR TITLE
fix(#885): name-collision dedup, AGENT token regex, owner sort default, settings export

### DIFF
--- a/__tests__/mode-aware-content.test.ts
+++ b/__tests__/mode-aware-content.test.ts
@@ -247,6 +247,25 @@ describe('MatchesClient — mode-aware column headers (#630)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Source analysis: MatchesClient — owner-mode default sort (#885 fix #3)
+// Owner default = TCE/day; charterer default = Fit %.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('MatchesClient — owner vs charterer default sort (#885)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'app/matches/MatchesClient.tsx'), 'utf8');
+
+  it('initial sortBy is isOwner-conditional, not hardcoded fit', () => {
+    // Must have isOwner ternary inside useState initializer
+    expect(src).toMatch(/useState<SortBy>\s*\(\s*\(\s*\)\s*=>\s*isOwner\s*\?\s*'tce'\s*:\s*'fit'\s*\)/);
+  });
+
+  it('mode-switch reset is isOwner-conditional (not hardcoded fit)', () => {
+    // The setSortBy inside the derived-state-during-render block must branch on isOwner
+    expect(src).toMatch(/setSortBy\s*\(\s*isOwner\s*\?\s*'tce'\s*:\s*'fit'\s*\)/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Source analysis: AIBar — reads mode from useMode hook (H3 regression, #630)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/__tests__/settings-export-section.test.ts
+++ b/__tests__/settings-export-section.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Settings export section — source analysis (PI2 behavioral + route-guard tests).
+ * Verifies /settings/export does not 404 (#885 fix #4).
+ *
+ * @jest-environment node
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+
+describe('settings/layout.tsx — Export entry in sidebar (#885)', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'app/settings/layout.tsx'), 'utf8');
+
+  it('SECTIONS contains an export entry', () => {
+    expect(src).toMatch(/id:\s*['"]export['"]/);
+  });
+
+  it('export entry is placed before danger zone', () => {
+    const exportIdx = src.indexOf("id: 'export'");
+    const dangerIdx = src.indexOf("id: 'danger'");
+    expect(exportIdx).toBeGreaterThan(-1);
+    expect(dangerIdx).toBeGreaterThan(-1);
+    expect(exportIdx).toBeLessThan(dangerIdx);
+  });
+});
+
+describe('settings/[section]/page.tsx — Export section not 404 (#885)', () => {
+  const src = fs.readFileSync(
+    path.join(ROOT, 'app/settings/[section]/page.tsx'),
+    'utf8',
+  );
+
+  it("VALID_SECTIONS includes 'export'", () => {
+    expect(src).toMatch(/['"]export['"]/);
+    // Must be in the VALID_SECTIONS tuple
+    expect(src).toMatch(/VALID_SECTIONS\s*=\s*\[[\s\S]*?['"]export['"][\s\S]*?\]/);
+  });
+
+  it('ExportSection component is defined', () => {
+    expect(src).toMatch(/function ExportSection/);
+  });
+
+  it('export case is handled in the page switch (not falling through to ComingSoon)', () => {
+    expect(src).toMatch(/case\s*['"]export['"]\s*:\s*return\s*<ExportSection/);
+  });
+
+  it('ExportSection has data-testid="settings-export"', () => {
+    expect(src).toMatch(/data-testid="settings-export"/);
+  });
+
+  it('ExportSection renders CSV and JSON export options', () => {
+    expect(src).toMatch(/CSV/);
+    expect(src).toMatch(/JSON/);
+  });
+});

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -108,12 +108,12 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
   const [expandedFitBreakdown, setExpandedFitBreakdown] = useState<number | null>(null);
   const [showModal, setShowModal] = useState<{ action: string; count: number } | null>(null);
   const [bulkError, setBulkError] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<SortBy>(() => 'fit');
+  const [sortBy, setSortBy] = useState<SortBy>(() => isOwner ? 'tce' : 'fit');
   // Derived-state-during-render resets sort on mode switch without cascading renders.
   const [prevIsOwner, setPrevIsOwner] = useState(isOwner);
   if (prevIsOwner !== isOwner) {
     setPrevIsOwner(isOwner);
-    setSortBy('fit');
+    setSortBy(isOwner ? 'tce' : 'fit');
   }
 
   // CD design state

--- a/app/settings/[section]/page.tsx
+++ b/app/settings/[section]/page.tsx
@@ -7,7 +7,7 @@ import { NotificationsForm } from './_forms/NotificationsForm';
 
 const VALID_SECTIONS = [
   'profile', 'password', 'notifications', 'integrations',
-  'team', 'api', 'billing', 'payment', 'invoices', 'danger',
+  'team', 'api', 'billing', 'payment', 'invoices', 'export', 'danger',
 ] as const;
 
 type Section = (typeof VALID_SECTIONS)[number];
@@ -155,6 +155,35 @@ function ApiSection() {
   );
 }
 
+function ExportSection() {
+  return (
+    <div className="space-y-6" data-testid="settings-export">
+      <div>
+        <h2 className="text-base font-semibold text-ds-text">Export your data</h2>
+        <p className="text-sm text-ds-text-muted mt-0.5">Download a copy of your Quantika data.</p>
+      </div>
+      <Card padding="md">
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-medium text-ds-text">All data (CSV)</p>
+            <p className="text-xs text-ds-text-muted mt-0.5">Vessels, cargoes, matches and economics in CSV format.</p>
+          </div>
+          <Button variant="secondary" size="sm" disabled>Export CSV</Button>
+        </div>
+      </Card>
+      <Card padding="md">
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-medium text-ds-text">All data (JSON)</p>
+            <p className="text-xs text-ds-text-muted mt-0.5">Full structured export including confidence fields.</p>
+          </div>
+          <Button variant="secondary" size="sm" disabled>Export JSON</Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
 function DangerSection() {
   return (
     <div className="space-y-6" data-testid="settings-danger">
@@ -203,6 +232,7 @@ export default async function SettingsSectionPage({
     case 'password':      return <PasswordSection />;
     case 'notifications': return <NotificationsSection />;
     case 'api':           return <ApiSection />;
+    case 'export':        return <ExportSection />;
     case 'danger':        return <DangerSection />;
     default:              return <ComingSoonSection section={section} />;
   }

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -15,6 +15,7 @@ const SECTIONS = [
   { id: 'billing',       label: 'Billing' },
   { id: 'payment',       label: 'Payment' },
   { id: 'invoices',      label: 'Invoices' },
+  { id: 'export',        label: 'Export' },
   { id: 'danger',        label: 'Danger zone', danger: true },
 ] as readonly { id: string; label: string; danger?: boolean }[];
 

--- a/app/vessels/page.tsx
+++ b/app/vessels/page.tsx
@@ -47,7 +47,16 @@ export default async function VesselsPage() {
     );
   }
 
-  const rows: VesselRow[] = session.parsedVessels.map((vessel) => {
+  // Pre-sort newest-open-date first so name-keyed dedup keeps the freshest snapshot.
+  const sortedParsedVessels = [...session.parsedVessels].sort((a, b) => {
+    const va = a.openDate?.value;
+    const vb = b.openDate?.value;
+    const da = typeof va === 'string' ? va : '';
+    const db = typeof vb === 'string' ? vb : '';
+    return db.localeCompare(da);
+  });
+
+  const rows: VesselRow[] = sortedParsedVessels.map((vessel) => {
     const email = session.emails.find((e) => e.id === vessel.emailId);
     const hasMatch = session.matches.some((m) => m.vesselEmailId === vessel.emailId);
     const vesselName = cfValue(vessel.vesselName) ?? 'Unknown vessel';
@@ -71,14 +80,13 @@ export default async function VesselsPage() {
     };
   });
 
-  // Collapse re-circulated duplicate vessels: the demo corpus carries the same
-  // vessel as items across several circular emails. Key on identity (name +
-  // open position + open date); a vessel at a genuinely different position/date
-  // stays as a separate row. Unknown-named rows are never collapsed (keyed by id).
-  // Prefer the row that already has a match so matched vessels stay visible.
+  // Collapse re-circulated duplicate vessels: the same vessel can appear across
+  // several circular emails with different position/date snapshots. Key on name
+  // only; the pre-sort above ensures we keep the freshest snapshot. Unknown-named
+  // rows are never collapsed (keyed by id). Matched rows still win over open rows.
   const dedupedVessels = dedupRows(rows, (r) =>
     r.vesselName && r.vesselName !== 'Unknown vessel'
-      ? `${r.vesselName}|${r.openPosition ?? ''}|${r.openDate ?? ''}`
+      ? r.vesselName
       : r.id,
   );
 

--- a/scripts/demo-seed/build.ts
+++ b/scripts/demo-seed/build.ts
@@ -155,7 +155,7 @@ function redactEmails(text: string): string {
 // name that happens to also be a port name (e.g. "Istanbul" → "CONTACT 3"), the JSON-level
 // replacement corrupts the structured field. Sanitize after anonymization.
 const LOCATION_FIELDS = ['openPosition', 'originPort', 'destinationPort'] as const;
-const CONTACT_TOKEN_RE = /^CONTACT\s+\d+$/i;
+const CONTACT_TOKEN_RE = /^(CONTACT|AGENT)\s+\d+$/i;
 
 export function sanitizeContactTokensFromLocations(items: unknown[]): unknown[] {
   return items.map((item) => {


### PR DESCRIPTION
Closes #885

## Summary

- **NAME-COLLISION** (`app/vessels/page.tsx`): `dedupRows` now keys on vessel name only (was `name|position|date`). Pre-sorts `parsedVessels` by raw `openDate` descending so the freshest snapshot is kept; match-status preference preserved.
- **AGENT-3 LEAK** (`scripts/demo-seed/build.ts:158`): `CONTACT_TOKEN_RE` broadened to `/(CONTACT|AGENT)\s+\d+$/i` — catches `AGENT N` tokens in `sanitizeContactTokensFromLocations`. **Note:** live demo seed already has AGENT 3 baked; seed rebuild/patch needed on next deploy (orchestrator handles separately).
- **OWNER-SORT** (`app/matches/MatchesClient.tsx:111,116`): initial `sortBy` and mode-switch reset now branch on `isOwner` → owner defaults to `tce`, charterer to `fit`. Previously hardcoded `fit` for both.
- **SETTINGS EXPORT** (`app/settings/layout.tsx` + `[section]/page.tsx`): `Export` section added to sidebar before Danger Zone; `VALID_SECTIONS` updated; `ExportSection` placeholder with CSV/JSON export buttons (disabled).

## Tests

- New `__tests__/settings-export-section.test.ts` — 6 assertions covering sidebar entry, route guard (not 404), component presence, CSV/JSON buttons.
- Extended `__tests__/mode-aware-content.test.ts` — 2 new assertions for `isOwner`-conditional `sortBy` init and mode-switch reset.
- 76/76 tests pass (6 suites), tsc clean.

## Do NOT merge

Orchestrator runs cold `/test-skill` then merges.