### PR TITLE
feat(quote-10b): match-aware justified indicative rate (#914 stage 10b)

### DIFF
--- a/__tests__/match-worksheet-migration.test.ts
+++ b/__tests__/match-worksheet-migration.test.ts
@@ -39,9 +39,9 @@ describe('migration 045 — worksheet_json column', () => {
     expect(m46?.name).toBe('matches-consumption-estimated');
     const m47 = allMigrations.find((m) => m.version === 47);
     expect(m47?.name).toBe('matches-ballast-distance');
-    // updated from 47→48: branch adds migration 048-ai-quote-jobs (PR #925)
+    // updated from 48→49: branch adds migration 049-quote-jobs-match-id (PR #914 stage 10b)
     const last = allMigrations[allMigrations.length - 1];
-    expect(last.version).toBe(48);
-    expect(last.name).toBe('048-ai-quote-jobs');
+    expect(last.version).toBe(49);
+    expect(last.name).toBe('049-quote-jobs-match-id');
   });
 });

--- a/app/api/ai/__tests__/draft-quote.test.ts
+++ b/app/api/ai/__tests__/draft-quote.test.ts
@@ -11,7 +11,7 @@ import { QueueFullError } from '@/lib/quote-jobs/store';
 jest.mock('@/lib/quote-jobs/store', () => {
   const { QueueFullError: ActualQueueFullError } = jest.requireActual('@/lib/quote-jobs/store') as { QueueFullError: typeof import('@/lib/quote-jobs/store').QueueFullError };
   return {
-    enqueueQuoteJob: jest.fn(() => ({ id: 'job-uuid-123', status: 'queued', session_id: 'session-1', email_id: 'email-1', result: null, error: null, attempts: 0, created_at: Date.now(), updated_at: Date.now() })),
+    enqueueQuoteJob: jest.fn(() => ({ id: 'job-uuid-123', status: 'queued', session_id: 'session-1', email_id: 'email-1', match_id: null, result: null, error: null, attempts: 0, created_at: Date.now(), updated_at: Date.now() })),
     QueueFullError: ActualQueueFullError,
   };
 });
@@ -133,7 +133,7 @@ describe('POST /api/ai/draft-quote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Reset enqueueQuoteJob to default success behaviour
-    mockEnqueueQuoteJob.mockReturnValue({ id: 'job-uuid-123', status: 'queued', session_id: 'session-1', email_id: 'email-1', result: null, error: null, attempts: 0, created_at: Date.now(), updated_at: Date.now() });
+    mockEnqueueQuoteJob.mockReturnValue({ id: 'job-uuid-123', status: 'queued', session_id: 'session-1', email_id: 'email-1', match_id: null, result: null, error: null, attempts: 0, created_at: Date.now(), updated_at: Date.now() });
   });
 
   // ── Auth / validation ──────────────────────────────────────────────────────
@@ -188,5 +188,16 @@ describe('POST /api/ai/draft-quote', () => {
     const body = await res.json();
     expect(body.error).toBe('queue_full');
     expect(body.retryable).toBe(true);
+  });
+
+  it('forwards matchId from the body into the enqueued job', async () => {
+    mockGetSession.mockReturnValue(baseSession);
+    const req = makeRequest({ emailId: 'email-1', matchId: '54332' }, 'session-1');
+    const res = await POST(req);
+    expect(res.status).toBe(202);
+    expect(mockEnqueueQuoteJob).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ emailId: 'email-1', matchId: '54332' }),
+    );
   });
 });

