### PR TITLE
fix(broker-audit M): submit PSC search on Enter (wrap input in form)

### DIFF
--- a/__tests__/psc/psc-search.test.tsx
+++ b/__tests__/psc/psc-search.test.tsx
@@ -214,5 +214,22 @@ describe('PscSearchForm', () => {
         expect(screen.queryByText(/IMO must be exactly 7 digits/i)).not.toBeInTheDocument();
       });
     });
+
+    it('submits search when Enter is pressed (form submit)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPscRecords,
+      });
+
+      render(<PscSearchForm />);
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '1234567' } });
+
+      fireEvent.submit(input.closest('form')!);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/vessels/1234567/psc-history');
+      });
+    });
   });
 });

--- a/components/psc/PscSearchForm.tsx
+++ b/components/psc/PscSearchForm.tsx
@@ -52,7 +52,7 @@ export function PscSearchForm() {
 
   return (
     <div className="space-y-6">
-      <div className="flex gap-2">
+      <form className="flex gap-2" onSubmit={(e) => { e.preventDefault(); handleSearch(); }}>
         <input
           type="text"
           value={imo}
@@ -62,13 +62,13 @@ export function PscSearchForm() {
           aria-label="IMO number"
         />
         <button
-          onClick={handleSearch}
+          type="submit"
           disabled={loading}
           className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 touch-target"
         >
           {loading ? 'Searching…' : 'Search'}
         </button>
-      </div>
+      </form>
 
       {error && (
         <p className="text-sm text-red-600" role="alert">


### PR DESCRIPTION
## Summary
- Wraps IMO input + Search button in `<form onSubmit={(e) => { e.preventDefault(); handleSearch(); }}>` so pressing Enter triggers the search
- Button changed from `onClick={handleSearch}` to `type="submit"`
- Adds behavioral test: type IMO → `fireEvent.submit(form)` → assert `fetch` called with correct URL

## Test plan
- [ ] `npx jest --findRelatedTests __tests__/psc/psc-search.test.tsx` — 13/13 green
- [ ] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)