### PR TITLE
fix(#884 part1): dedup vessel records in hydrate so display and fit-scoring agree (false overflow)

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session-dedup.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session-dedup.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test: dedup + grainCapacityUnit normalization in buildDemoSessionBlob.
+ *
+ * Three parsed_results rows for the same emailId|itemIndex vessel must collapse to
+ * one record (first-wins). Display path and scoring path must resolve to the same
+ * record. grainCapacityUnit must be 'cbm' and grainCapacity must be the first-row
+ * value (3994), eliminating the false "overflows the holds" for HRC at 115 MT.
+ */
+import Database from 'better-sqlite3';
+import { buildDemoSessionBlob } from '../hydrate-demo-session';
+import { scoreVolume } from '@/lib/sailing/fit-breakdown';
+
+const EMAIL_ID = '19e07aabbccddee';
+const ITEM_INDEX = 1;
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE emails (
+      account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+      from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+      body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+    );
+    CREATE TABLE parsed_results (
+      account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+      result_json TEXT, parsed_at INTEGER
+    );
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+      reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+      reason_structured TEXT
+    );
+  `);
+
+  db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, from_name, from_email, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+    VALUES ('demo',?,?,?,?,?,'me@demo.local','Vessel YUCATAN','2026-05-20','body','snip','["INBOX"]',0)`)
+    .run(EMAIL_ID, `t-${EMAIL_ID}`, `Sender <sender@demo.local>`, 'Sender', 'sender@demo.local');
+
+  // Three duplicate rows for the same emailId|itemIndex: first has correct cbft value that maps
+  // to 3994 cbm; second and third carry a previously-double-converted 113 cbm value.
+  const row1 = JSON.stringify([{
+    emailId: EMAIL_ID, itemIndex: ITEM_INDEX,
+    vesselName: 'YUCATAN', grainCapacity: 3994, grainCapacityUnit: 'cbft',
+    dwt: 3176,
+  }]);
+  const row2 = JSON.stringify([{
+    emailId: EMAIL_ID, itemIndex: ITEM_INDEX,
+    vesselName: 'YUCATAN', grainCapacity: 113, grainCapacityUnit: 'cbm',
+    dwt: 3176,
+  }]);
+  const row3 = JSON.stringify([{
+    emailId: EMAIL_ID, itemIndex: ITEM_INDEX,
+    vesselName: 'YUCATAN', grainCapacity: 113, grainCapacityUnit: 'cbm',
+    dwt: 3176,
+  }]);
+
+  const ins = db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at) VALUES ('demo',?,?,?,?,?)`);
+  ins.run(EMAIL_ID, 'vessel', 'v1', row1, 0);
+  ins.run(EMAIL_ID, 'vessel', 'v1', row2, 0);
+  ins.run(EMAIL_ID, 'vessel', 'v1', row3, 0);
+
+  return db;
+}
+
+describe('buildDemoSessionBlob — dedup + unit normalization (#884)', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = makeDb(); });
+  afterEach(() => { db.close(); });
+
+  it('deduplicates three vessel rows for the same emailId|itemIndex to exactly one', () => {
+    const blob = buildDemoSessionBlob(db);
+    const matches = blob.parsedVessels.filter(
+      (v) => v.emailId === EMAIL_ID && v.itemIndex === ITEM_INDEX,
+    );
+    expect(matches).toHaveLength(1);
+  });
+
+  it('display path and scoring path resolve to the same record', () => {
+    const blob = buildDemoSessionBlob(db);
+    const displayRecord = blob.parsedVessels.find(
+      (v) => v.emailId === EMAIL_ID && v.itemIndex === ITEM_INDEX,
+    );
+    const scoringRecord = new Map(
+      blob.parsedVessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]),
+    ).get(`${EMAIL_ID}|${ITEM_INDEX}`);
+    expect(displayRecord).toBeDefined();
+    expect(scoringRecord).toBeDefined();
+    expect(displayRecord).toEqual(scoringRecord);
+  });
+
+  it('first-row value preserved: grainCapacity=3994, grainCapacityUnit forced to cbm', () => {
+    const blob = buildDemoSessionBlob(db);
+    const vessel = blob.parsedVessels.find(
+      (v) => v.emailId === EMAIL_ID && v.itemIndex === ITEM_INDEX,
+    )!;
+    expect(vessel.grainCapacity).toBe(3994);
+    expect(vessel.grainCapacityUnit).toBe('cbm');
+  });
+
+  it('scoreVolume with corrected 3994 cbm capacity does NOT overflow for HRC 115 MT', () => {
+    const blob = buildDemoSessionBlob(db);
+    const vessel = blob.parsedVessels.find(
+      (v) => v.emailId === EMAIL_ID && v.itemIndex === ITEM_INDEX,
+    )!;
+    const result = scoreVolume(115, 'grain', vessel.grainCapacity ?? null, null);
+    expect(result.rationale).not.toContain('overflows the holds');
+  });
+});

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -55,6 +55,17 @@ function safeJsonObject<T>(json: string | null): T | undefined {
   }
 }
 
+function dedupByKey<T extends { emailId: string; itemIndex: number }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const it of items) {
+    const k = `${it.emailId}|${it.itemIndex}`;
+    if (seen.has(k)) continue;
+    seen.add(k); out.push(it);
+  }
+  return out;
+}
+
 export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   const emailRows = db.prepare(
     `SELECT gmail_message_id, thread_id, from_addr, from_name, from_email,