--- a/app/api/ai/draft-quote/route.ts
+++ b/app/api/ai/draft-quote/route.ts
@@ -16,13 +16,13 @@ export async function POST(request: NextRequest) {
   try { raw = await request.json(); } catch { return NextResponse.json({ error: 'Invalid request body' }, { status: 400 }); }
   const parsed = DraftQuoteBodySchema.safeParse(raw);
   if (!parsed.success) return NextResponse.json({ error: 'Invalid request body', details: parsed.error.format() }, { status: 400 });
-  const { emailId } = parsed.data;
+  const { emailId, matchId } = parsed.data;
 
   const parsedCargo = session.parsedCargos.find(r => r.emailId === emailId);
   if (!parsedCargo) return NextResponse.json({ error: 'Parsed request not found' }, { status: 404 });
 
   try {
-    const job = enqueueQuoteJob(getStore().getDb(), { sessionId, emailId });
+    const job = enqueueQuoteJob(getStore().getDb(), { sessionId, emailId, matchId });
     ensureWorker();
     return NextResponse.json({ jobId: job.id, status: job.status }, { status: 202 });
   } catch (err) {

--- a/components/__tests__/quote-tab-generate-draft.test.tsx
+++ b/components/__tests__/quote-tab-generate-draft.test.tsx
@@ -245,4 +245,34 @@ describe('QuoteTab — Generate Draft button (async job flow)', () => {
       expect(errP?.textContent?.toLowerCase()).toMatch(/unavailable/);
     });
   });
+
+  it('includes matchId in the enqueue POST body when matchId prop is set', async () => {
+    mockFetchResponses();
+    renderWithToast(<QuoteTab cargoEmailId="e1" matchId="54332" />);
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls;
+      const draftCall = calls.find((c: unknown[]) =>
+        typeof c[0] === 'string' && (c[0] as string).includes('/api/ai/draft-quote'),
+      );
+      expect(draftCall).toBeTruthy();
+      const sentBody = JSON.parse((draftCall![1] as { body: string }).body);
+      expect(sentBody.matchId).toBe('54332');
+    });
+  });
+
+  it('omits matchId from body when matchId prop is absent', async () => {
+    mockFetchResponses();
+    renderWithToast(<QuoteTab cargoEmailId="email-abc" />);
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls;
+      const draftCall = calls.find((c: unknown[]) =>
+        typeof c[0] === 'string' && (c[0] as string).includes('/api/ai/draft-quote'),
+      );
+      expect(draftCall).toBeTruthy();
+      const sentBody = JSON.parse((draftCall![1] as { body: string }).body);
+      expect(sentBody.matchId).toBeUndefined();
+    });
+  });
 });

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -112,6 +112,7 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, store
           <QuoteTab
             cargoEmailId={cargoEmailId}
             confidence={match.confidence}
