### PR TITLE
feat(tce): Stage 8 — migrate buildMatchEconomics + computeStoredMatchEconomics to computeTce

### DIFF
--- a/lib/matching/__tests__/stored-match-economics.test.ts
+++ b/lib/matching/__tests__/stored-match-economics.test.ts
@@ -156,4 +156,36 @@ describe('computeStoredMatchEconomics — single source of truth', () => {
     expect(result.tce_breakdown).not.toBeNull();
     expect(result.tce_breakdown!.da_usd).toBe(0);
   });
+
+  // Stage 8 behavioral: computeStoredMatchEconomics delegates breakdown derivation
+  // directly to computeTce — no computeEstimatedTce deprecation warning emitted.
+  it('Stage 8: no deprecation warn when bunkerPriceUsdPerMt omitted — direct computeTce for breakdown', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = computeStoredMatchEconomics({
+      cargo: {
+        emailId: 's8-c',
+        itemIndex: 0,
+        originPort: { value: 'Rotterdam', confidence: 'confirmed', source_text: 'Rotterdam' },
+        destinationPort: { value: 'Singapore', confidence: 'confirmed', source_text: 'Singapore' },
+        cargoType: 'BULK',
+        freightRateUsd: 30,
+        weightMt: { value: 55000, confidence: 'confirmed', source_text: '55000' },
+      } as any,
+      vessel: {
+        emailId: 's8-v',
+        itemIndex: 0,
+        dwtSummer: { value: 55000, confidence: 'confirmed', source_text: '55000' },
+        speedLaden: '13',
+        consumption: '26',
+        openPosition: null,
+      } as any,
+      // bunkerPriceUsdPerMt not supplied → DEFAULT applied without computeEstimatedTce warn
+    });
+    expect(result.tce_usd_per_day).not.toBeNull();
+    expect(result.tce_breakdown).not.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('computeEstimatedTce: bunkerPriceUsdPerMt not supplied'),
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -347,4 +347,29 @@ describe('buildMatchEconomics', () => {
     expect(withDa!.totalUsd).toBeGreaterThan(noDa!.totalUsd);
     expect(withDa!.tceUsdPerDay!).toBeLessThan(noDa!.tceUsdPerDay!);
   });
+
+  // Stage 8 behavioral: buildMatchEconomics delegates directly to computeTce —
+  // no computeEstimatedTce deprecation warning emitted when bunker not supplied.
+  it('Stage 8: no deprecation warn when bunkerPriceUsdPerMt omitted — direct computeTce path', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const econ = buildMatchEconomics({
+      cargoType: 'BULK',
+      distanceNm: 5000,
+      vesselDwt: 50000,
+      quantityMt: 40000,
+      speedKts: 13,
+      consumptionMt: 22,
+      loadPort: 'Rotterdam',
+      dischargePort: 'Singapore',
+      calculatedAt: '2026-06-11T00:00:00.000Z',
+      // bunkerPriceUsdPerMt omitted → DEFAULT_BUNKER_USD_PER_MT applied without warning
+    });
+    expect(econ).not.toBeNull();
+    expect(Number.isFinite(econ!.tceUsdPerDay!)).toBe(true);
+    expect(econ!.tceUsdPerDay).toBeGreaterThan(0);
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('computeEstimatedTce: bunkerPriceUsdPerMt not supplied'),
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/lib/matching/stored-match-economics.ts
+++ b/lib/matching/stored-match-economics.ts
@@ -25,11 +25,13 @@ import { resolveFreightRate } from '@/lib/matching/freight-resolver';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 import {
   buildMatchEconomics,
-  computeEstimatedTce,
   deriveEtsCoverage,
   parseLeadingNumber,
   parseConsumption,
 } from '@/lib/matching/tce-calculator';
+import { computeTce } from '@/lib/economics/compute-tce';
+import { resolveConsMtPerDay } from '@/lib/economics/vessel-consumption';
+import { DEFAULT_BUNKER_USD_PER_MT, FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import { now } from '@/lib/clock';
 
@@ -141,8 +143,8 @@ export function computeStoredMatchEconomics(
   }
 
   // Use fallback=0 so that absent consumption triggers resolveConsMtPerDay class-aware
-  // fallback inside buildCanonicalTceInputs (via computeEstimatedTce). The old flat-25
-  // default was fabricated; passing 0 lets the vessel-class estimator run instead.
+  // fallback (applied inside buildMatchEconomics and the breakdown re-derivation below).
+  // The old flat-25 default was fabricated; passing 0 lets the vessel-class estimator run.
   const rawCons = parseConsumption(vessel.consumption, 0);
   const consumptionEstimated = rawCons <= 0;
 
@@ -176,44 +178,45 @@ export function computeStoredMatchEconomics(
 
   if (!econ) return nullResult;
 
-  // NOTE: second computeEstimatedTce call — buildMatchEconomics returns EconomicsBreakdown,
-  // not TCEBreakdown. Same inputs as above so values agree; if buildMatchEconomics's
-  // canal/EUA/DA handling changes, keep this call in sync (or lift TCEBreakdown into EconomicsResult).
-  //
-  // The inner TCEBreakdown is not exposed on EconomicsResult.breakdown
-  // (which is EconomicsBreakdown). We re-derive it using the same inputs so
-  // callers (tests, A5 parity) can inspect da_usd, canal_usd, etc.
+  // Stage 8: re-derive TCEBreakdown via computeTce directly — same guards as
+  // computeEstimatedTce internals; no originPort/destinationPort (war_risk_usd=$0
+  // in breakdown, war-risk displayed from econ.breakdown). ECA-split not wired:
+  // stored path did not compute it before Stage 8 (qa-937 MEDIUM-2, no new behaviour).
   //
   // NOTE: tce_usd_per_day is always taken from econ.tceUsdPerDay (the authoritative value).
-  // This separate computeEstimatedTce call is read-only re-derivation for the breakdown.
+  // This re-derivation is read-only so callers (tests, A5 parity) can inspect da_usd, etc.
   let tce_breakdown: TCEBreakdown | null = null;
   try {
     const { originEu, destEu, euLegPercent } = deriveEtsCoverage(loadPort, dischargePort);
-    const euaPriceEur = liveEuaRow?.price_eur_per_tco2 ?? undefined;
+    const euaForBreakdown = (liveEuaRow?.price_eur_per_tco2 != null && liveEuaRow.price_eur_per_tco2 > 0)
+      ? liveEuaRow.price_eur_per_tco2
+      : FALLBACK_EUA_EUR_PER_TCO2;
     // Canal detection is internal to buildMatchEconomics; reuse the value it computed.
-    const canalUsd = econ.breakdown.canal_usd ?? 0;
-    const tceEst = computeEstimatedTce(
-      {
-        rate: resolvedFreight.value,
-        source: resolvedFreight.source,
-        confidence: resolvedFreight.confidence,
-      },
-      distanceResult.nm,
-      ecoDwt,
-      ecoQty,
-      ecoSpeed,
-      parseConsumption(vessel.consumption, 0),  // was parseConsumption(vessel.consumption)
-      ballastDistanceNm ?? undefined,
-      canalUsd > 0 ? canalUsd : undefined,
-      daUsd > 0 ? daUsd : undefined,
-      bunkerPriceUsdPerMt,
+    const canalUsdBk = econ.breakdown.canal_usd ?? 0;
+    const resolvedBunkerBk = bunkerPriceUsdPerMt ?? DEFAULT_BUNKER_USD_PER_MT;
+    const safeDwtBk = ecoDwt > 0 ? ecoDwt : 10_000;
+    const safeSpeedBk = ecoSpeed > 0 ? ecoSpeed : 12;
+    const safeQtyBk = ecoQty > 0 ? ecoQty : safeDwtBk * 0.65;
+    const safeConsBk = resolveConsMtPerDay(rawCons, safeDwtBk);
+    const bkResult = computeTce({
+      dwt: safeDwtBk,
+      valueUsd: estimateVesselValueUsd(ecoDwt),
+      speedKts: safeSpeedBk,
+      consumptionMtPerDay: safeConsBk,
+      freightRateUsdPerMt: resolvedFreight.value,
+      quantityMt: safeQtyBk,
+      distanceNm: distanceResult.nm,
+      ballastDistanceNm: ballastDistanceNm ?? undefined,
+      bunkerPriceUsdPerMt: resolvedBunkerBk,
+      euaPriceEur: euaForBreakdown,
+      canalUsd: canalUsdBk,
+      daUsd: daUsd > 0 ? daUsd : 0,
       euLegPercent,
       originEu,
       destEu,
-      euaPriceEur,
-      true, // excludeWarRiskFromDailyTce
-    );
-    tce_breakdown = tceEst.breakdown;
+      excludeWarRiskFromDailyTce: true,
+    });
+    tce_breakdown = bkResult.breakdown;
   } catch {
     tce_breakdown = null;
   }

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -332,27 +332,36 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
     ? input.euaPriceEur
     : FALLBACK_EUA_EUR_PER_TCO2;
 
-  const tce = computeEstimatedTce(
-    freight,
-    input.distanceNm,
-    input.vesselDwt,
-    input.quantityMt,
-    input.speedKts,
-    input.consumptionMt,
-    ballastNm ?? undefined,
-    canalUsd > 0 ? canalUsd : undefined,
-    input.daUsd != null && input.daUsd > 0 ? input.daUsd : undefined,
-    input.bunkerPriceUsdPerMt != null ? input.bunkerPriceUsdPerMt : undefined,
+  // Stage 8: call computeTce directly — same guards as computeEstimatedTce internals.
+  // No originPort/destinationPort: war risk is $0 in the TCE numerator (computed
+  // separately below for the breakdown display). ECA-split not wired: stored path
+  // did not compute it before Stage 8; not adding new behaviour (qa-937 MEDIUM-2).
+  const safeDwt = input.vesselDwt > 0 ? input.vesselDwt : 10_000;
+  const safeSpeed = input.speedKts > 0 ? input.speedKts : DEFAULT_SPEED_KTS;
+  const safeQty = input.quantityMt > 0 ? input.quantityMt : safeDwt * 0.65;
+  const safeConsumption = resolveConsMtPerDay(input.consumptionMt, safeDwt);
+  const resolvedBunker = input.bunkerPriceUsdPerMt != null
+    ? input.bunkerPriceUsdPerMt
+    : DEFAULT_BUNKER_USD_PER_MT;
+
+  const tce = computeTce({
+    dwt: safeDwt,
+    valueUsd: DEFAULT_VESSEL_VALUE_USD,
+    speedKts: safeSpeed,
+    consumptionMtPerDay: safeConsumption,
+    freightRateUsdPerMt: freight.rate,
+    quantityMt: safeQty,
+    distanceNm: input.distanceNm > 0 ? input.distanceNm : 0,
+    ballastDistanceNm: ballastNm ?? undefined,
+    bunkerPriceUsdPerMt: resolvedBunker,
+    euaPriceEur,
+    canalUsd,
+    daUsd: input.daUsd != null && input.daUsd > 0 ? input.daUsd : 0,
     euLegPercent,
     originEu,
     destEu,
-    euaPriceEur,
-    // Default false = legacy behaviour (war risk INCLUDED in daily-TCE headline) for callers
-    // that don't set the flag. Callers that want the canonical "exclude" convention must pass
-    // excludeWarRiskFromDailyTce: true explicitly — stored-match-economics.ts (line ~144) and
-    // app/api/voyage/tce/route.ts:373 already do so; golden-set runner must also opt in.
-    input.excludeWarRiskFromDailyTce ?? false,
-  );
+    excludeWarRiskFromDailyTce: input.excludeWarRiskFromDailyTce ?? false,
+  });
 
   const warLaden = calculateWarRiskPremium({
     route: { fromPort: input.loadPort ?? '', toPort: input.dischargePort ?? '' },
@@ -394,9 +403,9 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
     totalUsd: tce.breakdown.total_costs_usd + warCombinedTotal,
     calculatedAt: input.calculatedAt,
     dataFreshness: { bunker: 'estimated', eua: 'estimated' },
-    tceUsdPerDay: tce.tce_usd_per_day,
-    freightRateUsdPerMt: tce.freight_rate_usd_per_mt,
-    freightRateSource: tce.freight_rate_source,
+    tceUsdPerDay: tce.tceUsdPerDay,
+    freightRateUsdPerMt: freight.rate,
+    freightRateSource: freight.source,
     consumptionEstimated: input.consumptionMt <= 0 ? true : undefined,
     qtyEstimated: input.quantityMt <= 0 ? true : undefined,
     dataQuality: input.consumptionMt <= 0


### PR DESCRIPTION
## Summary

- **buildMatchEconomics** (`lib/matching/tce-calculator.ts`): internals now call `computeTce` directly instead of routing through `computeEstimatedTce`, applying the same guards (safeDwt, safeQty, `resolveConsMtPerDay`, explicit `DEFAULT_BUNKER_USD_PER_MT` fallback — no deprecation warning).
- **computeStoredMatchEconomics** (`lib/matching/stored-match-economics.ts`): the second `computeEstimatedTce` call used for `tce_breakdown` re-derivation is replaced with a direct `computeTce` call using the same inputs.
- Wrapper shape unchanged: canal resolution, DA, ETS coverage derivation, war-risk breakdown all stay in their existing places.

## ECA-wiring decision (qa-937 MEDIUM-2)

`resolvedOrigin`/`resolvedDest` NOT passed to `computeTce` in this path. The stored-economics path did not compute ECA split before Stage 8, so no new behaviour is added (preserves prod numbers).

## Baltic-gate #917

`ecoDwt > 0` guard at `stored-match-economics.ts:122` is untouched — `stored-match-economics-null-dwt.test.ts` 2/2 green.

## Test results

```
lib/matching + lib/economics: 561/561 pass (56 suites)
list-detail-tce-parity: 16/16 pass
golden-set runner: 1/1 pass
#917 null-dwt: 2/2 pass
component tests: 20/20 pass
```

2 new Stage 8 behavioral tests (RED→GREEN):
- `buildMatchEconomics — Stage 8: no deprecation warn when bunkerPriceUsdPerMt omitted`
- `computeStoredMatchEconomics — Stage 8: no deprecation warn when bunkerPriceUsdPerMt omitted`

Pre-existing failure: `test_economics_edge_cases.test.ts H8b` (calculateEuEts boundary) — fails on HEAD before this PR, unrelated to Stage 8.

## Acceptance — issue #917

| Issue | Criterion | Status | Evidence |
|-------|-----------|--------|----------|
| #917 | `dwtSummer=null` → `freight_rate_source==='estimated'` | ✓ | `stored-match-economics-null-dwt.test.ts:61` |
| #917 | `dwtSummer=82000` → `freight_rate_source==='baltic'` | ✓ | `stored-match-economics-null-dwt.test.ts:81` |
| #917 | `ecoDwt > 0` gate in `stored-match-economics.ts:122` | ✓ | unchanged, line 122 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)