### PR TITLE
feat(fb-D): extract payout condition from cargo email + show in Emails tab (#918 Task D)

### DIFF
--- a/__tests__/parsing/parse-cargo-payout.test.ts
+++ b/__tests__/parsing/parse-cargo-payout.test.ts
@@ -1,0 +1,15 @@
+import { parseCargoAIResponse } from '@/lib/parsing/parse-cargo-ai';
+
+const make = (item: Record<string, unknown>) =>
+  parseCargoAIResponse(JSON.stringify({ items: [item] }), 'email-1');
+
+describe('parseCargoAIResponse — payout_condition → payoutCondition', () => {
+  it('maps payout_condition string', () => {
+    const [c] = make({ payout_condition: 'Payment 100% on completion of discharge, LC at sight' });
+    expect(c.payoutCondition).toBe('Payment 100% on completion of discharge, LC at sight');
+  });
+  it('defaults to null when absent', () => {
+    const [c] = make({});
+    expect(c.payoutCondition).toBeNull();
+  });
+});

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -296,7 +296,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   balticRateAsOf={balticRateAsOf}
                   cargoEmailBody={cargoEmail?.body ?? null}
                   vesselEmailBody={vesselEmail?.body ?? null}
-                  payoutCondition={null}
+                  payoutCondition={cargo?.payoutCondition ?? null}
                 />
 
                 {cargo && cargoEmail && (

--- a/lib/parsing/parse-cargo-ai.ts
+++ b/lib/parsing/parse-cargo-ai.ts
@@ -24,6 +24,7 @@ export interface RawCargoItem {
   discharge_rate?: string | null;
   commission_percent?: number | string | null;
   commission_terms?: string | null;
+  payout_condition?: string | null;
   freight_rate_usd?: number | null;
   special_requirements?: string | null;
   stowage_factor?: string | null;
@@ -130,6 +131,7 @@ export function parseCargoAIResponse(raw: string, emailId: string): ParsedCargo[
       dischargeRate: extractStr(item.discharge_rate),
       commissionPercent: extractNum(item.commission_percent),
       commissionTerms: extractStr(item.commission_terms),
+      payoutCondition: extractStr(item.payout_condition),
       freightRateUsd: extractNum(item.freight_rate_usd),
       specialRequirements: extractStr(item.special_requirements),
       stowageFactor: extractStr(item.stowage_factor),

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -511,6 +511,7 @@ Extract per inquiry item:
   ✓ commission_percent={value:4, confidence:"confirmed", source_text:"4 ttl"}, commission_terms="4% TTL; Gcn 3.75% TTL"
   "Gcn" preceding a commission may mean "General cargo" or reference the Gencon form — capture verbatim.
 - commission_terms: e.g. "TTL BENDS", "address commission", "ADDCOMPUS", "pus"
+- payout_condition: payment / payout terms stated in the email — e.g. "100% freight payable on completion of discharge", "freight payable within 3 banking days after completion", "LC at sight", "CAD (cash against documents)", "payment 95/5". Capture the verbatim condition as a plain STRING. Null if the email states no payment/payout condition. Do NOT infer — extract only when explicitly written.
 - freight_rate_usd: freight rate in USD per metric ton if EXPLICITLY stated in the email.
   RULES:
   - Extract ONLY when a specific dollar amount per MT/ton is written (e.g. "$18/MT", "USD 22 pmt", "18.50 usd/mt", "frt usd 20/mt").

--- a/lib/schemas/parse-cargo.ts
+++ b/lib/schemas/parse-cargo.ts
@@ -58,6 +58,7 @@ const cargoItemSchema = {
     discharge_terms: { type: Type.STRING, nullable: true },
     commission_percent: { type: Type.NUMBER, nullable: true },
     commission_terms: { type: Type.STRING, nullable: true },
+    payout_condition: { type: Type.STRING, nullable: true },
     freight_rate_usd: { type: Type.NUMBER, nullable: true },
     special_requirements: { type: Type.STRING, nullable: true },
     stowage_factor: { type: Type.STRING, nullable: true },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -225,6 +225,9 @@ export interface ParsedCargo {
   dischargeRate: string | null;
   commissionPercent: number | null;
   commissionTerms: string | null;
+  /** Payment / payout condition stated in the cargo email (e.g. "100% on
+   *  completion of discharge", "LC at sight"). Null when not mentioned. */
+  payoutCondition?: string | null;
   freightRateUsd?: number | null;
   specialRequirements: string | null;
   stowageFactor: string | null;


### PR DESCRIPTION
## Summary

- Adds nullable `payoutCondition?: string | null` to `ParsedCargo` (additive optional field — zero migration, zero existing test breakage)
- Extends `PARSE_CARGO_SCHEMA` with `payout_condition: { type: Type.STRING, nullable: true }` so Gemini structured-output includes the field (per `.claude/rules/ai-provider.md` invariant — responseSchema must carry new fields)
- Adds extraction instruction to `lib/prompts/parse-cargo.ts`: verbatim payout/payment condition or null when not mentioned
- Maps `payout_condition → payoutCondition` in `parseCargoAIResponse` via `extractStr` (null-safe)
- Wires `cargo?.payoutCondition ?? null` into `<MatchTabs>` in `app/match/[id]/page.tsx` (was hardcoded `null` from Task A); EmailsTab already renders the amber highlight block when non-null

**Depends on:** Task A (#923, already merged — EmailsTab exists with payoutCondition slot)

## Test plan

- [x] `npx jest parse-cargo-payout` → 2/2 pass (new mapping test: string extraction + null default)
- [x] `npx jest --findRelatedTests lib/parsing/parse-cargo-ai.ts lib/schemas/parse-cargo.ts` → 31 suites / 319 tests green
- [x] `npx tsc --noEmit` → clean (0 errors; field is optional so existing fixtures unaffected)
- [ ] Manual verify: open any match page → Emails tab → cargo email with payment condition → amber "Payout condition" block appears below cargo email section

Closes #918 Task D

🤖 Generated with [Claude Code](https://claude.com/claude-code)