### PR TITLE
fix(db-followups): check WAL pragma return + tighten busy_timeout test + WAL on canal.db

### DIFF
--- a/__tests__/lib/db/getDb-singleton.test.ts
+++ b/__tests__/lib/db/getDb-singleton.test.ts
@@ -42,6 +42,6 @@ describe('getDb WAL + busy_timeout (H5)', () => {
     const dbPath = path.join(tmpDir, 'busy.db');
     const db = getDb(dbPath);
     const timeout = db.pragma('busy_timeout', { simple: true }) as number;
-    expect(timeout).toBeGreaterThan(0);
+    expect(timeout).toBe(5000);
   });
 });

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -30,7 +30,8 @@ export function getDb(dbPath: string = DEFAULT_DB_PATH): Database.Database {
 
   const db = new Database(resolved);
   sqliteVec.load(db);
-  db.pragma('journal_mode = WAL');
+  const walMode = db.pragma('journal_mode = WAL', { simple: true }) as string;
+  if (walMode !== 'wal') console.warn('[getDb] WAL not enabled for', resolved, '— got', walMode);
   db.pragma('busy_timeout = 5000');
   _cache.set(resolved, db);
   return db;

--- a/lib/economics/canals/db.ts
+++ b/lib/economics/canals/db.ts
@@ -33,6 +33,9 @@ function openDb(): Database.Database {
     fs.mkdirSync(dir, { recursive: true });
   }
   const db = new Database(DEFAULT_DB_PATH);
+  const walMode = db.pragma('journal_mode = WAL', { simple: true }) as string;
+  if (walMode !== 'wal') console.warn('[getCanalDb] WAL not enabled for', DEFAULT_DB_PATH, '— got', walMode);
+  db.pragma('busy_timeout = 5000');
   db.pragma('foreign_keys = ON');
   db.exec(CANAL_TARIFFS_SCHEMA);
   seedIfEmpty(db);

--- a/lib/session-store.ts
+++ b/lib/session-store.ts
@@ -40,7 +40,8 @@ export class SessionStore {
     this.db = new Database(dbPath);
     // Load sqlite-vec extension BEFORE migrations (required for migration 018 vec0 tables)
     sqliteVec.load(this.db);
-    this.db.pragma('journal_mode = WAL');
+    const walMode = this.db.pragma('journal_mode = WAL', { simple: true }) as string;
+    if (walMode !== 'wal') console.warn('[SessionStore] WAL not enabled for', dbPath, '— got', walMode);
     this.db.pragma('busy_timeout = 5000');
     // Enforce FK constraints (SQLite default is OFF). Required for migrations
     // that declare REFERENCES (e.g., 013 knowledge_sync_log → knowledge_sources)


### PR DESCRIPTION
Three follow-ups from cold review of #904 (WAL/singleton). FIX1 (MEDIUM): check journal_mode=WAL pragma return in getDb + SessionStore (silent fallback to delete previously undetectable). FIX2 (LOW): tighten busy_timeout test assert to exact 5000. FIX3 (LOW): add WAL+busy_timeout to canal.db openDb(). Recovered/opened by orchestrator after dispatch session hung post-commit. 🤖