### PR TITLE
chore(obs): warn on null bunker in compute-matches (parity with route.ts)

### DIFF
--- a/__tests__/api/compute-matches.test.ts
+++ b/__tests__/api/compute-matches.test.ts
@@ -193,4 +193,42 @@ describe('computeAndPersistMatches', () => {
       expect.objectContaining({ bunkerPriceUsdPerMt: 791 }),
     );
   });
+
+  it('obs: warns when bunker price row is null (observability parity with route.ts)', async () => {
+    getLatestBunkerPrice.mockReturnValueOnce(null);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { computeAndPersistMatches } = await import('@/lib/matching/compute-matches');
+    await computeAndPersistMatches(
+      [{ emailId: 'cargo-warn', itemIndex: 0 } as never],
+      [{ emailId: 'vessel-warn', itemIndex: 0 } as never],
+      'sess-warn-null',
+      db,
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('bunker price not found for NLRTM/VLSFO'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('obs: warns when bunker_prices table throws (observability parity with route.ts)', async () => {
+    getLatestBunkerPrice.mockImplementationOnce(() => {
+      throw new Error('no such table: bunker_prices');
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { computeAndPersistMatches } = await import('@/lib/matching/compute-matches');
+    await computeAndPersistMatches(
+      [{ emailId: 'cargo-warn2', itemIndex: 0 } as never],
+      [{ emailId: 'vessel-warn2', itemIndex: 0 } as never],
+      'sess-warn-throw',
+      db,
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('bunker_prices table unavailable'),
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/lib/matching/compute-matches.ts
+++ b/lib/matching/compute-matches.ts
@@ -47,8 +47,14 @@ export async function computeAndPersistMatches(
   // table (e.g. minimal test DBs) — falls through to the helper default.
   let bunkerPriceUsdPerMt: number | undefined;
   try {
-    bunkerPriceUsdPerMt = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO')?.price_usd_per_mt;
+    const bunkerRow = getLatestBunkerPrice(db, 'NLRTM', 'VLSFO');
+    if (bunkerRow !== null) {
+      bunkerPriceUsdPerMt = bunkerRow.price_usd_per_mt;
+    } else {
+      console.warn('[compute-matches] bunker price not found for NLRTM/VLSFO — board-demote floor uses helper default');
+    }
   } catch {
+    console.warn('[compute-matches] bunker_prices table unavailable — board-demote floor uses helper default');
     bunkerPriceUsdPerMt = undefined;
   }
 


### PR DESCRIPTION
## Summary

- `compute-matches.ts` (background auto-precompute) had a silent fallback when `getLatestBunkerPrice` returned `null` or threw — missing bunker data was invisible in logs
- `route.ts` gained `console.warn` in H3 (#911 cold-review LOW finding); this adds matching warns to the precompute path for observability parity
- Pure observability change: `bunkerPriceUsdPerMt` value and all downstream logic unchanged

## Changes

- `lib/matching/compute-matches.ts`: expand `?.price_usd_per_mt` optional chaining to explicit `null` check with `console.warn` on both null and catch paths
- `__tests__/api/compute-matches.test.ts`: 2 new behavioral tests verifying warn fires on null row and on throw

## Test plan

- [ ] `npx jest __tests__/api/compute-matches.test.ts --no-coverage --ci --forceExit --maxWorkers=1` → 8/8 green
- [ ] `tsc --noEmit --skipLibCheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)