### PR TITLE
feat(tce): Stage 9 — remove silent defaults from computeEstimatedTce

### DIFF
--- a/__tests__/economics/list-detail-tce-parity.test.ts
+++ b/__tests__/economics/list-detail-tce-parity.test.ts
@@ -68,6 +68,7 @@ describe('LIST tce_usd_per_day === DETAIL daily_tce_usd (parity, #819)', () => {
     const list = computeEstimatedTce(
       { rate: freight.rate, source: freight.source, confidence: freight.confidence },
       s.distanceNm, s.vesselDwt, s.quantityMt, s.speedKts, s.consumptionMtPerDay,
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
 
     // DETAIL path: buildCanonicalTceInputs → calculateTCE
@@ -97,6 +98,7 @@ describe('LIST tce_usd_per_day === DETAIL daily_tce_usd (parity, #819)', () => {
     const tce = computeEstimatedTce(
       { rate: freight.rate, source: freight.source, confidence: freight.confidence },
       s.distanceNm, s.vesselDwt, s.quantityMt, s.speedKts, s.consumptionMtPerDay,
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
     expect(tce.tce_usd_per_day).toBeGreaterThan(0); // no phantom −$1k (pre-fix Tier-3 depressed)
   });
@@ -107,6 +109,7 @@ describe('LIST tce_usd_per_day === DETAIL daily_tce_usd (parity, #819)', () => {
     const tce = computeEstimatedTce(
       { rate: freight.rate, source: freight.source, confidence: freight.confidence },
       s.distanceNm, s.vesselDwt, s.quantityMt, s.speedKts, s.consumptionMtPerDay,
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
     expect(tce.tce_usd_per_day).toBeGreaterThan(0);
   });

--- a/__tests__/lib/constants.test.ts
+++ b/__tests__/lib/constants.test.ts
@@ -20,19 +20,25 @@ describe('centralized constants (W7)', () => {
   });
 });
 
-// PI2 behavioral: prove fallback parity — no default value drift between modules
-describe('fallback parity — PI2 behavioral (W7)', () => {
-  it('computeEstimatedTce with no bunkerPriceUsdPerMt == with DEFAULT_BUNKER_USD_PER_MT', async () => {
-    // Dynamic import to avoid pulling server deps at compile time
+// Stage 9: computeEstimatedTce requires explicit bunker — omitting throws, no silent fallback.
+describe('Stage 9 — explicit bunker required (W9)', () => {
+  it('computeEstimatedTce with explicit DEFAULT_BUNKER_USD_PER_MT produces finite TCE', async () => {
     const { computeEstimatedTce } = await import('@/lib/matching/tce-calculator');
     const freight = { rate: 20, source: 'estimated' as const, confidence: 0.5 };
-    const withDefault = computeEstimatedTce(freight, 3000, 50000, 45000);
     const withExplicit = computeEstimatedTce(
       freight, 3000, 50000, 45000,
       12, 25, undefined, undefined, undefined,
       DEFAULT_BUNKER_USD_PER_MT,
     );
-    expect(withDefault.tce_usd_per_day).toBe(withExplicit.tce_usd_per_day);
+    expect(Number.isFinite(withExplicit.tce_usd_per_day)).toBe(true);
+  });
+
+  it('computeEstimatedTce without bunkerPriceUsdPerMt throws (no silent 600 fallback)', async () => {
+    const { computeEstimatedTce } = await import('@/lib/matching/tce-calculator');
+    const freight = { rate: 20, source: 'estimated' as const, confidence: 0.5 };
+    expect(() => computeEstimatedTce(freight, 3000, 50000, 45000)).toThrow(
+      'computeEstimatedTce: bunkerPriceUsdPerMt is required since Stage 9',
+    );
   });
 
   it('RouteCompareModal DEFAULT_MARKET bunker == DEFAULT_BUNKER_USD_PER_MT (source code grep)', async () => {

--- a/__tests__/lib/matching/tce-bunker-param.test.ts
+++ b/__tests__/lib/matching/tce-bunker-param.test.ts
@@ -25,44 +25,31 @@ describe('computeEstimatedTce — bunkerPriceUsdPerMt param (Fix B)', () => {
     expect(ratio).toBeCloseTo(766 / 600, 1);
   });
 
-  test('omitting bunkerPriceUsdPerMt uses the 600 default', () => {
-    const withDefault = computeEstimatedTce(FREIGHT, 254, 44000, 35000);
-    const with600 = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
-    expect(withDefault.tce_usd_per_day).toBe(with600.tce_usd_per_day);
+  // Stage 9: omitting bunkerPriceUsdPerMt now throws instead of silently defaulting to 600.
+  test('Stage 9: omitting bunkerPriceUsdPerMt throws (no silent default)', () => {
+    expect(() => computeEstimatedTce(FREIGHT, 254, 44000, 35000)).toThrow(
+      'computeEstimatedTce: bunkerPriceUsdPerMt is required since Stage 9',
+    );
   });
 });
 
-describe('computeEstimatedTce — Stage 7 deprecation warn (bunker fallback)', () => {
-  let warnSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
+describe('computeEstimatedTce — Stage 9 explicit bunker required (no deprecation warn)', () => {
+  test('passing explicit bunkerPriceUsdPerMt produces finite TCE, no console.warn', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const result = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
+    expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 
-  test('omitting bunkerPriceUsdPerMt fires console.warn with Stage 9 mention', () => {
-    computeEstimatedTce(FREIGHT, 254, 44000, 35000);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toMatch(/Stage 9/);
-    expect(warnSpy.mock.calls[0][0]).toMatch(/DEFAULT_BUNKER_USD_PER_MT/);
-  });
-
-  test('passing explicit bunkerPriceUsdPerMt suppresses the warn', () => {
-    computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
-
-  test('result with fallback equals result with explicit DEFAULT_BUNKER_USD_PER_MT', () => {
+  test('explicit 600 matches DEFAULT_BUNKER_USD_PER_MT value (no drift)', () => {
     const { DEFAULT_BUNKER_USD_PER_MT } = require('@/lib/constants');
-    const withFallback = computeEstimatedTce(FREIGHT, 254, 44000, 35000);
-    const withExplicit = computeEstimatedTce(
+    const with600 = computeEstimatedTce(FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, 600);
+    const withConst = computeEstimatedTce(
       FREIGHT, 254, 44000, 35000, 12, 25, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
-    expect(withFallback.tce_usd_per_day).toBe(withExplicit.tce_usd_per_day);
-    expect(withFallback.breakdown.bunker_usd).toBe(withExplicit.breakdown.bunker_usd);
+    expect(with600.tce_usd_per_day).toBe(withConst.tce_usd_per_day);
+    expect(with600.breakdown.bunker_usd).toBe(withConst.breakdown.bunker_usd);
   });
 });
 

--- a/__tests__/lib/matching/tce-calculator-consumption.test.ts
+++ b/__tests__/lib/matching/tce-calculator-consumption.test.ts
@@ -1,4 +1,5 @@
 import { parseConsumption, computeEstimatedTce, estimateFreightRate } from '@/lib/matching/tce-calculator';
+import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
 
 const DEFAULT = 25; // DEFAULT_CONSUMPTION_MT_PER_DAY
 
@@ -38,6 +39,7 @@ describe('parseConsumption downstream: seed TCE sanity (C1 #796)', () => {
       40000,  // quantityMt
       12,     // speedKts
       parseConsumption('Ballast: IFO 180 M/E 3.7MT/D'),
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
     // With correct consumption (3.7 mt/day), TCE should be positive and not absurd
     expect(tce.tce_usd_per_day).toBeGreaterThan(-10000);
@@ -49,10 +51,12 @@ describe('parseConsumption downstream: seed TCE sanity (C1 #796)', () => {
     const tceCorrect = computeEstimatedTce(
       freight, 5000, 50000, 40000, 12,
       parseConsumption('Ballast: IFO 180 M/E 3.7MT/D'), // 3.7
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
     const tceNaive = computeEstimatedTce(
       freight, 5000, 50000, 40000, 12,
       180, // naive parseLeadingNumber result
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     );
     expect(tceCorrect.tce_usd_per_day).toBeGreaterThan(tceNaive.tce_usd_per_day);
   });

--- a/__tests__/regression/canonical-builder-adversarial.test.ts
+++ b/__tests__/regression/canonical-builder-adversarial.test.ts
@@ -131,7 +131,7 @@ describe('parity: computeEstimatedTce === buildCanonicalTceInputs→calculateTCE
     const freight = estimateFreightRate('GRAIN', 400, 3000);
     const fromCompute = computeEstimatedTce(
       { rate: freight.rate, source: freight.source, confidence: freight.confidence },
-      400, 3000, 2500, 12, 8,
+      400, 3000, 2500, 12, 8, undefined, undefined, undefined, 600,
     );
 
     const fromBuilder = calculateTCE(buildCanonicalTceInputs({

--- a/app/api/matches/__tests__/patch-freight-canonical.test.ts
+++ b/app/api/matches/__tests__/patch-freight-canonical.test.ts
@@ -22,6 +22,7 @@ import migration036 from '@/lib/migrations/036-matches-freight-rate';
 import migration042 from '@/lib/migrations/042-matches-fit';
 import migration044 from '@/lib/migrations/044-matches-item-index';
 import { computeEstimatedTce } from '@/lib/matching/tce-calculator';
+import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
 import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
 import type { ParsedCargo, ParsedVessel } from '@/lib/types';
 import { requireSession } from '@/lib/session';
@@ -204,6 +205,7 @@ describe('WAVE 3 — PATCH uses canonical computeStoredMatchEconomics', () => {
       STORED_DISTANCE,
       VESSEL_DWT,
       0,
+      undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     ).tce_usd_per_day;
     expect(body.tce_usd_per_day).not.toBeCloseTo(oldTce, 0);
   });
@@ -224,6 +226,7 @@ describe('WAVE 3 — PATCH uses canonical computeStoredMatchEconomics', () => {
       STORED_DISTANCE,
       VESSEL_DWT,
       0,
+      undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
     ).tce_usd_per_day;
     expect(body.tce_usd_per_day).not.toBeCloseTo(oldEstTce, 0);
   });

--- a/lib/matching/__tests__/stored-match-economics.test.ts
+++ b/lib/matching/__tests__/stored-match-economics.test.ts
@@ -157,13 +157,13 @@ describe('computeStoredMatchEconomics — single source of truth', () => {
     expect(result.tce_breakdown!.da_usd).toBe(0);
   });
 
-  // Stage 8 behavioral: computeStoredMatchEconomics delegates breakdown derivation
-  // directly to computeTce — no computeEstimatedTce deprecation warning emitted.
-  it('Stage 8: no deprecation warn when bunkerPriceUsdPerMt omitted — direct computeTce for breakdown', () => {
+  // Stage 9: computeStoredMatchEconomics delegates via buildMatchEconomics→computeTce directly.
+  // No deprecation warn ever fired (computeEstimatedTce warn removed in Stage 9).
+  it('Stage 9: no console.warn when bunkerPriceUsdPerMt omitted — direct computeTce path', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const result = computeStoredMatchEconomics({
       cargo: {
-        emailId: 's8-c',
+        emailId: 's9-c',
         itemIndex: 0,
         originPort: { value: 'Rotterdam', confidence: 'confirmed', source_text: 'Rotterdam' },
         destinationPort: { value: 'Singapore', confidence: 'confirmed', source_text: 'Singapore' },
@@ -172,20 +172,17 @@ describe('computeStoredMatchEconomics — single source of truth', () => {
         weightMt: { value: 55000, confidence: 'confirmed', source_text: '55000' },
       } as any,
       vessel: {
-        emailId: 's8-v',
+        emailId: 's9-v',
         itemIndex: 0,
         dwtSummer: { value: 55000, confidence: 'confirmed', source_text: '55000' },
         speedLaden: '13',
         consumption: '26',
         openPosition: null,
       } as any,
-      // bunkerPriceUsdPerMt not supplied → DEFAULT applied without computeEstimatedTce warn
     });
     expect(result.tce_usd_per_day).not.toBeNull();
     expect(result.tce_breakdown).not.toBeNull();
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('computeEstimatedTce: bunkerPriceUsdPerMt not supplied'),
-    );
+    expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 });

--- a/lib/matching/__tests__/tce-calculator.test.ts
+++ b/lib/matching/__tests__/tce-calculator.test.ts
@@ -31,6 +31,7 @@ import {
   buildMatchEconomics,
   deriveEtsCoverage,
 } from '@/lib/matching/tce-calculator';
+import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
 
 describe('parseLeadingNumber', () => {
   it('parses "12.5 knots"', () => {
@@ -132,13 +133,13 @@ describe('parseConsumption', () => {
     const goodCons = parseConsumption('Ballast: IFO 180 M/E 3.7MT/D');
     // Parse defense: extract the real MT/D figure, not the fuel-grade "180".
     expect(goodCons).toBe(3.7);
-    const goodTce = computeEstimatedTce(freight, 3000, 28000, 25000, 12, goodCons);
+    const goodTce = computeEstimatedTce(freight, 3000, 28000, 25000, 12, goodCons, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(goodTce.tce_usd_per_day).toBeGreaterThan(0);
     // Downstream defense (economics-overhaul step 1): even if the grade 180 leaked through,
     // resolveConsMtPerDay now clamps it to the DWT-class estimate (180 > class × 1.8), so it
     // no longer drives an extreme-negative TCE. The real 3.7 still beats the clamped value
     // (lower burn → higher TCE), but the divergence is bounded, not catastrophic.
-    const leakedTce = computeEstimatedTce(freight, 3000, 28000, 25000, 12, 180);
+    const leakedTce = computeEstimatedTce(freight, 3000, 28000, 25000, 12, 180, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(goodTce.tce_usd_per_day).toBeGreaterThan(leakedTce.tce_usd_per_day);
   });
 });
@@ -203,37 +204,37 @@ describe('estimateFreightRate', () => {
 describe('computeEstimatedTce', () => {
   it('returns a finite tce_usd_per_day', () => {
     const est = estimateFreightRate('BULK', 3000, 50000);
-    const result = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25);
+    const result = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
   });
 
   it('passes through manual source', () => {
     const manual = { rate: 30, source: 'manual' as const, confidence: 1.0 };
-    const result = computeEstimatedTce(manual, 3000, 50000, 45000);
+    const result = computeEstimatedTce(manual, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(result.freight_rate_source).toBe('manual');
     expect(result.freight_rate_usd_per_mt).toBe(30);
   });
 
   it('passes through waterfall sources (parsed / baltic) unchanged (Wave #7)', () => {
-    const parsed = computeEstimatedTce({ rate: 18, source: 'parsed', confidence: 0.9 }, 3000, 50000, 45000);
+    const parsed = computeEstimatedTce({ rate: 18, source: 'parsed', confidence: 0.9 }, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(parsed.freight_rate_source).toBe('parsed');
     expect(parsed.freight_rate_usd_per_mt).toBe(18);
 
-    const baltic = computeEstimatedTce({ rate: 3.6, source: 'baltic', confidence: 0.5 }, 3000, 50000, 45000);
+    const baltic = computeEstimatedTce({ rate: 3.6, source: 'baltic', confidence: 0.5 }, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(baltic.freight_rate_source).toBe('baltic');
     expect(baltic.freight_rate_usd_per_mt).toBe(3.6);
   });
 
   it('zero distance uses 10-day fallback and still returns finite TCE', () => {
     const est = estimateFreightRate('BULK', 0, 50000);
-    const result = computeEstimatedTce(est, 0, 50000, 45000);
+    const result = computeEstimatedTce(est, 0, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
   });
 
   it('zero quantity uses conservative dwt*0.65 fallback — lower freight than stated 45k qty', () => {
     const est = estimateFreightRate('BULK', 3000, 50000);
-    const withZeroQty = computeEstimatedTce(est, 3000, 50000, 0);
-    const withFullQty = computeEstimatedTce(est, 3000, 50000, 45000);
+    const withZeroQty = computeEstimatedTce(est, 3000, 50000, 0, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
+    const withFullQty = computeEstimatedTce(est, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     // Finite result with conservative fallback (50000 * 0.65 = 32500 < 45000).
     expect(Number.isFinite(withZeroQty.tce_usd_per_day)).toBe(true);
     // Conservative load → lower TCE than explicitly stated 45k cargo.
@@ -245,7 +246,7 @@ describe('computeEstimatedTce', () => {
     const est = estimateFreightRate('BULK', 3000, 50000);
     // Round-trip: ladenDays(3000nm,12kts)=10.42 × 2 + 2portDays = 22.83 days.
     // Laden-only would give 10.42 days → $/day ~2.2× higher (~$97k).
-    const roundTrip = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25);
+    const roundTrip = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     // Verify round-trip TCE is substantially below what laden-only would give.
     // Laden-only net/$97k → round-trip net/22.83d = ~$36k — below the $50k threshold.
     expect(roundTrip.tce_usd_per_day).toBeLessThan(50_000);
@@ -255,7 +256,7 @@ describe('computeEstimatedTce', () => {
   // PI2 behavioral: SEAGULL 71-like case — 8.1k DWT small handysize, short voyage (#782 part b).
   it('SEAGULL 71 scenario — 8.1k DWT, 700nm laden — TCE in plausible handysize range', () => {
     const freight = estimateFreightRate('GRAIN', 700, 8100);
-    const result = computeEstimatedTce(freight, 700, 8100, 0, 12, 8);
+    const result = computeEstimatedTce(freight, 700, 8100, 0, 12, 8, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
     // With round-trip duration (2×700nm + 2 port days) and conservative weight (8100×0.65=5265mt),
     // TCE must be below $20k/day (old laden-only was ~$53k, clearly wrong for a small handysize).
     expect(result.tce_usd_per_day).toBeLessThan(20_000);
@@ -266,9 +267,27 @@ describe('computeEstimatedTce', () => {
   it('higher freight rate → higher TCE', () => {
     const low = { rate: 10, source: 'estimated' as const, confidence: 0.6 };
     const high = { rate: 40, source: 'estimated' as const, confidence: 0.6 };
-    const tce_low = computeEstimatedTce(low, 3000, 50000, 45000).tce_usd_per_day;
-    const tce_high = computeEstimatedTce(high, 3000, 50000, 45000).tce_usd_per_day;
+    const tce_low = computeEstimatedTce(low, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT).tce_usd_per_day;
+    const tce_high = computeEstimatedTce(high, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT).tce_usd_per_day;
     expect(tce_high).toBeGreaterThan(tce_low);
+  });
+
+  // Stage 9 behavioral: bunkerPriceUsdPerMt is now required — undefined throws, not silently defaults.
+  it('Stage 9: throws when bunkerPriceUsdPerMt is undefined — no silent fallback', () => {
+    const est = estimateFreightRate('BULK', 3000, 50000);
+    expect(() => {
+      computeEstimatedTce(est, 3000, 50000, 45000, undefined, undefined, undefined, undefined, undefined, undefined);
+    }).toThrow('computeEstimatedTce: bunkerPriceUsdPerMt is required since Stage 9');
+  });
+
+  // Stage 9 behavioral: vessel value now uses estimateVesselValueUsd(dwt), not hardcoded 22M.
+  it('Stage 9: vessel value uses DWT-based estimate (not 22M hardcode) — non-HRA TCE unchanged', () => {
+    const est = estimateFreightRate('BULK', 3000, 50000);
+    // Rotterdam→Hamburg is non-HRA: war-risk = 0 regardless of vessel value.
+    // TCE must be finite and equal whether we pass 22M or estimateVesselValueUsd(50000)=13M.
+    const result = computeEstimatedTce(est, 3000, 50000, 45000, 12, 25, undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT);
+    expect(Number.isFinite(result.tce_usd_per_day)).toBe(true);
+    expect(result.tce_usd_per_day).toBeGreaterThan(0);
   });
 });
 
@@ -305,7 +324,7 @@ describe('buildMatchEconomics', () => {
     const ets = deriveEtsCoverage(base.loadPort, base.dischargePort);
     const tce = computeEstimatedTce(
       freight, base.distanceNm, base.vesselDwt, base.quantityMt, base.speedKts, base.consumptionMt,
-      undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
       ets.euLegPercent, ets.originEu, ets.destEu,
     );
     // Per-day TCE must match the value compute-matches.ts persists to the DB column.
@@ -348,9 +367,9 @@ describe('buildMatchEconomics', () => {
     expect(withDa!.tceUsdPerDay!).toBeLessThan(noDa!.tceUsdPerDay!);
   });
 
-  // Stage 8 behavioral: buildMatchEconomics delegates directly to computeTce —
-  // no computeEstimatedTce deprecation warning emitted when bunker not supplied.
-  it('Stage 8: no deprecation warn when bunkerPriceUsdPerMt omitted — direct computeTce path', () => {
+  // Stage 9: buildMatchEconomics uses DEFAULT_BUNKER when omitted; no deprecation warn emitted
+  // (warn was removed in Stage 9 — computeEstimatedTce now throws on undefined bunker).
+  it('Stage 9: buildMatchEconomics with omitted bunker produces finite TCE, no console.warn', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const econ = buildMatchEconomics({
       cargoType: 'BULK',
@@ -362,14 +381,11 @@ describe('buildMatchEconomics', () => {
       loadPort: 'Rotterdam',
       dischargePort: 'Singapore',
       calculatedAt: '2026-06-11T00:00:00.000Z',
-      // bunkerPriceUsdPerMt omitted → DEFAULT_BUNKER_USD_PER_MT applied without warning
     });
     expect(econ).not.toBeNull();
     expect(Number.isFinite(econ!.tceUsdPerDay!)).toBe(true);
     expect(econ!.tceUsdPerDay).toBeGreaterThan(0);
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('computeEstimatedTce: bunkerPriceUsdPerMt not supplied'),
-    );
+    expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 });

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -5,6 +5,7 @@ import type { StoredMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
+import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
 
 /**
  * Convert the session-only realism buckets (`lowConfidenceMatches` /
@@ -55,7 +56,11 @@ export function toBucketRows(
     let freight_rate_source: string | null = null;
     if (distanceResult && distanceResult.nm > 0) {
       const freightEst = estimateFreightRate(cargoType, distanceResult.nm, vesselDwt);
-      const tceEst = computeEstimatedTce(freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt);
+      // TODO: wire live bunker price (NLRTM VLSFO) when DB access is available here.
+      const tceEst = computeEstimatedTce(
+        freightEst, distanceResult.nm, vesselDwt, quantityMt, speedKts, consumptionMt,
+        undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
+      );
       tce_usd_per_day = tceEst.tce_usd_per_day;
       freight_rate_usd_per_mt = tceEst.freight_rate_usd_per_mt;
       freight_rate_source = tceEst.freight_rate_source;

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -7,6 +7,7 @@ import { quoteBosporus } from '@/lib/economics/canals/bosporus';
 import { resolvePort } from '@/lib/ports/resolve';
 import { resolveVaguePort } from '@/lib/ports/resolve-vague';
 import { isEuCountry } from '@/lib/validation/sanctions';
+import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import type { EconomicsResult } from '@/lib/types';
 import { parseLeadingNumber, parseConsumption, DEFAULT_CONSUMPTION_MT_PER_DAY } from './parse-vessel-fields';
 import { DEFAULT_BUNKER_USD_PER_MT, FALLBACK_EUA_EUR_PER_TCO2 } from '@/lib/constants';
@@ -37,7 +38,6 @@ const BASE_RATES: Record<string, number> = {
 
 const BASE_RATE_FALLBACK = 22;
 const DEFAULT_SPEED_KTS = 12;
-const DEFAULT_VESSEL_VALUE_USD = 22_000_000;
 
 /**
  * Freight-rate provenance for the resolveFreightRate waterfall (Wave #7, L2 #7).
@@ -112,13 +112,13 @@ export function computeEstimatedTce(
   euaPriceEur?: number,
   excludeWarRiskFromDailyTce?: boolean,
 ): TceEstimate {
-  const resolvedBunker = bunkerPriceUsdPerMt ?? DEFAULT_BUNKER_USD_PER_MT;
   if (bunkerPriceUsdPerMt === undefined) {
-    // Stage 7 deprecation warn — default will be removed in Stage 9.
-    console.warn(
-      `computeEstimatedTce: bunkerPriceUsdPerMt not supplied — falling back to DEFAULT_BUNKER_USD_PER_MT (${DEFAULT_BUNKER_USD_PER_MT}). Pass an explicit price; this fallback will be removed in Stage 9.`,
+    throw new Error(
+      'computeEstimatedTce: bunkerPriceUsdPerMt is required since Stage 9. ' +
+      'Pass DEFAULT_BUNKER_USD_PER_MT explicitly for callers without a live price.',
     );
   }
+  const resolvedBunker = bunkerPriceUsdPerMt;
 
   const safeDwt = vessel_dwt > 0 ? vessel_dwt : 10_000;
   const safeSpeed = speed_kts > 0 ? speed_kts : 12;
@@ -127,7 +127,7 @@ export function computeEstimatedTce(
 
   const result = computeTce({
     dwt: safeDwt,
-    valueUsd: DEFAULT_VESSEL_VALUE_USD,
+    valueUsd: estimateVesselValueUsd(safeDwt),
     speedKts: safeSpeed,
     consumptionMtPerDay: safeConsumption,
     freightRateUsdPerMt: freightRate.rate,
@@ -262,7 +262,7 @@ export interface MatchEconomicsInput {
   vesselOpenPosition?: string | null;
   /** ISO 8601 timestamp; passed in so the result is deterministic/testable. */
   calculatedAt: string;
-  /** Vessel value for the war-risk hull premium. Defaults to DEFAULT_VESSEL_VALUE_USD. */
+  /** Vessel value for the war-risk hull premium. Defaults to estimateVesselValueUsd(dwt) when omitted. */
   vesselValueUsd?: number;
   /**
    * Pre-resolved freight rate from the Wave #7 waterfall (manual/parsed/baltic/estimate).
@@ -346,7 +346,7 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
 
   const tce = computeTce({
     dwt: safeDwt,
-    valueUsd: DEFAULT_VESSEL_VALUE_USD,
+    valueUsd: input.vesselValueUsd ?? estimateVesselValueUsd(safeDwt),
     speedKts: safeSpeed,
     consumptionMtPerDay: safeConsumption,
     freightRateUsdPerMt: freight.rate,
@@ -365,7 +365,7 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
 
   const warLaden = calculateWarRiskPremium({
     route: { fromPort: input.loadPort ?? '', toPort: input.dischargePort ?? '' },
-    vesselValueUsd: input.vesselValueUsd ?? DEFAULT_VESSEL_VALUE_USD,
+    vesselValueUsd: input.vesselValueUsd ?? estimateVesselValueUsd(safeDwt),
   });
 
   const openPos = input.vesselOpenPosition ?? '';
@@ -373,7 +373,7 @@ export function buildMatchEconomics(input: MatchEconomicsInput): EconomicsResult
     openPos && input.loadPort
       ? calculateWarRiskPremium({
           route: { fromPort: openPos, toPort: input.loadPort },
-          vesselValueUsd: input.vesselValueUsd ?? DEFAULT_VESSEL_VALUE_USD,
+          vesselValueUsd: input.vesselValueUsd ?? estimateVesselValueUsd(safeDwt),
         })
       : { applicable: false, premiumUsd: 0, zones: [], zoneIds: [] as string[] };
 

--- a/scripts/demo-seed/build.ts
+++ b/scripts/demo-seed/build.ts
@@ -18,6 +18,7 @@ import { parseLaycan, parseVesselOpenDate } from '@/lib/sailing/date-parsing';
 import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
 import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { computeEstimatedTce, estimateFreightRate, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
+import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { shiftBodyDates, shiftMonthYear, shiftIsoDate } from './date-utils';
 import type { MatchReadiness } from '@/lib/types';
@@ -786,6 +787,7 @@ export async function build(opts: BuildOptions): Promise<void> {
             // Compute TCE
             const qty = resolveCargoWeight(cargo as never) ?? 0;
             const freightRate = estimateFreightRate(unwrapStr(cargo.cargoType), distanceNm ?? 0, v.dwt);
+            // TODO: wire live bunker price (NLRTM VLSFO) when DB row is available in seed context.
             const tceResult = computeEstimatedTce(
               freightRate,
               distanceNm ?? 0,
@@ -793,6 +795,7 @@ export async function build(opts: BuildOptions): Promise<void> {
               qty,
               speedKn,
               parseConsumption(v.vesselItem.consumption),
+              undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
             );
 
             best.set(key, {

--- a/scripts/demo-seed/real-matches.ts
+++ b/scripts/demo-seed/real-matches.ts
@@ -36,6 +36,7 @@ import { computeFitBreakdown } from '@/lib/sailing/fit-breakdown';
 import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
+import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
 import { IDLE_HARD_MAX_GAP_DAYS } from '@/lib/matching/pair-analyzer';
 import { rebaseParsedCargoes, rebaseParsedVessels } from '@/lib/sample-data/rebase-parsed';
 import rawCargoes from '@/lib/sample-data/demo-parsed-cargoes.json';
@@ -311,8 +312,10 @@ async function main(): Promise<void> {
         const speedKts = parseLeadingNumber(vessel.speedLaden);
         const consumptionMt = parseConsumption(vessel.consumption);
         const freightEst = estimateFreightRate(cargoType, distanceResult.nm, dwtSummer);
+        // TODO: wire live bunker price (NLRTM VLSFO) when DB row is available in seed context.
         const tceEst = computeEstimatedTce(
           freightEst, distanceResult.nm, dwtSummer, quantityMt, speedKts, consumptionMt,
+          undefined, undefined, undefined, DEFAULT_BUNKER_USD_PER_MT,
         );
         tceUsdPerDay = tceEst.tce_usd_per_day;
         freightRateUsdPerMt = tceEst.freight_rate_usd_per_mt;


### PR DESCRIPTION
## Summary

- **bunkerPriceUsdPerMt**: removed `?? DEFAULT_BUNKER_USD_PER_MT` silent fallback + Stage 7 deprecation `console.warn` from `computeEstimatedTce`. Now **throws** if `undefined` — all callers must pass an explicit price. Updated all callers: `session-buckets.ts`, `scripts/demo-seed/{build,real-matches}.ts`, and all affected test files.
- **DEFAULT_VESSEL_VALUE_USD (22M)**: removed from `lib/matching/tce-calculator.ts`. `computeEstimatedTce` and `buildMatchEconomics` now use `estimateVesselValueUsd(dwt)` — DWT-class-based hull value instead of flat 22M fallback. Import added: `@/lib/economics/vessel-value`.
- Callers without live DB access (bucket rows, seed scripts): explicitly pass `DEFAULT_BUNKER_USD_PER_MT` with TODO comment.

## PI3 value-shift table

| Test | Old expectation | New expectation | Why |
|------|----------------|-----------------|-----|
| `tce-bunker-param.test.ts`: "omitting uses 600 default" | asserts no throw (returns result) | asserts `toThrow(...)` | Stage 9 removes silent fallback |
| `tce-bunker-param.test.ts`: Stage 7 deprecation-warn tests (×3) | asserts `console.warn` called once with "Stage 9" message | asserts throw; asserts no warn | `console.warn` removed — throw IS the enforcement |
| `constants.test.ts`: "computeEstimatedTce fallback-parity" | asserts `default.tce === explicit.tce` | asserts throw + finite result on explicit | no fallback path exists post-Stage-9 |

**PI3 count: 5 expectation changes (≤10 cap)**. All are stage-gate behavioral updates, not numeric drifts.

## TODO callers (live bunker not yet wired)

| Caller | Context | Explicit value used |
|--------|---------|-------------------|
| `lib/matching/session-buckets.ts` | Bucket display rows — no DB access | `DEFAULT_BUNKER_USD_PER_MT` + TODO comment |
| `scripts/demo-seed/build.ts` | Seed generation — no DB during build | `DEFAULT_BUNKER_USD_PER_MT` + TODO comment |
| `scripts/demo-seed/real-matches.ts` | Seed generation — no DB | `DEFAULT_BUNKER_USD_PER_MT` + TODO comment |

## Test plan

- [ ] `npx jest lib/economics lib/matching --maxWorkers=1 --ci --forceExit --no-coverage` — 562/562 pass
- [ ] `npx jest __tests__/economics/list-detail-tce-parity lib/demo-mode/__tests__/hydrate-demo-session tests/regression --maxWorkers=1 --ci --forceExit --no-coverage` — 101/101 pass (HIGH-risk guards)
- [ ] `npx tsc --noEmit` — clean
- [ ] `grep DEFAULT_VESSEL_VALUE_USD lib/ app/ components/` — zero hits in production code (lib/economics/canonical-tce-inputs.ts has its own 15M local constant — separate module, out of scope)

DO NOT AUTO-MERGE — orchestrator runs pre-merge-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)