### PR TITLE
feat(match-ui): persist full filter set + bucket reason; all-checks accordion (stages 0-0b-1)

### DIFF
--- a/components/match/AllChecksAccordion.tsx
+++ b/components/match/AllChecksAccordion.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { MatchHardFilters, HardFilterCheck } from '@/lib/types';
+
+const GATE_LABELS: Array<{ key: keyof MatchHardFilters; label: string }> = [
+  { key: 'draft', label: 'Draft (load port)' },
+  { key: 'destDraft', label: 'Draft (discharge port)' },
+  { key: 'crane', label: 'Cranes (load)' },
+  { key: 'destCrane', label: 'Cranes (discharge)' },
+  { key: 'volume', label: 'Volume / hold fit' },
+  { key: 'cargoWeight', label: 'Cargo weight vs capacity' },
+  { key: 'cargoVessel', label: 'Cargo ↔ vessel type' },
+  { key: 'imsbc', label: 'IMSBC compatibility' },
+  { key: 'vesselAge', label: 'Vessel age cap' },
+  { key: 'dimensions', label: 'Beam / LOA limits' },
+  { key: 'gearRequired', label: 'Gear required' },
+  { key: 'voyage', label: 'Voyage restrictions' },
+  { key: 'flagClass', label: 'Flag / class requirements' },
+  { key: 'warPositionVoyage', label: 'War-zone position / voyage' },
+];
+
+function verdict(check: HardFilterCheck): { icon: string; cls: string; label: string } {
+  if (check.warning) return { icon: '⚠️', cls: 'text-amber-600', label: 'Warn' };
+  if (check.pass) return { icon: '✓', cls: 'text-emerald-600', label: 'Pass' };
+  return { icon: '✗', cls: 'text-red-500', label: 'Fail' };
+}
+
+export function AllChecksAccordion({ hardFilters }: { hardFilters: MatchHardFilters }) {
+  const [open, setOpen] = useState(false);
+  const rows = GATE_LABELS
+    .map((g) => ({ ...g, check: hardFilters[g.key] }))
+    .filter((r): r is typeof r & { check: HardFilterCheck } => r.check != null);
+  const failCount = rows.filter((r) => !r.check.pass && !r.check.warning).length;
+  const warnCount = rows.filter((r) => r.check.warning).length;
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-xs text-ds-text-muted hover:text-ds-text transition-colors"
+        aria-expanded={open}
+        data-testid="all-checks-toggle"
+      >
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        All checks ({rows.length}) · {failCount > 0 ? `${failCount} fail` : 'all pass'}{warnCount > 0 ? ` · ${warnCount} warn` : ''}
+      </button>
+      {open && (
+        <ul className="mt-1.5 pl-3 border-l-2 border-ds-border space-y-1" data-testid="all-checks-body">
+          {rows.map(({ key, label, check }) => {
+            const v = verdict(check);
+            return (
+              <li key={String(key)} className="flex items-baseline justify-between gap-3 text-xs">
+                <span className="text-ds-text">{label}</span>
+                <span className={`shrink-0 ${v.cls}`}>
+                  {v.icon} {check.reason ?? v.label}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/match/AllChecksAccordion.tsx
+++ b/components/match/AllChecksAccordion.tsx
@@ -27,7 +27,7 @@ function verdict(check: HardFilterCheck): { icon: string; cls: string; label: st
   return { icon: '✗', cls: 'text-red-500', label: 'Fail' };
 }
 
-export function AllChecksAccordion({ hardFilters }: { hardFilters: MatchHardFilters }) {
+export function AllChecksAccordion({ hardFilters }: { hardFilters: Partial<MatchHardFilters> }) {
   const [open, setOpen] = useState(false);
   const rows = GATE_LABELS
     .map((g) => ({ ...g, check: hardFilters[g.key] }))

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -1,6 +1,7 @@
-import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
+import type { MatchWorksheet as MatchWorksheetType, MatchHardFilters } from '@/lib/types';
 import React from 'react';
 import { DraftCalcBreakdown } from './DraftCalcBreakdown';
+import { AllChecksAccordion } from './AllChecksAccordion';
 
 interface Props {
   worksheet: MatchWorksheetType | null;
@@ -168,6 +169,11 @@ export function MatchWorksheet({ worksheet }: Props) {
           ))}
         </tbody>
       </table>
+      {hf && (
+        <div className="px-3 pb-3 pt-1">
+          <AllChecksAccordion hardFilters={hf as MatchHardFilters} />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -1,4 +1,4 @@
-import type { MatchWorksheet as MatchWorksheetType, MatchHardFilters } from '@/lib/types';
+import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
 import React from 'react';
 import { DraftCalcBreakdown } from './DraftCalcBreakdown';
 import { AllChecksAccordion } from './AllChecksAccordion';
@@ -171,7 +171,7 @@ export function MatchWorksheet({ worksheet }: Props) {
       </table>
       {hf && (
         <div className="px-3 pb-3 pt-1">
-          <AllChecksAccordion hardFilters={hf as MatchHardFilters} />
+          <AllChecksAccordion hardFilters={hf} />
         </div>
       )}
     </div>

--- a/components/match/__tests__/AllChecksAccordion.test.tsx
+++ b/components/match/__tests__/AllChecksAccordion.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AllChecksAccordion } from '../AllChecksAccordion';
+import type { MatchHardFilters } from '@/lib/types';
+
+const hf: MatchHardFilters = {
+  draft: { pass: true }, crane: { pass: true, warning: true, reason: 'Confirm cranes' },
+  volume: { pass: true }, cargoVessel: { pass: true }, destDraft: { pass: true },
+  destCrane: { pass: true }, cargoWeight: { pass: true },
+  imsbc: { pass: false, reason: 'IMSBC Group B + DG-restricted' },
+  vesselAge: { pass: true }, dimensions: { pass: true }, gearRequired: { pass: true },
+  voyage: { pass: true }, flagClass: { pass: true }, warPositionVoyage: { pass: true },
+};
+
+test('collapsed by default, expands on click', () => {
+  render(<AllChecksAccordion hardFilters={hf} />);
+  expect(screen.queryByText(/IMSBC Group B/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('all-checks-toggle'));
+  expect(screen.getByText(/IMSBC Group B/)).toBeInTheDocument();
+});
+
+test('renders pass / fail / warn verdicts', () => {
+  render(<AllChecksAccordion hardFilters={hf} />);
+  fireEvent.click(screen.getByTestId('all-checks-toggle'));
+  const body = screen.getByTestId('all-checks-body');
+  expect(body).toHaveTextContent('IMSBC'); // failed gate shown
+  expect(body).toHaveTextContent('Confirm cranes'); // warn reason shown
+});
+
+test('omits gates absent from pre-this-PR data', () => {
+  const partial = { draft: { pass: true }, crane: { pass: true }, volume: { pass: true },
+    cargoVessel: { pass: true }, destDraft: { pass: true }, destCrane: { pass: true },
+    cargoWeight: { pass: true } } as MatchHardFilters;
+  render(<AllChecksAccordion hardFilters={partial} />);
+  fireEvent.click(screen.getByTestId('all-checks-toggle'));
+  expect(screen.queryByText(/War position/i)).not.toBeInTheDocument();
+});

--- a/lib/matching/__tests__/bucket-reason.test.ts
+++ b/lib/matching/__tests__/bucket-reason.test.ts
@@ -1,0 +1,26 @@
+import { deriveBucketReason } from '@/lib/matching/bucket-reason';
+
+test('unknown verdict → insufficientData', () => {
+  expect(deriveBucketReason({ verdict: 'unknown', gapDays: null, matchLevel: 'possible',
+    tceUsdPerDay: 9000, vesselDwt: 50000, issues: [] })).toEqual({
+      bucket: 'insufficientData',
+      reason: 'No distance/timing data — readiness verdict is unknown.',
+    });
+});
+
+test('idle gap > 21d → lowConfidence', () => {
+  expect(deriveBucketReason({ verdict: 'idle', gapDays: 30, matchLevel: 'good',
+    tceUsdPerDay: 9000, vesselDwt: 50000, issues: [] }).bucket).toBe('lowConfidence');
+});
+
+test('tce below DWT-tiered breakeven → lowConfidence', () => {
+  const r = deriveBucketReason({ verdict: 'ideal', gapDays: 1, matchLevel: 'good',
+    tceUsdPerDay: 4000, vesselDwt: 50000, issues: [] }); // 40k<dwt≤65k floor = $5,500
+  expect(r.bucket).toBe('lowConfidence');
+  expect(r.reason).toMatch(/below the \$5,500\/day breakeven/);
+});
+
+test('all clear → main', () => {
+  expect(deriveBucketReason({ verdict: 'ideal', gapDays: 1, matchLevel: 'good',
+    tceUsdPerDay: 12000, vesselDwt: 50000, issues: [] }).bucket).toBe('main');
+});

--- a/lib/matching/__tests__/persist-session-matches-worksheet-filters.test.ts
+++ b/lib/matching/__tests__/persist-session-matches-worksheet-filters.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Behavioral test — persistSessionMatches carries all 14 hard filters + sanctions
+ * into worksheet_json (stage 0). PI2: real in-memory DB + real function call.
+ */
+import Database from 'better-sqlite3';
+import { runMigrations } from '@/lib/migrations/runner';
+import { allMigrations } from '@/lib/migrations';
+import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
+import { listMatches } from '@/lib/matching/matches-repository';
+import { resolveSyntheticCargo, resolveSyntheticVessel } from '@/lib/sample-data/synthetic-economics';
+import type { Match, MatchWorksheet, MatchHardFilters } from '@/lib/types';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  runMigrations(db, allMigrations);
+  return db;
+}
+
+const FULL_HARD_FILTERS: MatchHardFilters = {
+  draft:  { pass: true },
+  crane:  { pass: true, warning: true, reason: 'Confirm cranes' },
+  volume: { pass: true },
+  cargoVessel: { pass: true },
+  destDraft: { pass: true },
+  destCrane: { pass: true },
+  cargoWeight: { pass: true },
+  imsbc: { pass: false, reason: 'IMSBC Group B + DG-restricted' },
+  vesselAge: { pass: true },
+  dimensions: { pass: true },
+  gearRequired: { pass: true },
+  voyage: { pass: true },
+  flagClass: { pass: true },
+  warPositionVoyage: { pass: true },
+};
+
+function makeMatch(now: Date): Match {
+  const cargo = resolveSyntheticCargo(now);
+  const vessel = resolveSyntheticVessel(now);
+  const worksheet: MatchWorksheet = {
+    readiness: { verdict: 'ideal', explanation: '', openPosition: null,
+      openDate: null, laycanStart: null, laycanEnd: null, distanceNm: null,
+      distanceExact: false, speedKn: null, sailingDays: null, arrivalDate: null, gapDays: null },
+    vessel: { draftMax: null, grainCapacity: null, grainCapacityUnit: null, geared: true,
+      vesselType: 'BULK CARRIER', flag: 'PAN', built: 2010, pandi: null, classSociety: null,
+      lastCargoes: null, dwtSummer: 57000, dwcc: null },
+    cargo: { weightMt: 50000, cargoType: 'GRAIN', loadPort: 'NOLA', dischargePort: 'Rotterdam' },
+    hardFilters: { draft: { pass: true }, crane: { pass: true }, volume: { pass: true } },
+  };
+  return {
+    cargoEmailId: cargo.emailId,
+    cargoItemIndex: 0,
+    vesselEmailId: vessel.emailId,
+    vesselItemIndex: 0,
+    score: 80,
+    matchLevel: 'good',
+    matchReasons: ['test'],
+    issues: [],
+    hardFilters: FULL_HARD_FILTERS,
+    sanctions: { risk: 'MEDIUM', reason: 'flag on watch list', blocking: false },
+    worksheet,
+  };
+}
+
+test('worksheet_json carries all 14 hard-filter keys', () => {
+  const now = new Date();
+  const db = freshDb();
+  const cargo = resolveSyntheticCargo(now);
+  const vessel = resolveSyntheticVessel(now);
+  const m = makeMatch(now);
+  persistSessionMatches(db, 'sess-1', [m], [cargo], [vessel]);
+  const [row] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+  const ws = JSON.parse(row.worksheet_json!);
+  const keys = Object.keys(ws.hardFilters);
+  expect(keys).toEqual(expect.arrayContaining([
+    'draft','crane','volume','cargoVessel','destDraft','destCrane','cargoWeight',
+    'imsbc','vesselAge','dimensions','gearRequired','voyage','flagClass','warPositionVoyage',
+  ]));
+  expect(ws.hardFilters.imsbc.reason).toMatch(/IMSBC Group B/);
+  expect(ws.hardFilters.crane.warning).toBe(true);
+});
+
+test('worksheet_json carries sanctions', () => {
+  const now = new Date();
+  const db = freshDb();
+  const cargo = resolveSyntheticCargo(now);
+  const vessel = resolveSyntheticVessel(now);
+  const m = makeMatch(now);
+  persistSessionMatches(db, 'sess-2', [m], [cargo], [vessel]);
+  const [row] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+  const ws = JSON.parse(row.worksheet_json!);
+  expect(ws.sanctions).toEqual({ risk: 'MEDIUM', reason: 'flag on watch list', blocking: false });
+});
+
+test('worksheet_json gracefully omits sanctions when absent on Match', () => {
+  const now = new Date();
+  const db = freshDb();
+  const cargo = resolveSyntheticCargo(now);
+  const vessel = resolveSyntheticVessel(now);
+  const m = makeMatch(now);
+  delete (m as Partial<Match>).sanctions;
+  persistSessionMatches(db, 'sess-3', [m], [cargo], [vessel]);
+  const [row] = listMatches(db, { sortBy: 'score', sortDir: 'desc' });
+  const ws = JSON.parse(row.worksheet_json!);
+  expect(ws.sanctions).toBeUndefined();
+});

--- a/lib/matching/bucket-reason.ts
+++ b/lib/matching/bucket-reason.ts
@@ -1,0 +1,40 @@
+import { breakevenTceByDwt } from '@/lib/economics/breakeven-thresholds';
+import type { MatchLevel, ReadinessVerdict } from '@/lib/types';
+
+export type RealismBucket = 'main' | 'lowConfidence' | 'insufficientData' | 'blocked';
+
+export interface BucketReason {
+  bucket: RealismBucket;
+  reason: string;
+}
+
+export interface BucketReasonInput {
+  verdict: ReadinessVerdict;
+  gapDays: number | null;
+  matchLevel: MatchLevel;
+  tceUsdPerDay: number | null;
+  vesselDwt: number | null;
+  issues: string[];
+}
+
+const IDLE_HARD_MAX_GAP_DAYS = 21;
+
+/** Pure mirror of the realism-bucket partition, returning a broker-facing reason.
+ *  Evaluated once at persist time; the UI renders the string verbatim. */
+export function deriveBucketReason(i: BucketReasonInput): BucketReason {
+  if (i.verdict === 'unknown')
+    return { bucket: 'insufficientData', reason: 'No distance/timing data — readiness verdict is unknown.' };
+  if (i.verdict === 'idle' && i.gapDays != null && i.gapDays > IDLE_HARD_MAX_GAP_DAYS)
+    return { bucket: 'lowConfidence', reason: `Vessel idle ${i.gapDays} days before laycan (> ${IDLE_HARD_MAX_GAP_DAYS}-day cap).` };
+  if (i.matchLevel === 'weak')
+    return { bucket: 'lowConfidence', reason: 'Fit score is in the weak band.' };
+  if (i.issues.some((s) => s.startsWith('SIZE:')))
+    return { bucket: 'lowConfidence', reason: 'Deadfreight risk — cargo undersized for the vessel.' };
+  if (i.tceUsdPerDay != null && i.vesselDwt != null) {
+    const floor = breakevenTceByDwt(i.vesselDwt);
+    if (i.tceUsdPerDay < floor)
+      return { bucket: 'lowConfidence',
+        reason: `TCE $${Math.round(i.tceUsdPerDay).toLocaleString('en-US')}/day is below the $${floor.toLocaleString('en-US')}/day breakeven for this size.` };
+  }
+  return { bucket: 'main', reason: 'Passed all hard filters and economic thresholds.' };
+}

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -5,6 +5,7 @@ import { createMatch } from '@/lib/matching/matches-repository';
 import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
+import { deriveBucketReason } from '@/lib/matching/bucket-reason';
 import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { scoreEconomics } from '@/lib/sailing/fit-breakdown';
@@ -95,8 +96,18 @@ export function persistSessionMatches(
     // worksheet laycan, recompute readiness rather than carrying stale data verbatim.
     // This catches seed rows whose worksheet_json was built against a pre-normalization
     // July laycan while parsed_results now has the correct June string (#821).
+    const bucketReason = m.worksheet
+      ? deriveBucketReason({
+          verdict: m.worksheet.readiness?.verdict ?? 'unknown',
+          gapDays: m.worksheet.readiness?.gapDays ?? null,
+          matchLevel: m.matchLevel,
+          tceUsdPerDay: tce_usd_per_day,
+          vesselDwt: vesselDwt || null,
+          issues: m.issues ?? [],
+        })
+      : undefined;
     const worksheetForPersist = m.worksheet
-      ? { ...m.worksheet, hardFilters: m.hardFilters ?? m.worksheet.hardFilters, sanctions: m.sanctions }
+      ? { ...m.worksheet, hardFilters: m.hardFilters ?? m.worksheet.hardFilters, sanctions: m.sanctions, bucketReason }
       : null;
     let worksheetJson: string | null = worksheetForPersist ? JSON.stringify(worksheetForPersist) : null;
     if (m.worksheet && cargo && laycan) {

--- a/lib/matching/persist-session-matches.ts
+++ b/lib/matching/persist-session-matches.ts
@@ -95,7 +95,10 @@ export function persistSessionMatches(
     // worksheet laycan, recompute readiness rather than carrying stale data verbatim.
     // This catches seed rows whose worksheet_json was built against a pre-normalization
     // July laycan while parsed_results now has the correct June string (#821).
-    let worksheetJson: string | null = m.worksheet ? JSON.stringify(m.worksheet) : null;
+    const worksheetForPersist = m.worksheet
+      ? { ...m.worksheet, hardFilters: m.hardFilters ?? m.worksheet.hardFilters, sanctions: m.sanctions }
+      : null;
+    let worksheetJson: string | null = worksheetForPersist ? JSON.stringify(worksheetForPersist) : null;
     if (m.worksheet && cargo && laycan) {
       const storedLaycanStart = m.worksheet.readiness?.laycanStart ?? null;
       const freshLaycanStart = laycan.start.toISOString().slice(0, 10);
@@ -116,7 +119,7 @@ export function persistSessionMatches(
           ` stored=${storedLaycanStart} fresh=${freshLaycanStart}`,
         );
         worksheetJson = JSON.stringify({
-          ...m.worksheet,
+          ...worksheetForPersist,
           readiness: {
             openDate: freshReadiness.openDate,
             laycanStart: freshReadiness.laycanStart,

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -6,6 +6,7 @@ import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { estimateFreightRate, computeEstimatedTce, parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
 import { DEFAULT_BUNKER_USD_PER_MT } from '@/lib/constants';
+import { deriveBucketReason } from '@/lib/matching/bucket-reason';
 
 /**
  * Convert the session-only realism buckets (`lowConfidenceMatches` /
@@ -66,6 +67,20 @@ export function toBucketRows(
       freight_rate_source = tceEst.freight_rate_source;
     }
 
+    const bucketReason = m.worksheet
+      ? deriveBucketReason({
+          verdict: m.worksheet.readiness?.verdict ?? 'unknown',
+          gapDays: m.worksheet.readiness?.gapDays ?? null,
+          matchLevel: m.matchLevel,
+          tceUsdPerDay: tce_usd_per_day,
+          vesselDwt: vesselDwt || null,
+          issues: m.issues ?? [],
+        })
+      : undefined;
+    const worksheetJson = m.worksheet
+      ? JSON.stringify({ ...m.worksheet, bucketReason })
+      : null;
+
     const row: StoredMatch = {
       id: idStart - i,
       cargo_id: m.cargoEmailId,
@@ -89,6 +104,7 @@ export function toBucketRows(
       freight_rate_source,
       vessel_name: null,
       cargo_ref: null,
+      worksheet_json: worksheetJson,
     };
     return row;
   });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -474,7 +474,7 @@ export interface MatchWorksheet {
   };
   /** Full hard-filter result set (all 14 gates) — persisted for the all-checks accordion.
    *  Optional gates absent in pre-this-PR persisted data render with a neutral "not evaluated" state. */
-  hardFilters: MatchHardFilters;
+  hardFilters: Partial<MatchHardFilters>;
   /** Sanctions screening result — persisted for the sanctions disclosure. Absent pre-this-PR. */
   sanctions?: MatchSanctions;
   /** Realism-bucket placement + reason (derived at persist time). Absent pre-this-PR. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -474,7 +474,7 @@ export interface MatchWorksheet {
   };
   /** Full hard-filter result set (all 14 gates) — persisted for the all-checks accordion.
    *  Optional gates absent in pre-this-PR persisted data render with a neutral "not evaluated" state. */
-  hardFilters: Partial<MatchHardFilters>;
+  hardFilters: Pick<MatchHardFilters, 'draft' | 'crane' | 'volume'> & Partial<Omit<MatchHardFilters, 'draft' | 'crane' | 'volume'>>;
   /** Sanctions screening result — persisted for the sanctions disclosure. Absent pre-this-PR. */
   sanctions?: MatchSanctions;
   /** Realism-bucket placement + reason (derived at persist time). Absent pre-this-PR. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -472,13 +472,11 @@ export interface MatchWorksheet {
     loadPort: string | null;
     dischargePort: string | null;
   };
-  hardFilters: {
-    draft: HardFilterCheck;
-    crane: HardFilterCheck;
-    volume: HardFilterCheck;
-    /** M4: destination (discharge) port draft check — optional, absent in pre-M4 persisted data. */
-    destDraft?: HardFilterCheck;
-  };
+  /** Full hard-filter result set (all 14 gates) — persisted for the all-checks accordion.
+   *  Optional gates absent in pre-this-PR persisted data render with a neutral "not evaluated" state. */
+  hardFilters: MatchHardFilters;
+  /** Sanctions screening result — persisted for the sanctions disclosure. Absent pre-this-PR. */
+  sanctions?: MatchSanctions;
 }
 
 export interface Match {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -477,6 +477,8 @@ export interface MatchWorksheet {
   hardFilters: MatchHardFilters;
   /** Sanctions screening result — persisted for the sanctions disclosure. Absent pre-this-PR. */
   sanctions?: MatchSanctions;
+  /** Realism-bucket placement + reason (derived at persist time). Absent pre-this-PR. */
+  bucketReason?: import('./matching/bucket-reason').BucketReason;
 }
 
 export interface Match {


### PR DESCRIPTION
## Summary

- **Stage 0** (committed in previous session as `7dbf56a0`): widened `worksheet_json` to carry all 14 hard filters + sanctions
- **Stage 0b**: pure `deriveBucketReason()` helper + persist `bucketReason` into `worksheet_json` at persist time; also wired into `session-buckets.ts` synthetic rows
- **Stage 1**: `<AllChecksAccordion>` component — collapses by default, expands to show all 14 hard-filter gates with pass/fail/warn verdicts; wired below the table in `MatchWorksheet`

## What changed

- `lib/matching/bucket-reason.ts` — new pure function, no LLM calls, no recompute
- `lib/matching/__tests__/bucket-reason.test.ts` — 4 table-driven tests across all bucket partitions
- `lib/types.ts` — `MatchWorksheet.hardFilters` widened to full `MatchHardFilters`; added `sanctions?` and `bucketReason?`
- `lib/matching/persist-session-matches.ts` — `worksheetForPersist` now carries `m.hardFilters` (all 14), `m.sanctions`, and derived `bucketReason`
- `lib/matching/session-buckets.ts` — bucket rows get same `bucketReason` derivation
- `components/match/AllChecksAccordion.tsx` — new `'use client'` accordion component
- `components/match/__tests__/AllChecksAccordion.test.tsx` — 3 RTL tests (collapsed default, verdicts render, graceful absent-gates)
- `components/match/MatchWorksheet.tsx` — renders `<AllChecksAccordion>` below the worksheet table

## Test plan

- [ ] `npx tsc --noEmit` — clean ✅
- [ ] `npx jest bucket-reason AllChecksAccordion MatchWorksheet persist-session-matches --maxWorkers=1 --forceExit` — 17/17 ✅
- [ ] On `/match/[id]`: click "All checks (14) · all pass" toggle → 14 rows render with ✓/✗/⚠️
- [ ] On a match with `imsbc` gate failed: row shows "IMSBC compatibility ✗ IMSBC Group B + DG-restricted"
- [ ] Pre-existing seeded matches (before this PR): accordion shows only the gates present in their `worksheet_json` (graceful degradation)

## Stages not in this PR (sequenced)

- Stage 2: Bucket-reason card on MatchDetailPanel (uses `worksheet.bucketReason` now persisted)
- Stage 3: Freight waterfall accordion + breakeven line in EconomicsTab
- Stages 4–8: DRY primitive + secondary accordions (timing, IMSBC, vetting, utilisation/charterer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)