+            matchId={matchDbId?.toString()}
           />
         )}
         {activeTab === 'emails' && (

--- a/components/match/QuoteTab.tsx
+++ b/components/match/QuoteTab.tsx
@@ -12,12 +12,13 @@ import { useQuoteJob } from '@/lib/quote-jobs/use-quote-job';
 interface QuoteTabProps {
   cargoEmailId?: string;
   confidence?: MatchConfidence;
+  matchId?: string;
 }
 
-export function QuoteTab({ cargoEmailId, confidence }: QuoteTabProps) {
+export function QuoteTab({ cargoEmailId, confidence, matchId }: QuoteTabProps) {
   const toast = useToast();
   const { state, draft: hookDraft, error: hookError, start, retry } =
-    useQuoteJob(cargoEmailId, (msg) => toast.error(msg));
+    useQuoteJob(cargoEmailId, (msg) => toast.error(msg), matchId);
   const [draft, setDraft] = useState('');
   const [prevHookDraft, setPrevHookDraft] = useState('');
   const [benchmark, setBenchmark] = useState<MarketBenchmark | null | 'loading'>('loading');

--- a/lib/api-schemas.ts
+++ b/lib/api-schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const DraftQuoteBodySchema = z.object({
   emailId: z.string().min(1),
+  matchId: z.string().optional(),
 });
 
 export type DraftQuoteBody = z.infer<typeof DraftQuoteBodySchema>;

--- a/lib/migrations/049-quote-jobs-match-id.ts
+++ b/lib/migrations/049-quote-jobs-match-id.ts
@@ -1,0 +1,10 @@
+import type { Migration } from './types';
+
+const migration049: Migration = {
+  version: 49,
+  name: '049-quote-jobs-match-id',
+  up(db)  { db.exec(`ALTER TABLE ai_quote_jobs ADD COLUMN match_id TEXT`); },
+  down(db){ db.exec(`ALTER TABLE ai_quote_jobs DROP COLUMN match_id`); },
+};
+
+export default migration049;

--- a/lib/migrations/__tests__/049-quote-jobs-match-id.test.ts
+++ b/lib/migrations/__tests__/049-quote-jobs-match-id.test.ts
@@ -1,0 +1,35 @@
+import Database from 'better-sqlite3';
+import migration048 from '@/lib/migrations/048-ai-quote-jobs';
+import migration049 from '@/lib/migrations/049-quote-jobs-match-id';
+
+it('adds a nullable match_id column to ai_quote_jobs', () => {
+  const db = new Database(':memory:');
+  migration048.up(db);
+  migration049.up(db);
+  const cols = (db.prepare(`PRAGMA table_info(ai_quote_jobs)`).all() as { name: string }[]).map(c => c.name);
+  expect(cols).toContain('match_id');
+  // existing inserts without match_id still work (nullable)
+  expect(() =>
+    db.prepare(`INSERT INTO ai_quote_jobs (id,session_id,email_id,status) VALUES ('j','s','e','queued')`).run(),
+  ).not.toThrow();
+});
+
+it('match_id accepts a string value', () => {
+  const db = new Database(':memory:');
+  migration048.up(db);
+  migration049.up(db);
+  expect(() =>
+    db.prepare(`INSERT INTO ai_quote_jobs (id,session_id,email_id,status,match_id) VALUES ('j2','s','e','queued','54332')`).run(),
+  ).not.toThrow();
+  const row = db.prepare(`SELECT match_id FROM ai_quote_jobs WHERE id='j2'`).get() as { match_id: string };
+  expect(row.match_id).toBe('54332');
+});
+
+it('down() drops the match_id column', () => {
+  const db = new Database(':memory:');
+  migration048.up(db);
+  migration049.up(db);
+  migration049.down(db);
+  const cols = (db.prepare(`PRAGMA table_info(ai_quote_jobs)`).all() as { name: string }[]).map(c => c.name);
+  expect(cols).not.toContain('match_id');
+});

--- a/lib/migrations/index.ts
+++ b/lib/migrations/index.ts
@@ -46,6 +46,7 @@ import migration045 from './045-matches-worksheet';
 import migration046 from './046-matches-consumption-estimated';
 import migration047 from './047-matches-ballast-distance';
 import migration048 from './048-ai-quote-jobs';
+import migration049 from './049-quote-jobs-match-id';
 import type { Migration } from './types';
 
-export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043, migration044, migration045, migration046, migration047, migration048];
+export const allMigrations: Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007, migration008, migration009, migration010, migration011, migration012, migration013, migration014, migration015, migration016, migration017, migration018, migration019, migration020, migration021, migration022, migration023, migration024, migration025, migration026, migration027, migration028, migration029, migration030, migration031, migration032, migration033, migration034, migration035, migration036, migration037, migration038, migration039, migration040, migration041, migration042, migration043, migration044, migration045, migration046, migration047, migration048, migration049];

--- a/lib/quote-jobs/__tests__/claim-race.test.ts
+++ b/lib/quote-jobs/__tests__/claim-race.test.ts
@@ -1,8 +1,14 @@
 import Database from 'better-sqlite3';
 import migration048 from '@/lib/migrations/048-ai-quote-jobs';
+import migration049 from '@/lib/migrations/049-quote-jobs-match-id';
 import { enqueueQuoteJob, claimNextJob } from '@/lib/quote-jobs/store';
 
-function db() { const d = new Database(':memory:'); migration048.up(d); return d; }
+function db() {
+  const d = new Database(':memory:');
+  migration048.up(d);
+  migration049.up(d);
+  return d;
+}
 
 // Simulate the race condition: job is already 'processing' (Process A claimed it).
 // Without the outer `AND status='queued'` guard, Process B can UPDATE the row again.

--- a/lib/quote-jobs/__tests__/match-context.test.ts
+++ b/lib/quote-jobs/__tests__/match-context.test.ts
@@ -1,0 +1,93 @@
+import Database from 'better-sqlite3';
+import { buildMatchQuoteContext, INDICATIVE_SPREAD_PCT } from '@/lib/quote-jobs/match-context';
+
+// Mock getCurrentBenchmark to avoid network calls in tests
+jest.mock('@/lib/market/benchmark', () => ({
+  getCurrentBenchmark: jest.fn().mockResolvedValue(null),
+}));
+
+function buildMatchesDb(): { db: Database.Database; matchId: string } {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cargo_id TEXT NOT NULL DEFAULT '',
+      vessel_id TEXT NOT NULL DEFAULT '',
+      score INTEGER NOT NULL DEFAULT 0,
+      reason TEXT NOT NULL DEFAULT '',
+      user_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL DEFAULT 0,
+      tce_usd_per_day REAL,
+      distance_nm REAL,
+      freight_rate_usd_per_mt REAL,
+      freight_rate_source TEXT,
+      vessel_name TEXT,
+      vessel_dwt REAL,
+      load_port TEXT,
+      discharge_port TEXT
+    )
+  `);
+  const r = db.prepare(`
+    INSERT INTO matches (vessel_name, vessel_dwt, load_port, discharge_port, tce_usd_per_day, freight_rate_usd_per_mt, freight_rate_source, distance_nm)
+    VALUES (?,?,?,?,?,?,?,?)
+  `).run('MV TEST VESSEL', 50000, 'Rotterdam', 'Singapore', 12450, 18.00, 'computed', 9000);
+  return { db, matchId: String(r.lastInsertRowid) };
+}
+
+it('returns a block carrying ONLY the match numbers + a derived band', async () => {
+  const { db, matchId } = buildMatchesDb();
+  const ctx = await buildMatchQuoteContext(db, matchId);
+  expect(ctx).not.toBeNull();
+  expect(ctx!.block).toContain('MATCH ECONOMICS');
+  expect(ctx!.offeredRate).toBeCloseTo(18.00, 2);
+  expect(ctx!.marketLow).toBeCloseTo(18.00 * (1 - INDICATIVE_SPREAD_PCT), 2);
+  expect(ctx!.marketHigh).toBeCloseTo(18.00 * (1 + INDICATIVE_SPREAD_PCT), 2);
+  expect(ctx!.block).toContain('INDICATIVE');
+  expect(ctx!.block).toMatch(/use only/i);
+});
+
+it('band math is exact at ±5%', async () => {
+  const { db, matchId } = buildMatchesDb();
+  const ctx = await buildMatchQuoteContext(db, matchId);
+  expect(ctx!.marketLow).toBeCloseTo(18.00 * 0.95, 5);
+  expect(ctx!.marketHigh).toBeCloseTo(18.00 * 1.05, 5);
+  expect(ctx!.block).toContain('17.10');
+  expect(ctx!.block).toContain('18.90');
+});
+
+it('returns null for an unknown match (caller falls back to the cargo path)', async () => {
+  const { db } = buildMatchesDb();
+  expect(await buildMatchQuoteContext(db, '999999')).toBeNull();
+});
+
+it('returns null for a non-numeric matchId', async () => {
+  const { db } = buildMatchesDb();
+  expect(await buildMatchQuoteContext(db, 'cargo-123-vessel-456')).toBeNull();
+});
+
+it('returns null when freight_rate_usd_per_mt is null', async () => {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cargo_id TEXT NOT NULL DEFAULT '',
+      vessel_id TEXT NOT NULL DEFAULT '',
+      score INTEGER NOT NULL DEFAULT 0,
+      reason TEXT NOT NULL DEFAULT '',
+      user_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL DEFAULT 0,
+      tce_usd_per_day REAL,
+      distance_nm REAL,
+      freight_rate_usd_per_mt REAL,
+      freight_rate_source TEXT,
+      vessel_name TEXT,
+      vessel_dwt REAL,
+      load_port TEXT,
+      discharge_port TEXT
+    )
+  `);
+  const r = db.prepare(`INSERT INTO matches (vessel_name) VALUES ('MV NO RATE')`).run();
+  expect(await buildMatchQuoteContext(db, String(r.lastInsertRowid))).toBeNull();
+});

