### PR TITLE
fix(db): WAL mode + busy_timeout + getDb singleton (H4/H5)

### DIFF
--- a/__tests__/lib/db/getDb-singleton.test.ts
+++ b/__tests__/lib/db/getDb-singleton.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getDb } from '@/lib/db';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'getdb-singleton-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getDb singleton (H4)', () => {
+  it('two calls with the same path return the same instance', () => {
+    const dbPath = path.join(tmpDir, 'test.db');
+    const db1 = getDb(dbPath);
+    const db2 = getDb(dbPath);
+    expect(db1).toBe(db2);
+  });
+
+  it(':memory: calls return independent instances', () => {
+    const db1 = getDb(':memory:');
+    const db2 = getDb(':memory:');
+    expect(db1).not.toBe(db2);
+    db1.close();
+    db2.close();
+  });
+});
+
+describe('getDb WAL + busy_timeout (H5)', () => {
+  it('sets journal_mode = WAL on new file connection', () => {
+    const dbPath = path.join(tmpDir, 'wal.db');
+    const db = getDb(dbPath);
+    const mode = db.pragma('journal_mode', { simple: true }) as string;
+    expect(mode).toBe('wal');
+  });
+
+  it('sets busy_timeout to a positive value', () => {
+    const dbPath = path.join(tmpDir, 'busy.db');
+    const db = getDb(dbPath);
+    const timeout = db.pragma('busy_timeout', { simple: true }) as number;
+    expect(timeout).toBeGreaterThan(0);
+  });
+});

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -5,17 +5,33 @@ import * as path from 'path';
 const DEFAULT_DB_PATH =
   process.env.SESSIONS_DB_PATH ?? path.join(process.cwd(), 'data', 'sessions.db');
 
+const _cache = new Map<string, Database.Database>();
+
 /**
- * Initialize and return a SQLite database connection with sqlite-vec extension loaded.
+ * Return a cached singleton SQLite connection for the given path.
+ * sqlite-vec is loaded once per connection. WAL mode and busy_timeout are
+ * applied at open time so concurrent readers/writers never get SQLITE_BUSY.
  *
- * CRITICAL: sqlite-vec.load() MUST be called BEFORE migrations run, so that
- * future migrations can safely use vec0 virtual tables.
- *
- * @param dbPath - Path to SQLite database file (defaults to SESSIONS_DB_PATH env var or data/sessions.db)
- * @returns Database instance with sqlite-vec extension loaded
+ * NOTE: `:memory:` databases are NOT shared — each call returns a new
+ * in-memory database (required for test isolation).
  */
 export function getDb(dbPath: string = DEFAULT_DB_PATH): Database.Database {
-  const db = new Database(dbPath);
+  if (dbPath === ':memory:') {
+    const db = new Database(':memory:');
+    sqliteVec.load(db);
+    return db;
+  }
+
+  const resolved = path.resolve(dbPath);
+  const cached = _cache.get(resolved);
+  if (cached && cached.open) {
+    return cached;
+  }
+
+  const db = new Database(resolved);
   sqliteVec.load(db);
+  db.pragma('journal_mode = WAL');
+  db.pragma('busy_timeout = 5000');
+  _cache.set(resolved, db);
   return db;
 }

--- a/lib/session-store.ts
+++ b/lib/session-store.ts
@@ -40,6 +40,8 @@ export class SessionStore {
     this.db = new Database(dbPath);
     // Load sqlite-vec extension BEFORE migrations (required for migration 018 vec0 tables)
     sqliteVec.load(this.db);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
     // Enforce FK constraints (SQLite default is OFF). Required for migrations
     // that declare REFERENCES (e.g., 013 knowledge_sync_log → knowledge_sources)
     // to actually reject orphan inserts at runtime.


### PR DESCRIPTION
## Summary

- **H4**: `getDb()` in `lib/db/index.ts` now returns a cached singleton keyed on resolved path — vec extension loads once, no more handle leak per call
- **H5**: All runtime SQLite connections (`getDb` + `SessionStore`) now set `journal_mode = WAL` and `busy_timeout = 5000` — eliminates SQLITE_BUSY under concurrent demo traffic
- `:memory:` databases (test isolation) are exempt from the singleton cache
- `__tests__/lib/db/getDb-singleton.test.ts`: behavioral tests for singleton identity, WAL mode, busy_timeout

## Test plan

- [x] `npx jest "__tests__/lib/db" "lib/__tests__/session-store"` — 30/30 green
- [x] `npx jest "__tests__/lib/knowledge"` — 762 pass, 21 skip, 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] Cold test-skill review — APPROVE, 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)