### PR TITLE
fix(broker-audit L): add missing charter-party families to /clauses filter dropdown

### DIFF
--- a/__tests__/api/clauses.test.ts
+++ b/__tests__/api/clauses.test.ts
@@ -306,4 +306,36 @@ describe('GET /api/knowledge/clauses', () => {
       expect(meta.charterParty).toBe('GENCON 2022');
     }
   });
+
+  // TC-API-14: Behavioral — NYPE 1946 charter party filter returns only NYPE 1946 clauses
+  it('returns only NYPE 1946 clauses when cp=NYPE+1946 with fixture data', async () => {
+    process.env.BIMCO_RAG_ENABLED = 'true';
+
+    const stmt = db.prepare('INSERT INTO bimco_fts (content, metadata) VALUES (?, ?)');
+    for (const clause of BIMCO_FIXTURE_CLAUSES) {
+      stmt.run(
+        clause.text,
+        JSON.stringify({
+          source: 'bimco',
+          charterParty: clause.charterParty,
+          clauseNumber: clause.clauseNumber,
+          title: clause.title,
+          id: clause.id,
+        }),
+      );
+    }
+
+    const { GET } = await import('@/app/api/knowledge/clauses/route');
+    const req = new Request('http://localhost:3000/api/knowledge/clauses?q=charterer&cp=NYPE+1946');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.results.length).toBeGreaterThanOrEqual(1);
+
+    for (const result of json.results) {
+      const meta = JSON.parse(result.metadata);
+      expect(meta.charterParty).toBe('NYPE 1946');
+    }
+  });
 });

--- a/app/clauses/page.tsx
+++ b/app/clauses/page.tsx
@@ -119,6 +119,10 @@ export default function ClausesPage() {
                 <option value="GENCON 2022">GENCON 2022</option>
                 <option value="HEAVYCON">HEAVYCON</option>
                 <option value="PROJECTCON">PROJECTCON</option>
+                <option value="NYPE 1946">NYPE 1946</option>
+                <option value="SHELLVOY 6">SHELLVOY 6</option>
+                <option value="BALTIME">BALTIME</option>
+                <option value="CONGENBILL">CONGENBILL</option>
               </select>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds 4 missing charter parties to the `/clauses` filter `<select>`: NYPE 1946, SHELLVOY 6, BALTIME, CONGENBILL
- All 7 BIMCO fixture corpus charter parties are now filterable
- Adds TC-API-14: behavioral test for `cp=NYPE 1946` filter → asserts ≥1 result with `charterParty === 'NYPE 1946'`

## Root cause
Dropdown was hardcoded to 3 charter parties from initial spec (gamma-09). Corpus was subsequently expanded with 4 more parties that were never added to the UI.

## Files changed
- `app/clauses/page.tsx` — 4 new `<option>` elements
- `__tests__/api/clauses.test.ts` — TC-API-14 added

## Test plan
- [ ] 14/14 clauses tests pass (`npx jest --testPathPatterns="__tests__/api/clauses"`)
- [ ] TypeCheck clean (`NODE_OPTIONS="--max-old-space-size=4096" npx tsc --noEmit`)
- [ ] No RAG/retriever/vector layer touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)