### PR TITLE
test(#885): regression tests for AGENT-token sanitization + vessel dedup

### DIFF
--- a/__tests__/vessels-dedup.test.ts
+++ b/__tests__/vessels-dedup.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression #885-F2: dedupRows behavioral tests — vessel name-collision dedup.
+ * Locks the fix in app/vessels/page.tsx that collapses same-name vessels to 1 row.
+ */
+import { dedupRows } from '@/app/vessels/page';
+import type { VesselRow } from '@/app/vessels/VesselsClient';
+
+function makeRow(vesselName: string, openDate: string | null, status: 'open' | 'match' = 'open'): VesselRow {
+  return {
+    id: `${vesselName}:${openDate ?? 'null'}`,
+    emailId: `email-${vesselName}-${openDate ?? 'null'}`,
+    itemIndex: 0,
+    vesselName,
+    vesselType: 'bulk carrier',
+    vesselKey: 'bulk',
+    dwtSummer: '50k',
+    openPosition: 'Rotterdam',
+    openDate,
+    status,
+    sourceTag: 'Email',
+    sourceName: 'Test Broker',
+  };
+}
+
+// Pre-sort utility matching page.tsx logic: newest date first, nulls last.
+function presort(rows: VesselRow[]): VesselRow[] {
+  return [...rows].sort((a, b) => {
+    const da = a.openDate ?? '';
+    const db = b.openDate ?? '';
+    return db.localeCompare(da);
+  });
+}
+
+function keyFn(r: VesselRow): string {
+  return r.vesselName && r.vesselName !== 'Unknown vessel' ? r.vesselName : r.id;
+}
+
+describe('dedupRows — regression #885-F2', () => {
+  it('3 rows named "SEAGULL 41" with different openDates collapse to 1 row', () => {
+    const rows = presort([
+      makeRow('SEAGULL 41', '2026-06-04'),
+      makeRow('SEAGULL 41', '2026-05-31'),
+      makeRow('SEAGULL 41', '2026-05-25'),
+    ]);
+    const result = dedupRows(rows, keyFn);
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps the newest openDate when collapsing duplicates', () => {
+    const rows = presort([
+      makeRow('SEAGULL 41', '2026-06-04'),
+      makeRow('SEAGULL 41', '2026-05-31'),
+      makeRow('SEAGULL 41', '2026-05-25'),
+    ]);
+    const result = dedupRows(rows, keyFn);
+    expect(result[0].openDate).toBe('2026-06-04');
+  });
+
+  it('vessel with null openDate sorts after dated vessels and is not promoted', () => {
+    // null-date row appears last in presort (empty string localeCompare loses)
+    const rows = presort([
+      makeRow('SEAGULL 41', '2026-06-04'),
+      makeRow('SEAGULL 41', null),
+    ]);
+    // Pre-sort should place the dated row first
+    expect(rows[0].openDate).toBe('2026-06-04');
+    const result = dedupRows(rows, keyFn);
+    expect(result).toHaveLength(1);
+    expect(result[0].openDate).toBe('2026-06-04');
+  });
+
+  it('match-status row wins over open-status row regardless of insertion order', () => {
+    // Match row comes AFTER the open row in iteration (presort puts newer date first,
+    // but here we test the match-preference logic directly)
+    const open = makeRow('SEAGULL 41', '2026-06-04', 'open');
+    const match = makeRow('SEAGULL 41', '2026-05-25', 'match');
+    // Simulate: open row seen first (newer date), match row seen second
+    const result = dedupRows([open, match], keyFn);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('match');
+  });
+
+  it('distinct vessel names each produce a separate row', () => {
+    const rows = presort([
+      makeRow('SEAGULL 41', '2026-06-04'),
+      makeRow('SEAGULL 42', '2026-06-04'),
+      makeRow('SEAGULL 43', '2026-06-04'),
+    ]);
+    const result = dedupRows(rows, keyFn);
+    expect(result).toHaveLength(3);
+  });
+
+  it('"Unknown vessel" rows are never collapsed (each gets its own id key)', () => {
+    const rows = [
+      makeRow('Unknown vessel', '2026-06-04'),
+      makeRow('Unknown vessel', '2026-05-31'),
+    ];
+    // Override id to be unique per row
+    rows[0].id = 'email1:0';
+    rows[1].id = 'email2:0';
+    const result = dedupRows(rows, keyFn);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/app/vessels/page.tsx
+++ b/app/vessels/page.tsx
@@ -94,7 +94,7 @@ export default async function VesselsPage() {
 }
 
 /** Keep one row per content key, preferring a row that already has a match. */
-function dedupRows<T extends { status: 'open' | 'match' }>(rows: T[], key: (r: T) => string): T[] {
+export function dedupRows<T extends { status: 'open' | 'match' }>(rows: T[], key: (r: T) => string): T[] {
   const seen = new Map<string, T>();
   for (const r of rows) {
     const k = key(r);

--- a/scripts/demo-seed/__tests__/anonymizer-fields.test.ts
+++ b/scripts/demo-seed/__tests__/anonymizer-fields.test.ts
@@ -90,4 +90,26 @@ describe('sanitizeContactTokensFromLocations — unit', () => {
     expect((result[0] as Record<string, unknown>).originPort).toBeNull();
     expect((result[0] as Record<string, unknown>).destinationPort).toBeNull();
   });
+
+  // Regression #885-F1: AGENT N tokens must be sanitized the same as CONTACT N
+  it('clears AGENT N from openPosition string (regression #885)', async () => {
+    const { sanitizeContactTokensFromLocations } = await import('../build');
+    const items = [{ openPosition: 'AGENT 3', dwtSummer: 12000 }];
+    const result = sanitizeContactTokensFromLocations(items);
+    expect((result[0] as Record<string, unknown>).openPosition).toBeNull();
+  });
+
+  it('does NOT clear "AGENT NAME" (non-numeric) from openPosition — no over-match', async () => {
+    const { sanitizeContactTokensFromLocations } = await import('../build');
+    const items = [{ openPosition: 'AGENT NAME', dwtSummer: 12000 }];
+    const result = sanitizeContactTokensFromLocations(items);
+    expect((result[0] as Record<string, unknown>).openPosition).toBe('AGENT NAME');
+  });
+
+  it('does NOT clear "AGENT 3 extra" (trailing text) from openPosition — no over-match', async () => {
+    const { sanitizeContactTokensFromLocations } = await import('../build');
+    const items = [{ openPosition: 'AGENT 3 extra', dwtSummer: 12000 }];
+    const result = sanitizeContactTokensFromLocations(items);
+    expect((result[0] as Record<string, unknown>).openPosition).toBe('AGENT 3 extra');
+  });
 });


### PR DESCRIPTION
## Summary

- **F1** — Add 3 tests to `scripts/demo-seed/__tests__/anonymizer-fields.test.ts`: asserts `AGENT 3` as `openPosition` is cleared to `null`; asserts `AGENT NAME` and `AGENT 3 extra` are NOT over-matched (stay unchanged). Locks the `/^(CONTACT|AGENT)\s+\d+$/i` fix at `build.ts:158` from PR #890.
- **F2** — Export `dedupRows` from `app/vessels/page.tsx` (minimal test-only export); add `__tests__/vessels-dedup.test.ts` with 6 behavioral tests: 3×SEAGULL-41 → 1 row, newest date kept, null-date sorts last, match-status preference, distinct names not collapsed, Unknown vessel rows never merged.

## Test plan
- [ ] `npx jest anonymizer-fields --maxWorkers=1 --forceExit` → 9/9 pass
- [ ] `npx jest vessels-dedup --maxWorkers=1 --forceExit` → 6/6 pass
- [ ] `tsc --noEmit` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)