### PR TITLE
fix(broker-audit F): hide non-ranking score sub-label, Fit% as sole metric

### DIFF
--- a/__tests__/match-detail.test.tsx
+++ b/__tests__/match-detail.test.tsx
@@ -158,10 +158,12 @@ describe('app/match/[id]/page.tsx — FIT% hero circle (#fit-primary)', () => {
     expect(src).toMatch(/Math\.round.*fit_percent|fit_percent.*Math\.round/);
   });
 
-  it('hero falls back to storedMatch.score + "score" when fit_percent is null', () => {
+  it('hero shows no pill when fit_percent is null (Option A: score label removed)', () => {
     const src = readSource(pagePath);
-    // null branch still has "score" JSX text label
-    expect(src).toMatch(/>score</);
+    // Option A: score fallback pill removed; no ">score<" label in source
+    expect(src).not.toMatch(/>score</);
+    // The fit pill path still exists
+    expect(src).toMatch(/fit_percent.*!=.*null[\s\S]{0,50}&&/);
   });
 });
 

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -17,7 +17,6 @@ import { MatchWorksheet } from '@/components/match/MatchWorksheet';
 import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
 import { cfValue } from '@/lib/types';
 import { getPortDistance } from '@/lib/sailing/port-distances';
-import { effectiveScore } from '@/lib/utils/effective-score';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 import { lookupCii } from '@/lib/imo/cii-lookup';
 
@@ -130,9 +129,6 @@ export default async function MatchDetailPage({ params }: Props) {
     (vessel && cargo
       ? (getPortDistance(cfValue(vessel.openPosition) ?? '', cfValue(cargo.originPort) ?? '')?.nm ?? null)
       : null);
-
-  // eslint-disable-next-line react-hooks/purity -- Server Component; Date.now() runs once per request, not in client render
-  const now = Date.now();
 
   // W6a: Baltic TC staleness badge. When the stored freight rate came from the Baltic
   // tier-2 waterfall, surface the rate's price_date so EconomicsTab can show a stale badge.

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -169,7 +169,7 @@ export default async function MatchDetailPage({ params }: Props) {
 
           <div className="flex items-center gap-4 sm:gap-6">
             {/* Score / Fit pill */}
-            {storedMatch.fit_percent != null ? (() => {
+            {storedMatch.fit_percent != null && (() => {
               const fitPct = Math.round(storedMatch.fit_percent!);
               const fitColor = fitPct >= 85
                 ? 'bg-emerald-100 text-emerald-800'
@@ -188,18 +188,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   <span className="text-xs font-medium opacity-60 mt-0.5">fit</span>
                 </div>
               );
-            })() : (
-              <div
-                className="flex-shrink-0 flex flex-col items-center justify-center rounded-full bg-ds-accent-soft text-ds-accent-soft-fg w-20 h-20 sm:w-24 sm:h-24"
-                data-testid="score-pill"
-                aria-label={`Match score: ${storedMatch.score}`}
-              >
-                <span className="font-mono text-3xl sm:text-4xl font-semibold leading-none">
-                  {effectiveScore(storedMatch, now)}
-                </span>
-                <span className="text-xs font-medium opacity-60 mt-0.5">score</span>
-              </div>
-            )}
+            })()}
 
             {/* Headline + meta */}
             <div className="min-w-0 flex-1">

--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -750,9 +750,6 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                             ) : (
                               <div className="text-lg font-bold text-blue-600">{effectiveScore(match, clientNow)}%</div>
                             )}
-                            {match.fit_percent != null && (
-                              <div className="text-xs text-gray-400 font-mono">score {effectiveScore(match, clientNow)}</div>
-                            )}
                             <div className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 capitalize">
                               {match.status}
                             </div>


### PR DESCRIPTION
## Summary
- Removes `score {N}` gray sub-label from match list cards (MatchesClient.tsx) — shown under Fit pill when fit_percent is set
- Removes score fallback pill from match detail hero (app/match/[id]/page.tsx) — shown when fit_percent is null
- Removes dead `effectiveScore` import and `now` variable from page.tsx (left over after pill removal)
- Updates `match-detail.test.tsx` assertion: was checking `>score<` exists → now checks it is absent

**Score remains** in data model, sort tiebreaker (`fitDiff !== 0 ? fitDiff : b.score - a.score`), and MatchDetailPanel interface — only display is removed.

## Why
fit_percent is the de-facto ranking metric for ALL sort modes (even the "Score" sort option sorts by fit_percent, using score only as a tiebreaker). Showing both "Fit 92%" and "score 84" on every card forced brokers to infer which one ranks the list — this implements Option A from the recon (2-file display fix, zero model risk).

> **NOTE:** This implements the recon's recommended Option A. The founder may instead prefer **Option B** — keep both metrics visible but label them explicitly: "Fit 92% · ranking" (badge) + "Match confidence: 84" (sub-label) + tooltip explaining the hierarchy. Option A is fully reversible (the score data is preserved); reverting is a 3-line add-back.

## Test plan
- [ ] `npx jest --findRelatedTests app/matches/MatchesClient.tsx app/match/\\[id\\]/page.tsx __tests__/match-detail.test.tsx --maxWorkers=1 --forceExit` → 37 passed
- [ ] `tsc --noEmit --skipLibCheck` → exit 0
- [ ] Verify match list cards show only "N% fit" pill, no gray "score N" sub-label below
- [ ] Verify match detail hero shows only the Fit % circle, not a second "score" circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)