--- a/lib/quote-jobs/__tests__/prompt.test.ts
+++ b/lib/quote-jobs/__tests__/prompt.test.ts
@@ -35,3 +35,61 @@ it('omits RAG context when ragEnabled is false', async () => {
   const { system } = await buildQuotePrompt({ parsedCargo: cargo as any, email: email as any, ragEnabled: false });
   expect(system).not.toContain('IMSBC Cargo Safety Context');
 });
+
+// ── Stage 10b: match economics block ──────────────────────────────────────────
+
+import Database from 'better-sqlite3';
+
+// Mock getCurrentBenchmark to avoid network in tests
+jest.mock('@/lib/market/benchmark', () => ({
+  getCurrentBenchmark: jest.fn().mockResolvedValue(null),
+}));
+
+function buildMatchDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cargo_id TEXT NOT NULL DEFAULT '',
+      vessel_id TEXT NOT NULL DEFAULT '',
+      score INTEGER NOT NULL DEFAULT 0,
+      reason TEXT NOT NULL DEFAULT '',
+      user_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL DEFAULT 0,
+      tce_usd_per_day REAL,
+      distance_nm REAL,
+      freight_rate_usd_per_mt REAL,
+      freight_rate_source TEXT,
+      vessel_name TEXT,
+      vessel_dwt REAL,
+      load_port TEXT,
+      discharge_port TEXT
+    )
+  `);
+  const r = db.prepare(`
+    INSERT INTO matches (vessel_name, vessel_dwt, load_port, discharge_port, tce_usd_per_day, freight_rate_usd_per_mt, freight_rate_source, distance_nm)
+    VALUES ('MV GRAIN', 52000, 'Rotterdam', 'Jeddah', 14000, 18.00, 'computed', 6800)
+  `).run();
+  return { db, matchId: String(r.lastInsertRowid) };
+}
+
+it('injects the match economics block + indicative-rate instruction when matchId is given', async () => {
+  const { db, matchId } = buildMatchDb();
+  const { user } = await buildQuotePrompt({ parsedCargo: cargo as any, email: email as any, ragEnabled: false, matchId, db });
+  expect(user).toContain('MATCH ECONOMICS');
+  expect(user).toMatch(/indicative/i);
+  expect(user).not.toContain('[RATE TO BE CONFIRMED]');
+  expect(user).toContain('18.00');
+});
+
+it('matchId omitted → no economics block (cargo path unchanged)', async () => {
+  const { user } = await buildQuotePrompt({ parsedCargo: cargo as any, email: email as any, ragEnabled: false });
+  expect(user).not.toContain('MATCH ECONOMICS');
+});
+
+it('matchId given but unknown match → no economics block (fallback to cargo path)', async () => {
+  const { db } = buildMatchDb();
+  const { user } = await buildQuotePrompt({ parsedCargo: cargo as any, email: email as any, ragEnabled: false, matchId: '999999', db });
+  expect(user).not.toContain('MATCH ECONOMICS');
+});

--- a/lib/quote-jobs/__tests__/store.test.ts
+++ b/lib/quote-jobs/__tests__/store.test.ts
@@ -1,11 +1,17 @@
 import Database from 'better-sqlite3';
 import migration048 from '@/lib/migrations/048-ai-quote-jobs';
+import migration049 from '@/lib/migrations/049-quote-jobs-match-id';
 import {
   enqueueQuoteJob, getQuoteJob, claimNextJob, completeJob, failJob, reapStaleJobs,
   heartbeatJob, QueueFullError, countQueued,
 } from '@/lib/quote-jobs/store';
 
-function db() { const d = new Database(':memory:'); migration048.up(d); return d; }
+function db() {
+  const d = new Database(':memory:');
+  migration048.up(d);
+  migration049.up(d);
+  return d;
+}
 
 it('enqueues a queued job and finds it by id', () => {
   const d = db();
@@ -87,4 +93,16 @@ it('heartbeatJob keeps a processing job safe from the reaper', () => {
   // Reaper with a short TTL should NOT reap (updated_at just refreshed)
   expect(reapStaleJobs(d, 300_000)).toBe(0);
   expect(getQuoteJob(d, a.id)?.status).toBe('processing');
+});
+
+it('persists match_id when enqueued from a match', () => {
+  const d = db();
+  const job = enqueueQuoteJob(d, { sessionId: 's1', emailId: 'e1', matchId: '54332' });
+  expect(getQuoteJob(d, job.id)?.match_id).toBe('54332');
+});
+
+it('match_id defaults to null when not provided', () => {
+  const d = db();
+  const job = enqueueQuoteJob(d, { sessionId: 's1', emailId: 'e2' });
+  expect(getQuoteJob(d, job.id)?.match_id).toBeNull();
 });

--- a/lib/quote-jobs/match-context.ts
+++ b/lib/quote-jobs/match-context.ts
@@ -1,0 +1,47 @@
+import type Database from 'better-sqlite3';
+import { getMatch } from '@/lib/matching/matches-repository';
+import { getCurrentBenchmark } from '@/lib/market/benchmark';
+
+export const INDICATIVE_SPREAD_PCT = 0.05;
+
+export interface MatchQuoteContext {
+  block: string;
+  offeredRate: number;
+  marketLow: number;
+  marketHigh: number;
+}
+
+/**
+ * Returns a numbers-only economics block for a match, or null if:
+ *   - matchId is not a numeric DB id
+ *   - the match doesn't exist
+ *   - freight_rate_usd_per_mt is null (caller keeps the [RATE TO BE CONFIRMED] path)
+ */
+export async function buildMatchQuoteContext(
+  db: Database.Database,
+  matchId: string,
+): Promise<MatchQuoteContext | null> {
+  if (!/^\d+$/.test(matchId)) return null;
+  const m = getMatch(db, Number(matchId));
+  if (!m || m.freight_rate_usd_per_mt == null) return null;
+
+  const offeredRate = m.freight_rate_usd_per_mt;
+  const marketLow = offeredRate * (1 - INDICATIVE_SPREAD_PCT);
+  const marketHigh = offeredRate * (1 + INDICATIVE_SPREAD_PCT);
+
+  const tmi = await getCurrentBenchmark('TOEPFER_TMI').catch(() => null);
+
+  const lines = [
+    '=== MATCH ECONOMICS & MARKET DATA (use ONLY these numbers — do NOT invent or re-round a rate) ===',
+    `Vessel: ${m.vessel_name ?? 'n/a'} (DWT ${m.vessel_dwt ?? 'n/a'})`,
+    `Route: ${m.load_port ?? 'n/a'} → ${m.discharge_port ?? 'n/a'} (${m.distance_nm ?? 'n/a'} nm)`,
+    `Computed TCE: USD ${m.tce_usd_per_day ?? 'n/a'}/day (freight source: ${m.freight_rate_source ?? 'n/a'})`,
+    `Offered freight rate (INDICATIVE): USD ${offeredRate.toFixed(2)}/mt`,
+    `Indicative market range for this route: USD ${marketLow.toFixed(2)}–${marketHigh.toFixed(2)}/mt`,
+    tmi ? `Market benchmark (Toepfer TMI ${tmi.period}): USD ${tmi.value}/day TCE` : null,
+    'Present the offered rate as INDICATIVE; cite the market range. Do NOT substitute a placeholder — use only the specific offered rate above.',
+    '====================================================================================',
+  ].filter(Boolean) as string[];
+
+  return { block: lines.join('\n'), offeredRate, marketLow, marketHigh };
+}

--- a/lib/quote-jobs/prompt.ts
+++ b/lib/quote-jobs/prompt.ts
@@ -1,13 +1,19 @@
+import type Database from 'better-sqlite3';
 import { DRAFT_QUOTE_SYSTEM_PROMPT } from '@/lib/prompts';
 import { resolveSenderName } from '@/lib/utils/resolve-sender-name';
+import { buildMatchQuoteContext } from './match-context';
 
 interface BuildArgs {
   parsedCargo: { emailId: string; cargoType?: string; cargoDescription?: unknown };
   email?: { id: string; from?: string | null; fromName?: string | null; subject?: string | null; body?: string | null };
   ragEnabled: boolean;
+  /** When provided, appends a MATCH ECONOMICS block to the user prompt with real numbers. */
+  matchId?: string;
+  /** Database instance needed to resolve match numbers (required when matchId is set). */
+  db?: Database.Database;
 }
 
-export async function buildQuotePrompt({ parsedCargo, email, ragEnabled }: BuildArgs): Promise<{ system: string; user: string }> {
+export async function buildQuotePrompt({ parsedCargo, email, ragEnabled, matchId, db }: BuildArgs): Promise<{ system: string; user: string }> {
   const fromName = resolveSenderName({ fromName: email?.fromName, from: email?.from });
 
   const ragContextParts: string[] = [];
@@ -40,7 +46,7 @@ export async function buildQuotePrompt({ parsedCargo, email, ragEnabled }: Build
     ? `${DRAFT_QUOTE_SYSTEM_PROMPT}\n\n${ragContextParts.join('\n')}`
     : DRAFT_QUOTE_SYSTEM_PROMPT;
 
-  const user = `
+  let user = `
 Parsed cargo inquiry data:
 ${JSON.stringify(parsedCargo, null, 2)}
 
@@ -52,6 +58,16 @@ Body: ${email?.body?.slice(0, 1500) || ''}
 Address the reply to: ${fromName}
 
 Generate a professional draft quote email.`;
