### PR TITLE
docs(plan): null/unparseable DWT → Handysize Baltic-class bias fix plan

### DIFF
--- a/.test-review/attack_plan.md
+++ b/.test-review/attack_plan.md
@@ -1,62 +1,19 @@
-# Attack Plan — fix-econ-a-bunker
+# Phase 2 — Attack Surface (2026-06-09, Round 2)
+
+## Scope
+Verify Round 1 followups only (H1/M1/M2/L1). No new attack surface added.
 
 ## Classification Table
 
-| File | Class | Severity | Technique |
-|------|-------|----------|-----------|
-| `tce/route.ts` (bunkerPort guard) | validator/route-handler | HIGH | contract test + adversarial value shapes |
-| `EconomicsTab.tsx` (null state + gate) | React state machine | HIGH | RTL behavioral (already tested) + edge cases |
-| `bunker-recommendation/route.ts` (A1 stale log) | log/monitoring | LOW | unit (already tested) |
+| Finding | Class | Target | Severity | Result |
+|---------|-------|--------|----------|--------|
+| H1: live TCE in fit component | normalizer/merger | patchEconomicsComponent() | HIGH | FIXED ✓ |
+| M1: duration float→1dp | UI display | CalculationWaterfall:88,182 | MEDIUM | FIXED ✓ |
+| M2: war-risk addback row | UI math | CalculationWaterfall:166-181 | MEDIUM | FIXED ✓ (code+tests; no HRA in demo) |
+| L1: fmtUsd(-0)→$-0 | formatter | fmtUsd()→line 22 | LOW | FIXED ✓ |
 
-## Ordered Attack List (HIGH first)
-
-### A — tce/route.ts bunkerPort guard
-1. `bunkerPort` absent + no manual price → 400 bunker_port_required [COVERED by tce-missing-bunker-port]
-2. `bunkerPort` = '' → Zod rejects first (400 validation error)
-3. `bunkerPort` = 'sgsin' (lower) → 200, SGSIN price used [COVERED]
-4. `bunkerPort` = 'XXXXX' → 422 [COVERED]
-5. `bunkerPriceUsdPerMt: 0` (manual zero) → bypasses bunkerPort check, calculates with 0 bunker [NOT TESTED]
-6. `bunkerPriceUsdPerMt: -500` (negative) → bypasses check, calculates with -500 [NOT TESTED]
-7. `bunkerPriceUsdPerMt` present + bunkerPort absent → manual path, 200 [COVERED]
-
-### B — EconomicsTab state machine
-8. recommendation returns port → bunkerPort set → P&L fires with that port NOT 'SGSIN' [COVERED]
-9. recommendation returns fallback (port=null) → bunkerPort stays null → P&L gated [COVERED]
-10. route change (cargo changes while mounted, bunkerPortManual=false) → stale port from previous route
-    — **NOT COVERED** — potential regression where fallback doesn't reset bunkerPort to null
-11. user manually sets port BEFORE recommendation arrives → bunkerPortManual=true → recommendation doesn't override [NOT TESTED DIRECTLY]
-12. `voyageInputData.input` contains bunkerPort when ready=true → confirm it's non-null string [implicit in RTL test]
-
-### C — A1 freshness watchdog  
-13. Stale price → console.warn [COVERED]
-14. Fresh price → no warn [COVERED]
-15. Port with no price row → skipped (not stale-checked) — implicit in existing tests
-
-## Uncovered Attack Scenarios (to execute in Phase 3)
-- Attack 5: `bunkerPriceUsdPerMt: 0` — API behaviour
-- Attack 6: `bunkerPriceUsdPerMt: -500` — API behaviour (negative price)
-- Attack 10: component re-render with new cargo after fallback — bunkerPort not reset
-- Attack 11: manual port selection prevents recommendation override
-
-## Attack 10 Analysis: bunkerPort NOT reset on fallback (post-first-render)
-
-When the component is mounted with one route (→ recommendation sets 'GIGIB'),
-then cargo changes to a route with no on-route hub (recommendation returns fallback),
-the `bunkerPort` state stays 'GIGIB' (not reset to null).
-
-This means: P&L fires with GIGIB bunker price even for a route where GIGIB is wrong.
-
-**Severity:** MEDIUM (only affects multi-cargo UX flows where component stays mounted)
-
-**In practice:** EconomicsTab is likely unmounted/remounted per match-route change
-(Next.js page navigation). BUT if the component is kept mounted across cargo changes
-(e.g. in a carousel or comparison view), this bug manifests.
-
-**Is it introduced by this PR?** PARTIALLY:
-- Pre-PR: SGSIN was always the default; on fallback, SGSIN stayed → wrong for Med routes
-- Post-PR: Previous recommendation port persists on fallback → also wrong but in a different direction
-- The "null → loading" state eliminates the wrong-SGSIN case for first render (IMPROVEMENT)
-- But the "stale non-null port on fallback" is a new edge case that didn't apply before
-
-**Verdict contribution:** APPROVE-WITH-FOLLOWUPS (not BLOCK — first-render case fixed, 
-multi-cargo stale port is edge case only reproducible in stateful navigation)
+## Attack Plan (executed)
+1. Code review of diffs in #877 + #878 ✓
+2. Regression test suite 140/140 ✓
+3. Browser E2E: /matches list + 10 match detail pages + passport tabs ✓
+4. API-level: /api/matches for fit%/TCE distribution check ✓