@@ -89,6 +100,14 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
       case 'vessel': parsedVessels.push(...safeJsonArray<ParsedVessel>(row.result_json, 'vessel')); break;
       case 'recap': parsedFixtureRecaps.push(...safeJsonArray<ParsedFixtureRecap>(row.result_json, 'recap')); break;
       case 'classify': classifications.push(...safeJsonArray<Classification>(row.result_json, 'classify')); break;
+    }
+  }
+
+  const dedupedVessels = dedupByKey(parsedVessels);
+  const dedupedCargos  = dedupByKey(parsedCargos);
+  for (const v of dedupedVessels) {
+    if (v.grainCapacityUnit && v.grainCapacityUnit !== 'cbm') {
+      v.grainCapacityUnit = 'cbm';
     }
   }
 
@@ -180,13 +199,13 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   const lowConfidenceMatches = rowsToMatches(reviewRows);
   const insufficientData = rowsToMatches(insufficientRows);
 
-  const processedEmails = buildProcessedEmails(emails, classifications, parsedCargos, parsedVessels);
+  const processedEmails = buildProcessedEmails(emails, classifications, dedupedCargos, dedupedVessels);
 
   return {
     emails,
     classifications,
-    parsedCargos,
-    parsedVessels,
+    parsedCargos: dedupedCargos,
+    parsedVessels: dedupedVessels,
     parsedFixtureRecaps,
     processedEmails,
     matches,


### PR DESCRIPTION
## Root Cause

`buildDemoSessionBlob` pushes ALL `parsed_results` vessel rows into `parsedVessels[]` with no deduplication. `emailId 19e07d53e7d46b71` (SEAGULL 41 / MV YUCATAN) has **3 rows** with conflicting grain capacity values.

The display path (`app/match/[id]/page.tsx` → `.find()` → **first** record → `grainCapacity: 3994, unit: 'cbft'`) and the scoring path (`lib/matching/persist-session-matches.ts` → `new Map()` → **last** record → `grainCapacity: 113, unit: 'cbm'`) were binding to **different objects** from that unsorted array. This caused the Vessels tab to show 3,994 but the volume scorer to compute ratio on 113, producing a false "cargo overflows the holds" on 5 affected matches.

## Fix (Part 1)

- Added `dedupByKey` (first-wins on `emailId|itemIndex`) applied to `parsedVessels` + `parsedCargos` after the `parsed_results` loop in `hydrate-demo-session.ts`
- Force `grainCapacityUnit → 'cbm'` on deduped vessels — scoring unconditionally treats `grainCapacity` as m³, so 3994 is already the correct cbm magnitude; only the label was wrong
- Updated `buildProcessedEmails` call and return blob to use the deduped arrays

## Part 2 (NOT in this PR — founder-gated prod write)

The `fit_breakdown` overflow string is **baked** into the seeded `matches` rows at regen time and is **never recomputed** at runtime (only the economics component is patched at hydrate). Part 2 is a surgical `demo-seed.db` patch (script `scripts/diag/patch-seagull41-capacity.ts --apply`) that:
- Corrects + deduplicates the 3 `parsed_results` vessel rows
- Patches `fit_breakdown` on the 5 affected seeded matches (recomputes volume component with 3994 cbm)
- Clears stale per-session copies so they rebuild from corrected seed

Part 2 requires an explicit founder go-ahead before running against the live `data/demo-seed.db`.

## VALUE_CHECK Oracle (Part 1)

```
3 duplicate parsed_results vessel rows for emailId|itemIndex → buildDemoSessionBlob → parsedVessels.length = 1
blob.parsedVessels.find(...) === Map(blob.parsedVessels).get(key)  // display == scoring
vessel.grainCapacity === 3994, vessel.grainCapacityUnit === 'cbm'
scoreVolume(115, 'grain', 3994, null).rationale  // does NOT contain "overflows the holds"
```

All 4 assertions pass in `lib/demo-mode/__tests__/hydrate-demo-session-dedup.test.ts`.

## Tests

10/10 passing (`hydrate-demo-session*` suites). TypeCheck: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)