### PR TITLE
fix(draft): show formula + neutral verdict when stored gate lacks laden fields

### DIFF
--- a/components/match/DraftCalcBreakdown.tsx
+++ b/components/match/DraftCalcBreakdown.tsx
@@ -67,11 +67,17 @@ export function DraftCalcBreakdown({
 }: Props) {
   const [open, setOpen] = useState(false);
 
-  const est = draftCheck.estimatedLadenDraftM;
+  // Use stored estimate when available; for pre-M4 stored matches it may be absent even
+  // when vessel DWT and cargo weight are live on the worksheet — compute on the fly then.
+  // Display-only: gate pass/fail comes from the persisted HardFilterCheck.pass, not recomputed.
+  let est = draftCheck.estimatedLadenDraftM;
+  if (est == null && dwtSummer != null && weightMt != null && dwtSummer > 0 && weightMt > 0) {
+    const fullLoad = 0.4991 * Math.pow(dwtSummer, 0.2991);
+    const ratio = Math.min(weightMt / dwtSummer, 1);
+    est = Math.ceil(fullLoad * Math.pow(ratio, 0.3) * 10) / 10;
+  }
   const hasEstimate = est != null;
 
-  // Intermediate display steps — mirrors lib/sailing/laden-draft.ts empirical formula.
-  // Display only; gate verdict comes from persisted HardFilterCheck, not recomputed here.
   let fullLoadDraftM: number | null = null;
   let rawDraftM: number | null = null;
   if (hasEstimate && dwtSummer != null && weightMt != null && dwtSummer > 0 && weightMt > 0) {
@@ -79,8 +85,6 @@ export function DraftCalcBreakdown({
     const ratio = Math.min(weightMt / dwtSummer, 1);
     rawDraftM = fullLoadDraftM * Math.pow(ratio, 0.3);
   }
-
-  const bothPass = draftCheck.pass && (destDraftCheck == null || destDraftCheck.pass);
 
   return (
     <div className="mt-1">
@@ -137,14 +141,24 @@ export function DraftCalcBreakdown({
               />
             ) : (
               <div className="text-xs text-ds-text-muted">
-                Discharge port {dischargePort ?? '(unknown)'}: check data unavailable
+                Discharge port {dischargePort ?? '(unknown)'}: limit unknown → pass (no data)
               </div>
             )}
           </div>
 
-          {/* Worst-of-two verdict */}
-          <div className={`text-xs font-medium ${bothPass ? 'text-emerald-600' : 'text-red-500'}`}>
-            {bothPass ? '✓ Clears both ports' : '✗ Fails one or more ports (worst-of-two)'}
+          {/* Worst-of-two verdict — only claim "both" when discharge data is present */}
+          <div className={`text-xs font-medium ${
+            !draftCheck.pass || (destDraftCheck != null && !destDraftCheck.pass)
+              ? 'text-red-500'
+              : destDraftCheck != null
+                ? 'text-emerald-600'
+                : 'text-ds-text-muted'
+          }`}>
+            {!draftCheck.pass || (destDraftCheck != null && !destDraftCheck.pass)
+              ? '✗ Fails one or more ports (worst-of-two)'
+              : destDraftCheck != null
+                ? '✓ Clears both ports'
+                : '✓ Load port clears · discharge: no data'}
           </div>
         </div>
       )}

--- a/components/match/__tests__/DraftCalcBreakdown.test.tsx
+++ b/components/match/__tests__/DraftCalcBreakdown.test.tsx
@@ -155,7 +155,7 @@ describe('DraftCalcBreakdown', () => {
     expect(body.textContent).toContain('approximate, conservative');
   });
 
-  it('no destDraftCheck → shows "check data unavailable" for discharge port', () => {
+  it('no destDraftCheck → shows neutral "limit unknown → pass (no data)" for discharge port', () => {
     setup({
       loadPort: 'Gdańsk',
       dischargePort: 'Cape Town',
@@ -165,6 +165,39 @@ describe('DraftCalcBreakdown', () => {
     fireEvent.click(screen.getByTestId('draft-calc-toggle'));
     const body = screen.getByTestId('draft-calc-body');
     expect(body.textContent).toContain('Discharge port Cape Town');
-    expect(body.textContent).toContain('check data unavailable');
+    expect(body.textContent).toContain('limit unknown → pass (no data)');
+  });
+
+  it('no destDraftCheck + load passes → verdict is neutral, NOT green "Clears both ports"', () => {
+    setup({
+      loadPort: 'Gdańsk',
+      dischargePort: 'Liverpool',
+      draftCheck: DRAFT_PASS,
+      dwtSummer: 3178,
+      weightMt: 2720,
+      statedMaxDraftM: 5.51,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    expect(body.textContent).not.toContain('Clears both ports');
+    expect(body.textContent).toContain('discharge: no data');
+  });
+
+  it('stored gate without estimatedLadenDraftM, DWT+cargo available → formula renders with numbers', () => {
+    setup({
+      loadPort: 'Szczecin',
+      dischargePort: 'Liverpool',
+      draftCheck: DRAFT_NO_ESTIMATE,   // { pass: true } — no estimatedLadenDraftM stored
+      dwtSummer: 3178,
+      weightMt: 2720,
+      statedMaxDraftM: 5.51,
+    });
+    fireEvent.click(screen.getByTestId('draft-calc-toggle'));
+    const body = screen.getByTestId('draft-calc-body');
+    // Formula must render with real DWT/cargo numbers, not fallback "unknown" message
+    expect(body.textContent).not.toContain('cargo weight / DWT unknown');
+    expect(body.textContent).toContain('3,178');
+    expect(body.textContent).toContain('2,720');
+    expect(body.textContent).toContain('approximate, conservative');
   });
 });


### PR DESCRIPTION
## Root cause

Two independent bugs in `DraftCalcBreakdown`, both triggered by pre-M4 stored matches
where `HardFilterCheck` lacked `estimatedLadenDraftM` and `destDraft`.

### Bug 1: "cargo weight / DWT unknown" even when data is available

The formula block was gated entirely on `draftCheck.estimatedLadenDraftM != null`.
Pre-M4 stored seed matches never persisted this field → fell through to static fallback,
even though `worksheet.vessel.dwtSummer` (3,178) and `worksheet.cargo.weightMt` (2,720)
were live on the page (Weight row showed them correctly).

**Fix:** When `estimatedLadenDraftM` is absent but `dwtSummer` + `weightMt` are
available, compute the estimate on the fly using the same empirical formula
(`laden-draft.ts`) with conservative ceil-to-0.1m. Display-only — gate
`pass/fail` is still the persisted value.

### Bug 2: "Discharge port Liverpool: check data unavailable → ✓ Clears both ports"

`bothPass = loadPass && (destNull || destPass)` made `bothPass = true` when
`destDraftCheck` was entirely absent, rendering a confident green "✓ Clears both ports".

**Fix:**
- `null destDraftCheck` → muted neutral verdict: "✓ Load port clears · discharge: no data"
- Port row text: "check data unavailable" → "limit unknown → pass (no data)"
- "✓ Clears both ports" (green) only rendered when both checks are present and pass

## Tests

+3 behavioral cases:
- `stored gate without estimatedLadenDraftM, DWT+cargo available → formula renders with numbers`
- `no destDraftCheck + load passes → verdict is neutral, NOT green "Clears both ports"`
- `no destDraftCheck → shows neutral "limit unknown → pass (no data)" for discharge port`

140 related tests pass (10 DraftCalcBreakdown + 130 laden-draft + match-filters).

## Files changed

- `components/match/DraftCalcBreakdown.tsx` — fix formula fallback + discharge port verdict
- `components/match/__tests__/DraftCalcBreakdown.test.tsx` — updated test + 3 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)