### PR TITLE
fix(broker-audit N): clean sender name on email detail + strip anonymization-token artifacts from body

### DIFF
--- a/__tests__/pages/email-detail-sender.test.ts
+++ b/__tests__/pages/email-detail-sender.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression guard: email detail page must display fromName (clean anonymized name)
+ * not email.from (raw token like "SENDER 1" or "contact6@demo.local").
+ *
+ * Issue N — detail page showed raw from_addr while list page used fromName ?? from.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const PAGE_SRC = fs.readFileSync(
+  path.join(ROOT, 'app/email/[id]/page.tsx'),
+  'utf8',
+);
+
+describe('app/email/[id]/page.tsx — sender display (issue N)', () => {
+  it('renders fromName with fallback to from, not bare email.from', () => {
+    expect(PAGE_SRC).toContain('email.fromName ?? email.from');
+  });
+
+  it('does NOT use bare {email.from} in the From: display line', () => {
+    const fromLine = PAGE_SRC.match(/From:[^}]*\{[^}]+\}/)?.[0] ?? '';
+    expect(fromLine).not.toMatch(/\{email\.from\}(?!\s*\?\?)/);
+  });
+});
+
+describe('fromName ?? from — fallback logic (behavioral)', () => {
+  it('returns fromName when set (clean anonymized name)', () => {
+    const email = { fromName: 'BROKER 1', from: 'SENDER 1' };
+    const display = email.fromName ?? email.from;
+    expect(display).toBe('BROKER 1');
+    expect(display).not.toBe('SENDER 1');
+  });
+
+  it('falls back to from when fromName is null', () => {
+    const email = { fromName: null, from: 'contact6@demo.local' };
+    const display = email.fromName ?? email.from;
+    expect(display).toBe('contact6@demo.local');
+  });
+
+  it('list page pattern fromName ?? from mirrors detail page fix', () => {
+    const listSrc = fs.readFileSync(path.join(ROOT, 'app/email/page.tsx'), 'utf8');
+    expect(listSrc).toContain('email.fromName ?? email.from');
+  });
+});

--- a/__tests__/utils/sanitize-email-body.test.ts
+++ b/__tests__/utils/sanitize-email-body.test.ts
@@ -1,0 +1,51 @@
+import { sanitizeEmailBody } from '@/lib/utils';
+
+describe('sanitizeEmailBody — anonymization token stripping', () => {
+  it('strips <SENDER N> angle-bracket token from forwarded header', () => {
+    const body = 'To: ETMS Management <SENDER 1>; chartering\n<SENDER 3>';
+    const result = sanitizeEmailBody(body);
+    expect(result).not.toContain('<SENDER 1>');
+    expect(result).not.toContain('<SENDER 3>');
+  });
+
+  it('strips <CONTACT N> token', () => {
+    const body = 'From: Some Org <CONTACT 6>';
+    expect(sanitizeEmailBody(body)).not.toContain('<CONTACT 6>');
+  });
+
+  it('strips <BROKER N> token', () => {
+    const body = 'Reply-To: <BROKER 2>';
+    expect(sanitizeEmailBody(body)).not.toContain('<BROKER 2>');
+  });
+
+  it('strips <AGENT N> token', () => {
+    const body = 'Cc: <AGENT 10>';
+    expect(sanitizeEmailBody(body)).not.toContain('<AGENT 10>');
+  });
+
+  it('is case-insensitive', () => {
+    expect(sanitizeEmailBody('From: <sender 1>')).not.toContain('<sender 1>');
+    expect(sanitizeEmailBody('From: <Broker 3>')).not.toContain('<Broker 3>');
+  });
+
+  it('preserves surrounding text when stripping token', () => {
+    const body = 'To: ETMS Management ; chartering\n<SENDER 3>\nBody continues here.';
+    const result = sanitizeEmailBody(body);
+    expect(result).toContain('ETMS Management');
+    expect(result).toContain('Body continues here.');
+  });
+
+  it('leaves real email addresses intact', () => {
+    const body = 'From: Alice <alice@example.com>';
+    const result = sanitizeEmailBody(body);
+    expect(result).toContain('<alice@example.com>');
+  });
+
+  it('preserves existing mailto: → address behavior alongside new rule', () => {
+    const body = 'See <mailto:broker@demo.local> and <SENDER 1>';
+    const result = sanitizeEmailBody(body);
+    expect(result).toContain('broker@demo.local');
+    expect(result).not.toContain('<mailto:broker@demo.local>');
+    expect(result).not.toContain('<SENDER 1>');
+  });
+});

--- a/app/email/[id]/page.tsx
+++ b/app/email/[id]/page.tsx
@@ -94,7 +94,7 @@ export default async function EmailDetailPage({ params }: Props) {
         <div>
           <h1 className="text-lg font-bold">{email.subject}</h1>
           <p className="text-sm text-muted-foreground">
-            From: {email.from} · {formatDate(email.date)}
+            From: {email.fromName ?? email.from} · {formatDate(email.date)}
           </p>
         </div>
         {legendItems.length > 0 && (

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -59,6 +59,7 @@ export function sanitizeEmailBody(body: string): string {
     .replace(/<file:\/\/\/[^>]*>/gi, '')
     .replace(/<mailto:([^>]+)>/gi, '$1')
     .replace(/<(https?:\/\/[^>]+)>/gi, '$1')
+    .replace(/<(?:SENDER|CONTACT|BROKER|AGENT)\s+\d+>/gi, '')
     .replace(/^.*(AVG|Avast|Norton|Kaspersky|ESET|McAfee).*virus.*$/gim, '')
     .replace(/^[ \t]*\+{3,}[ \t]*$/gm, '')
     .replace(/\n{3,}/g, '\n\n')


### PR DESCRIPTION
## Summary

- **Sub-fix 1 (MAIN):** `app/email/[id]/page.tsx:97` — changed `{email.from}` → `{email.fromName ?? email.from}` so the detail page shows clean anonymized names (BROKER 1 / CONTACT 6) instead of raw tokens (SENDER 1 / contact6@demo.local). Mirrors the list page pattern.
- **Sub-fix 2:** `lib/utils.ts sanitizeEmailBody` — added `.replace(/<(?:SENDER|CONTACT|BROKER|AGENT)\s+\d+>/gi, '')` to strip angle-bracket-wrapped anonymization tokens that appear in forwarded email header lines (old DB: `<SENDER 1>`, `<SENDER 3>`). Consistent with existing rules stripping `<mailto:>` and `<file:///...>`.
- **Tests:** 13 new tests — `email-detail-sender.test.ts` (static source guard + behavioral fallback logic), `sanitize-email-body.test.ts` (8 cases: SENDER/CONTACT/BROKER/AGENT, case-insensitive, preserves surrounding text and real emails).

## Test plan

- [x] `npx jest __tests__/utils/sanitize-email-body.test.ts __tests__/pages/email-detail-sender.test.ts` — 13/13 passed
- [x] Related regression tests (email-body-viewer-sanitize, format-date-locale, format-number, resolve-sender-name) — 24/24 passed
- [x] TypeScript typecheck clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)