### PR TITLE
fix(H3): board-demote floor uses live bunker price (Wave 2 stage 3)

### DIFF
--- a/__tests__/api/compute-matches.test.ts
+++ b/__tests__/api/compute-matches.test.ts
@@ -16,9 +16,15 @@ jest.mock('@/lib/ai-provider', () => ({ callAiJson: jest.fn() }));
 jest.mock('@/lib/matching/pair-analyzer', () => ({
   analyzePairs: jest.fn().mockResolvedValue({ matches: [], blockedMatches: [] }),
 }));
+jest.mock('@/lib/market/bunker-repository', () => ({
+  getLatestBunkerPrice: jest.fn().mockReturnValue(null),
+}));
 
 const { analyzePairs } = require('@/lib/matching/pair-analyzer') as {
   analyzePairs: jest.Mock;
+};
+const { getLatestBunkerPrice } = require('@/lib/market/bunker-repository') as {
+  getLatestBunkerPrice: jest.Mock;
 };
 
 function makeDb(): Database.Database {
@@ -163,5 +169,28 @@ describe('computeAndPersistMatches', () => {
     // Only one row in DB
     const stored = listMatches(db, { user_id: 'sess-dup', sortBy: 'score', sortDir: 'desc' });
     expect(stored).toHaveLength(1);
+  });
+
+  it('H3: passes live bunker price to analyzePairs for board-demote floor check', async () => {
+    // Arrange: DB has a live bunker price of 791 (NLRTM/VLSFO)
+    getLatestBunkerPrice.mockReturnValueOnce({ price_usd_per_mt: 791 });
+    analyzePairs.mockResolvedValueOnce({ matches: [], blockedMatches: [] });
+
+    const { computeAndPersistMatches } = await import('@/lib/matching/compute-matches');
+    await computeAndPersistMatches(
+      [{ emailId: 'cargo-b', itemIndex: 0 } as never],
+      [{ emailId: 'vessel-b', itemIndex: 0 } as never],
+      'sess-bunker',
+      db,
+    );
+
+    // analyzePairs must receive live bunker price so the board-demote floor
+    // check judges pairs at $791, not the hardcoded $600 default.
+    expect(analyzePairs).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ bunkerPriceUsdPerMt: 791 }),
+    );
   });
 });

--- a/app/api/ai/match/route.ts
+++ b/app/api/ai/match/route.ts
@@ -8,6 +8,7 @@ import { MATCH_PROMPT } from '@/lib/prompts';
 import { analyzePairs, AiScorer, RawMatch } from '@/lib/matching/pair-analyzer';
 import { getStore } from '@/lib/session-store';
 import { isRagEnabled } from '@/lib/knowledge/flags';
+import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import type { Match } from '@/lib/types';
 
 /** Demo match IDs — must stay in sync with /api/sample/route.ts */
