### PR TITLE
fix(#666): draft-quote graceful error handling + toast (silent 500)

### DIFF
--- a/__tests__/api/draft-quote-greeting.test.ts
+++ b/__tests__/api/draft-quote-greeting.test.ts
@@ -76,3 +76,28 @@ describe('POST /api/ai/draft-quote — greeting #812', () => {
     expect(addressLine).toBe('Address the reply to: Alice Cooper');
   });
 });
+
+describe('POST /api/ai/draft-quote — error handling', () => {
+  it('returns 500 JSON with error:ai_error when callAiText throws a generic Error', async () => {
+    mockRequireSession.mockReturnValue({ session: sessionWith({ from: 'a@b.com', fromName: 'Alice' }), sessionId: 'sid' });
+    mockCallAiText.mockRejectedValueOnce(new Error('Gemini credentials missing'));
+
+    const res = await POST(makeReq({ emailId: 'e1' }));
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string; message: string };
+    expect(body.error).toBe('ai_error');
+    expect(body.message).toBe('Gemini credentials missing');
+  });
+
+  it('returns 504 JSON with error:ai_timeout when callAiText throws LLMTimeoutError', async () => {
+    mockRequireSession.mockReturnValue({ session: sessionWith({ from: 'a@b.com', fromName: 'Alice' }), sessionId: 'sid' });
+    const { LLMTimeoutError } = await import('@/lib/openai');
+    mockCallAiText.mockRejectedValueOnce(new LLMTimeoutError('AI call timed out after 30s'));
+
+    const res = await POST(makeReq({ emailId: 'e1' }));
+    expect(res.status).toBe(504);
+    const body = await res.json() as { error: string; retryable: boolean };
+    expect(body.error).toBe('ai_timeout');
+    expect(body.retryable).toBe(true);
+  });
+});

--- a/__tests__/components/QuoteTab.test.tsx
+++ b/__tests__/components/QuoteTab.test.tsx
@@ -88,3 +88,44 @@ describe('QuoteTab — Save Draft + Send Quote handlers', () => {
     expect(screen.getByRole('button', { name: 'Send Quote' })).toBeDisabled();
   });
 });
+
+describe('QuoteTab — generateDraft error shows toast', () => {
+  it('calls toast.error with the error message when API returns non-ok', async () => {
+    const { csrfFetch } = await import('@/lib/csrf-client');
+    (csrfFetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'ai_error', message: 'Gemini credentials missing' }),
+    });
+
+    const user = userEvent.setup();
+    const { getByRole, findAllByText } = renderQuoteTab({ cargoEmailId: 'email-1' });
+
+    await user.click(getByRole('button', { name: 'Generate' }));
+
+    // Toast renders the error message in the DOM (toast + inline error both show it)
+    const matches = await findAllByText('Gemini credentials missing');
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    // Verify at least one is from the toast (data-variant="error")
+    const toastEl = matches.find(el => el.closest('[data-variant="error"]'));
+    expect(toastEl).toBeTruthy();
+  });
+
+  it('shows inline error text when API returns non-ok', async () => {
+    const { csrfFetch } = await import('@/lib/csrf-client');
+    (csrfFetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'ai_error', message: 'AI draft generation failed' }),
+    });
+
+    const user = userEvent.setup();
+    renderQuoteTab({ cargoEmailId: 'email-1' });
+
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      // Inline error paragraph shows the message
+      const errorEl = screen.getByText('AI draft generation failed', { selector: 'p' });
+      expect(errorEl).toBeInTheDocument();
+    });
+  });
+});

--- a/app/api/ai/__tests__/draft-quote.test.ts
+++ b/app/api/ai/__tests__/draft-quote.test.ts
@@ -242,10 +242,14 @@ describe('POST /api/ai/draft-quote', () => {
     expect(body.retryable).toBe(true);
   });
 
-  it('re-throws non-timeout errors', async () => {
+  it('returns 500 JSON with error:ai_error for non-timeout errors', async () => {
     mockGetSession.mockReturnValue(baseSession);
     mockCallAiText.mockRejectedValue(new Error('unexpected error'));
     const req = makeRequest({ emailId: 'email-1' }, 'session-1');
-    await expect(POST(req)).rejects.toThrow('unexpected error');
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('ai_error');
+    expect(body.message).toBe('unexpected error');
   });
 });

--- a/app/api/ai/draft-quote/route.ts
+++ b/app/api/ai/draft-quote/route.ts
@@ -125,6 +125,7 @@ Generate a professional draft quote email.`;
         { status: 504 },
       );
     }
-    throw err;
+    const message = err instanceof Error ? err.message : 'AI draft generation failed';
+    return NextResponse.json({ error: 'ai_error', message }, { status: 500 });
   }
 }

--- a/components/__tests__/quote-tab-generate-draft.test.tsx
+++ b/components/__tests__/quote-tab-generate-draft.test.tsx
@@ -100,7 +100,7 @@ describe('QuoteTab — Generate Draft button (fix #351)', () => {
     fireEvent.click(screen.getByRole('button', { name: /generate/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Service unavailable')).toBeInTheDocument();
+      expect(screen.getByText('Service unavailable', { selector: 'p' })).toBeInTheDocument();
     });
   });
 

--- a/components/match/QuoteTab.tsx
+++ b/components/match/QuoteTab.tsx
@@ -42,11 +42,13 @@ export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
         method: 'POST',
         body: JSON.stringify({ emailId: cargoEmailId }),
       });
-      const data = await res.json() as { draft?: string; error?: string };
-      if (!res.ok) throw new Error(data.error ?? 'Failed to generate draft');
+      const data = await res.json() as { draft?: string; error?: string; message?: string };
+      if (!res.ok) throw new Error(data.message ?? data.error ?? 'Failed to generate draft');
       setDraft(data.draft ?? '');
     } catch (err) {
-      setGenerateError(err instanceof Error ? err.message : 'Failed to generate draft');
+      const msg = err instanceof Error ? err.message : 'Failed to generate draft';
+      setGenerateError(msg);
+      toast.error(msg);
     } finally {
       setGenerating(false);
     }


### PR DESCRIPTION
## Bug A (broker-audit 2026-06-09, HIGH)
`POST /api/ai/draft-quote` returned HTTP 500 **silently** — no toast, empty textarea, broker saw the core quote feature as dead.

## Root
- **Server:** `route.ts:128` re-threw non-timeout errors → bare 500. Happens when provider ≠ openai without creds.
- **Client:** `QuoteTab.tsx:49` catch set inline error text but never `toast.error()`.

## Fix
- `route.ts:128` → structured JSON: `LLMTimeoutError`→504, else→500 `{error,message}`. 400/401 guards unchanged.
- `QuoteTab.tsx:49` → `toast.error(msg)` alongside `setGenerateError`.
- Did NOT touch `assertGeminiEnv/assertBedrockEnv` throws (ai-provider invariant).
- 4 new tests (server error-path + client toast/inline), 1 stale test updated.

## Note
Whether generation *succeeds* end-to-end on the demo depends on prod LLM provider config (out of scope of this code fix). This PR makes failures **graceful + visible** instead of silent 500.

Closes #666