### PR TITLE
fix(fb-I): cranes scoring considers discharge port + named port in rationale (#918 Task I)

### DIFF
--- a/lib/matching/reason-enricher.ts
+++ b/lib/matching/reason-enricher.ts
@@ -26,6 +26,7 @@ const ENRICHMENT_RULES: Array<{
     enrich: (ctx) => {
       if (ctx.craneCapacity) return `Vessel geared (${ctx.craneCapacity})`;
       if (ctx.vesselDwt) return `Vessel geared on ${formatNumber(ctx.vesselDwt)} DWT carrier`;
+      // TODO(I-MIN follow-up): gearless+discharge-crane enrichment needs ctx.dischargeHasCranes
       return null;
     },
   },

--- a/lib/sailing/__tests__/score-cranes-discharge.test.ts
+++ b/lib/sailing/__tests__/score-cranes-discharge.test.ts
@@ -1,0 +1,32 @@
+import { scoreCranes } from '@/lib/sailing/fit-breakdown';
+
+// Port data from data/ports/port-master.json:
+//   Constanta (RO) → hasShoreCranes: true
+//   Karasu (TR)    → hasShoreCranes: true
+//   Skikda (DZ)    → hasShoreCranes: false
+//   Felixstowe (GB)→ hasShoreCranes: false
+
+describe('scoreCranes — discharge port participates', () => {
+  it('geared vessel ignores both ports → full points', () => {
+    const c = scoreCranes(true, 'Constanta', 'Novorossiysk');
+    expect(c.score).toBe(6);
+  });
+
+  it('gearless, cranes only at discharge → 85% and rationale names discharge port', () => {
+    // load: Skikda (no cranes), discharge: Constanta (has cranes)
+    const c = scoreCranes(false, 'Skikda', 'Constanta');
+    expect(Math.round((c.score / c.weight) * 100)).toBe(85);
+    expect(c.rationale.toLowerCase()).toContain('discharge');
+    expect(c.rationale).toContain('Constanta');
+  });
+
+  it('gearless, neither port has cranes → 0', () => {
+    const c = scoreCranes(false, 'Skikda', 'Felixstowe');
+    expect(c.score).toBe(0);
+  });
+
+  it('gearless, both unknown → conservative 55%', () => {
+    const c = scoreCranes(false, null, null);
+    expect(Math.round((c.score / c.weight) * 100)).toBe(55);
+  });
+});

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -334,24 +334,33 @@ export function scoreCargoTypeQuality(
   };
 }
 
-/** Cranes — geared vessel is always 100%; gearless depends on port crane availability. */
+/** Cranes — geared vessel is always 100%; gearless depends on shore cranes at
+ *  EITHER cargo-handling end (load and/or discharge). Names which end has them. */
 export function scoreCranes(
   geared: boolean | null | undefined,
   loadPort: string | null,
+  dischargePort: string | null,
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.cranes;
   if (geared === true) {
     return { factor: 'cranes', label: 'Cranes', weight: w, score: w, rationale: 'Ship is geared — no dependence on shore cranes.' };
   }
   if (geared === false) {
-    const portCranes = portHasShoreCranes(loadPort);
-    if (portCranes === true) {
-      return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.85 * 10) / 10, rationale: 'Ship is gearless, but the port has shore cranes — workable.' };
+    const loadCranes = portHasShoreCranes(loadPort);
+    const dischCranes = portHasShoreCranes(dischargePort);
+    const loadName = loadPort ?? 'load port';
+    const dischName = dischargePort ?? 'discharge port';
+    if (loadCranes === false && dischCranes === false) {
+      return { factor: 'cranes', label: 'Cranes', weight: w, score: 0, rationale: 'Ship is gearless and neither load nor discharge port has cranes — not workable.' };
     }
-    if (portCranes === false) {
-      return { factor: 'cranes', label: 'Cranes', weight: w, score: 0, rationale: 'Ship is gearless and the port has no cranes — not workable.' };
+    if (loadCranes === true || dischCranes === true) {
+      let where: string;
+      if (loadCranes === true && dischCranes === true) where = `both ports (${loadName} and ${dischName}) have shore cranes`;
+      else if (dischCranes === true) where = `discharge port (${dischName}) has shore cranes`;
+      else where = `load port (${loadName}) has shore cranes`;
+      return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.85 * 10) / 10, rationale: `Ship is gearless, but ${where} — workable.` };
     }
-    return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.55 * 10) / 10, rationale: 'Ship is gearless; port crane availability not yet confirmed.' };
+    return { factor: 'cranes', label: 'Cranes', weight: w, score: Math.round(w * 0.55 * 10) / 10, rationale: 'Ship is gearless; crane availability at load/discharge not yet confirmed.' };
   }
   return unknown('cranes', 'Cranes', 'Vessel gear status not stated, scored conservatively.');
 }
@@ -571,7 +580,7 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
     scoreBallast(readiness?.distanceNm ?? null, dwt),
     scoreClassFit(cargoWtNominal, dwt, partCargo),
     scoreCargoTypeQuality(cargo.cargoType, vessel.vesselType, vessel.lastCargoes),
-    scoreCranes(vessel.geared, cfValue(cargo.originPort)),
+    scoreCranes(vessel.geared, cfValue(cargo.originPort), cfValue(cargo.destinationPort)),
     scoreVolume(cargoWtNominal, desc, vessel.grainCapacity, cargo.stowageFactor),
     scoreDraft(hardFilters),
     scoreVetting(vessel, refYear, detentionCount),


### PR DESCRIPTION
## Summary

- `scoreCranes` now checks shore cranes at **both** load and discharge ports (was load-only)
- Gearless vessel with cranes only at discharge now scores 85% instead of 0%
- Rationale names which port(s) carry the cranes
- Call site updated: `cfValue(cargo.destinationPort)` passed as 3rd arg

## Scoring logic

| Vessel | Load cranes | Discharge cranes | Score |
|--------|-------------|-----------------|-------|
| geared | any | any | 100% |
| gearless | ✓ | ✓ | 85% — "both ports (X and Y) have shore cranes" |
| gearless | ✓ | ✗ | 85% — "load port (X) has shore cranes" |
| gearless | ✗ | ✓ | 85% — "discharge port (Y) has shore cranes" (partner case) |
| gearless | ✗ | ✗ | 0% — not workable |
| gearless | null | null | 55% — conservative |

## Follow-up (not in this PR)

`reason-enricher.ts` gearless+discharge-crane enrichment branch needs `ctx.dischargeHasCranes` (not in `MatchContext`) — left as `TODO(I-MIN follow-up)` comment.

## Test plan

- [ ] 4 new behavioral tests in `lib/sailing/__tests__/score-cranes-discharge.test.ts` — all green
- [ ] 89 existing `fit-breakdown` tests unchanged (PI3)
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)