### PR TITLE
feat(broker-audit B): itemize war-risk in P&L (Hull/Crew/P&I/Total) per founder

### DIFF
--- a/components/economics/CalculationWaterfall.tsx
+++ b/components/economics/CalculationWaterfall.tsx
@@ -10,11 +10,13 @@
 
 import * as React from 'react';
 import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';
+import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
 import { DataQualityBadge } from '@/components/data-quality/DataQualityBadge';
 import { deriveTier } from '@/lib/data-quality/derive';
 
 interface Props {
   breakdown: TCEBreakdown;
+  warRiskBreakdown?: WarRiskBreakdown | null;
 }
 
 /** Broker convention: negatives render as `-$X`, not `$-X` (matches VoyageBreakdownChart). */
@@ -25,7 +27,7 @@ function fmtUsd(n: number): string {
     : `$${n.toLocaleString('en-US')}`;
 }
 
-export function CalculationWaterfall({ breakdown }: Props) {
+export function CalculationWaterfall({ breakdown, warRiskBreakdown }: Props) {
   const {
     freight_rate_usd_per_mt,
     quantity_mt,
@@ -139,6 +141,19 @@ export function CalculationWaterfall({ breakdown }: Props) {
             </span>
             <span>{fmtUsd(-war_risk_usd)}</span>
           </div>
+          {warRiskBreakdown && warRiskBreakdown.totalPremiumUsd > 0 && (
+            <div
+              className="text-xs text-gray-400 pl-4"
+              data-testid="war-risk-breakdown"
+            >
+              Hull premium{' '}
+              <span data-testid="war-risk-hull">${warRiskBreakdown.hullPremiumUsd.toLocaleString('en-US')}</span>
+              {' · '}Crew war bonus{' '}
+              <span data-testid="war-risk-crew">${warRiskBreakdown.crewWarBonusUsd.toLocaleString('en-US')}</span>
+              {' · '}P&amp;I surcharge{' '}
+              <span data-testid="war-risk-pi">${warRiskBreakdown.piSurchargeUsd.toLocaleString('en-US')}</span>
+            </div>
+          )}
           <div
             className="text-xs text-gray-400 pl-4"
             data-testid="war-risk-caption"

--- a/components/economics/CalculationWaterfall.tsx
+++ b/components/economics/CalculationWaterfall.tsx
@@ -139,7 +139,11 @@ export function CalculationWaterfall({ breakdown, warRiskBreakdown }: Props) {
                 </span>
               )}
             </span>
-            <span>{fmtUsd(-war_risk_usd)}</span>
+            <span data-testid="war-risk-total">
+              {warRiskBreakdown && warRiskBreakdown.totalPremiumUsd > 0
+                ? fmtUsd(-Math.round(warRiskBreakdown.totalPremiumUsd))
+                : fmtUsd(-war_risk_usd)}
+            </span>
           </div>
           {warRiskBreakdown && warRiskBreakdown.totalPremiumUsd > 0 && (
             <div
@@ -147,11 +151,11 @@ export function CalculationWaterfall({ breakdown, warRiskBreakdown }: Props) {
               data-testid="war-risk-breakdown"
             >
               Hull premium{' '}
-              <span data-testid="war-risk-hull">${warRiskBreakdown.hullPremiumUsd.toLocaleString('en-US')}</span>
+              <span data-testid="war-risk-hull">${Math.round(warRiskBreakdown.hullPremiumUsd).toLocaleString('en-US')}</span>
               {' · '}Crew war bonus{' '}
-              <span data-testid="war-risk-crew">${warRiskBreakdown.crewWarBonusUsd.toLocaleString('en-US')}</span>
+              <span data-testid="war-risk-crew">${Math.round(warRiskBreakdown.crewWarBonusUsd).toLocaleString('en-US')}</span>
               {' · '}P&amp;I surcharge{' '}
-              <span data-testid="war-risk-pi">${warRiskBreakdown.piSurchargeUsd.toLocaleString('en-US')}</span>
+              <span data-testid="war-risk-pi">${Math.round(warRiskBreakdown.piSurchargeUsd).toLocaleString('en-US')}</span>
             </div>
           )}
           <div

--- a/components/economics/__tests__/CalculationWaterfall.test.tsx
+++ b/components/economics/__tests__/CalculationWaterfall.test.tsx
@@ -11,6 +11,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CalculationWaterfall } from '../CalculationWaterfall';
 import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';
+import type { WarRiskBreakdown } from '@/lib/economics/war-risk';
 
 const FIXTURE: TCEBreakdown = {
   // derivation inputs (B1)
@@ -113,5 +114,39 @@ describe('CalculationWaterfall', () => {
     const canalRow = screen.getByTestId('cost-canal');
     expect(canalRow).toHaveTextContent('-$45,000');
     expect(screen.queryByTestId('canal-zero-note')).not.toBeInTheDocument();
+  });
+
+  it('renders Hull/Crew/P&I sub-breakdown under war risk when warRiskBreakdown provided', () => {
+    const warBreakdown: WarRiskBreakdown = {
+      hullPremiumUsd: 667,
+      crewWarBonusUsd: 10_000,
+      piSurchargeUsd: 20_000,
+      totalPremiumUsd: 30_667,
+    };
+    render(<CalculationWaterfall breakdown={{ ...FIXTURE, war_risk_usd: 30_667 }} warRiskBreakdown={warBreakdown} />);
+    const breakdown = screen.getByTestId('war-risk-breakdown');
+    expect(breakdown).toBeInTheDocument();
+    expect(screen.getByTestId('war-risk-hull')).toHaveTextContent('$667');
+    expect(screen.getByTestId('war-risk-crew')).toHaveTextContent('$10,000');
+    expect(screen.getByTestId('war-risk-pi')).toHaveTextContent('$20,000');
+    // total shown in main row
+    const warRow = screen.getByTestId('cost-war-risk');
+    expect(warRow).toHaveTextContent('-$30,667');
+  });
+
+  it('does not render war-risk sub-breakdown when warRiskBreakdown is absent', () => {
+    render(<CalculationWaterfall breakdown={FIXTURE} />);
+    expect(screen.queryByTestId('war-risk-breakdown')).not.toBeInTheDocument();
+  });
+
+  it('does not render war-risk sub-breakdown when totalPremiumUsd is 0', () => {
+    const zeroBreakdown: WarRiskBreakdown = {
+      hullPremiumUsd: 0,
+      crewWarBonusUsd: 0,
+      piSurchargeUsd: 0,
+      totalPremiumUsd: 0,
+    };
+    render(<CalculationWaterfall breakdown={FIXTURE} warRiskBreakdown={zeroBreakdown} />);
+    expect(screen.queryByTestId('war-risk-breakdown')).not.toBeInTheDocument();
   });
 });

--- a/components/economics/__tests__/CalculationWaterfall.test.tsx
+++ b/components/economics/__tests__/CalculationWaterfall.test.tsx
@@ -139,6 +139,28 @@ describe('CalculationWaterfall', () => {
     expect(screen.queryByTestId('war-risk-breakdown')).not.toBeInTheDocument();
   });
 
+  it('hull + crew + P&I rendered amounts sum exactly to war-risk total (sub-sum invariant)', () => {
+    const warBreakdown: WarRiskBreakdown = {
+      hullPremiumUsd: 666.7,   // fractional — rounds to 667
+      crewWarBonusUsd: 10_000,
+      piSurchargeUsd: 20_000,
+      totalPremiumUsd: 30_666.7, // rounds to 30667; war_risk_usd=13500 differs → catches wrong source
+    };
+    render(
+      <CalculationWaterfall
+        breakdown={{ ...FIXTURE, war_risk_usd: 13_500 }}
+        warRiskBreakdown={warBreakdown}
+      />,
+    );
+    const parseAmt = (el: HTMLElement) =>
+      parseInt((el.textContent ?? '').replace(/[$,\-]/g, ''), 10);
+    const hull = parseAmt(screen.getByTestId('war-risk-hull'));
+    const crew = parseAmt(screen.getByTestId('war-risk-crew'));
+    const pi = parseAmt(screen.getByTestId('war-risk-pi'));
+    const total = parseAmt(screen.getByTestId('war-risk-total'));
+    expect(hull + crew + pi).toBe(total);
+  });
+
   it('does not render war-risk sub-breakdown when totalPremiumUsd is 0', () => {
     const zeroBreakdown: WarRiskBreakdown = {
       hullPremiumUsd: 0,

--- a/components/match/EconomicsTab.tsx
+++ b/components/match/EconomicsTab.tsx
@@ -711,7 +711,7 @@ export function EconomicsTab({ commissionPercent, vessel, cargo, routeDistanceNm
                 </button>
                 {showCalc && (
                   <div className="mt-3 rounded border border-gray-200 bg-gray-50 p-3">
-                    <CalculationWaterfall breakdown={voyageBreakdown} />
+                    <CalculationWaterfall breakdown={voyageBreakdown} warRiskBreakdown={warRiskBreakdown} />
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary

- Adds Hull premium / Crew war bonus / P&I surcharge sub-lines under the ⚔️ War risk total in `CalculationWaterfall`
- Numbers sourced from `warRiskBreakdown.{hullPremiumUsd, crewWarBonusUsd, piSurchargeUsd}` — no hardcoded values
- TCE/day unchanged (war risk intentionally excluded from daily TCE by design)
- Sub-breakdown hidden when `totalPremiumUsd = 0` (route has no HRA zone)

## Files changed

- `components/economics/CalculationWaterfall.tsx` — added `warRiskBreakdown?: WarRiskBreakdown | null` prop; sub-line rendering with testids `war-risk-breakdown`, `war-risk-hull`, `war-risk-crew`, `war-risk-pi`
- `components/match/EconomicsTab.tsx` — passes `warRiskBreakdown` into `CalculationWaterfall`
- `components/economics/__tests__/CalculationWaterfall.test.tsx` — 3 new behavioral tests (breakdown renders, absent when no prop, hidden at zero)

## Test plan

- [ ] `npx jest --findRelatedTests components/economics/CalculationWaterfall.tsx` → 111 passed
- [ ] TypeCheck clean (`npx tsc --noEmit`)
- [ ] Open a match with HRA route → P&L waterfall shows Hull/Crew/P&I sub-lines under War risk total
- [ ] Open a match without HRA route → single $0 war risk line, no sub-lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)