### PR TITLE
refactor(M6): single source for class breakeven thresholds (Wave 2 stage 2)

### DIFF
--- a/lib/economics/__tests__/breakeven-thresholds.test.ts
+++ b/lib/economics/__tests__/breakeven-thresholds.test.ts
@@ -1,0 +1,51 @@
+import { breakevenTceByDwt } from '../breakeven-thresholds';
+
+describe('breakevenTceByDwt', () => {
+  describe('≤15000 DWT class', () => {
+    test('dwt=5000 returns 1500', () => {
+      expect(breakevenTceByDwt(5000)).toBe(1500);
+    });
+
+    test('dwt=15000 (boundary) returns 1500', () => {
+      expect(breakevenTceByDwt(15000)).toBe(1500);
+    });
+  });
+
+  describe('≤40000 DWT class', () => {
+    test('dwt=15001 (just above boundary) returns 3000', () => {
+      expect(breakevenTceByDwt(15001)).toBe(3000);
+    });
+
+    test('dwt=30000 returns 3000', () => {
+      expect(breakevenTceByDwt(30000)).toBe(3000);
+    });
+
+    test('dwt=40000 (boundary) returns 3000', () => {
+      expect(breakevenTceByDwt(40000)).toBe(3000);
+    });
+  });
+
+  describe('≤65000 DWT class', () => {
+    test('dwt=40001 (just above boundary) returns 5500', () => {
+      expect(breakevenTceByDwt(40001)).toBe(5500);
+    });
+
+    test('dwt=55000 returns 5500', () => {
+      expect(breakevenTceByDwt(55000)).toBe(5500);
+    });
+
+    test('dwt=65000 (boundary) returns 5500', () => {
+      expect(breakevenTceByDwt(65000)).toBe(5500);
+    });
+  });
+
+  describe('>65000 DWT class', () => {
+    test('dwt=65001 (just above boundary) returns 7500', () => {
+      expect(breakevenTceByDwt(65001)).toBe(7500);
+    });
+
+    test('dwt=75000 returns 7500', () => {
+      expect(breakevenTceByDwt(75000)).toBe(7500);
+    });
+  });
+});

--- a/lib/economics/breakeven-thresholds.ts
+++ b/lib/economics/breakeven-thresholds.ts
@@ -1,0 +1,6 @@
+export function breakevenTceByDwt(dwt: number): number {
+  if (dwt <= 15_000) return 1_500;
+  if (dwt <= 40_000) return 3_000;
+  if (dwt <= 65_000) return 5_500;
+  return 7_500;
+}

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -30,6 +30,7 @@ import { resolveChartererTier } from '@/lib/matching/charterer-tier';
 import { formatNumber } from '@/lib/utils';
 import { LLMTimeoutError } from '@/lib/openai';
 import { now } from '@/lib/clock';
+import { breakevenTceByDwt } from '../economics/breakeven-thresholds';
 
 export interface RawMatch {
   cargo_email_id?: string;
@@ -826,10 +827,7 @@ export async function analyzePairs(
       );
       const floorDwt = floorVessel ? (cfValue(floorVessel.dwtSummer) ?? 0) : 0;
       if (floorDwt > 0) {
-        const breakeven = floorDwt <= 15_000 ? 1_500
-          : floorDwt <= 40_000 ? 3_000
-          : floorDwt <= 65_000 ? 5_500
-          : 7_500;
+        const breakeven = breakevenTceByDwt(floorDwt);
         if (floorTce < breakeven) {
           m.matchLevel = 'weak';
           m.issues = [...(m.issues ?? []), 'Below-breakeven economics (true-voyage TCE) — manual review'];

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -32,6 +32,7 @@ import type {
 } from '@/lib/types';
 import { cfValue } from '@/lib/types';
 import { resolveCargoWeight } from './cargo-weight';
+import { breakevenTceByDwt } from '../economics/breakeven-thresholds';
 import { computeVesselVetting } from './vessel-vetting';
 import { classifyVesselByDwt } from './readiness-gap';
 import { BALLAST_GOOD_MAX_NM, isPartCargo } from './match-scoring';
@@ -443,11 +444,6 @@ export function scoreVetting(vessel: ParsedVessel, refYear?: number, detentionCo
  *  Neutral (0.5) at class breakeven; profit above → toward 1; loss below → toward 0.
  *  null/undefined TCE → 0.5 (no reward, no penalty). NOT a binary cap.
  *
- *  Breakeven thresholds match pair-analyzer.ts:835-838:
- *    DWT ≤ 15 000  → $1 500 /day
- *    DWT ≤ 40 000  → $3 000 /day
- *    DWT ≤ 65 000  → $5 500 /day
- *    DWT  > 65 000 → $7 500 /day
  */
 function clamp01(x: number): number {
   return Math.min(1, Math.max(0, x));
@@ -455,10 +451,7 @@ function clamp01(x: number): number {
 
 function economicsNorm(tceUsdPerDay: number | null | undefined, vesselDwt: number): number {
   if (tceUsdPerDay == null || !Number.isFinite(tceUsdPerDay) || !(vesselDwt > 0)) return 0.5;
-  const breakeven = vesselDwt <= 15_000 ? 1_500
-    : vesselDwt <= 40_000 ? 3_000
-    : vesselDwt <= 65_000 ? 5_500
-    : 7_500;
+  const breakeven = breakevenTceByDwt(vesselDwt);
   const scale = Math.max(breakeven, 1);
   return clamp01(0.5 + 0.5 * Math.tanh((tceUsdPerDay - breakeven) / scale));
 }
@@ -477,10 +470,7 @@ export function scoreEconomics(
   } else if (!(dwt > 0)) {
     rationale = 'Vessel DWT not stated — economics scored neutral.';
   } else {
-    const breakeven = dwt <= 15_000 ? 1_500
-      : dwt <= 40_000 ? 3_000
-      : dwt <= 65_000 ? 5_500
-      : 7_500;
+    const breakeven = breakevenTceByDwt(dwt);
     const diff = tceUsdPerDay - breakeven;
     if (diff >= 0) {
       rationale = `TCE $${Math.round(tceUsdPerDay).toLocaleString('en-US')}/day — $${Math.round(diff).toLocaleString('en-US')}/day above class breakeven.`;


### PR DESCRIPTION
## Summary

- Extract duplicated DWT-class breakeven ladder into `lib/economics/breakeven-thresholds.ts` (`breakevenTceByDwt`)
- Replace 3 inline copies: `economicsNorm`, `scoreEconomics` (fit-breakdown.ts), pair-analyzer floor-TCE check
- Remove stale cross-ref comment at fit-breakdown.ts (referenced pair-analyzer.ts:835-838 which had already drifted)
- Pure refactor — numbers byte-identical, zero behaviour change

## Test plan

- [x] `lib/economics/__tests__/breakeven-thresholds.test.ts` — 10 tests, all DWT class boundaries
- [x] `lib/sailing/__tests__/fit-breakdown-economics.test.ts` — pins all 4 class breakevens (lines 189, 217, 227, 234) — unchanged, green
- [x] `npx jest --findRelatedTests` — 545 tests / 60 suites, all green
- [x] `npx tsc --noEmit --skipLibCheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)