### PR TITLE
fix(broker-audit G+H): bunker dropdown shows selected port + P&L shows estimated TCE (est. badge) not missing-qty block

### DIFF
--- a/__tests__/components/match/EconomicsTab-bunker-route-aware.test.tsx
+++ b/__tests__/components/match/EconomicsTab-bunker-route-aware.test.tsx
@@ -81,13 +81,18 @@ test('bunker dropdown shows route candidates when API returns them', async () =>
   expect(options).not.toContain('SGSIN');
 });
 
-test('bunker dropdown defaults to recommended (candidates[0]) port', async () => {
+// Bug G fix: NLRTM is always included in options so the selected default (Rotterdam/NLRTM)
+// is visible in the dropdown even when route-specific candidates arrive.
+test('bunker dropdown includes NLRTM so selected value (Rotterdam) is visible', async () => {
   await act(async () => {
     render(<EconomicsTab vessel={vessel} cargo={cargo} />);
   });
 
   const portSelect = screen.getByLabelText('Bunker port') as HTMLSelectElement;
-  expect(portSelect.value).toBe('ESCEU');
+  const options = Array.from(portSelect.options).map(o => o.value);
+  expect(options).toContain('NLRTM');
+  // NLRTM is selected (baseline state for list==detail parity)
+  expect(portSelect.value).toBe('NLRTM');
 });
 
 test('Ceuta label renders as "Ceuta" not raw locode', async () => {

--- a/__tests__/components/match/EconomicsTab-pnl.test.tsx
+++ b/__tests__/components/match/EconomicsTab-pnl.test.tsx
@@ -162,10 +162,9 @@ describe('EconomicsTab — voyage P&L chart', () => {
     expect(screen.getByTestId('voyage-missing-hint')).toHaveTextContent(/route distance/i);
   });
 
-  // Gate5 P&L: cargo weightMt absent (match 40098 Thisvi→Monfalcone) gave an EMPTY
-  // "Voyage P&L" block because voyageInputData.missing never listed cargo quantity —
-  // ready=false + missing=[] → render fell through to null. Must show the hint.
-  it('shows missing-hint when cargo quantity absent (no empty block)', async () => {
+  // Bug H fix: when cargo weightMt absent, DWT×0.65 fallback runs (same as list path).
+  // P&L renders with an est. badge disclosing the assumed quantity — no missing-qty block.
+  it('when cargo quantity absent — P&L renders with est. badge (DWT×0.65 fallback)', async () => {
     const noQty = { ...FULL_CARGO, weightMt: undefined };
     await act(async () => {
       render(
@@ -174,12 +173,14 @@ describe('EconomicsTab — voyage P&L chart', () => {
           cargo={noQty as any}
           routeDistanceNm={8500}
           storedFreightRate={15}
+          matchDbId={1}
         />,
       );
     });
-    expect(screen.getByTestId('voyage-missing-hint')).toBeInTheDocument();
-    expect(screen.getByTestId('voyage-missing-hint')).toHaveTextContent(/cargo quantity/i);
-    expect(screen.queryByTestId('voyage-breakdown-chart')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('qty-estimated-badge')).toBeInTheDocument());
+    expect(screen.getByTestId('qty-estimated-badge')).toHaveTextContent(/est\./i);
+    expect(screen.getByTestId('voyage-breakdown-chart')).toBeInTheDocument();
+    expect(screen.queryByTestId('voyage-missing-hint')).not.toBeInTheDocument();
   });
 
   it('shows missing-hint when load/discharge ports absent (no empty block)', async () => {

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -294,7 +294,11 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     const consumptionMtPerDay = resolveConsMtPerDay(rawConsumptionMtPerDay, dwt);
     const originPort = cargo?.originPort?.value ?? '';
     const destinationPort = cargo?.destinationPort?.value ?? '';
-    const quantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
+    const rawQuantityMt = resolveCargoWeight(cargo ?? null) ?? 0;
+    // Bug H: when qty=0 but DWT is known, apply the same DWT×0.65 fallback the list
+    // path uses — so P&L is consistent with the stored TCE (same number, disclosed).
+    const qtyEstimated = rawQuantityMt === 0 && dwt > 0;
+    const quantityMt = qtyEstimated ? dwt * 0.65 : rawQuantityMt;
     const distanceNm = routeDistanceNm ?? 0;
     // #819: drop ?? 28 — seed now persists freight_rate_usd_per_mt so storedFreightRate
     // is non-null for canonical matches. null → "freight rate required" hint, not fabrication.
@@ -307,7 +311,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
     if (!speedKts) missing.push('vessel speed');
     if (!rawConsumptionMtPerDay) missing.push('fuel consumption');
     if (!distanceNm) missing.push('route distance');
-    if (!quantityMt) missing.push('cargo quantity');
+    if (!rawQuantityMt && !qtyEstimated) missing.push('cargo quantity');
     if (!bunkerPort) missing.push('bunker port');
     if (freightRateUsdPerMt == null || freightRateUsdPerMt <= 0) missing.push('freight rate');
 
@@ -357,7 +361,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
         }
       : null;
 
-    return { ready, missing, input };
+    return { ready, missing, input, qtyEstimated };
   }, [vessel, cargo, routeDistanceNm, currentRate, storedFreightRate, bunkerPort, bunkerGrade, bunkerPriceUsdPerMt, euaData, ballastDistanceNm]);
 
   useEffect(() => {
@@ -505,7 +509,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
             className="flex-1 border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:border-blue-400"
           >
             {(bunkerCandidates.length > 0
-              ? Array.from(new Map(bunkerCandidates.map(c => [c.port, c])).values()).map(c => c.port)
+              ? Array.from(new Set(['NLRTM', ...Array.from(new Map(bunkerCandidates.map(c => [c.port, c])).values()).map(c => c.port)]))
               : BUNKER_PORTS.map(p => p.value)
             ).map((code) => (
               <option key={code} value={code}>
@@ -699,6 +703,12 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
                   ⚠ Approximate port{approxPorts.length > 1 ? 's' : ''} — P&amp;L estimated:{' '}
                   {approxPorts.map((a) => `${a.input} → ${a.resolvedTo}`).join('; ')}. Confirm before fixing.
                 </p>
+              )}
+              {voyageInputData.qtyEstimated && (
+                <div data-testid="qty-estimated-badge" className="mb-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs">
+                  <span className="font-medium text-amber-700">est.</span>{' '}
+                  <span className="text-gray-600">Cargo quantity unknown — estimated at DWT × 0.65</span>
+                </div>
               )}
               <VoyageBreakdownChart breakdown={voyageBreakdown} />
               <div className="mt-2">


### PR DESCRIPTION
## Summary

- **G (display-only):** Always include `NLRTM` in the bunker port dropdown options when route-specific candidates arrive. Previously, the dropdown showed only route candidates (e.g. Fujairah, Piraeus) while the selected value and helper text both said Rotterdam — visual contradiction. Fix: prepend `'NLRTM'` to the candidate `Set`. No calc change; `bunkerPort` state stays `NLRTM` for list==detail parity.
- **H (P&L consistency):** When cargo quantity is missing (`quantityMt === 0`), apply the same `DWT × 0.65` fallback that the stored list path already uses (`canonical-tce-inputs.ts:36`). Let `ready=true` and render the P&L with an amber **est.** badge disclosing the assumed quantity. Previously the P&L hard-blocked with "Missing: cargo quantity" while the list showed ~$30.8k from the same fallback. H discloses the estimate via badge — same number the list already shows, no new computation. No DB migration, no new column, no list changes.

## Files changed

- `components/match/EconomicsTab.tsx` — 4 targeted edits (G: dropdown options; H: qty fallback + qtyEstimated return + est. badge)
- `__tests__/components/match/EconomicsTab-pnl.test.tsx` — update cargo-qty-absent test to verify est. badge + chart (not missing-hint)
- `__tests__/components/match/EconomicsTab-bunker-route-aware.test.tsx` — update value expectation to NLRTM; add NLRTM-in-options assertion

## Test plan

- [ ] `npx jest --findRelatedTests components/match/EconomicsTab.tsx --maxWorkers=1` — 88/88 green
- [ ] `npx tsc --noEmit` — no errors
- [ ] Open match detail with missing cargo qty → P&L renders with amber "est." badge instead of missing-qty block
- [ ] Open match detail on a Med/Black-Sea route → bunker dropdown shows Rotterdam as selected option (visible, not contradicted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)