@@ -102,6 +103,26 @@ export async function POST(request: NextRequest) {
   };
 
   try {
+    const sessionDb = getStore().getDatabase();
+
+    // Live bunker price (NLRTM/VLSFO) for board-demote floor check (H3 fix).
+    // Null only when the DB row is genuinely missing — warn and use 600 explicitly
+    // so the floor check still runs deterministically (no silent fallback).
+    // try/catch: bunker_prices table may be absent in minimal/test DBs.
+    let bunkerPriceUsdPerMt: number;
+    try {
+      const bunkerRow = getLatestBunkerPrice(sessionDb, 'NLRTM', 'VLSFO');
+      if (bunkerRow !== null) {
+        bunkerPriceUsdPerMt = bunkerRow.price_usd_per_mt;
+      } else {
+        console.warn('[match] bunker price not found for NLRTM/VLSFO — board-demote floor uses DEFAULT_BUNKER=600');
+        bunkerPriceUsdPerMt = 600;
+      }
+    } catch {
+      console.warn('[match] bunker_prices table unavailable — board-demote floor uses DEFAULT_BUNKER=600');
+      bunkerPriceUsdPerMt = 600;
+    }
+
     const {
       matches,
       blockedMatches,
@@ -110,7 +131,8 @@ export async function POST(request: NextRequest) {
     } = await analyzePairs(parsedCargos, parsedVessels, aiScorer, {
       refYear,
       today,
-      db: getStore().getDatabase(),
+      db: sessionDb,
+      bunkerPriceUsdPerMt,
     });
 
     // Idempotency guard: if this is a sample-data session, preserve the demo

--- a/lib/__tests__/matching/board-demote-bunker.test.ts
+++ b/lib/__tests__/matching/board-demote-bunker.test.ts
@@ -1,0 +1,279 @@
+/**
+ * TDD regression: H3 — board-demote floor must use live bunker price.
+ *
+ * Before the fix, analyzePairs() is called without bunkerPriceUsdPerMt so the
+ * breakeven floor check uses DEFAULT_BUNKER=600 while the displayed TCE uses the
+ * live NLRTM/VLSFO price (~$791). A pair that clears $600 but fails $791 wrongly
+ * stays on the board.
+ *
+ * This test pins the behaviour: a near-floor pair (TCE above $5,500 at $600 but
+ * below $5,500 at $791) must land in lowConfidenceMatches when analyzePairs is
+ * called with bunkerPriceUsdPerMt=791.
+ */
+
+import { analyzePairs, type AiScorer, type RawMatch } from '@/lib/matching/pair-analyzer';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+import type { StoredMatchEconomicsResult } from '@/lib/matching/stored-match-economics';
+
+// ── Core pair-analysis mocks (same as economics-wiring.test.ts) ──────────────
+
+jest.mock('@/lib/sailing/readiness-gap', () => ({
+  calculateReadinessGap: jest.fn().mockReturnValue({
+    verdict: 'ideal',
+    gapDays: 5,
+    sailingDays: 3,
+    explanation: 'ok',
+    distanceNm: 500,
+    arrivalDate: null,
+    openDate: null,
+    laycanStart: null,
+    laycanEnd: null,
+    speedKn: null,
+  }),
+  detectSpot: jest.fn().mockReturnValue(false),
+  classifyVesselByDwt: jest.fn().mockReturnValue('supramax'),
+}));
+
+jest.mock('@/lib/sailing/match-filters', () => ({
+  runHardFilters: jest.fn().mockReturnValue({
+    pass: true,
+    failures: [],
+    checks: {
+      draft: { pass: true },
+      crane: { pass: true },
+      volume: { pass: true },
+      cargoVessel: { pass: true },
+    },
+  }),
+}));
+
+jest.mock('@/lib/sailing/match-scoring', () => ({
+  applyReadinessScoring: jest.fn().mockImplementation((m) => m),
+  computeScoreBreakdown: jest.fn().mockReturnValue({
+    components: [],
+    basePhysical: 75,
+    readinessAdjustment: 0,
+    sanctionsAdjustment: 0,
+    finalScore: 75, // → 'good' → main match bucket
+  }),
+  deriveMatchLevel: jest.fn().mockImplementation((score: number) =>
+    score > 70 ? 'good' : score > 40 ? 'possible' : 'weak',
+  ),
+  deriveMatchLevelFromFit: jest.fn().mockImplementation((fit: number) =>
+    fit >= 70 ? 'good' : fit >= 60 ? 'possible' : 'weak',
+  ),
+  applyBallastSizeCap: jest.fn().mockImplementation((input) => input.match),
+  isPartCargo: jest.fn().mockReturnValue(false),
+  BALLAST_GOOD_MAX_NM: { handysize: 1500, supramax: 2000, panamax: 2500, capesize: 4000 },
+}));
+
+jest.mock('@/lib/sailing/date-parsing', () => ({
+  parseLaycan: jest.fn().mockReturnValue(null),
+  parseVesselOpenDate: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('@/lib/sailing/date-sanity', () => ({
+  validateDates: jest.fn().mockReturnValue({ valid: true, issues: [] }),
+  isLaycanValid: jest.fn().mockReturnValue({ valid: true }),
+}));
+
+jest.mock('@/lib/validation/sanctions', () => ({
+  ...jest.requireActual('@/lib/validation/sanctions'),
+  checkSanctions: jest.fn().mockReturnValue({ risk: 'NONE', blocking: false }),
+}));
+
+jest.mock('@/lib/matching/reason-enricher', () => ({
+  enrichReasons: jest.fn().mockImplementation((reasons: string[], issues: string[]) => ({ reasons, issues })),
+}));
+
+jest.mock('@/lib/sailing/port-distances', () => ({
+  getPortDistance: jest.fn().mockReturnValue({ nm: 3000, exact: true }),
+}));
+
+// ── Economics mock: returns TCE determined by bunker price ──────────────────
+// Supramax (50k DWT) breakeven = $5,500/day.
+// At $600 bunker → TCE $6,200 (above floor → stays on board).
+// At $791 bunker → TCE $4,800 (below floor → board-demotes to lowConfidence).
+const mockComputeStoredMatchEconomics = jest.fn();
+jest.mock('@/lib/matching/stored-match-economics', () => ({
+  computeStoredMatchEconomics: (...args: unknown[]) => mockComputeStoredMatchEconomics(...args),
+}));
+
+function makeEconomicsResult(tceUsdPerDay: number): StoredMatchEconomicsResult {
+  return {
+    tce_usd_per_day: tceUsdPerDay,
+    freight_rate_usd_per_mt: 22,
+    freight_rate_source: 'market',
+    distance_nm: 3000,
+    tce_breakdown: null,
+    consumption_estimated: false,
+    ballast_distance_nm: null,
+    economics: {
+      tceUsdPerDay,
+      freightRateUsdPerMt: 22,
+      freightRateSource: 'market',
+      breakdown: {
+        bunkerCost: 50000,
+        bunkerPort: 'NLRTM',
+        euEtsAmount: 0,
+        euEtsApplicable: false,
+        warRiskPremium: 0,
+        warRiskZones: [],
+      },
+      totalUsd: 50000,
+      calculatedAt: '2026-01-01T00:00:00.000Z',
+      dataFreshness: { bunker: '2026-01-01', eua: '2026-01-01' },
+    },
+  };
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeCargo(overrides: Partial<ParsedCargo> = {}): ParsedCargo {
+  return {
+    emailId: 'cargo-h3',
+    itemIndex: 0,
+    originPort: { value: 'Rotterdam', confidence: 'confirmed' } as unknown as ParsedCargo['originPort'],
+    originCountry: null,
+    destinationPort: { value: 'Durban', confidence: 'confirmed' } as unknown as ParsedCargo['destinationPort'],
+    destinationCountry: null,
+    cargoDescription: null,
+    weightMt: { value: 45000, confidence: 'confirmed' } as unknown as ParsedCargo['weightMt'],
+    weightMtMin: null,
+    weightMtMax: null,
+    volumeCbm: null,
+    dimensions: null,
+    cargoType: 'BULK',
+    containerType: null,
+    quantity: null,
+    incoterms: null,
+    preferredDates: null,
+    laycan: null,
+    loadingRate: null,
+    dischargeRate: null,
+    commissionPercent: null,
+    commissionTerms: null,
+    specialRequirements: null,
+    stowageFactor: null,
+    missingInfo: [],
+    ...overrides,
+  };
+}
+
+function makeVessel(overrides: Partial<ParsedVessel> = {}): ParsedVessel {
+  return {
+    emailId: 'vessel-h3',
+    itemIndex: 0,
+    vesselName: { value: 'MV Test', confidence: 'confirmed' } as unknown as ParsedVessel['vesselName'],
+    imo: null,
+    flag: null,
+    built: null,
+    classSociety: null,
+    pandi: null,
+    // 50,000 DWT → breakeven = $5,500/day (supramax/handymax tier)
+    dwtSummer: { value: 50000, confidence: 'confirmed' } as unknown as ParsedVessel['dwtSummer'],
+    dwcc: null,
+    draftMax: null,
+    loa: null,
+    beam: null,
+    grt: null,
+    nrt: null,
+    holdsCount: null,
+    hatchesCount: null,
+    grainCapacity: null,
+    grainCapacityUnit: null,
+    baleCapacity: null,
+    holdDimensions: null,
+    hatchDimensions: null,
+    tankTopStrength: null,
+    geared: null,
+    craneCapacity: null,
+    hatchType: null,
+    vesselType: null,
+    openPosition: null,
+    openDate: null,
+    direction: null,
+    restrictions: [],
+    lastCargoes: null,
+    speedLaden: '13 knots',
+    speedBallast: null,
+    consumption: '28 mt/day',
+    deckCapacity: null,
+    specialFeatures: [],
+    ...overrides,
+  };
+}
+
+function rawMatchFor(cargo: ParsedCargo, vessel: ParsedVessel, score = 80): RawMatch {
+  return {
+    cargo_email_id: cargo.emailId,
+    cargo_item_index: cargo.itemIndex,
+    vessel_email_id: vessel.emailId,
+    vessel_item_index: vessel.itemIndex,
+    score,
+    match_level: 'good',
+    match_reasons: ['DWT fits cargo'],
+    issues: [],
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('H3 board-demote floor uses live bunker price', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: economics mock derives TCE from the bunker price argument.
+    // At $600 → $6,200 TCE (above $5,500 breakeven → stays on board).
+    // At $791 → $4,800 TCE (below $5,500 breakeven → demoted).
+    mockComputeStoredMatchEconomics.mockImplementation(
+      ({ bunkerPriceUsdPerMt }: { bunkerPriceUsdPerMt?: number }) => {
+        const price = bunkerPriceUsdPerMt ?? 600;
+        const tce = price > 700 ? 4_800 : 6_200;
+        return makeEconomicsResult(tce);
+      },
+    );
+  });
+
+  it('near-floor pair demotes to lowConfidenceMatches when live bunker price 791 is passed', async () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    const aiScorer: AiScorer = jest.fn().mockResolvedValue([rawMatchFor(cargo, vessel)]);
+
+    const result = await analyzePairs([cargo], [vessel], aiScorer, {
+      bunkerPriceUsdPerMt: 791,
+    });
+
+    // Pair must NOT appear in main matches
+    expect(result.matches).toHaveLength(0);
+    // Pair MUST appear in lowConfidenceMatches with breakeven-economics issue
+    expect(result.lowConfidenceMatches).toHaveLength(1);
+    const demoted = result.lowConfidenceMatches[0];
+    expect(demoted.issues).toEqual(
+      expect.arrayContaining([expect.stringContaining('Below-breakeven economics')]),
+    );
+  });
+
+  it('same near-floor pair stays on board when no bunker price is passed (defaults to 600)', async () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    const aiScorer: AiScorer = jest.fn().mockResolvedValue([rawMatchFor(cargo, vessel)]);
+
+    // No bunkerPriceUsdPerMt → internal default 600 → TCE 6200 > 5500 breakeven
+    const result = await analyzePairs([cargo], [vessel], aiScorer);
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.lowConfidenceMatches).toHaveLength(0);
+  });
+
+  it('computeStoredMatchEconomics receives live bunker price when passed via analyzePairs', async () => {
+    const cargo = makeCargo();
+    const vessel = makeVessel();
+    const aiScorer: AiScorer = jest.fn().mockResolvedValue([rawMatchFor(cargo, vessel)]);
+
+    await analyzePairs([cargo], [vessel], aiScorer, { bunkerPriceUsdPerMt: 791 });
+
+    expect(mockComputeStoredMatchEconomics).toHaveBeenCalledWith(
+      expect.objectContaining({ bunkerPriceUsdPerMt: 791 }),
+    );
+  });
+});

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -41,6 +41,17 @@ export async function computeAndPersistMatches(
     return result.matches ?? [];
   };
 
+  // Live bunker price (NLRTM/VLSFO) for list↔detail parity. Fetched before
+  // analyzePairs so the board-demote floor check uses the same live price as the
+  // stored tce_usd_per_day column (H3 fix). Resilient to a missing bunker_prices
+  // table (e.g. minimal test DBs) — falls through to the helper default.
+  let bunkerPriceUsdPerMt: number | undefined;
+  try {
+    bunkerPriceUsdPerMt = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO')?.price_usd_per_mt;
+  } catch {
+    bunkerPriceUsdPerMt = undefined;
+  }
+
   // Realism buckets (handover 2026-05-30, point 2): we intentionally take ONLY the
   // main `matches` here. The auto-precompute → DB path is a curated *shortlist*, and
   // the matches table has no column for the lowConfidenceMatches / insufficientData
@@ -49,22 +60,13 @@ export async function computeAndPersistMatches(
   // path computes the same partition and persists all buckets to the session
   // (see app/api/ai/match/route.ts + its route tests). So this path shows the
   // shortlist; the full bucketed list is served live.
-  // Pass db so the economics-enrichment loop in analyzePairs can resolve the same
-  // Baltic tier-2 rate the persisted tce_usd_per_day column uses → match.economics
-  // stays consistent with the DB column on the auto-precompute path (code-review #2).
-  const { matches } = await analyzePairs(cargos, vessels, aiScorer, { db });
+  // Pass db and bunkerPriceUsdPerMt so analyzePairs board-demote floor check uses
+  // the live bunker price (H3), and the Baltic tier-2 rate stays consistent with
+  // the persisted tce_usd_per_day column (code-review #2).
+  const { matches } = await analyzePairs(cargos, vessels, aiScorer, { db, bunkerPriceUsdPerMt });
 
   const cargoMap = new Map(cargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselMap = new Map(vessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
-
-  // Live bunker price (NLRTM/VLSFO) for list↔detail parity. Resilient to a missing
-  // bunker_prices table (e.g. minimal test DBs) — falls through to the helper default.
-  let bunkerPriceUsdPerMt: number | undefined;
-  try {
-    bunkerPriceUsdPerMt = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO')?.price_usd_per_mt;
-  } catch {
-    bunkerPriceUsdPerMt = undefined;
-  }
 
   for (const m of matches) {
     const cargo = cargoMap.get(`${m.cargoEmailId}|${m.cargoItemIndex}`);


### PR DESCRIPTION
## Problem (H3)

The board-demote floor check in `analyzePairs` used `DEFAULT_BUNKER_USD_PER_MT = 600` because the live bunker price was fetched **after** the `analyzePairs` call in both execution paths. Meanwhile, `tce_usd_per_day` stored in the DB (and displayed to users) was computed with the live price (~$791 NLRTM/VLSFO). This created a split: a near-floor pair whose live-price TCE is below class breakeven ($5,500/day for supramax) appeared to clear the floor at $600, so it stayed on board when it should have demoted to `lowConfidenceMatches`.

**Example oracle (from test fixture):** supramax 50k DWT, distance 3000nm — TCE $6,200 at $600 bunker (above $5,500 breakeven → wrongly stays on board), TCE $4,800 at $791 bunker (below breakeven → correctly demoted after fix).

## Fix

- `lib/matching/compute-matches.ts`: hoist `getLatestBunkerPrice(db, 'NLRTM', 'VLSFO')` **above** the `analyzePairs` call; pass `bunkerPriceUsdPerMt` into options
- `app/api/ai/match/route.ts`: add same `getLatestBunkerPrice` call before `analyzePairs`; null → warn + explicit 600 (deterministic, no silent fallback)
- `lib/__tests__/matching/board-demote-bunker.test.ts` (new, 279 lines): TDD regression covering the demote-at-791 / stay-at-600 split and the economics forwarding invariant
- `__tests__/api/compute-matches.test.ts`: mock `getLatestBunkerPrice`; add H3 behavioral test asserting `analyzePairs` receives live price 791

## Tests

- 9/9 new + modified tests green (`board-demote-bunker`, `compute-matches`)
- 43/43 high-risk guards green (`list-detail-tce-parity`, `fit-breakdown-economics`, `economics-wiring`)
- 179/179 related tests green (`findRelatedTests` on changed files)
- `tsc --noEmit`: exit 0

## DO NOT AUTO-MERGE — orchestrator runs pre-merge-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)