+
+  // Append match economics block when matchId + db are available.
+  // System prompt (DRAFT_QUOTE_SYSTEM_PROMPT) is not edited — its [RATE TO BE CONFIRMED]
+  // literal is suppressed by the block's own instruction when an offered rate is present.
+  if (matchId && db) {
+    const ctx = await buildMatchQuoteContext(db, matchId);
+    if (ctx) {
+      user = user + '\n\n' + ctx.block;
+    }
+  }
 
   return { system, user };
 }

--- a/lib/quote-jobs/store.ts
+++ b/lib/quote-jobs/store.ts
@@ -7,6 +7,7 @@ export interface QuoteJob {
   id: string;
   session_id: string;
   email_id: string;
+  match_id: string | null;
   status: QuoteJobStatus;
   result: string | null;
   error: string | null;
@@ -31,7 +32,7 @@ export function getQuoteJob(db: Database.Database, id: string): QuoteJob | undef
 
 export function enqueueQuoteJob(
   db: Database.Database,
-  input: { sessionId: string; emailId: string },
+  input: { sessionId: string; emailId: string; matchId?: string },
   opts: { maxDepth?: number } = {},
 ): QuoteJob {
   const existing = db.prepare(
@@ -46,8 +47,8 @@ export function enqueueQuoteJob(
 
   const id = randomUUID();
   const r = db.prepare(
-    `INSERT OR IGNORE INTO ai_quote_jobs (id, session_id, email_id, status) VALUES (?,?,?,'queued')`,
-  ).run(id, input.sessionId, input.emailId);
+    `INSERT OR IGNORE INTO ai_quote_jobs (id, session_id, email_id, status, match_id) VALUES (?,?,?,'queued',?)`,
+  ).run(id, input.sessionId, input.emailId, input.matchId ?? null);
 
   if (r.changes === 0) {
     // Concurrent enqueue won the race; return their in-flight row

--- a/lib/quote-jobs/use-quote-job.ts
+++ b/lib/quote-jobs/use-quote-job.ts
@@ -27,6 +27,7 @@ const POLL_INTERVAL_MS = 3_000;
 export function useQuoteJob(
   emailId?: string,
   onError?: (msg: string) => void,
+  matchId?: string,
 ): UseQuoteJobResult {
   const [state, setState] = useState<QuoteJobUiState>('idle');
   const [draft, setDraft] = useState('');
@@ -150,9 +151,11 @@ export function useQuoteJob(
     setError('');
 
     try {
+      const body: Record<string, string> = { emailId };
+      if (matchId) body.matchId = matchId;
       const res = await csrfFetch('/api/ai/draft-quote', {
         method: 'POST',
-        body: JSON.stringify({ emailId }),
+        body: JSON.stringify(body),
       });
       const data = await parseJsonResponse<{ jobId: string }>(res);
       subscribeToSse(data.jobId);
@@ -166,7 +169,7 @@ export function useQuoteJob(
     }
   // subscribeToSse / startPolling close over stable refs — no extra deps needed
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [emailId]);
+  }, [emailId, matchId]);
 
   const retry = useCallback(async () => {
     cleanup();

--- a/scripts/quote-workshop/worker.ts
+++ b/scripts/quote-workshop/worker.ts
@@ -52,7 +52,7 @@ async function main() {
     heartbeatJob(db, job.id);
 
     try {
-      const { system, user } = await buildQuotePrompt({ parsedCargo, email, ragEnabled: isRagEnabled() });
+      const { system, user } = await buildQuotePrompt({ parsedCargo, email, ragEnabled: isRagEnabled(), matchId: job.match_id ?? undefined, db });
       // NOTE: callClaudeCliRaw is synchronous (spawnSync) and will block the event loop.
       // Heartbeat before and after is the best we can do without async subprocess.
       const { text } = callClaudeCliRaw(system, user, MODEL, { maxBudgetUsd: BUDGET, timeoutMs: 85_000 });


### PR DESCRIPTION
## Summary
- Stage 10b of the draft-quote workshop plan (docs/superpowers/plans/2026-06-10-draft-quote-claude-cli-workshop.md): when a quote is generated from the match page, the prompt gains a deterministic MATCH ECONOMICS & MARKET DATA block — vessel, TCE, breakeven, TOEPFER_TMI benchmark, and a code-computed indicative band (±5%, INDICATIVE_SPREAD_PCT constant)
- Model is instructed to use ONLY the numbers provided and present the rate as indicative; cargo-page path (no matchId) is unchanged, [RATE TO BE CONFIRMED] literal untouched
- Migration 049: nullable match_id on ai_quote_jobs; QuoteTab threads matchId; DraftQuoteCard does not

## Recovery note
Worker session hit the ~30-min cap after committing and running 306/306 suites green; push + PR performed by orchestrator (commits b4f48156, 9f49385d).

## Verification
- 306/306 test suites green in worktree (compare-routes-da errors pre-existing, OpenAI-key related)
- VALUE_CHECK to be emitted after cold QA verifies block numbers vs repository values

🤖 Generated with [Claude Code](https://claude.com/claude-code)