### PR TITLE
fix(broker-audit B+D+E): war-risk total in P&L, Berbera util consistency, English Economics panel

### DIFF
--- a/components/economics/CalculationWaterfall.tsx
+++ b/components/economics/CalculationWaterfall.tsx
@@ -66,6 +66,12 @@ export function CalculationWaterfall({ breakdown }: Props) {
             ${freight_rate_usd_per_mt}/MT × {quantity_mt.toLocaleString('en-US')} MT
           </span>
         </div>
+        <div
+          className="text-xs text-gray-400 pl-4"
+          data-testid="freight-qty-disclosure"
+        >
+          max quantity incl. cargo option
+        </div>
         <div className="flex justify-between font-semibold border-b border-gray-200 pb-1">
           <span>= Revenue</span>
           <span data-testid="gross-freight">{fmtUsd(gross_freight_usd)}</span>

--- a/components/economics/CalculationWaterfall.tsx
+++ b/components/economics/CalculationWaterfall.tsx
@@ -2,10 +2,10 @@
  * CalculationWaterfall — "Show calculation" expandable transparent-math panel.
  *
  * Pure presentational component. Renders the approved waterfall layout:
- *   ВЫРУЧКА ЗА РЕЙС → МИНУС РАСХОДЫ → ЧИСТЫМИ ЗА РЕЙС → ÷ дней → ЗАРАБОТОК В ДЕНЬ
+ *   REVENUE PER VOYAGE → MINUS COSTS → NET VOYAGE → ÷ days → DAILY TCE
  *
  * Uses the same fmtUsd broker convention as VoyageBreakdownChart: -$X not $-X.
- * Russian labels — founder-facing UI.
+ * English labels — founder-facing UI.
  */
 
 import * as React from 'react';
@@ -53,61 +53,61 @@ export function CalculationWaterfall({ breakdown }: Props) {
   return (
     <div className="space-y-4 text-sm font-mono" data-testid="calculation-waterfall">
 
-      {/* ── ВЫРУЧКА ЗА РЕЙС ───────────────────────────────── */}
+      {/* ── REVENUE PER VOYAGE ─────────────────────────────── */}
       <section className="space-y-1">
         <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-          Выручка за рейс (что платит фрахтователь)
+          Revenue per voyage (what the charterer pays)
         </div>
         <div className="flex justify-between">
           <span className="text-gray-600">
-            Ставка фрахта × {quantity_mt.toLocaleString('en-US')} т
+            Freight rate × {quantity_mt.toLocaleString('en-US')} MT
           </span>
           <span className="text-gray-500 text-xs self-center">
-            ${freight_rate_usd_per_mt}/т × {quantity_mt.toLocaleString('en-US')} т
+            ${freight_rate_usd_per_mt}/MT × {quantity_mt.toLocaleString('en-US')} MT
           </span>
         </div>
         <div className="flex justify-between font-semibold border-b border-gray-200 pb-1">
-          <span>= Выручка</span>
+          <span>= Revenue</span>
           <span data-testid="gross-freight">{fmtUsd(gross_freight_usd)}</span>
         </div>
       </section>
 
-      {/* ── МИНУС РАСХОДЫ РЕЙСА ───────────────────────────── */}
+      {/* ── MINUS VOYAGE COSTS ─────────────────────────────── */}
       <section className="space-y-2">
         <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-          Минус расходы рейса
+          Minus voyage costs
         </div>
 
-        {/* Топливо */}
+        {/* Bunker */}
         <div className="space-y-0.5" data-testid="cost-bunker">
           <div className="flex justify-between">
-            <span>⛽ Топливо</span>
+            <span>⛽ Bunker</span>
             <span>{fmtUsd(-bunker_usd)}</span>
           </div>
           <div
             className="text-xs text-gray-400 pl-4"
             data-testid="bunker-caption"
           >
-            расход {bunker_consumption_mt_per_day} т/день · {duration_days.toFixed(1)} дн · цена ${bunker_price_usd_per_mt}/т
+            consumption {bunker_consumption_mt_per_day} MT/day · {duration_days.toFixed(1)} days · price ${bunker_price_usd_per_mt}/MT
           </div>
         </div>
 
-        {/* Каналы */}
+        {/* Canals */}
         {canal_usd > 0 ? (
           <div className="flex justify-between" data-testid="cost-canal">
-            <span>🚢 Каналы</span>
+            <span>🚢 Canals</span>
             <span>{fmtUsd(-canal_usd)}</span>
           </div>
         ) : (
           <div className="text-xs text-gray-400 pl-4" data-testid="canal-zero-note">
-            🚢 Каналы — $0 (маршрут не идёт через Суэц/Босфор)
+            🚢 Canals — $0 (route does not pass via Suez/Bosphorus)
           </div>
         )}
 
-        {/* Портовые сборы (DA) */}
+        {/* Port dues (DA) */}
         <div className="flex justify-between" data-testid="cost-da">
           <span>
-            ⚓ Портовые сборы
+            ⚓ Port dues
             {da_quality && da_quality.tier !== 'live' && (
               <span className="ml-1">
                 <DataQualityBadge tier={da_quality.tier} asOf={da_quality.asOf} />
@@ -117,11 +117,11 @@ export function CalculationWaterfall({ breakdown }: Props) {
           <span>{fmtUsd(-da_usd)}</span>
         </div>
 
-        {/* Военный риск */}
+        {/* War risk */}
         <div className="space-y-0.5" data-testid="cost-war-risk">
           <div className="flex justify-between">
             <span>
-              ⚔️ Военный риск
+              ⚔️ War risk
               {warRiskRateTier && warRiskRateTier !== 'live' && (
                 <span
                   data-testid="war-risk-rate-badge"
@@ -137,32 +137,32 @@ export function CalculationWaterfall({ breakdown }: Props) {
             className="text-xs text-gray-400 pl-4"
             data-testid="war-risk-caption"
           >
-            показано, но не влияет на $/день (исключён из расчёта TCE)
+            shown, but does not affect $/day (excluded from TCE)
           </div>
         </div>
 
-        {/* Углеродный ЕС (ETS) */}
+        {/* EU Carbon (ETS) */}
         {applicable.ets && ets_usd > 0 ? (
           <div className="flex justify-between" data-testid="cost-ets">
-            <span>🌍 Углеродный ЕС (ETS)</span>
+            <span>🌍 EU Carbon (ETS)</span>
             <span>{fmtUsd(-ets_usd)}</span>
           </div>
         ) : (
           <div className="text-xs text-gray-400 pl-4" data-testid="ets-zero-note">
-            🌍 Углеродный ЕС — $0 (ни один порт не в ЕС)
+            🌍 EU Carbon — $0 (no EU ports on route)
           </div>
         )}
 
-        {/* Итого расходы */}
+        {/* Total costs */}
         <div className="flex justify-between font-semibold border-b border-gray-200 pb-1">
-          <span>= Все расходы</span>
+          <span>= Total costs</span>
           <span>{fmtUsd(-total_costs_usd)}</span>
         </div>
       </section>
 
-      {/* ── ЧИСТЫМИ ЗА РЕЙС ──────────────────────────────── */}
+      {/* ── NET VOYAGE EARNINGS ─────────────────────────────── */}
       <div className="flex justify-between font-semibold">
-        <span>Чистыми за рейс</span>
+        <span>Net voyage earnings</span>
         <span data-testid="net-voyage">{fmtUsd(net_voyage_usd)}</span>
       </div>
 
@@ -170,29 +170,29 @@ export function CalculationWaterfall({ breakdown }: Props) {
       {war_risk_usd > 0 && (
         <>
           <div className="flex justify-between text-gray-600 text-xs" data-testid="tce-basis-addback">
-            <span>+ Военный риск возвращён в базу TCE</span>
+            <span>+ War risk added back to TCE basis</span>
             <span>{fmtUsd(war_risk_usd)}</span>
           </div>
           <div className="flex justify-between font-semibold" data-testid="tce-basis">
-            <span>= Чистыми для TCE</span>
+            <span>= Net for TCE</span>
             <span>{fmtUsd(net_voyage_usd + war_risk_usd)}</span>
           </div>
         </>
       )}
 
-      {/* ── ДЛИНА РЕЙСА ──────────────────────────────────── */}
+      {/* ── VOYAGE LENGTH ──────────────────────────────────── */}
       <div className="flex justify-between text-gray-600" data-testid="duration-days">
-        <span>÷ Длина рейса</span>
-        <span>{duration_days.toFixed(1)} дней</span>
+        <span>÷ Voyage length</span>
+        <span>{duration_days.toFixed(1)} days</span>
       </div>
 
-      {/* ── ЗАРАБОТОК В ДЕНЬ (TCE) ───────────────────────── */}
+      {/* ── DAILY TCE ───────────────────────────────────────── */}
       <div
         className="flex justify-between font-bold text-base border-t-2 border-gray-800 pt-2"
         data-testid="daily-tce"
       >
-        <span>💰 Заработок в день</span>
-        <span>{fmtUsd(daily_tce_usd)}/день</span>
+        <span>💰 Daily TCE</span>
+        <span>{fmtUsd(daily_tce_usd)}/day</span>
       </div>
     </div>
   );

--- a/components/economics/__tests__/CalculationWaterfall.test.tsx
+++ b/components/economics/__tests__/CalculationWaterfall.test.tsx
@@ -85,7 +85,7 @@ describe('CalculationWaterfall', () => {
     expect(etsNote).toBeInTheDocument();
   });
 
-  it('shows "Чистыми за рейс" with net_voyage_usd', () => {
+  it('shows "Net voyage earnings" with net_voyage_usd', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} />);
     expect(screen.getByTestId('net-voyage')).toHaveTextContent('1,116,340');
   });

--- a/components/economics/__tests__/CalculationWaterfall.test.tsx
+++ b/components/economics/__tests__/CalculationWaterfall.test.tsx
@@ -3,7 +3,7 @@
  *
  * B2 — CalculationWaterfall presentational component tests.
  *
- * Asserts the approved Russian-label waterfall layout renders correctly:
+ * Asserts the approved English-label waterfall layout renders correctly:
  *   revenue → each cost line (negative) → net voyage → ÷ days → daily TCE.
  */
 import React from 'react';
@@ -40,23 +40,23 @@ const FIXTURE: TCEBreakdown = {
 };
 
 describe('CalculationWaterfall', () => {
-  it('shows "Выручка" section with gross_freight_usd', () => {
+  it('shows "Revenue" section with gross_freight_usd', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} />);
-    expect(screen.getByText(/Выручка за рейс/)).toBeInTheDocument();
+    expect(screen.getByText(/Revenue per voyage/)).toBeInTheDocument();
     // gross freight formatted as $1,500,000
     expect(screen.getByTestId('gross-freight')).toHaveTextContent('1,500,000');
   });
 
-  it('shows bunker cost row with negative value and расход/цена caption', () => {
+  it('shows bunker cost row with negative value and consumption/price caption', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} />);
     const bunkerRow = screen.getByTestId('cost-bunker');
     expect(bunkerRow).toBeInTheDocument();
     // negative format: -$308,000
     expect(bunkerRow).toHaveTextContent('-$308,000');
-    // caption contains расход and цена
+    // caption contains consumption and price
     const caption = screen.getByTestId('bunker-caption');
-    expect(caption.textContent).toMatch(/расход/);
-    expect(caption.textContent).toMatch(/цена/);
+    expect(caption.textContent).toMatch(/consumption/);
+    expect(caption.textContent).toMatch(/price/);
   });
 
   it('shows DA cost row with negative value', () => {
@@ -65,12 +65,12 @@ describe('CalculationWaterfall', () => {
     expect(daRow).toHaveTextContent('-$60,000');
   });
 
-  it('shows war risk row with "не влияет на $/день" caption', () => {
+  it('shows war risk row with "does not affect $/day" caption', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} />);
     const warRow = screen.getByTestId('cost-war-risk');
     expect(warRow).toBeInTheDocument();
     const caption = screen.getByTestId('war-risk-caption');
-    expect(caption.textContent).toMatch(/не влияет на/);
+    expect(caption.textContent).toMatch(/does not affect/);
   });
 
   it('shows canal zero-note when canal is 0', () => {
@@ -90,14 +90,14 @@ describe('CalculationWaterfall', () => {
     expect(screen.getByTestId('net-voyage')).toHaveTextContent('1,116,340');
   });
 
-  it('shows "÷ N дней" with duration_days', () => {
+  it('shows "÷ N days" with duration_days', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} />);
     const durationRow = screen.getByTestId('duration-days');
     expect(durationRow.textContent).toMatch(/20/);
-    expect(durationRow.textContent).toMatch(/дн/);
+    expect(durationRow.textContent).toMatch(/days/);
   });
 
-  it('shows "Заработок в день" with daily_tce_usd', () => {
+  it('shows "Daily TCE" with daily_tce_usd', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} />);
     const tceRow = screen.getByTestId('daily-tce');
     expect(tceRow).toHaveTextContent('55,817');

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -31,9 +31,10 @@ export function MatchWorksheet({ worksheet }: Props) {
   const { readiness: r, vessel: v, cargo: c, hardFilters: hf } = worksheet;
 
   const capacityMt = v.dwcc ?? v.dwtSummer;
+  const utilWeight = c.weightMtEffective ?? c.weightMt;  // worst-case when present; graceful fallback
   const util =
-    capacityMt != null && capacityMt > 0 && c.weightMt != null
-      ? Math.round((c.weightMt / capacityMt) * 100)
+    capacityMt != null && capacityMt > 0 && utilWeight != null
+      ? Math.round((utilWeight / capacityMt) * 100)
       : null;
 
   const transitChain = (() => {
@@ -65,9 +66,13 @@ export function MatchWorksheet({ worksheet }: Props) {
     {
       label: '⚖️ Weight',
       vessel: v.dwtSummer != null ? `${v.dwtSummer.toLocaleString('en-US')} DWT${v.dwcc != null ? ` / ${v.dwcc.toLocaleString('en-US')} DWCC` : ''}` : '—',
-      cargoPort: c.weightMt != null ? `${c.weightMt.toLocaleString('en-US')} mt` : '—',
+      cargoPort: c.weightMt != null
+          ? (c.weightMtEffective != null && c.weightMtEffective !== c.weightMt
+              ? `${c.weightMt.toLocaleString('en-US')} mt (${c.weightMtEffective.toLocaleString('en-US')} max w/ option)`
+              : `${c.weightMt.toLocaleString('en-US')} mt`)
+          : '—',
       verdict: util != null
-        ? `${util}% utilisation${util >= 85 ? ' ✅' : util >= 70 ? ' ⚠️' : ' ❌'}`
+        ? `${util}% utilisation${util > 100 ? ' ❌' : util >= 85 ? ' ✅' : util >= 70 ? ' ⚠️' : ' ❌'}`
         : verdictBadge(hf.volume.pass, hf.volume.reason),
     },
     {

--- a/components/match/__tests__/MatchWorksheet-weight.test.tsx
+++ b/components/match/__tests__/MatchWorksheet-weight.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Behavioral tests — MatchWorksheet weight util% (Layer D green-lie fix)
+ *
+ * PI2: real component call via direct render, checks util% verdict string.
+ * Covers:
+ *  - weightMtEffective present → uses worst-case → overflow ❌
+ *  - weightMtEffective absent → graceful fallback to nominal → OK ✅
+ */
+import { MatchWorksheet } from '../MatchWorksheet';
+import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
+
+function makeWeightWorksheet(overrides: {
+  weightMt: number | null;
+  weightMtEffective?: number | null;
+  dwcc?: number | null;
+  dwtSummer?: number | null;
+}): MatchWorksheetType {
+  return {
+    readiness: {
+      verdict: 'ideal',
+      explanation: '',
+      openDate: null,
+      openPosition: null,
+      laycanStart: null,
+      laycanEnd: null,
+      distanceNm: null,
+      sailingDays: null,
+      speedKn: null,
+      arrivalDate: null,
+      gapDays: null,
+    },
+    vessel: {
+      draftMax: null,
+      grainCapacity: null,
+      grainCapacityUnit: null,
+      geared: null,
+      vesselType: null,
+      flag: null,
+      built: null,
+      pandi: null,
+      classSociety: null,
+      lastCargoes: null,
+      dwtSummer: overrides.dwtSummer ?? null,
+      dwcc: overrides.dwcc ?? null,
+    },
+    cargo: {
+      weightMt: overrides.weightMt,
+      weightMtEffective: overrides.weightMtEffective,
+      cargoType: null,
+      loadPort: null,
+      dischargePort: null,
+    },
+    hardFilters: {
+      draft: { pass: true },
+      crane: { pass: true },
+      volume: { pass: true },
+    },
+  };
+}
+
+describe('MatchWorksheet — weight util% (Layer D)', () => {
+  it('Berbera-like: weightMtEffective=3080, dwcc=2962 → overflow (>100%) ❌', () => {
+    const ws = makeWeightWorksheet({
+      weightMt: 2800,
+      weightMtEffective: 3080,
+      dwcc: 2962,
+    });
+    const el = MatchWorksheet({ worksheet: ws });
+    const text = JSON.stringify(el);
+    // util = round(3080/2962*100) = round(104.0) = 104% → overflow
+    expect(text).toMatch(/104%/);
+    // must NOT show ✅ for weight (overflow should show ❌ or no checkmark)
+    expect(text).not.toContain('104% utilisation ✅');
+  });
+
+  it('weightMtEffective absent → graceful fallback to nominal (no crash)', () => {
+    const ws = makeWeightWorksheet({
+      weightMt: 2800,
+      weightMtEffective: undefined,
+      dwcc: 2962,
+    });
+    const el = MatchWorksheet({ worksheet: ws });
+    const text = JSON.stringify(el);
+    // util = round(2800/2962*100) = round(94.5) = 95% → OK (≥85%)
+    expect(text).toMatch(/95%/);
+    expect(text).toContain('utilisation ✅');
+  });
+});

--- a/lib/economics/voyage-calculator.ts
+++ b/lib/economics/voyage-calculator.ts
@@ -191,7 +191,10 @@ export function calculateTCE(input: VoyageInput): TCEResult {
     vesselValueUsd: valueUsd,
     daysInHra,
   });
-  const warRiskUsd = Math.round(warResult.premiumUsd);
+  // Intentional spec change: war-risk.ts:128 designates breakdown.totalPremiumUsd as the full
+  // per-voyage cost (hull + crew bonus + P&I). premiumUsd is hull-only, kept for backward compat.
+  // REVERSIBLE: change back to warResult.premiumUsd to revert to hull-only convention.
+  const warRiskUsd = Math.round(warResult.breakdown?.totalPremiumUsd ?? warResult.premiumUsd);
   // βf-04: gate on calculator-reported applicability, not USD > 0.
   // A matched HRA zone is "applicable" even if (in degenerate edge cases)
   // the rounded premium were zero — so downstream UI surfaces the warning.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -445,6 +445,7 @@ export interface MatchWorksheet {
   };
   cargo: {
     weightMt: number | null;
+    weightMtEffective?: number | null;  // worst-case (resolveCargoWeight) for util% gating
     cargoType: string | null;
     loadPort: string | null;
     dischargePort: string | null;

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -386,7 +386,7 @@ async function main(): Promise<void> {
             dwtSummer: cfValue(vessel.dwtSummer),
             dwcc: cfValue(vessel.dwcc),
           },
-          cargo: { weightMt: cfValue(cargo.weightMt), cargoType, loadPort, dischargePort },
+          cargo: { weightMt: cfValue(cargo.weightMt), weightMtEffective: resolveCargoWeight(cargo) ?? null, cargoType, loadPort, dischargePort },
           hardFilters: { draft: hf.checks.draft, crane: hf.checks.crane, volume: hf.checks.volume },
         }),
         bucket,

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -43,6 +43,7 @@ import { seedPscHistoryWithDb } from '../knowledge/seeds/seed-psc-history';
 import { seedPortDa, type BaselinePort } from '../seed-port-da';
 import { lookupCii } from '@/lib/imo/cii-lookup';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 
 // ── CII hydration helper ──────────────────────────────────────────────────────
 
@@ -356,6 +357,7 @@ export async function rebuildWorksheets(
       },
       cargo: {
         weightMt: cfValue(cargo.weightMt) ?? null,
+        weightMtEffective: resolveCargoWeight(cargo) ?? null,
         cargoType: cargoTypeStr(cargo),
         loadPort: cfValue(cargo.originPort) ?? null,
         dischargePort: cfValue(cargo.destinationPort) ?? null,

--- a/tests/fixtures/voyage-tce/antwerp-singapore-suez.json
+++ b/tests/fixtures/voyage-tce/antwerp-singapore-suez.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "war_risk = totalPremiumUsd (hull+crew+P&I) per war-risk.ts:128 spec",
   "input": {
     "vessel": {
       "dwt": 75000,
@@ -28,12 +29,12 @@
     "bunker_usd": 472000,
     "canal_usd": 520000,
     "da_usd": 120000,
-    "war_risk_usd": 26250,
+    "war_risk_usd": 56250,
     "ets_eur": 60499.2,
     "ets_usd": 65339,
     "gross_freight_usd": 1960000,
-    "total_costs_usd": 1203589,
-    "net_voyage_usd": 756411,
-    "daily_tce_usd": 30256
+    "total_costs_usd": 1233589,
+    "net_voyage_usd": 726411,
+    "daily_tce_usd": 29056
   }
 }

--- a/tests/fixtures/voyage-tce/berbera-rotterdam.json
+++ b/tests/fixtures/voyage-tce/berbera-rotterdam.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "war_risk = totalPremiumUsd (hull+crew+P&I) per war-risk.ts:128 spec",
   "input": {
     "vessel": {
       "dwt": 35000,
@@ -28,12 +29,12 @@
     "bunker_usd": 229680,
     "canal_usd": 280000,
     "da_usd": 90000,
-    "war_risk_usd": 15000,
+    "war_risk_usd": 45000,
     "ets_eur": 49911.84,
     "ets_usd": 53905,
     "gross_freight_usd": 875000,
-    "total_costs_usd": 668585,
-    "net_voyage_usd": 206415,
-    "daily_tce_usd": 11468
+    "total_costs_usd": 698585,
+    "net_voyage_usd": 176415,
+    "daily_tce_usd": 9801
   }
 }

--- a/tests/fixtures/voyage-tce/lagos-rotterdam.json
+++ b/tests/fixtures/voyage-tce/lagos-rotterdam.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "war_risk = totalPremiumUsd (hull+crew+P&I) per war-risk.ts:128 spec",
   "input": {
     "vessel": {
       "dwt": 58000,
@@ -28,12 +29,12 @@
     "bunker_usd": 235200,
     "canal_usd": 0,
     "da_usd": 75000,
-    "war_risk_usd": 14000,
+    "war_risk_usd": 29000,
     "ets_eur": 49407.68,
     "ets_usd": 53360,
     "gross_freight_usd": 1500000,
-    "total_costs_usd": 377560,
-    "net_voyage_usd": 1122440,
-    "daily_tce_usd": 80174
+    "total_costs_usd": 392560,
+    "net_voyage_usd": 1107440,
+    "daily_tce_usd": 79103
   }
 }


### PR DESCRIPTION
## Summary

Bundles three broker-audit fixes that all touch `components/economics/CalculationWaterfall.tsx` — shipped together to avoid merge conflicts.

## Bug E — English Economics panel (22 strings)

Translated all 22 Russian user-visible strings and comments in `CalculationWaterfall.tsx` to English. Co-updated 11 Russian regex assertions in the companion test file. No logic changes — purely mechanical string replacement.

**String count:** 22 UI strings + section comments replaced.

## Bug B — War-risk total in P&L (FOUNDER-FLAG ⚠️ REVERSIBLE)

**Change:** `lib/economics/voyage-calculator.ts:194` now uses `breakdown?.totalPremiumUsd ?? premiumUsd` instead of `premiumUsd` (hull-only).

**Domain decision:** `war-risk.ts:128` designates `breakdown.totalPremiumUsd` as the full per-voyage cost (hull + crew war bonus + P&I surcharge). `premiumUsd` is hull-only, kept for backward compat. This fix makes the Waterfall P&L and `total_costs` internally consistent with the already-correct stored `totalUsd`.

**VALUE_CHECK oracle:** War risk section = **$30,667** for the canonical vessel-value case (hull $667 + crew $10,000 + P&I $20,000 Red-Sea). Fixture `berbera-rotterdam` → war_risk_usd = **45,000** (hull 15k + crew 10k + P&I 20k).

**REVERSIBILITY:** Revert is a one-line change at `voyage-calculator.ts:194` back to `warResult.premiumUsd` plus reverting the 3 fixtures. Nothing else needs touching — TCE/day on app paths is war-risk-excluded either way.

**Fixture updates:** 3 voyage-tce fixtures updated (berbera: 15k→45k, lagos: 14k→29k, antwerp-sg: 26.25k→56.25k). All 12 fixture tests pass.

## Bug D — Berbera util% consistency (weight green-lie)

**Problem:** `MatchWorksheet` showed ~90% ✅ while `fit-breakdown` showed ~104% ❌ on the same screen — contradiction for the Berbera match.

**Approach:** Added `weightMtEffective?: number | null` to `MatchWorksheet.cargo` (worst-case = `resolveCargoWeight` result). `MatchWorksheet.tsx` gates util% on `weightMtEffective ?? weightMt` (graceful fallback for rows without it). Display remains nominal; appends `(N max w/ option)` hint when effective differs. Also fixed latent overflow bug: `util > 100` now shows ❌ instead of ✅.

**Waterfall disclosure:** Added `data-testid="freight-qty-disclosure"` caption "max quantity incl. cargo option" under the freight rate line.

**VALUE_CHECK oracle:** On Berbera match, `MatchWorksheet` util% == fit cap input (both use `dwcc ?? dwtSummer` capacity and worst-case 3,080 mt) → both show ~104% → no green/red contradiction on the same screen.

**⚠️ Reseed required:** Fix takes effect on live demo data only after `npm run demo:seed` (existing stored rows lack `weightMtEffective` → graceful fallback to nominal behaviour). No crash risk — code is forward-correct with `??` fallback.

## Tests

- `components/economics/__tests__/CalculationWaterfall.test.tsx` — 11 assertions updated to English ✅
- `tests/economics/voyage-calculator.test.ts` — 12 fixture tests pass with new values ✅
- `lib/matching/__tests__/tce-calculator.test.ts` — 44 tests stay green ✅
- `components/match/__tests__/MatchWorksheet-weight.test.tsx` — new PI2 behavioral test: overflow=❌, fallback=✅

## Files changed

| File | Bug |
|------|-----|
| `components/economics/CalculationWaterfall.tsx` | E + D |
| `components/economics/__tests__/CalculationWaterfall.test.tsx` | E |
| `lib/economics/voyage-calculator.ts` | B |
| `tests/fixtures/voyage-tce/berbera-rotterdam.json` | B |
| `tests/fixtures/voyage-tce/lagos-rotterdam.json` | B |
| `tests/fixtures/voyage-tce/antwerp-singapore-suez.json` | B |
| `lib/types.ts` | D |
| `components/match/MatchWorksheet.tsx` | D |
| `components/match/__tests__/MatchWorksheet-weight.test.tsx` | D (new) |
| `scripts/demo-seed/real-matches.ts` | D |
| `scripts/demo-seed/regenerate-matches.ts` | D |

🤖 Generated with [Claude Code](https://claude.com/claude-code)