### PR TITLE
feat(ui): laden-draft math breakdown — both ports

### DIFF
--- a/app/matches/MatchesClient.tsx
+++ b/app/matches/MatchesClient.tsx
@@ -16,6 +16,8 @@ import { freightBadge, FREIGHT_BADGE_CLASSES } from '@/lib/matching/freight-badg
 import { useDemoNow } from '@/lib/clock-client';
 import { fitDisplay } from '@/lib/matching/fit-display';
 import { effectiveScore } from '@/lib/utils/effective-score';
+import { DraftCalcBreakdown } from '@/components/match/DraftCalcBreakdown';
+import type { MatchWorksheet } from '@/lib/types';
 
 interface Props {
   initialMatches: (StoredMatch & { laycan_display?: string | null })[];
@@ -828,6 +830,8 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                         let fb: { components: Array<{ factor: string; label: string; weight: number; score: number; rationale: string }> } | null = null;
                         try { fb = JSON.parse(match.fit_breakdown as string); } catch { fb = null; }
                         if (!fb || !Array.isArray(fb.components)) return null;
+                        let ws: MatchWorksheet | null = null;
+                        try { ws = match.worksheet_json ? JSON.parse(match.worksheet_json) as MatchWorksheet : null; } catch { ws = null; }
                         return (
                           <div className="mt-2 space-y-2 border-t pt-2">
                             <h4 className="text-xs font-semibold text-emerald-700">Fit Breakdown</h4>
@@ -847,6 +851,17 @@ export default function MatchesClient({ initialMatches, isComputing = false, car
                                 </div>
                                 {c.rationale && (
                                   <p className="text-xs text-gray-500">{c.rationale}</p>
+                                )}
+                                {c.factor === 'draft' && ws && (
+                                  <DraftCalcBreakdown
+                                    loadPort={ws.cargo.loadPort}
+                                    dischargePort={ws.cargo.dischargePort}
+                                    draftCheck={ws.hardFilters.draft}
+                                    destDraftCheck={ws.hardFilters.destDraft}
+                                    dwtSummer={ws.vessel.dwtSummer}
+                                    weightMt={ws.cargo.weightMtEffective ?? ws.cargo.weightMt}
+                                    statedMaxDraftM={ws.vessel.draftMax}
+                                  />
                                 )}
                               </div>
                             ))}

--- a/components/match/DraftCalcBreakdown.tsx
+++ b/components/match/DraftCalcBreakdown.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { HardFilterCheck } from '@/lib/types';
+
+interface Props {
+  loadPort: string | null;
+  dischargePort: string | null;
+  /** Load port draft check (hf.draft) — always present. */
+  draftCheck: HardFilterCheck;
+  /** Discharge port draft check (hf.destDraft) — absent in pre-M4 stored data. */
+  destDraftCheck?: HardFilterCheck;
+  /** Vessel DWT — used for intermediate formula display only, not gate logic. */
+  dwtSummer?: number | null;
+  /** Cargo weight (effective max) — used for intermediate formula display only. */
+  weightMt?: number | null;
+  /** Vessel stated max draft — shown in static-check fallback. */
+  statedMaxDraftM?: number | null;
+}
+
+interface PortRowProps {
+  portLabel: string;
+  roleLabel: string;
+  check: HardFilterCheck;
+  statedMaxDraftM: number | null | undefined;
+  hasEstimate: boolean;
+}
+
+function PortRow({ portLabel, roleLabel, check, statedMaxDraftM, hasEstimate }: PortRowProps) {
+  if (!hasEstimate) {
+    const draftRef = statedMaxDraftM != null ? `${statedMaxDraftM} m` : '—';
+    const icon = check.pass ? '✓' : '✗';
+    const verdict = check.pass ? 'clears' : 'exceeds';
+    return (
+      <div className={`text-xs ${check.pass ? 'text-emerald-600' : 'text-red-500'}`}>
+        {roleLabel} {portLabel}: static check vs stated max draft {draftRef} → {icon} {verdict}
+      </div>
+    );
+  }
+
+  if (check.portLimitM == null) {
+    return (
+      <div className="text-xs text-ds-text-muted">
+        {roleLabel} {portLabel}: limit unknown → pass (no data)
+      </div>
+    );
+  }
+
+  const icon = check.pass ? '✓' : '✗';
+  const verdict = check.pass ? 'clears' : 'exceeds';
+  return (
+    <div className={`text-xs ${check.pass ? 'text-emerald-600' : 'text-red-500'}`}>
+      {roleLabel} {portLabel}: limit {check.portLimitM.toFixed(1)} m → {icon} {verdict}
+    </div>
+  );
+}
+
+export function DraftCalcBreakdown({
+  loadPort,
+  dischargePort,
+  draftCheck,
+  destDraftCheck,
+  dwtSummer,
+  weightMt,
+  statedMaxDraftM,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const est = draftCheck.estimatedLadenDraftM;
+  const hasEstimate = est != null;
+
+  // Intermediate display steps — mirrors lib/sailing/laden-draft.ts empirical formula.
+  // Display only; gate verdict comes from persisted HardFilterCheck, not recomputed here.
+  let fullLoadDraftM: number | null = null;
+  let rawDraftM: number | null = null;
+  if (hasEstimate && dwtSummer != null && weightMt != null && dwtSummer > 0 && weightMt > 0) {
+    fullLoadDraftM = 0.4991 * Math.pow(dwtSummer, 0.2991);
+    const ratio = Math.min(weightMt / dwtSummer, 1);
+    rawDraftM = fullLoadDraftM * Math.pow(ratio, 0.3);
+  }
+
+  const bothPass = draftCheck.pass && (destDraftCheck == null || destDraftCheck.pass);
+
+  return (
+    <div className="mt-1">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-xs text-ds-text-muted hover:text-ds-text transition-colors"
+        aria-expanded={open}
+        data-testid="draft-calc-toggle"
+      >
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        Draft calculation
+      </button>
+
+      {open && (
+        <div className="mt-1.5 pl-3 border-l-2 border-ds-border space-y-1.5" data-testid="draft-calc-body">
+          {/* Formula header — 3 lines */}
+          {hasEstimate && fullLoadDraftM != null && rawDraftM != null ? (
+            <div className="text-xs text-ds-text-muted space-y-0.5">
+              <div>
+                Full-load: 0.4991 × {Math.round(dwtSummer!).toLocaleString('en-US')}^0.2991
+                {' '}= {fullLoadDraftM.toFixed(2)} m
+              </div>
+              <div>
+                Cargo-adjust: × ({Math.round(weightMt!).toLocaleString('en-US')}&thinsp;/&thinsp;{Math.round(dwtSummer!).toLocaleString('en-US')})^0.3
+                {' '}= {rawDraftM.toFixed(2)} m
+              </div>
+              <div className="text-ds-text">
+                → {est!.toFixed(1)} m (approximate, conservative)
+              </div>
+            </div>
+          ) : (
+            <div className="text-xs text-ds-text-muted">
+              cargo weight / DWT unknown → static check vs stated max draft{' '}
+              {statedMaxDraftM != null ? `${statedMaxDraftM} m` : '—'}
+            </div>
+          )}
+
+          {/* Port comparison rows */}
+          <div className="space-y-0.5">
+            <PortRow
+              portLabel={loadPort ?? '(unknown)'}
+              roleLabel="Load port"
+              check={draftCheck}
+              statedMaxDraftM={statedMaxDraftM}
+              hasEstimate={hasEstimate}
+            />
+            {destDraftCheck != null ? (
+              <PortRow
+                portLabel={dischargePort ?? '(unknown)'}
+                roleLabel="Discharge port"
+                check={destDraftCheck}
+                statedMaxDraftM={statedMaxDraftM}
+                hasEstimate={hasEstimate}
+              />
+            ) : (
+              <div className="text-xs text-ds-text-muted">
+                Discharge port {dischargePort ?? '(unknown)'}: check data unavailable
+              </div>
+            )}
+          </div>
+
+          {/* Worst-of-two verdict */}
+          <div className={`text-xs font-medium ${bothPass ? 'text-emerald-600' : 'text-red-500'}`}>
+            {bothPass ? '✓ Clears both ports' : '✗ Fails one or more ports (worst-of-two)'}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -1,4 +1,6 @@
 import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
+import React from 'react';
+import { DraftCalcBreakdown } from './DraftCalcBreakdown';
 
 interface Props {
   worksheet: MatchWorksheetType | null;
@@ -48,7 +50,7 @@ export function MatchWorksheet({ worksheet }: Props) {
     return parts.length > 0 ? parts.join(' → ') : '—';
   })();
 
-  const rows: Array<{ label: string; vessel: string; cargoPort: string; verdict: string }> = [
+  const rows: Array<{ label: string; vessel: string; cargoPort: string; verdict: string; detail?: React.ReactNode }> = [
     {
       label: '⏱ Time',
       vessel: [r.openDate ? `free ${r.openDate}` : null, r.openPosition ? `@ ${r.openPosition}` : null].filter(Boolean).join(' ') || '—',
@@ -103,6 +105,17 @@ export function MatchWorksheet({ worksheet }: Props) {
       vessel: v.draftMax != null ? `${v.draftMax} m` : '—',
       cargoPort: hf.draft.reason ? hf.draft.reason : '—',
       verdict: verdictBadge(hf.draft.pass, hf.draft.reason),
+      detail: (
+        <DraftCalcBreakdown
+          loadPort={c.loadPort}
+          dischargePort={c.dischargePort}
+          draftCheck={hf.draft}
+          destDraftCheck={hf.destDraft}
+          dwtSummer={v.dwtSummer}
+          weightMt={c.weightMtEffective ?? c.weightMt}
+          statedMaxDraftM={v.draftMax}
+        />
+      ),
     },
     {
       label: '🛡 Quality',
@@ -137,12 +150,21 @@ export function MatchWorksheet({ worksheet }: Props) {
         </thead>
         <tbody>
           {rows.map((row) => (
-            <tr key={row.label} className="border-t border-ds-border hover:bg-ds-bg/50">
-              <td className="py-2 px-3 font-medium text-ds-text-muted whitespace-nowrap">{row.label}</td>
-              <td className="py-2 px-3 text-ds-text">{row.vessel}</td>
-              <td className="py-2 px-3 text-ds-text">{row.cargoPort}</td>
-              <td className="py-2 px-3 text-ds-text">{row.verdict}</td>
-            </tr>
+            <React.Fragment key={row.label}>
+              <tr className="border-t border-ds-border hover:bg-ds-bg/50">
+                <td className="py-2 px-3 font-medium text-ds-text-muted whitespace-nowrap">{row.label}</td>
+                <td className="py-2 px-3 text-ds-text">{row.vessel}</td>
+                <td className="py-2 px-3 text-ds-text">{row.cargoPort}</td>
+                <td className="py-2 px-3 text-ds-text">{row.verdict}</td>
+              </tr>
+              {row.detail && (
+                <tr className="border-t border-ds-border/40 bg-ds-bg/30">
+                  <td colSpan={4} className="px-3 pb-2">
+                    {row.detail}
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
           ))}
         </tbody>
       </table>

--- a/components/match/__tests__/DraftCalcBreakdown.test.tsx
+++ b/components/match/__tests__/DraftCalcBreakdown.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DraftCalcBreakdown } from '../DraftCalcBreakdown';
+import type { HardFilterCheck } from '@/lib/types';
+
+const DRAFT_PASS: HardFilterCheck = {
+  pass: true,
+  estimatedLadenDraftM: 11.2,
+  portLimitM: 13.0,
+};
+
+const DEST_DRAFT_PASS: HardFilterCheck = {
+  pass: true,
+  estimatedLadenDraftM: 11.2,
+  portLimitM: 12.5,
+};
+
+const DEST_DRAFT_FAIL: HardFilterCheck = {
+  pass: false,
+  reason: 'estimated laden draft 11.2m exceeds port max 10.5m (approximate)',
+  estimatedLadenDraftM: 11.2,
+  portLimitM: 10.5,
+};
+
+const DRAFT_NO_ESTIMATE: HardFilterCheck = {
+  pass: true,
+};
+
+function setup(props: React.ComponentProps<typeof DraftCalcBreakdown>) {
+  render(<DraftCalcBreakdown {...props} />);
+  const toggle = screen.getByTestId('draft-calc-toggle');
+  return { toggle };
+}
+
+describe('DraftCalcBreakdown', () => {
+  it('renders collapsed by default', () => {
+    const { toggle } = setup({
+      loadPort: 'Odesa',
+      dischargePort: 'Burgas',
+      draftCheck: DRAFT_PASS,
+      destDraftCheck: DEST_DRAFT_PASS,
+      dwtSummer: 58000,
+      weightMt: 52000,
+      statedMaxDraftM: 14.0,
+    });
+    expect(screen.queryByTestId('draft-calc-body')).toBeNull();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands on click and shows content', () => {
+    const { toggle } = setup({
+      loadPort: 'Odesa',
+      dischargePort: 'Burgas',
+      draftCheck: DRAFT_PASS,
+      destDraftCheck: DEST_DRAFT_PASS,
+      dwtSummer: 58000,
+      weightMt: 52000,
+      statedMaxDraftM: 14.0,
+    });
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('draft-calc-body')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('both-ports-pass: shows ✓ for both ports and "Clears both" verdict', () => {
+    setup({
+      loadPort: 'Odesa',
+      dischargePort: 'Burgas',
+      draftCheck: DRAFT_PASS,
+      destDraftCheck: DEST_DRAFT_PASS,
+      dwtSummer: 58000,
+      weightMt: 52000,
+      statedMaxDraftM: 14.0,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).toContain('Load port Odesa');
+    expect(body.textContent).toContain('13.0 m');
+    expect(body.textContent).toContain('clears');
+    expect(body.textContent).toContain('Discharge port Burgas');
+    expect(body.textContent).toContain('12.5 m');
+    expect(body.textContent).toContain('Clears both ports');
+  });
+
+  it('one-fail worst-of-two: discharge fails → verdict shows fails', () => {
+    setup({
+      loadPort: 'Rotterdam',
+      dischargePort: 'Mykolaiv',
+      draftCheck: DRAFT_PASS,
+      destDraftCheck: DEST_DRAFT_FAIL,
+      dwtSummer: 75000,
+      weightMt: 68000,
+      statedMaxDraftM: 15.0,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).toContain('Load port Rotterdam');
+    expect(body.textContent).toContain('clears');
+    expect(body.textContent).toContain('Discharge port Mykolaiv');
+    expect(body.textContent).toContain('10.5 m');
+    expect(body.textContent).toContain('exceeds');
+    expect(body.textContent).toContain('Fails one or more ports');
+  });
+
+  it('fallback-unknown: no estimate → static check message shown for both ports', () => {
+    const destNoEst: HardFilterCheck = { pass: true };
+    setup({
+      loadPort: 'Hamburg',
+      dischargePort: 'Santos',
+      draftCheck: DRAFT_NO_ESTIMATE,
+      destDraftCheck: destNoEst,
+      statedMaxDraftM: 14.5,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).toContain('static check vs stated max draft');
+    expect(body.textContent).toContain('14.5 m');
+    expect(body.textContent).toContain('Load port Hamburg');
+    expect(body.textContent).toContain('Discharge port Santos');
+  });
+
+  it('port-no-limit: portLimitM null with estimate → "limit unknown → pass"', () => {
+    const noLimit: HardFilterCheck = { pass: true, estimatedLadenDraftM: 11.2 };
+    setup({
+      loadPort: 'Tanjung Pelepas',
+      dischargePort: null,
+      draftCheck: noLimit,
+      destDraftCheck: { pass: true, estimatedLadenDraftM: 11.2 },
+      dwtSummer: 58000,
+      weightMt: 52000,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).toContain('limit unknown → pass (no data)');
+  });
+
+  it('shows formula steps when dwt + weight available', () => {
+    setup({
+      loadPort: 'Odesa',
+      dischargePort: 'Istanbul',
+      draftCheck: DRAFT_PASS,
+      destDraftCheck: DEST_DRAFT_PASS,
+      dwtSummer: 58000,
+      weightMt: 52000,
+      statedMaxDraftM: 14.0,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).toMatch(/Full-load.*0\.4991.*58.*0\.2991/);
+    expect(body.textContent).toMatch(/Cargo-adjust.*52.*58.*0\.3/);
+    expect(body.textContent).toContain('approximate, conservative');
+  });
+
+  it('no destDraftCheck → shows "check data unavailable" for discharge port', () => {
+    setup({
+      loadPort: 'Gdańsk',
+      dischargePort: 'Cape Town',
+      draftCheck: DRAFT_PASS,
+      statedMaxDraftM: 13.5,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).toContain('Discharge port Cape Town');
+    expect(body.textContent).toContain('check data unavailable');
+  });
+});

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -476,6 +476,8 @@ export interface MatchWorksheet {
     draft: HardFilterCheck;
     crane: HardFilterCheck;
     volume: HardFilterCheck;
+    /** M4: destination (discharge) port draft check — optional, absent in pre-M4 persisted data. */
+    destDraft?: HardFilterCheck;
   };
 }
 

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -387,7 +387,7 @@ async function main(): Promise<void> {
             dwcc: cfValue(vessel.dwcc),
           },
           cargo: { weightMt: cfValue(cargo.weightMt), weightMtEffective: resolveCargoWeight(cargo) ?? null, cargoType, loadPort, dischargePort },
-          hardFilters: { draft: hf.checks.draft, crane: hf.checks.crane, volume: hf.checks.volume },
+          hardFilters: { draft: hf.checks.draft, crane: hf.checks.crane, volume: hf.checks.volume, destDraft: hf.checks.destDraft },
         }),
         bucket,
         readinessVerdict: readiness.verdict,


### PR DESCRIPTION
## Summary
- Collapsible `Draft calculation` block under Draft row in fit-breakdown (MatchesClient expand panel + MatchWorksheet table)
- 3-line formula display: full-load draft → cargo-adjust → estimated laden draft `(approximate, conservative)`
- Per-port rows: `Load port {X}: limit L m → ✓/✗` + `Discharge port {Y}: limit L m → ✓/✗`
- Worst-of-two verdict; fallback to static stated-max-draft when cargo/DWT unknown; `limit unknown → pass (no data)` when no port limit data
- Display-only — gate verdict from persisted `HardFilterCheck`, not recomputed

## Files
- `components/match/DraftCalcBreakdown.tsx` — new collapsible component
- `components/match/__tests__/DraftCalcBreakdown.test.tsx` — 8 behavioral tests
- `components/match/MatchWorksheet.tsx` — adds detail row under Draft
- `app/matches/MatchesClient.tsx` — wires component into fit-breakdown expand panel
- `lib/types.ts` — adds `destDraft?: HardFilterCheck` to `MatchWorksheet.hardFilters`
- `scripts/demo-seed/real-matches.ts` — backfills destDraft in seed data

## Test plan
- [ ] Expand fit-breakdown on a match with draft data → see "Draft calculation" disclosure
- [ ] Click disclosure → formula lines, port rows, verdict visible
- [ ] Match where discharge port limit fails → verdict shows `✗ Fails one or more ports`
- [ ] Match without cargo weight data → fallback static check message
- [ ] `npm test` — 149 tests green, 8 new behavioral tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)