### PR TITLE
fix(H6): thread timeout+abort into callAiVision and callAiAudio branches

### DIFF
--- a/lib/__tests__/ai-provider-vision-audio-timeout.test.ts
+++ b/lib/__tests__/ai-provider-vision-audio-timeout.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for H6: callAiVision and callAiAudio must honor timeoutMs + signal from AiOpts.
+ *
+ * Before this fix, callGeminiVision, the bedrock branch in callAiVision,
+ * callBedrockAudio, and the gemini branch in callAiAudio constructed SDK clients
+ * with NO buildAbortController / requestTimeout / abortSignal / Promise.race.
+ * A hung Vertex or Bedrock call would hang forever up to platform maxDuration.
+ */
+
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations/index';
+
+// ── Mock providers ───────────────────────────────────────────────────────────
+
+jest.mock('@/lib/openai', () => {
+  const ActualErr = jest.requireActual('@/lib/openai').LLMTimeoutError;
+  return {
+    callAiJson: jest.fn().mockResolvedValue({ result: 'openai-json' }),
+    callAiText: jest.fn().mockResolvedValue('openai-text'),
+    LLMTimeoutError: ActualErr,
+  };
+});
+
+const mockGeminiGenerate = jest.fn();
+jest.mock('@google/genai', () => ({
+  GoogleGenAI: jest.fn().mockImplementation(() => ({
+    models: { generateContent: mockGeminiGenerate },
+  })),
+}), { virtual: true });
+
+const mockBedrockSend = jest.fn();
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn().mockImplementation((opts: unknown) => ({
+    __ctorOpts: opts,
+    send: mockBedrockSend,
+  })),
+  InvokeModelCommand: jest.fn().mockImplementation((opts: unknown) => opts),
+}), { virtual: true });
+
+let testDb: Database.Database;
+jest.mock('@/lib/session-store', () => ({
+  getStore: jest.fn(() => ({ getDatabase: jest.fn(() => testDb) })),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function setEnv(vars: Record<string, string | undefined>): void {
+  for (const [k, v] of Object.entries(vars)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+const GEMINI_ENV = {
+  AI_PROVIDER: 'gemini',
+  GOOGLE_APPLICATION_CREDENTIALS: '/dev/null',
+  GOOGLE_CLOUD_PROJECT: 'test-project',
+  AI_MODEL_GEMINI_DEFAULT: 'gemini-2.5-flash',
+};
+
+const BEDROCK_ENV = {
+  AI_PROVIDER: 'bedrock',
+  AWS_REGION: 'us-east-1',
+  AWS_ACCESS_KEY_ID: 'k',
+  AWS_SECRET_ACCESS_KEY: 's',
+  BEDROCK_MODEL_ID: 'anthropic.claude-opus-4-7',
+};
+
+const FAKE_IMAGE = { data: 'aGVsbG8=', mimeType: 'image/jpeg' };
+const FAKE_AUDIO = Buffer.from('audio-data');
+
+function clearEnv(): void {
+  const keys = [
+    'AI_PROVIDER',
+    'GOOGLE_APPLICATION_CREDENTIALS', 'GOOGLE_CLOUD_PROJECT', 'GOOGLE_CLOUD_LOCATION',
+    'AI_MODEL_GEMINI_DEFAULT',
+    'AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'BEDROCK_MODEL_ID',
+  ];
+  for (const k of keys) delete process.env[k];
+}
+
+beforeEach(() => {
+  testDb = new Database(':memory:');
+  runMigrations(testDb, allMigrations);
+  clearEnv();
+  jest.clearAllMocks();
+  const sessionStore = require('@/lib/session-store');
+  (sessionStore.getStore as jest.Mock).mockReturnValue({ getDatabase: jest.fn(() => testDb) });
+  mockGeminiGenerate.mockResolvedValue({ text: 'result text' });
+  mockBedrockSend.mockResolvedValue({
+    body: new TextEncoder().encode(JSON.stringify({ content: [{ text: 'result' }] })),
+  });
+});
+
+afterEach(() => testDb.close());
+
+// ── callAiVision (Gemini) ────────────────────────────────────────────────────
+
+describe('callAiVision (gemini) threads abortSignal + timeoutMs', () => {
+  it('passes an AbortSignal into the Gemini generateContent config', async () => {
+    setEnv(GEMINI_ENV);
+    const { callAiVision } = require('@/lib/ai-provider');
+    await callAiVision('whatsapp_ocr', 'describe image', [FAKE_IMAGE], { timeoutMs: 5000 });
+
+    expect(mockGeminiGenerate).toHaveBeenCalledTimes(1);
+    const cfg = mockGeminiGenerate.mock.calls[0][0].config;
+    expect(cfg.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(cfg.abortSignal.aborted).toBe(false);
+  });
+
+  it('rejects with LLMTimeoutError when Gemini vision call never resolves within timeoutMs', async () => {
+    setEnv(GEMINI_ENV);
+    mockGeminiGenerate.mockImplementation(() => new Promise(() => {}));
+    const { callAiVision } = require('@/lib/ai-provider');
+    const { LLMTimeoutError } = require('@/lib/openai');
+    await expect(
+      callAiVision('whatsapp_ocr', 'describe image', [FAKE_IMAGE], { timeoutMs: 20 }),
+    ).rejects.toBeInstanceOf(LLMTimeoutError);
+  });
+});
+
+// ── callAiVision (Bedrock) ───────────────────────────────────────────────────
+
+describe('callAiVision (bedrock) threads abortSignal + requestTimeout', () => {
+  it('passes { abortSignal } as the 2nd arg to client.send', async () => {
+    setEnv(BEDROCK_ENV);
+    const { callAiVision } = require('@/lib/ai-provider');
+    await callAiVision('whatsapp_ocr', 'describe image', [FAKE_IMAGE], { timeoutMs: 5000 });
+
+    expect(mockBedrockSend).toHaveBeenCalledTimes(1);
+    const sendOpts = mockBedrockSend.mock.calls[0][1];
+    expect(sendOpts).toBeDefined();
+    expect(sendOpts.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('sets requestHandler.requestTimeout from timeoutMs on the Bedrock vision client', async () => {
+    setEnv(BEDROCK_ENV);
+    const { BedrockRuntimeClient } = require('@aws-sdk/client-bedrock-runtime');
+    const { callAiVision } = require('@/lib/ai-provider');
+    await callAiVision('whatsapp_ocr', 'describe image', [FAKE_IMAGE], { timeoutMs: 9999 });
+
+    const ctorOpts = (BedrockRuntimeClient as jest.Mock).mock.calls[0][0];
+    expect(ctorOpts.requestHandler?.requestTimeout).toBe(9999);
+  });
+
+  it('rejects with LLMTimeoutError when an aborted caller signal cancels the Bedrock vision call', async () => {
+    setEnv(BEDROCK_ENV);
+    mockBedrockSend.mockImplementation((_cmd: unknown, opts?: { abortSignal?: AbortSignal }) => {
+      if (opts?.abortSignal?.aborted) {
+        const e = new Error('Request aborted');
+        e.name = 'AbortError';
+        return Promise.reject(e);
+      }
+      return Promise.resolve({
+        body: new TextEncoder().encode(JSON.stringify({ content: [{ text: 'ok' }] })),
+      });
+    });
+    const ac = new AbortController();
+    ac.abort();
+    const { callAiVision } = require('@/lib/ai-provider');
+    const { LLMTimeoutError } = require('@/lib/openai');
+    await expect(
+      callAiVision('whatsapp_ocr', 'describe image', [FAKE_IMAGE], { signal: ac.signal }),
+    ).rejects.toBeInstanceOf(LLMTimeoutError);
+  });
+});
+
+// ── callAiAudio (Bedrock) ────────────────────────────────────────────────────
+
+describe('callAiAudio (bedrock) threads abortSignal + requestTimeout', () => {
+  it('passes { abortSignal } as the 2nd arg to client.send', async () => {
+    setEnv(BEDROCK_ENV);
+    const { callAiAudio } = require('@/lib/ai-provider');
+    await callAiAudio('whatsapp_voice', FAKE_AUDIO, { timeoutMs: 5000 });
+
+    expect(mockBedrockSend).toHaveBeenCalledTimes(1);
+    const sendOpts = mockBedrockSend.mock.calls[0][1];
+    expect(sendOpts).toBeDefined();
+    expect(sendOpts.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('sets requestHandler.requestTimeout from timeoutMs on the Bedrock audio client', async () => {
+    setEnv(BEDROCK_ENV);
+    const { BedrockRuntimeClient } = require('@aws-sdk/client-bedrock-runtime');
+    const { callAiAudio } = require('@/lib/ai-provider');
+    await callAiAudio('whatsapp_voice', FAKE_AUDIO, { timeoutMs: 6666 });
+
+    const ctorOpts = (BedrockRuntimeClient as jest.Mock).mock.calls[0][0];
+    expect(ctorOpts.requestHandler?.requestTimeout).toBe(6666);
+  });
+
+  it('rejects with LLMTimeoutError when an aborted caller signal cancels the Bedrock audio call', async () => {
+    setEnv(BEDROCK_ENV);
+    mockBedrockSend.mockImplementation((_cmd: unknown, opts?: { abortSignal?: AbortSignal }) => {
+      if (opts?.abortSignal?.aborted) {
+        const e = new Error('Request aborted');
+        e.name = 'AbortError';
+        return Promise.reject(e);
+      }
+      return Promise.resolve({
+        body: new TextEncoder().encode(JSON.stringify({ content: [{ text: 'transcription' }] })),
+      });
+    });
+    const ac = new AbortController();
+    ac.abort();
+    const { callAiAudio } = require('@/lib/ai-provider');
+    const { LLMTimeoutError } = require('@/lib/openai');
+    await expect(
+      callAiAudio('whatsapp_voice', FAKE_AUDIO, { signal: ac.signal }),
+    ).rejects.toBeInstanceOf(LLMTimeoutError);
+  });
+});
+
+// ── callAiAudio (Gemini) ─────────────────────────────────────────────────────
+
+describe('callAiAudio (gemini) threads abortSignal + timeoutMs', () => {
+  it('passes an AbortSignal into the Gemini generateContent config', async () => {
+    setEnv(GEMINI_ENV);
+    const { callAiAudio } = require('@/lib/ai-provider');
+    await callAiAudio('whatsapp_voice', FAKE_AUDIO, { timeoutMs: 5000 });
+
+    expect(mockGeminiGenerate).toHaveBeenCalledTimes(1);
+    const callArgs = mockGeminiGenerate.mock.calls[0][0];
+    expect(callArgs.config).toBeDefined();
+    expect(callArgs.config.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(callArgs.config.abortSignal.aborted).toBe(false);
+  });
+
+  it('rejects with LLMTimeoutError when Gemini audio call never resolves within timeoutMs', async () => {
+    setEnv(GEMINI_ENV);
+    mockGeminiGenerate.mockImplementation(() => new Promise(() => {}));
+    const { callAiAudio } = require('@/lib/ai-provider');
+    const { LLMTimeoutError } = require('@/lib/openai');
+    await expect(
+      callAiAudio('whatsapp_voice', FAKE_AUDIO, { timeoutMs: 20 }),
+    ).rejects.toBeInstanceOf(LLMTimeoutError);
+  });
+});

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -673,6 +673,7 @@ async function callGeminiVision(
   user: string,
   images: ImageInput[],
   model: string,
+  opts?: AiOpts,
 ): Promise<{ text: string; usage?: Usage }> {
   assertGeminiEnv();
   const { GoogleGenAI } = require('@google/genai') as {
@@ -681,7 +682,7 @@ async function callGeminiVision(
         generateContent: (params: {
           model: string;
           contents: Array<{ role: string; parts: unknown[] }>;
-          config?: { systemInstruction?: string };
+          config?: { systemInstruction?: string; abortSignal?: AbortSignal };
         }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
       };
     };
@@ -700,13 +701,34 @@ async function callGeminiVision(
     })),
   ];
 
-  const response = await ai.models.generateContent({
-    model,
-    contents: [{ role: 'user', parts }],
-    config: { systemInstruction: system },
+  const { controller, cleanup, timeoutMs } = buildAbortController(opts);
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new openaiLib.LLMTimeoutError(`Gemini vision timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
   });
 
-  return { text: response.text ?? '', usage: extractGeminiUsage(response.usageMetadata) };
+  try {
+    const response = await Promise.race([
+      ai.models.generateContent({
+        model,
+        contents: [{ role: 'user', parts }],
+        config: { systemInstruction: system, abortSignal: controller.signal },
+      }),
+      timeoutPromise,
+    ]);
+    return { text: response.text ?? '', usage: extractGeminiUsage(response.usageMetadata) };
+  } catch (err) {
+    if (controller.signal.aborted && !(err instanceof openaiLib.LLMTimeoutError)) {
+      throw new openaiLib.LLMTimeoutError(`Gemini vision aborted after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutHandle);
+    cleanup();
+  }
 }
 
 interface BedrockUsage {
@@ -795,14 +817,21 @@ async function callBedrockText(
 async function callBedrockAudio(
   audioBuffer: Buffer,
   model: string,
+  opts?: AiOpts,
 ): Promise<{ text: string; usage?: Usage }> {
   assertBedrockEnv();
   const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
-    BedrockRuntimeClient: new (opts: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } }) => {
-      send: (cmd: unknown) => Promise<{ body: Uint8Array }>;
+    BedrockRuntimeClient: new (opts: {
+      region: string;
+      credentials: { accessKeyId: string; secretAccessKey: string };
+      requestHandler?: { requestTimeout?: number };
+    }) => {
+      send: (cmd: unknown, options?: { abortSignal?: AbortSignal }) => Promise<{ body: Uint8Array }>;
     };
     InvokeModelCommand: new (opts: { modelId: string; contentType: string; accept: string; body: string }) => unknown;
   };
+
+  const { controller, cleanup, timeoutMs } = buildAbortController(opts);
 
   const client = new BedrockRuntimeClient({
     region: process.env.AWS_REGION!,
@@ -810,6 +839,7 @@ async function callBedrockAudio(
       accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
     },
+    requestHandler: { requestTimeout: timeoutMs },
   });
 
   const audioBase64 = audioBuffer.toString('base64');
@@ -832,10 +862,84 @@ async function callBedrockAudio(
     body: JSON.stringify(payload),
   });
 
-  const response = await client.send(cmd);
-  const decoded = new TextDecoder().decode(response.body);
-  const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
-  return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
+  try {
+    const response = await client.send(cmd, { abortSignal: controller.signal });
+    const decoded = new TextDecoder().decode(response.body);
+    const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
+    return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
+  } catch (err) {
+    if (controller.signal.aborted && !(err instanceof openaiLib.LLMTimeoutError)) {
+      throw new openaiLib.LLMTimeoutError(`Bedrock audio aborted after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    cleanup();
+  }
+}
+
+async function callBedrockVision(
+  prompt: string,
+  images: ImageInput[],
+  model: string,
+  opts?: AiOpts,
+): Promise<{ text: string; usage?: Usage }> {
+  assertBedrockEnv();
+  const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
+    BedrockRuntimeClient: new (opts: {
+      region: string;
+      credentials: { accessKeyId: string; secretAccessKey: string };
+      requestHandler?: { requestTimeout?: number };
+    }) => {
+      send: (cmd: unknown, options?: { abortSignal?: AbortSignal }) => Promise<{ body: Uint8Array }>;
+    };
+    InvokeModelCommand: new (opts: { modelId: string; contentType: string; accept: string; body: string }) => unknown;
+  };
+
+  const { controller, cleanup, timeoutMs } = buildAbortController(opts);
+
+  const client = new BedrockRuntimeClient({
+    region: process.env.AWS_REGION!,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    },
+    requestHandler: { requestTimeout: timeoutMs },
+  });
+
+  const content: Array<{ type: string; source?: { type: string; media_type: string; data: string }; text?: string }> = [
+    { type: 'text', text: prompt },
+    ...images.map((img) => ({
+      type: 'image',
+      source: { type: 'base64', media_type: img.mimeType, data: img.data },
+    })),
+  ];
+
+  const payload = {
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content }],
+  };
+
+  const cmd = new InvokeModelCommand({
+    modelId: model,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify(payload),
+  });
+
+  try {
+    const response = await client.send(cmd, { abortSignal: controller.signal });
+    const decoded = new TextDecoder().decode(response.body);
+    const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
+    return { text: parsed.content?.[0]?.text ?? '', usage: extractBedrockUsage(parsed.usage) };
+  } catch (err) {
+    if (controller.signal.aborted && !(err instanceof openaiLib.LLMTimeoutError)) {
+      throw new openaiLib.LLMTimeoutError(`Bedrock vision aborted after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    cleanup();
+  }
 }
 
 // ─── Public callAi* functions ─────────────────────────────────────────────────
@@ -1000,54 +1104,15 @@ export async function callAiVision(
     let result: string;
     switch (provider) {
       case 'gemini': {
-        const r = await callGeminiVision('', prompt, images, model);
+        const r = await callGeminiVision('', prompt, images, model, opts);
         usage = r.usage;
         result = r.text;
         break;
       }
       case 'bedrock': {
-        assertBedrockEnv();
-        const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime') as {
-          BedrockRuntimeClient: new (opts: { region: string; credentials: { accessKeyId: string; secretAccessKey: string } }) => {
-            send: (cmd: unknown) => Promise<{ body: Uint8Array }>;
-          };
-          InvokeModelCommand: new (opts: { modelId: string; contentType: string; accept: string; body: string }) => unknown;
-        };
-
-        const client = new BedrockRuntimeClient({
-          region: process.env.AWS_REGION!,
-          credentials: {
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-          },
-        });
-
-        const content: Array<{ type: string; source?: { type: string; media_type: string; data: string }; text?: string }> = [
-          { type: 'text', text: prompt },
-          ...images.map((img) => ({
-            type: 'image',
-            source: { type: 'base64', media_type: img.mimeType, data: img.data },
-          })),
-        ];
-
-        const payload = {
-          anthropic_version: 'bedrock-2023-05-31',
-          max_tokens: 4096,
-          messages: [{ role: 'user', content }],
-        };
-
-        const cmd = new InvokeModelCommand({
-          modelId: model,
-          contentType: 'application/json',
-          accept: 'application/json',
-          body: JSON.stringify(payload),
-        });
-
-        const response = await client.send(cmd);
-        const decoded = new TextDecoder().decode(response.body);
-        const parsed = JSON.parse(decoded) as { content: Array<{ text?: string }>; usage?: BedrockUsage };
-        usage = extractBedrockUsage(parsed.usage);
-        result = parsed.content?.[0]?.text ?? '';
+        const r = await callBedrockVision(prompt, images, model, opts);
+        usage = r.usage;
+        result = r.text;
         break;
       }
       case 'openai':
@@ -1110,7 +1175,7 @@ export async function callAiAudio(
     let result: string;
     switch (provider) {
       case 'bedrock': {
-        const r = await callBedrockAudio(audioBuffer, model);
+        const r = await callBedrockAudio(audioBuffer, model, opts);
         usage = r.usage;
         result = r.text;
         break;
@@ -1123,6 +1188,7 @@ export async function callAiAudio(
               generateContent: (params: {
                 model: string;
                 contents: Array<{ role: string; parts: unknown[] }>;
+                config?: { abortSignal?: AbortSignal };
               }) => Promise<{ text: string; usageMetadata?: GeminiUsageMetadata }>;
             };
           };
@@ -1135,18 +1201,41 @@ export async function callAiAudio(
         });
 
         const audioBase64 = audioBuffer.toString('base64');
-        const response = await ai.models.generateContent({
-          model,
-          contents: [{
-            role: 'user',
-            parts: [
-              { text: 'Transcribe the following audio.' },
-              { inlineData: { data: audioBase64, mimeType: 'audio/mp4' } },
-            ],
-          }],
+        const { controller: audioCtrl, cleanup: audioCleanup, timeoutMs: audioTimeout } = buildAbortController(opts);
+        let audioTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const audioTimeoutPromise = new Promise<never>((_, reject) => {
+          audioTimeoutHandle = setTimeout(
+            () => reject(new openaiLib.LLMTimeoutError(`Gemini audio timed out after ${audioTimeout}ms`)),
+            audioTimeout,
+          );
         });
-        usage = extractGeminiUsage(response.usageMetadata);
-        result = response.text ?? '';
+
+        try {
+          const response = await Promise.race([
+            ai.models.generateContent({
+              model,
+              contents: [{
+                role: 'user',
+                parts: [
+                  { text: 'Transcribe the following audio.' },
+                  { inlineData: { data: audioBase64, mimeType: 'audio/mp4' } },
+                ],
+              }],
+              config: { abortSignal: audioCtrl.signal },
+            }),
+            audioTimeoutPromise,
+          ]);
+          usage = extractGeminiUsage(response.usageMetadata);
+          result = response.text ?? '';
+        } catch (audioErr) {
+          if (audioCtrl.signal.aborted && !(audioErr instanceof openaiLib.LLMTimeoutError)) {
+            throw new openaiLib.LLMTimeoutError(`Gemini audio aborted after ${audioTimeout}ms`);
+          }
+          throw audioErr;
+        } finally {
+          clearTimeout(audioTimeoutHandle);
+          audioCleanup();
+        }
         break;
       }
       case 'openai':


### PR DESCRIPTION
## Summary

- **H6 fix**: `callGeminiVision`, `callBedrockAudio`, the new `callBedrockVision` helper, and the inline Gemini audio branch in `callAiAudio` all previously constructed SDK clients with no `buildAbortController`, no `requestTimeout`, no `abortSignal`, and no `Promise.race` — callers passing `timeoutMs`/`signal` via `AiOpts` were silently ignored.
- Added `opts?: AiOpts` parameter to `callGeminiVision` and `callBedrockAudio`; extracted inline bedrock vision code to `callBedrockVision` helper.
- All four branches now match the timeout/abort pattern already used by `callGeminiText` and `callBedrockText`: `buildAbortController` → `requestHandler.requestTimeout` (Bedrock) → `abortSignal` → `Promise.race` → `LLMTimeoutError` on expiry.

## Test plan

- [x] 10 new behavioral tests in `lib/__tests__/ai-provider-vision-audio-timeout.test.ts` — TDD RED→GREEN; each test verifies a specific timeout/abort behavior per provider×modality combination
- [x] `npx jest --findRelatedTests lib/ai-provider.ts`: **100 suites, 1127 tests passed**
- [x] `npx tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)