--- a/.test-review/discovery.md
+++ b/.test-review/discovery.md
@@ -1,30 +1,31 @@
-# Discovery — fix-econ-a-bunker (PR #822)
+# Phase 1 — Discovery (2026-06-09, Round 2)
 
-## Commits
-- ec9dcf12 fix(economics): remove SGSIN default — gate P&L on bunker-rec response (#820)
-- 8dbd3973 docs(plan): econ-cluster fix plan (plan doc only)
+## Context
+Round 2 cold QA. Round 1 (2026-06-08) found M1/M2/L1 as MEDIUM/LOW gate-relevant issues and H1 as PRE-EXISTING HIGH.
+PRs merged after Round 1:
+- #877: fix(waterfall): M1 duration float→1dp, M2 TCE-basis reconcile, L1 negative-zero guard
+- #878: fix(fit): recompute economics component from live TCE after computeStoredMatchEconomics (H1)
 
-## Changed Source Files (3)
-1. `app/api/voyage/bunker-recommendation/route.ts` — A1: freshness watchdog (log-only)
-2. `app/api/voyage/tce/route.ts` — A2.2: 400 on missing bunkerPort (removes SGSIN ?? default)
-3. `components/match/EconomicsTab.tsx` — A2.1: useState null + gate voyageInputData on bunkerPort != null
+## Commits in scope (main as of 2026-06-09 tip = 24fb6917)
+- 24fb6917 fix(fit): recompute economics component from live TCE after computeStoredMatchEconomics (H1) (#878)
+- 967ad0a1 fix(waterfall): M1 duration float→1dp, M2 TCE-basis reconcile, L1 negative-zero guard (#877)
+- e2cacec8 feat(w6a): surface economics provenance — DA confidence badge, Baltic-TC staleness, canal tag rename, war-risk rate date (I7/I12) (#876)
+- c17b7af9 feat(w6b): surface CII llm-fallback disclosure, PSC/charterers demo banners (#875)
+- b548d034 feat(counts): canonical match-count + ROI window + effectiveScore shared util (W8, closes I10, I11) (#873)
 
-## Key Behavior Changes
-- `tce/route.ts`: `(data.bunkerPort ?? 'SGSIN').toUpperCase()` → explicit 400 when bunkerPort absent
-- `EconomicsTab`: initial bunkerPort=null; P&L call gated; port set from recommendation response
-- `bunker-recommendation`: stale price warning (read-only, log-only)
+## Files changed by #877 + #878 (primary targets)
+- components/economics/CalculationWaterfall.tsx (M1/M2/L1)
+- lib/matching/persist-session-matches.ts (H1: recompute after computeStoredMatchEconomics)
+- __tests__/economics/persist-session-matches-fit-recompute.test.ts (H1 regression test)
+- components/economics/CalculationWaterfall.test.tsx (M1/M2/L1 regression tests)
 
-## New Tests Added
-- `bunker-freshness-watchdog.test.ts` — A1 stale/fresh price logging (PI2 route handler)
-- `tce-missing-bunker-port.test.ts` — A2.2 400/200/422 value shapes
-- `EconomicsTab-bunker-null.test.tsx` — A2.1 RTL: GIGIB not SGSIN, fallback gates P&L
+## UI files changed (latest waves) → Browser E2E Gate ACTIVE
+- components/economics/CalculationWaterfall.tsx
+- lib/matching/persist-session-matches.ts (affects Passport tab TCE display)
 
-## Modified Tests (setup, not assertions)
-- `EconomicsTab-pnl.test.tsx` — added bunker-recommendation mock to setupFetch
-- `EconomicsTab-cons-clamp.test.tsx` — changed fallback mock → valid port mock
-- `tce-auto-bunker.test.ts` — 1 assertion change: SGSIN default test → 400 required
-
-## What Existing Tests Cover
-- Basin filter, eff-split, candidates, consumption/DWT clamp, reco adversarial
-- TCE backward-compat, EUA auto-derive, ETS auto-derive
-- EconomicsTab: bunker-hint, bunker-route-aware, EUA, war-risk, compare-inputs, P&L
+## Verification targets
+1. H1: Passport tab economics $ == live TCE displayed on match card; fit% not inflated for below-breakeven
+2. M1: CalculationWaterfall duration_days shown as "X.X дней" (1dp), not raw float
+3. M2: war-risk line in waterfall reconciles: total_tce = base_tce - war_risk/days
+4. L1: No "$-0" anywhere in economics display
+5. Fresh sweep: /matches list, cards, filter, /match/[id] tabs, dashboard counts, vetting badges

--- a/.test-review/findings.md
+++ b/.test-review/findings.md
@@ -1,36 +1,51 @@
-# test-skill Findings — claude/tce-list-detail-unify (#819)
+# test-skill findings — 2026-06-09 (Round 2)
 
-## HIGH findings (gate-relevant)
+## Round 1 Followups — Verified Fixed
 
-### BUG-1: bunkerPriceUsdPerMt=0 always sent when user has no manual price
+### ✓ FIXED: H1 — fit_breakdown economics component now uses live TCE
+- PR #878: patchEconomicsComponent() replaces only economics component with scoreEconomics(liveTce, dwt)
+- Browser: Passport TCE = Header TCE (delta=0 on tested matches: $2,230, $27,152)
+- Economics penalty working: avg fit% neg-TCE (60%) < avg fit% pos-TCE (70%)
+- Regression: 140/140 tests pass
 
-**Severity:** HIGH — introduced by this PR (Task 5)
-**File:** `components/match/EconomicsTab.tsx`
-**Root cause:** `buildCanonicalTceInputs` always gets `bunkerPriceUsdPerMt: 0` when user hasn't entered a price. The VoyageInput result always has `bunkerPriceUsdPerMt: 0`. The POST body includes `"bunkerPriceUsdPerMt": 0`. API: `typeof 0 === 'number'` → TRUE → uses $0 as manual bunker price → bunker cost = $0 → inflated TCE.
+### ✓ FIXED: M1 — CalculationWaterfall duration shown 1dp
+- PR #877: `duration_days.toFixed(1)` in duration-days row and bunker-caption
+- Browser (match/54117): "÷ Длина рейса **7.2 дней**", bunker caption "· **7.2 дн** ·" — no raw float
+- Regression: 140/140 tests pass
 
-**Test:** `__tests__/regression/economics-tab-bunker-price-zero.test.tsx` — FAILS (bunkerPriceUsdPerMt is 0 in body)
+### ✓ FIXED: M2 — waterfall war-risk math reconciliation
+- PR #877: "Чистыми для TCE" addback row renders when war_risk_usd > 0
+- Code fix correct: `{war_risk_usd > 0 && (<div data-testid="tce-basis-addback">...)}`
+- Browser unverifiable: no HRA routes with war_risk>0 in demo seed (all 73 matches have war_risk_usd=0)
+- Regression: 140/140 tests pass
 
-**Fix:** Override `bunkerPriceUsdPerMt` in the spread after buildCanonicalTceInputs:
-```typescript
-...(bunkerPriceUsdPerMt !== '' ? { bunkerPriceUsdPerMt: Number(bunkerPriceUsdPerMt) } : {}),
-```
-(restore old conditional spread for this specific field)
+### ✓ FIXED: L1 — no $-0 in CalculationWaterfall
+- PR #877: `fmtUsd` guards `n === 0 → '$0'`
+- Browser: strict $-0 absent on all tested pages (matches list + 4 match detail pages)
+- Regression: 140/140 tests pass
 
----
+## Findings (gate-relevant, introduced by recent changes)
+**NONE**
 
-## MEDIUM findings (informational)
+## Fresh Sweep — No New Issues
+- /matches list: 73 matches, body 6418 chars, 0 console errors, 0 hydration errors
+- Fit% values: [86, 82, 82, 81, 80, 80, 79, 76] — reasonable spread for top matches
+- Vetting badges: PSC=35 HTML refs, charterer=110 (demo banners) — present
+- Dashboard (/dashboard): functional, body 1395 chars
+- Match detail (/match/[id]): Economics + Passport tabs functional
+- Deployed version: confirmed `sentry-release=24fb6917` (correct)
 
-### BUG-2: compareInputs.cargo.freightRateUsdPerMt=0 when no rate available
-**Severity:** MEDIUM — UX regression. Old: `?? 28`, New: `?? 0`. Route comparison modal shows all-loss with $0 freight revenue when no rate available. Fix: gate compareInputs.ready on freightRateUsdPerMt > 0.
+## Pre-existing Issues (informational, do not affect gate)
+### B18e (pre-existing): fmtTce sign format
+- File: app/matches/MatchesClient.tsx:80-83
+- `fmtTce(-800)` → `$-0.8k` (should be `-$0.8k`); small negatives: `$-0.0k`
+- Last modified: commit b548d034 (PR #873, 2026-06-07), NOT introduced by #877/#878
+- Documented in BUGFIX-HANDOFF-2026-06-05.md as B18e
+- Gate impact: none (pre-existing, not a regression)
 
----
+## Browser E2E Gate
+PASS — 0 console errors, 0 hydration errors
+All pages functional. Screenshots: /tmp/pw-final-matches.png, /tmp/pw-wf-54117.png, /tmp/pw-pp-54117.png, /tmp/pw-neg-tce-passport.png
 
-## Pre-existing Issues (not introduced by this PR)
-None.
-
-## Coverage Summary
-- buildCanonicalTceInputs adversarial: 10 tests PASS
-- distanceFactor 0.7→1.0: existing tests cover
-- session-buckets B(c): dead-code traced, no regression
-- regenerate-matches INSERT: column count verified (25 cols, 25 values)
-- EconomicsTab bunker price: BUG-1 HIGH FAIL
+## Verdict
+APPROVE

--- a/.test-review/verdict.md
+++ b/.test-review/verdict.md
@@ -1,34 +1,18 @@
-# test-skill Verdict — claude/tce-list-detail-unify (#819)
+# Verdict: APPROVE
 
-**Verdict: APPROVE**
+## Round 2 — 2026-06-09
 
-## What was tested
+## Gate-relevant findings: 0
+## Pre-existing (informational): 1 (B18e fmtTce sign format, not new)
+## No BLOCK-level issues
 
-- buildCanonicalTceInputs: 10 adversarial tests (negative/NaN/zero inputs) → all PASS
-- distanceFactor 0.7→1.0: honesty positive verified for 44101/44100-class
-- computeEstimatedTce delegation parity: PASS
-- session-buckets B(c) removal: dead-code confirmed (m.economics never set for bucket rows)
-- regenerate-matches INSERT column count: 25 cols = 25 values ✓
-- EconomicsTab bunker price: BUG-1 found and FIXED
-- compareInputs freight rate: BUG-2 found and FIXED
+All Round 1 followups resolved:
+- H1 (fit_breakdown live TCE): FIXED — patchEconomicsComponent() wired; browser confirmed Passport TCE = Header TCE
+- M1 (waterfall duration raw float): FIXED — 7.2 дней shown correctly
+- M2 (war-risk addback row): FIXED by code + regression tests; browser N/A (no HRA in demo seed)
+- L1 (fmtUsd $-0): FIXED — no strict $-0 on any page
 
-## Bugs found and fixed in this session
+Fresh sweep: clean. 73 matches functional. Dashboard functional. 0 console errors. 0 hydration errors.
 
-### BUG-1 (HIGH → FIXED):
-`bunkerPriceUsdPerMt: 0` was always sent to /api/voyage/tce when user had no manual
-price. API treated `typeof 0 === 'number'` as manual price → bunker cost $0 → inflated TCE.
-Fix: explicit field spread only when user-entered; absent field → API auto-resolves from DB.
-Test: `__tests__/regression/economics-tab-bunker-price-zero.test.tsx` → now PASS.
-
-### BUG-2 (MEDIUM → FIXED):
-compareInputs `?? 0` fallback allowed modal to open with $0 freight revenue → shows
-all-loss voyage. Fix: gated compareInputs.ready on `freightRateForCompare > 0`.
-PI3: 1 existing test expectation updated (was asserting old ?? 28 behavior).
-
-## Final test runs
-
-- 88 suites, 917 tests → 917 PASS, 0 FAIL (after fixes)
-- TypeCheck: clean
-
-## Pre-existing Issues
-None.
+Regression suite: 140/140 pass (H1+M1+M2+L1 specific tests).
+Deployed version: 24fb6917 (confirmed via Sentry release header).

--- a/docs/superpowers/plans/2026-06-10-null-dwt-baltic.md
+++ b/docs/superpowers/plans/2026-06-10-null-dwt-baltic.md
@@ -1,0 +1,176 @@
+# null/unparseable DWT → Handysize Baltic-class bias — Fix Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:test-driven-development (Tier S). Steps use checkbox (`- [ ]`) syntax. **RED test first.** PI3: do NOT rewrite existing test expectations to fit the impl.
+
+**Goal:** When a vessel's `dwtSummer` is missing/unparseable, stop the stored-match economics path from silently treating the vessel as Handysize (`dwt = 0` → `balticIndexCodeForDwt(0) = 'BHSI_TC'`). That false class anchor pollutes `tce_usd_per_day` and `freight_rate_usd_per_mt` for vessels that may be Supramax/Panamax, with a misleadingly market-precise `freight_rate_source='baltic'`.
+
+---
+
+## ⚠️ Root-cause correction (read before implementing)
+
+The dispatch hypothesis named `persist-session-matches.ts:67` → `patchEconomicsComponent` (line 90) → `balticIndexCodeForDwt(0)=Handysize` as the bias locus. **Tracing shows that path is already safe** and the real bias lives elsewhere. The plan is written against the _actual_ root cause.
+
+### Consumer trace of `dwtSummer ?? 0`
+
+`grep -rn 'dwtSummer' lib/ app/ | grep '?? 0'` → five sites. Classified:
+
+| Site                                       | What `dwt=0` feeds                                                                                                 | Biased?                                                                                                                                                                            |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `persist-session-matches.ts:67`            | `patchEconomicsComponent(bd, tce, 0)` → `scoreEconomics(tce, 0)` → `economicsNorm`                                 | **No** — `economicsNorm` returns neutral `0.5` when `!(dwt>0)` (fit-breakdown.ts:457); `scoreEconomics` rationale = "Vessel DWT not stated — neutral" (line 477). Fit% is correct. |
+| `compute-matches.ts:82`                    | same `patchEconomicsComponent` pattern + `vessel_dwt` column (`\|\| null`)                                         | **No** — same neutral path.                                                                                                                                                        |
+| `stored-match-economics.ts:101` (`ecoDwt`) | **`getBalticDayRate(db, ecoDwt)` (line 120)** + `resolveFreightRate` + `sumMatchPortDaUsd` + `buildMatchEconomics` | **YES** — this is the bias. See below.                                                                                                                                             |
+| `session-buckets.ts:43`                    | a parallel (4th) write path **not** routed through `computeStoredMatchEconomics`; does not call `getBalticDayRate` | No Baltic bias (out of scope — see Out-of-scope).                                                                                                                                  |
+| `pair-analyzer.ts:827` (`floorDwt`)        | floor-vessel comparison only                                                                                       | Not this bug.                                                                                                                                                                      |
+
+### The double path, resolved
+
+Both `persist-session-matches.ts` and `compute-matches.ts` compute their own `vesselDwt` (for the _fit_ component, which is neutral-safe) **and** separately call `computeStoredMatchEconomics({ cargo, vessel, db })`, which **re-derives `ecoDwt` itself** from `vessel.dwtSummer` (stored-match-economics.ts:101). So the TCE/freight numbers do **not** come from the caller's `vesselDwt` — they come from `ecoDwt`. The Baltic bias is therefore **centralized in one module**, fed by one independent parse.
+
+### Why only one call site
+
+`grep -rn 'getBalticDayRate' lib/ app/` → exactly **one** production caller: `stored-match-economics.ts:120`. (The pair-analyzer copy referenced in the 2026-06-07 port-DA plan was consolidated into this module — see its header comment "all three write-paths route through it".) **One line carries the bias.**
+
+### Exact harm
+
+`stored-match-economics.ts:120`:
+
+```ts
+balticDayRate: db ? getBalticDayRate(db, ecoDwt) : null,
+```
+
+With `ecoDwt = 0`: `getBalticDayRate(db, 0)` → `balticIndexCodeForDwt(0) = 'BHSI_TC'` (Handysize, since `0 < 45000`) → returns a **positive** Handysize day-rate. In `resolveFreightRate` (freight-resolver.ts:71-88) tier-2 fires (Baltic, `confidence 0.5`) and **wins over** tier-3 estimate (`confidence 0.3`). Result: a vessel of unknown class gets a freight `$/mt` derived from a _Handysize_ market day-rate spread across a possibly-Panamax cargo tonnage → biased `tce_usd_per_day`, and `freight_rate_source='baltic'` advertises false market precision.
+
+**Precision note for QA:** the bias surfaces in `tce_usd_per_day`, `freight_rate_usd_per_mt`, `freight_rate_source`. It does **not** move fit% — the economics fit component is already neutral when DWT is unknown. The dispatch framing ("economics-fit scored against Handysize") is the part to correct; the value harm is in displayed/ranked TCE & freight.
+
+### Already-safe siblings (no change needed)
+
+- `economicsNorm` / `scoreEconomics`: neutral on `dwt<=0`. ✓
+- `buildMatchEconomics` canal quotes: already guarded `input.vesselDwt > 0` (tce-calculator.ts:298,302,308,311) — skip canal cost when class unknown rather than fake it. ✓
+- tier-3 `estimateFreightRate`: `dwtFactor(0) = 1.0` (tce-calculator.ts:77) — class-neutral, not Handysize-biased. ✓
+
+---
+
+## Why this approach (design decision)
+
+**Chosen semantic: skip-Baltic-bench — gate the tier-2 Baltic lookup on a known positive DWT.** When DWT is unknown, do not consult the per-class Baltic day-rate at all; fall through to the class-neutral tier-3 estimate (`dwtFactor(0)=1.0`, `confidence 0.3`).
+
+```ts
+balticDayRate: db && ecoDwt > 0 ? getBalticDayRate(db, ecoDwt) : null,
+```
+
+**Why this over the alternatives:**
+
+1. **vs. null-propagate-everything** (make `EconomicsResult` null / blank TCE when DWT unknown): rejected. It would erase `tce_usd_per_day` for _every_ unknown-DWT match (worse demo UX, lots of "—"), and regress the documented class-aware consumption fallback (`resolveConsMtPerDay`, fed by `parseConsumption(...,0)`) which legitimately runs with `dwt=0`. Over-correction far beyond the bias.
+2. **vs. "default unknown DWT to a median class"** (e.g. Supramax): rejected — inventing a class is the same category of error as Handysize, just centred differently. Honest degradation (skip the market tier, drop to estimate, lower confidence) beats a fabricated anchor.
+3. **Minimal blast radius:** one line, one module, one call site. tier-3 estimate is already the documented always-present floor; `confidence` correctly drops `0.5 → 0.3`, signalling "class unknown". scoreEconomics / canal / DA already self-guard on `dwt>0`, so no coordinated multi-file change.
+4. **Consistency:** matches the existing convention in the same call chain (canal quotes already skip when `vesselDwt <= 0`). We extend the same "don't price class-dependent terms when class is unknown" rule to the Baltic freight tier.
+
+**Leave `ecoDwt = 0` as-is for the other consumers in the function** (`resolveFreightRate.vesselDwt`, `sumMatchPortDaUsd`, `buildMatchEconomics.vesselDwt`): they already degrade correctly on `0` (`dwtFactor(0)=1.0`, canal guards, DA tier fallback). Only the Baltic call is anchored to a wrong _class_; only it needs the gate. Optionally extract `const dwtKnown = ecoDwt > 0;` for readability — but do **not** broaden the change.
+
+---
+
+## Tech Stack
+
+TypeScript, better-sqlite3, Jest (`--maxWorkers=1 --forceExit --no-coverage`). Behavioral test calls `computeStoredMatchEconomics(...)` against an in-memory seeded `baltic_indices` table — not a string-match (PI2).
+
+---
+
+## File Structure
+
+- **Modify** `lib/matching/stored-match-economics.ts` — line 120: gate `getBalticDayRate` on `ecoDwt > 0`. (~1 line; optional `dwtKnown` local.)
+- **Create** `lib/matching/__tests__/stored-match-economics-null-dwt.test.ts` — behavioral RED test: unparseable/NULL `dwtSummer` + seeded `baltic_indices` + Panamax-sized cargo → assert tier-2 is **skipped** (`freight_rate_source !== 'baltic'`), and a parsable Panamax DWT control **still** resolves Baltic. (Reuse the in-memory DB seeding pattern from `__tests__/lib/matching/persist-session-matches-canonical-tce.test.ts` and `__tests__/lib/market/baltic-freight.test.ts`.)
+
+No production behavior file other than the one module. No new exports, no env vars, no routes — **no pre-removal grep needed** (nothing removed).
+
+---
+
+## Task 1: RED test — unknown DWT must not anchor to Handysize Baltic
+
+**Files:**
+
+- Create: `lib/matching/__tests__/stored-match-economics-null-dwt.test.ts`
+
+- [ ] **Step 1: Write the failing test (RED).** Seed an in-memory DB with a `baltic_indices` row for `BHSI_TC` (positive day-rate) so tier-2 _would_ fire. Build a `ParsedVessel` whose `dwtSummer` is unparseable (e.g. confidence-field value `'TBN'` / `null`) and a `ParsedCargo` with resolvable load/discharge ports (so distance > 0) and a Panamax-scale `quantityMt` (~65,000). Call `computeStoredMatchEconomics({ cargo, vessel, db })`.
+
+```ts
+// Behavioral assertion — exercises the real resolver, not a string match.
+const res = computeStoredMatchEconomics({
+  cargo: vesselUnknownDwtCargo,
+  vessel: vesselUnknownDwt,
+  db,
+});
+expect(res.freight_rate_source).not.toBe("baltic"); // tier-2 skipped when class unknown
+expect(res.freight_rate_source).toBe("estimated"); // falls through to tier-3 floor
+expect(res.tce_usd_per_day).not.toBeNull(); // still produces a number (not blanked)
+```
+
+- [ ] **Step 2: Control test (guards over-correction).** Same fixtures but `dwtSummer` parses to a real Panamax (e.g. `82000`). With a seeded `BPI_TC`/`BSI_TC` row, assert tier-2 **still** resolves: `expect(res.freight_rate_source).toBe('baltic')`. This proves the gate only affects the unknown-DWT case, not the happy path.
+
+- [ ] **Step 3: Run RED.** `npx jest --findRelatedTests lib/matching/__tests__/stored-match-economics-null-dwt.test.ts --maxWorkers=1 --no-coverage` → Step-1 assertion **fails** today (current `freight_rate_source==='baltic'`), Step-2 passes. Confirm the failure reason is the Handysize anchor, not a fixture bug.
+
+## Task 2: GREEN — gate the Baltic lookup
+
+**Files:**
+
+- Modify: `lib/matching/stored-match-economics.ts` (line 120)
+
+- [ ] **Step 1:** Change
+
+  ```ts
+  balticDayRate: db ? getBalticDayRate(db, ecoDwt) : null,
+  ```
+
+  to
+
+  ```ts
+  balticDayRate: db && ecoDwt > 0 ? getBalticDayRate(db, ecoDwt) : null,
+  ```
+
+  (Optionally add `const dwtKnown = ecoDwt > 0;` near line 101 and use it, plus a one-line comment: "Unknown DWT → skip per-class Baltic tier; tier-3 estimate is class-neutral floor (#null-dwt-baltic).")
+
+- [ ] **Step 2: Run GREEN.** Same `--findRelatedTests` command → both tests pass.
+
+- [ ] **Step 3: Regression sweep.** Run the existing economics suites that exercise this module:
+      `npx jest --findRelatedTests lib/matching/stored-match-economics.ts --maxWorkers=1 --no-coverage`
+      plus `__tests__/economics/list-detail-tce-parity.test.ts` and `__tests__/lib/matching/persist-session-matches-canonical-tce.test.ts`. **PI3:** if any existing expectation changes, STOP — the gate must not move TCE for matches whose DWT is known/positive (the only legitimate change is unknown-DWT matches flipping `baltic → estimated`).
+
+---
+
+## VALUE_CHECK oracle (orchestrator runs the prod SELECT — NOT the implementer)
+
+**Scale estimate — how many prod matches carry the bias.** `vessel_dwt` is persisted as `vesselDwt || null`, so `NULL` ≈ unparseable/absent DWT. The biased population = NULL-DWT matches that nonetheless got a Baltic-anchored freight:
+
+```sql
+-- Run against the prod matches DB (orchestrator).
+SELECT
+  COUNT(*)                                                          AS null_dwt_matches,
+  SUM(CASE WHEN freight_rate_source = 'baltic' THEN 1 ELSE 0 END)   AS baltic_anchored_null_dwt,
+  SUM(CASE WHEN tce_usd_per_day IS NOT NULL THEN 1 ELSE 0 END)      AS with_tce
+FROM matches
+WHERE vessel_dwt IS NULL;
+```
+
+`baltic_anchored_null_dwt` is the count of matches whose `tce_usd_per_day` / `freight_rate_usd_per_mt` change after this fix (flip to `estimated`). If `0`, the bias is latent (no prod impact yet); if `> 0`, that is the exact remediation count.
+
+**Before/after oracle for one match.** Pick one row from `baltic_anchored_null_dwt` (`SELECT id, vessel_name, freight_rate_usd_per_mt, tce_usd_per_day, fit_percent FROM matches WHERE vessel_dwt IS NULL AND freight_rate_source='baltic' LIMIT 1;`). Re-run its session regen on the fix branch and compare:
+
+- `freight_rate_source`: `baltic → estimated` (expected).
+- `freight_rate_usd_per_mt`, `tce_usd_per_day`: change (expected — Handysize anchor removed).
+- `fit_percent`: **unchanged** (economics component is neutral on unknown DWT — confirms the fix is scoped to TCE/freight, not fit).
+
+If `fit_percent` moves, the root-cause analysis is wrong — STOP and re-investigate.
+
+---
+
+## Cold test-skill before merge
+
+Run `/test-skill` (cold adversarial QA, zero context) on the branch. Diff includes a freight/TCE resolver branch → in-scope per its triggers (resolvers, economics). Expected severity: LOW (single guarded conditional). Emit verdict marker; `BLOCK → FAIL`, `APPROVE → PASS`.
+
+---
+
+## Out of scope
+
+1. **`session-buckets.ts:43`** — a 4th write path not routed through `computeStoredMatchEconomics`; it does not call `getBalticDayRate`, so no Baltic bias. Consolidating it onto the shared helper is a separate consistency task.
+2. **`pair-analyzer.ts:827` `floorDwt`** — floor-vessel comparison, unrelated to freight benchmarking.
+3. **Blanking TCE / null-propagation through `buildMatchEconomics`** — explicitly rejected above; do not implement here.
+4. **Improving DWT parsing** (so fewer vessels are unknown in the first place) — upstream parser concern, separate task.


### PR DESCRIPTION
## Plan-only PR (no code changed, do not merge to ship — this is the fix plan)

Plan for the **null-dwt-baltic** bug. `docs/superpowers/plans/2026-06-10-null-dwt-baltic.md`.

### Root-cause correction
Dispatch hypothesis named `persist-session-matches.ts:67 → patchEconomicsComponent → balticIndexCodeForDwt(0)=Handysize`. Tracing shows **that path is neutral-safe** — `economicsNorm` returns `0.5` when `dwt<=0`, so fit% is correct.

**Actual bias:** `stored-match-economics.ts:120`
```ts
balticDayRate: db ? getBalticDayRate(db, ecoDwt) : null,
```
`ecoDwt = cfValue(vessel.dwtSummer) ?? 0` (line 101). With `ecoDwt=0`, `getBalticDayRate(db, 0)` → `balticIndexCodeForDwt(0)='BHSI_TC'` (Handysize) → tier-2 Baltic freight (conf 0.5) **wins over** tier-3 estimate (conf 0.3) → `tce_usd_per_day` / `freight_rate_usd_per_mt` of an unknown-class vessel anchored to a Handysize day-rate, with false-precision `freight_rate_source='baltic'`.

### Double path confirmed
Callers compute their own `vesselDwt` (fit component, neutral-safe) **and** call `computeStoredMatchEconomics`, which re-derives `ecoDwt` itself. Bias is **centralized in one module**, **one** production `getBalticDayRate` call site.

### Precision
Bias surfaces in **TCE / freight rate / source**, NOT in **fit%** (already neutral). VALUE_CHECK asserts fit% is unchanged before/after.

### Chosen fix (plan)
**skip-Baltic-bench** — `balticDayRate: db && ecoDwt > 0 ? getBalticDayRate(db, ecoDwt) : null;`. Unknown DWT → skip per-class Baltic tier → class-neutral tier-3 floor (`dwtFactor(0)=1.0`). One line. Rejected null-propagate (blanks all unknown-DWT TCE) and median-class-default (invents a class).

### Plan contents
- Full consumer trace of all 5 `dwtSummer ?? 0` sites (4 already safe, 1 biased)
- TDD steps: RED test (unknown DWT must not anchor Baltic) + control (known Panamax still resolves Baltic)
- Prod-scale SELECT (orchestrator runs, not implementer)
- VALUE_CHECK before/after oracle + cold test-skill gate
- Out-of-scope list

🤖 Generated with [Claude Code](https://claude.com/claude-code)