### PR TITLE
feat(match-ui): timing, IMSBC, vetting, utilisation accordions (stages 5-8)

### DIFF
--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -299,6 +299,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   vesselEmailBody={vesselEmail?.body ?? null}
                   payoutCondition={cargo?.payoutCondition ?? null}
                   storedBreakevenTce={storedMatch.breakeven_tce_usd_per_day}
+                  fitBreakdown={storedMatch.fit_breakdown ?? null}
                 />
 
                 {cargo && cargoEmail && (

--- a/components/match/BucketReasonCard.tsx
+++ b/components/match/BucketReasonCard.tsx
@@ -10,7 +10,7 @@ const BUCKET_LABEL: Record<BucketReason['bucket'], { title: string; cls: string 
 
 export function BucketReasonCard({ bucketReason }: { bucketReason?: BucketReason }) {
   if (!bucketReason) return null;
-  const meta = BUCKET_LABEL[bucketReason.bucket];
+  const meta = BUCKET_LABEL[bucketReason.bucket] ?? { title: bucketReason.bucket, cls: 'text-slate-500' };
   return (
     <Card size="sm" data-testid="bucket-reason-card">
       <CardHeader>

--- a/components/match/ImsbcDisclosure.tsx
+++ b/components/match/ImsbcDisclosure.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { LogicDisclosure } from './LogicDisclosure';
+import type { HardFilterCheck } from '@/lib/types';
+
+export function ImsbcDisclosure({ imsbc }: { imsbc?: HardFilterCheck }) {
+  if (!imsbc) return null;
+
+  const { pass, warning, reason } = imsbc;
+  const verdictText = warning
+    ? `⚠️ Caution${reason ? ` — ${reason}` : ''}`
+    : pass
+      ? '✅ IMSBC compatible'
+      : `❌ Not compatible${reason ? ` — ${reason}` : ''}`;
+  const verdictCls = warning ? 'text-amber-600' : pass ? 'text-emerald-600' : 'text-red-500';
+
+  return (
+    <LogicDisclosure label="IMSBC / hold compatibility" testId="imsbc">
+      <p className={`text-xs py-1 ${verdictCls}`}>{verdictText}</p>
+    </LogicDisclosure>
+  );
+}

--- a/components/match/MatchDetailPanel.tsx
+++ b/components/match/MatchDetailPanel.tsx
@@ -8,6 +8,7 @@ import { csrfFetch } from '@/lib/csrf-client';
 import { CounterModal } from './CounterModal';
 import { BucketReasonCard } from './BucketReasonCard';
 import type { BucketReason } from '@/lib/matching/bucket-reason';
+import { UtilisationChartererDisclosure } from './UtilisationChartererDisclosure';
 
 export interface MatchDetailPanelProps {
   matchDbId: number;
@@ -238,6 +239,9 @@ function PanelContent({
           </Card>
         );
       })()}
+
+      {/* Utilisation & charterer detail */}
+      <UtilisationChartererDisclosure fitBreakdown={fitBreakdown} />
     </div>
   );
 }

--- a/components/match/MatchTabs.tsx
+++ b/components/match/MatchTabs.tsx
@@ -44,9 +44,11 @@ interface MatchTabsProps {
   payoutCondition?: string | null;
   /** DWT-tiered breakeven TCE floor (persisted, migration 050). */
   storedBreakevenTce?: number | null;
+  /** Serialised fit_breakdown JSON for the vetting accordion. */
+  fitBreakdown?: string | null;
 }
 
-export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, storedFreightRate, freightRateSource, storedDistanceNm, storedTceUsdPerDay, ballastDistanceNm, consumptionEstimated, balticRateAsOf, cargoEmailBody, vesselEmailBody, payoutCondition, storedBreakevenTce }: MatchTabsProps) {
+export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, storedFreightRate, freightRateSource, storedDistanceNm, storedTceUsdPerDay, ballastDistanceNm, consumptionEstimated, balticRateAsOf, cargoEmailBody, vesselEmailBody, payoutCondition, storedBreakevenTce, fitBreakdown }: MatchTabsProps) {
   const [activeTab, setActiveTab] = useState<TabId>('vessels');
   const uid = useId();
 
@@ -85,7 +87,7 @@ export function MatchTabs({ match, vessel, cargo, cargoEmailId, matchDbId, store
         className="p-4"
       >
         {activeTab === 'vessels' && (
-          <VesselsTab vessel={vessel} newCargo={cargo?.cargoDescription?.value ?? undefined} />
+          <VesselsTab vessel={vessel} newCargo={cargo?.cargoDescription?.value ?? undefined} fitBreakdown={fitBreakdown} />
         )}
         {activeTab === 'economics' && (
           <EconomicsTab

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -2,6 +2,7 @@ import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
 import React from 'react';
 import { DraftCalcBreakdown } from './DraftCalcBreakdown';
 import { AllChecksAccordion } from './AllChecksAccordion';
+import { ReadinessDisclosure } from './ReadinessDisclosure';
 import { getPortMaster } from '@/lib/sailing/port-master';
 
 interface Props {
@@ -60,6 +61,7 @@ export function MatchWorksheet({ worksheet }: Props) {
       verdict: r.verdict !== 'unknown'
         ? `${readinessLabel(r.verdict)}${r.gapDays != null ? ` (${r.gapDays}d gap)` : ''}`
         : '— Unknown timing',
+      detail: <ReadinessDisclosure readiness={r} />,
     },
     {
       label: '📍 Where / Transit',

--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { DraftCalcBreakdown } from './DraftCalcBreakdown';
 import { AllChecksAccordion } from './AllChecksAccordion';
 import { ReadinessDisclosure } from './ReadinessDisclosure';
+import { ImsbcDisclosure } from './ImsbcDisclosure';
 import { getPortMaster } from '@/lib/sailing/port-master';
 
 interface Props {
@@ -177,6 +178,7 @@ export function MatchWorksheet({ worksheet }: Props) {
       {hf && (
         <div className="px-3 pb-3 pt-1">
           <AllChecksAccordion hardFilters={hf} />
+          <ImsbcDisclosure imsbc={hf.imsbc} />
         </div>
       )}
     </div>

--- a/components/match/ReadinessDisclosure.tsx
+++ b/components/match/ReadinessDisclosure.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { LogicDisclosure } from './LogicDisclosure';
+import type { WorksheetReadiness } from '@/lib/types';
+
+function verdictColor(v: string): string {
+  if (v === 'ideal') return 'text-emerald-600';
+  if (v === 'tight' || v === 'idle') return 'text-amber-600';
+  if (v === 'late') return 'text-red-500';
+  return 'text-slate-400';
+}
+
+const VERDICT_LABEL: Record<string, string> = {
+  ideal: 'Ideal timing', tight: 'Tight laycan', idle: 'Vessel idle pre-laycan',
+  late: 'Late arrival', unknown: 'Unknown',
+};
+
+export function ReadinessDisclosure({ readiness: r }: { readiness: WorksheetReadiness }) {
+  const label = (
+    <span>
+      Timing detail
+      {r.verdict !== 'unknown' && r.gapDays != null && (
+        <span className="ml-1 text-ds-text-muted">({r.gapDays}d gap)</span>
+      )}
+    </span>
+  );
+
+  return (
+    <LogicDisclosure label={label} testId="readiness-detail">
+      {r.verdict === 'unknown' ? (
+        <p className="text-xs text-ds-text-muted py-1">No timing data — distance / routing not available.</p>
+      ) : (
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs py-1">
+          <dt className="text-ds-text-muted">Verdict</dt>
+          <dd className={`font-medium ${verdictColor(r.verdict)}`}>{VERDICT_LABEL[r.verdict] ?? r.verdict}</dd>
+          {r.gapDays != null && (
+            <>
+              <dt className="text-ds-text-muted">Gap</dt>
+              <dd className="text-ds-text">{r.gapDays}d between arrival and laycan open</dd>
+            </>
+          )}
+          {r.arrivalDate && (
+            <>
+              <dt className="text-ds-text-muted">ETA</dt>
+              <dd className="text-ds-text font-mono">{r.arrivalDate}</dd>
+            </>
+          )}
+          {(r.laycanStart || r.laycanEnd) && (
+            <>
+              <dt className="text-ds-text-muted">Laycan</dt>
+              <dd className="text-ds-text font-mono">
+                {r.laycanStart ?? '—'}{r.laycanEnd ? ` – ${r.laycanEnd}` : ''}
+              </dd>
+            </>
+          )}
+          {r.distanceNm != null && (
+            <>
+              <dt className="text-ds-text-muted">Distance</dt>
+              <dd className="text-ds-text">{Math.round(r.distanceNm).toLocaleString('en-US')} nm</dd>
+            </>
+          )}
+          {r.sailingDays != null && (
+            <>
+              <dt className="text-ds-text-muted">Sailing</dt>
+              <dd className="text-ds-text">
+                ≈{r.sailingDays.toFixed(1)} days
+                {r.speedKn != null && <span className="text-ds-text-muted ml-1">@ {r.speedKn} kn</span>}
+              </dd>
+            </>
+          )}
+        </dl>
+      )}
+    </LogicDisclosure>
+  );
+}

--- a/components/match/UtilisationChartererDisclosure.tsx
+++ b/components/match/UtilisationChartererDisclosure.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { LogicDisclosure } from './LogicDisclosure';
+
+interface FitComponent {
+  factor: string;
+  label: string;
+  weight: number;
+  score: number;
+  rationale: string;
+  bracketData?: string;
+}
+
+export function UtilisationChartererDisclosure({ fitBreakdown }: { fitBreakdown: string | null | undefined }) {
+  if (!fitBreakdown) return null;
+
+  let util: FitComponent | undefined;
+  let chartererPenalty = 0;
+  try {
+    const fb = JSON.parse(fitBreakdown);
+    util = (fb.components as FitComponent[] | undefined)?.find((c) => c.factor === 'utilisation');
+    chartererPenalty = fb.chartererPenalty ?? 0;
+  } catch {
+    return null;
+  }
+  if (!util && chartererPenalty === 0) return null;
+
+  return (
+    <LogicDisclosure label="Utilisation & charterer" testId="util-charterer">
+      <div className="text-xs py-1 space-y-1.5">
+        {util && (
+          <div>
+            <p className="text-ds-text-muted leading-relaxed">{util.rationale}</p>
+            {util.bracketData && (
+              <p className="text-ds-text-subtle font-mono mt-0.5">[{util.bracketData}]</p>
+            )}
+          </div>
+        )}
+        {chartererPenalty > 0 && (
+          <div className="flex justify-between text-xs border-t border-ds-border-subtle pt-1">
+            <span className="text-ds-text-muted">Charterer tier penalty</span>
+            <span className="font-mono text-amber-600">−{chartererPenalty}</span>
+          </div>
+        )}
+      </div>
+    </LogicDisclosure>
+  );
+}

--- a/components/match/VesselsTab.tsx
+++ b/components/match/VesselsTab.tsx
@@ -7,10 +7,12 @@ import { safeRender } from '@/lib/ui-render';
 import { CiiRatingBadge } from '@/components/vessel/CiiRatingBadge';
 import { DismissableDemoBadge } from '@/components/ui/DismissableDemoBadge';
 import { checkCompatibility, parseLastCargoes } from '@/lib/cargo/l5c-matrix';
+import { VettingBreakdown } from './VettingBreakdown';
 
 interface VesselsTabProps {
   vessel?: ParsedVessel;
   newCargo?: string;
+  fitBreakdown?: string | null;
 }
 
 const CII_D_E_PATTERN = /\bCII\s+rating\s+([DE])\b/i;
@@ -63,7 +65,7 @@ function RejectedDetails({ vessel }: { vessel: ParsedVessel }) {
   );
 }
 
-export function VesselsTab({ vessel, newCargo }: VesselsTabProps) {
+export function VesselsTab({ vessel, newCargo, fitBreakdown }: VesselsTabProps) {
   const [showDetails, setShowDetails] = useState(false);
 
   const ciiRejectedRating = vessel ? parseCiiDorE(vessel.restrictions) : null;
@@ -179,6 +181,7 @@ export function VesselsTab({ vessel, newCargo }: VesselsTabProps) {
               Extra hold cleaning required
             </p>
           )}
+          <VettingBreakdown fitBreakdown={fitBreakdown} />
         </>
       )}
     </div>

--- a/components/match/VettingBreakdown.tsx
+++ b/components/match/VettingBreakdown.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { LogicDisclosure } from './LogicDisclosure';
+
+interface FitComponent {
+  factor: string;
+  label: string;
+  weight: number;
+  score: number;
+  rationale: string;
+  bracketData?: string;
+}
+
+export function VettingBreakdown({ fitBreakdown }: { fitBreakdown: string | null | undefined }) {
+  if (!fitBreakdown) return null;
+  let vetting: FitComponent | undefined;
+  try {
+    const fb = JSON.parse(fitBreakdown);
+    vetting = (fb.components as FitComponent[] | undefined)?.find((c) => c.factor === 'vetting');
+  } catch {
+    return null;
+  }
+  if (!vetting) return null;
+
+  const pct = Math.round((vetting.score / vetting.weight) * 100);
+  const pctCls = pct >= 80 ? 'text-emerald-600' : pct >= 50 ? 'text-amber-600' : 'text-red-500';
+
+  return (
+    <LogicDisclosure
+      label={<span>Vetting detail <span className={`font-mono ml-1 ${pctCls}`}>{pct}%</span></span>}
+      testId="vetting-detail"
+    >
+      <div className="text-xs py-1 space-y-1">
+        <p className="text-ds-text-muted leading-relaxed">{vetting.rationale}</p>
+        {vetting.bracketData && (
+          <p className="text-ds-text-subtle font-mono">[{vetting.bracketData}]</p>
+        )}
+      </div>
+    </LogicDisclosure>
+  );
+}

--- a/components/match/__tests__/FreightWaterfall.test.tsx
+++ b/components/match/__tests__/FreightWaterfall.test.tsx
@@ -18,3 +18,12 @@ test('unknown source → no winner highlighted, no crash', () => {
   fireEvent.click(screen.getByTestId('freight-waterfall-toggle'));
   expect(screen.queryByTestId('freight-tier-baltic')).toHaveAttribute('data-winner', 'false');
 });
+
+test('source=custom (unknown string) → no tier highlighted, no crash', () => {
+  render(<FreightWaterfall source="custom" rateUsdPerMt={10} />);
+  fireEvent.click(screen.getByTestId('freight-waterfall-toggle'));
+  expect(screen.getByTestId('freight-tier-manual')).toHaveAttribute('data-winner', 'false');
+  expect(screen.getByTestId('freight-tier-parsed')).toHaveAttribute('data-winner', 'false');
+  expect(screen.getByTestId('freight-tier-baltic')).toHaveAttribute('data-winner', 'false');
+  expect(screen.getByTestId('freight-tier-estimated')).toHaveAttribute('data-winner', 'false');
+});

--- a/components/match/__tests__/ImsbcDisclosure.test.tsx
+++ b/components/match/__tests__/ImsbcDisclosure.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImsbcDisclosure } from '../ImsbcDisclosure';
+
+test('renders IMSBC reason when check present and expanded', () => {
+  render(<ImsbcDisclosure imsbc={{ pass: false, reason: 'IMSBC Group B + DG-restricted' }} />);
+  fireEvent.click(screen.getByTestId('imsbc-toggle'));
+  expect(screen.getByTestId('imsbc-body')).toHaveTextContent('IMSBC Group B + DG-restricted');
+});
+
+test('shows pass state when imsbc.pass is true', () => {
+  render(<ImsbcDisclosure imsbc={{ pass: true }} />);
+  fireEvent.click(screen.getByTestId('imsbc-toggle'));
+  expect(screen.getByTestId('imsbc-body')).toHaveTextContent(/compatible/i);
+});
+
+test('renders neutral state when imsbc absent', () => {
+  render(<ImsbcDisclosure imsbc={undefined} />);
+  expect(screen.queryByTestId('imsbc-toggle')).not.toBeInTheDocument();
+});

--- a/components/match/__tests__/ReadinessDisclosure.test.tsx
+++ b/components/match/__tests__/ReadinessDisclosure.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReadinessDisclosure } from '../ReadinessDisclosure';
+import type { WorksheetReadiness } from '@/lib/types';
+
+const r: WorksheetReadiness = {
+  verdict: 'ideal', openDate: '2026-07-01', openPosition: 'Rotterdam',
+  laycanStart: '2026-07-05', laycanEnd: '2026-07-10',
+  distanceNm: 1200, sailingDays: 5.2, speedKn: 12.5, arrivalDate: '2026-07-06',
+  gapDays: 1, explanation: '',
+};
+
+test('collapsed by default, expands on click', () => {
+  render(<ReadinessDisclosure readiness={r} />);
+  expect(screen.queryByText(/2026-07-06/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('readiness-detail-toggle'));
+  expect(screen.getByTestId('readiness-detail-body')).toBeInTheDocument();
+});
+
+test('shows arrival date and laycan when expanded', () => {
+  render(<ReadinessDisclosure readiness={r} />);
+  fireEvent.click(screen.getByTestId('readiness-detail-toggle'));
+  expect(screen.getByTestId('readiness-detail-body')).toHaveTextContent('2026-07-06');
+  expect(screen.getByTestId('readiness-detail-body')).toHaveTextContent('2026-07-05');
+});
+
+test('unknown verdict → shows "no timing data" message', () => {
+  render(<ReadinessDisclosure readiness={{ ...r, verdict: 'unknown', gapDays: null, arrivalDate: null }} />);
+  fireEvent.click(screen.getByTestId('readiness-detail-toggle'));
+  expect(screen.getByTestId('readiness-detail-body')).toHaveTextContent(/no timing data/i);
+});

--- a/components/match/__tests__/UtilisationChartererDisclosure.test.tsx
+++ b/components/match/__tests__/UtilisationChartererDisclosure.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UtilisationChartererDisclosure } from '../UtilisationChartererDisclosure';
+
+const fbWithBoth = JSON.stringify({
+  components: [
+    { factor: 'utilisation', label: 'Size / utilisation', weight: 19, score: 14.4,
+      rationale: 'Cargo fills ~90% of the ship — a near-full load.', bracketData: '45,000 / 50,000 mt' },
+  ],
+  totalWeight: 100, sanctionsPenalty: 0, chartererPenalty: 4,
+});
+
+const fbNoChartererPenalty = JSON.stringify({
+  components: [
+    { factor: 'utilisation', label: 'Size / utilisation', weight: 19, score: 14.4,
+      rationale: 'Cargo fills ~90% of the ship.', bracketData: '45,000 / 50,000 mt' },
+  ],
+  totalWeight: 100, sanctionsPenalty: 0, chartererPenalty: 0,
+});
+
+test('collapsed by default, expands on click', () => {
+  render(<UtilisationChartererDisclosure fitBreakdown={fbWithBoth} />);
+  expect(screen.queryByText(/45,000/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('util-charterer-toggle'));
+  expect(screen.getByTestId('util-charterer-body')).toBeInTheDocument();
+});
+
+test('shows utilisation bracket when expanded', () => {
+  render(<UtilisationChartererDisclosure fitBreakdown={fbWithBoth} />);
+  fireEvent.click(screen.getByTestId('util-charterer-toggle'));
+  expect(screen.getByTestId('util-charterer-body')).toHaveTextContent('45,000 / 50,000 mt');
+});
+
+test('shows charterer penalty line when penalty > 0', () => {
+  render(<UtilisationChartererDisclosure fitBreakdown={fbWithBoth} />);
+  fireEvent.click(screen.getByTestId('util-charterer-toggle'));
+  expect(screen.getByTestId('util-charterer-body')).toHaveTextContent('−4');
+});
+
+test('no charterer penalty line when penalty is 0', () => {
+  render(<UtilisationChartererDisclosure fitBreakdown={fbNoChartererPenalty} />);
+  fireEvent.click(screen.getByTestId('util-charterer-toggle'));
+  expect(screen.queryByText('−4')).not.toBeInTheDocument();
+});
+
+test('renders nothing when fitBreakdown is null', () => {
+  const { container } = render(<UtilisationChartererDisclosure fitBreakdown={null} />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/components/match/__tests__/VettingBreakdown.test.tsx
+++ b/components/match/__tests__/VettingBreakdown.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VettingBreakdown } from '../VettingBreakdown';
+
+const fitBreakdownWithVetting = JSON.stringify({
+  components: [
+    { factor: 'vetting', label: 'Vessel vetting', weight: 7, score: 5.6,
+      rationale: 'Items to confirm before fixing: CII rating D, age 22yr.', bracketData: '2 detentions' },
+  ],
+  totalWeight: 100, sanctionsPenalty: 0,
+});
+
+test('collapsed by default, expands on click', () => {
+  render(<VettingBreakdown fitBreakdown={fitBreakdownWithVetting} />);
+  expect(screen.queryByText(/CII rating D/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('vetting-detail-toggle'));
+  expect(screen.getByTestId('vetting-detail-body')).toBeInTheDocument();
+});
+
+test('shows vetting rationale when expanded', () => {
+  render(<VettingBreakdown fitBreakdown={fitBreakdownWithVetting} />);
+  fireEvent.click(screen.getByTestId('vetting-detail-toggle'));
+  expect(screen.getByTestId('vetting-detail-body')).toHaveTextContent(/CII rating D/);
+  expect(screen.getByTestId('vetting-detail-body')).toHaveTextContent(/2 detentions/);
+});
+
+test('renders nothing when no vetting component in fit_breakdown', () => {
+  const noVetting = JSON.stringify({ components: [], totalWeight: 100, sanctionsPenalty: 0 });
+  const { container } = render(<VettingBreakdown fitBreakdown={noVetting} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('renders nothing when fitBreakdown is null', () => {
+  const { container } = render(<VettingBreakdown fitBreakdown={null} />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/lib/matching/bucket-reason.ts
+++ b/lib/matching/bucket-reason.ts
@@ -36,5 +36,7 @@ export function deriveBucketReason(i: BucketReasonInput): BucketReason {
       return { bucket: 'lowConfidence',
         reason: `TCE $${Math.round(i.tceUsdPerDay).toLocaleString('en-US')}/day is below the $${floor.toLocaleString('en-US')}/day breakeven for this size.` };
   }
+  // 'blocked' is assigned by the sanctions-gate (pair-analyzer.ts) before persist-session-matches
+  // runs, and copied directly into worksheetForPersist. deriveBucketReason never returns 'blocked'.
   return { bucket: 'main', reason: 'Passed all hard filters and economic thresholds.' };
 }


### PR DESCRIPTION
## Summary
- **Stage 5**: `ReadinessDisclosure` accordion on ⏱ Time row in MatchWorksheet — verdict band, gap days, ETA, laycan window, distance, sailing days
- **Stage 6**: `ImsbcDisclosure` accordion in MatchWorksheet — IMSBC group pass/caution/fail + reason from persisted `hardFilters.imsbc`
- **Stage 7**: `VettingBreakdown` accordion in VesselsTab — 5-factor vetting rationale + detention bracketData from `fit_breakdown`; threads `fitBreakdown` through `MatchTabs` → `VesselsTab`
- **Stage 8**: `UtilisationChartererDisclosure` accordion in MatchDetailPanel — utilisation cargo/capacity bracket + charterer tier penalty from `fit_breakdown`
- **QA-959 fixes**: BucketReasonCard runtime guard for unknown bucket (`?? fallback`); FreightWaterfall `source=custom` test; `deriveBucketReason` comment clarifying `blocked` is assigned by sanctions-gate

All components use `<LogicDisclosure>` (shared primitive from stage 4), render persisted data only (no recompute, no LLM), and degrade gracefully when fields absent (pre-stage-0 rows).

## Test plan
- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] 95/95 related jest tests green (verified — 21 suites)
- [ ] Navigate to `/match/<id>` → Worksheet tab: expand ⏱ Time row → see readiness detail; check IMSBC disclosure below AllChecks
- [ ] Vessels tab: see Vetting detail accordion (collapses/expands)
- [ ] Right panel Fit Score section: see Utilisation & charterer disclosure
- [ ] Match with no `imsbc` field (pre-stage-0 data): IMSBC block absent; vetting returns null gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)