### PR TITLE
fix(draft): honest wording — stated max draft, laden not computed

### DIFF
--- a/lib/sailing/__tests__/fit-breakdown.test.ts
+++ b/lib/sailing/__tests__/fit-breakdown.test.ts
@@ -9,6 +9,7 @@ import {
   scoreUtilisation,
   scoreTiming,
   scoreVetting,
+  scoreDraft,
 } from '../fit-breakdown';
 import type { MatchReadiness, MatchSanctions, MatchHardFilters, ParsedCargo, ParsedVessel } from '@/lib/types';
 
@@ -653,5 +654,13 @@ describe('#884 — HRC cargo on corrected-capacity YUCATAN vessel is a comfortab
     const vol = fit.components.find(c => c.factor === 'volume');
     expect(vol?.rationale).not.toContain('overflows');
     expect(vol?.rationale).toContain('comfortable');
+  });
+
+  it('S1: scoreDraft pass-branch uses honest wording (stated max draft, laden not computed)', () => {
+    const result = scoreDraft({ draft: { pass: true } } as MatchHardFilters);
+    expect(result.rationale).toBe(
+      "Vessel's maximum stated draft is within the port's limit. Actual laden draft not computed.",
+    );
+    expect(result.score).toBe(FIT_WEIGHTS.draft);
   });
 });

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -427,7 +427,7 @@ export function scoreDraft(hardFilters: MatchHardFilters | undefined): FitBreakd
     return unknown('draft', 'Draft / port headroom', 'Draft check not performed, scored conservatively.');
   }
   if (draftCheck.pass) {
-    return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: w, rationale: "Loaded ship sits within the port's draft limit." };
+    return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: w, rationale: "Vessel's maximum stated draft is within the port's limit. Actual laden draft not computed." };
   }
   return { factor: 'draft', label: 'Draft / port headroom', weight: w, score: 0, rationale: `Ship draws too much for the port${draftCheck.reason ? ` — ${draftCheck.reason}` : ''}.` };
 }


### PR DESCRIPTION
## Summary

- `scoreDraft` pass-branch rationale: `"Loaded ship sits within the port's draft limit."` → `"Vessel's maximum stated draft is within the port's limit. Actual laden draft not computed."`
- Adds `scoreDraft` import to `fit-breakdown.test.ts` + behavioral assertion on the new wording
- Zero logic/score change — pure copy fix

## Why

The old string was a **display lie**: the draft gate only compares the vessel's design-maximum (empty) draft against the port limit; the loaded draft is not computed at this stage. A broker partner flagged this. Stage M2 (next PR) will wire the laden-draft estimator; until then the honest interim wording is "stated max draft … laden not computed."

## Test plan

- [x] `npx jest lib/sailing/__tests__/fit-breakdown.test.ts` → 64/64 green (new `S1: scoreDraft pass-branch uses honest wording` test passes)
- [x] `NODE_OPTIONS="--max-old-space-size=3072" npx tsc --noEmit --skipLibCheck` → clean
- [x] Cross-cutting grep `"Loaded ship sits within"` → 0 hits remaining

## Concurrency note

Per plan §Concurrency: diff is confined to one string literal in `scoreDraft`. Neither Task I (discharge cranes) nor Task G (brackets) edited `scoreDraft`. Rebased on `a4b28aa4` which includes both #933 and #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)