### PR TITLE
fix(regen): carry full filter passport + bucket reason + breakeven in offline regen

### DIFF
--- a/__tests__/scripts/regenerate-matches-freight.test.ts
+++ b/__tests__/scripts/regenerate-matches-freight.test.ts
@@ -100,7 +100,7 @@ function makeMatch(overrides: Partial<Match> = {}): Match {
     vesselEmailId: 'vessel-1',
     vesselItemIndex: 0,
     score: 85,
-    matchLevel: 'strong',
+    matchLevel: 'good',
     matchReasons: [],
     issues: [],
     readiness: BASE_READINESS,
@@ -198,7 +198,7 @@ describe('breakeven_tce_usd_per_day — persisted via createMatch (#959)', () =>
       });
       const rows = listMatches(db, { user_id: null, sortBy: 'score', sortDir: 'desc' });
       expect(rows).toHaveLength(1);
-      expect((rows[0] as Record<string, unknown>).breakeven_tce_usd_per_day).toBe(5500);
+      expect((rows[0] as unknown as Record<string, unknown>).breakeven_tce_usd_per_day).toBe(5500);
     } finally {
       db.close();
     }

--- a/__tests__/scripts/regenerate-matches-freight.test.ts
+++ b/__tests__/scripts/regenerate-matches-freight.test.ts
@@ -1,6 +1,9 @@
 /**
  * Behavioral tests for Task 6 (#819): seed persists freight_rate_usd_per_mt + freight_rate_source.
  * Tests buildMatchEconomics returns the freight fields so writeBucket can persist them.
+ *
+ * Also covers regen worksheet passport (#958/#959): buildWorksheet carries full hardFilters,
+ * sanctions, bucketReason, and breakeven_tce_usd_per_day.
  */
 import Database from 'better-sqlite3';
 import migration032 from '@/lib/migrations/032-matches';
@@ -12,8 +15,13 @@ import migration041 from '@/lib/migrations/041-matches-vessel-name';
 import migration042 from '@/lib/migrations/042-matches-fit';
 import migration044 from '@/lib/migrations/044-matches-item-index';
 import migration045 from '@/lib/migrations/045-matches-worksheet';
+import migration046 from '@/lib/migrations/046-matches-consumption-estimated';
+import migration047 from '@/lib/migrations/047-matches-ballast-distance';
+import migration050 from '@/lib/migrations/050-matches-breakeven';
 import { buildMatchEconomics } from '@/lib/matching/tce-calculator';
 import { listMatches, createMatch } from '@/lib/matching/matches-repository';
+import { buildWorksheet } from '@/scripts/demo-seed/regenerate-matches';
+import type { Match, ParsedCargo, ParsedVessel } from '@/lib/types';
 
 function freshDb(): Database.Database {
   const db = new Database(':memory:');
@@ -63,6 +71,134 @@ describe('buildMatchEconomics — freight rate persisted for seed (#819 Task 6)'
       expect(rows).toHaveLength(1);
       expect(rows[0].freight_rate_usd_per_mt).toBe(25.2);
       expect(rows[0].freight_rate_source).toBe('estimated');
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// ── Regen worksheet passport (#958/#959) ─────────────────────────────────────
+
+const BASE_READINESS = {
+  openDate: '2026-06-09',
+  laycanStart: '2026-06-15',
+  laycanEnd: '2026-06-20',
+  distanceNm: 400,
+  distanceExact: true,
+  speedKn: 12,
+  sailingDays: 1.4,
+  arrivalDate: '2026-06-10',
+  gapDays: 5,
+  verdict: 'ideal' as const,
+  explanation: 'arrives in window',
+};
+
+function makeMatch(overrides: Partial<Match> = {}): Match {
+  return {
+    cargoEmailId: 'cargo-1',
+    cargoItemIndex: 0,
+    vesselEmailId: 'vessel-1',
+    vesselItemIndex: 0,
+    score: 85,
+    matchLevel: 'strong',
+    matchReasons: [],
+    issues: [],
+    readiness: BASE_READINESS,
+    hardFilters: {
+      draft: { pass: true },
+      crane: { pass: false, reason: 'crane required' },
+      volume: { pass: true },
+      cargoVessel: { pass: true },
+      destDraft: { pass: true },
+      destCrane: { pass: true },
+      cargoWeight: { pass: true },
+      imsbc: { pass: true },
+    },
+    sanctions: { risk: 'LOW', blocking: false },
+    economics: {
+      tceUsdPerDay: 6500,
+      freightRateUsdPerMt: 28,
+      freightRateSource: 'index',
+      breakdown: {} as never,
+      totalUsd: 0,
+      calculatedAt: '2026-06-11T00:00:00.000Z',
+      dataFreshness: { bunker: '2026-06-11T00:00:00.000Z', eua: '2026-06-11T00:00:00.000Z' },
+    },
+    ...overrides,
+  };
+}
+
+describe('buildWorksheet — full filter passport (#958/#959)', () => {
+  test('carries all hardFilter gates beyond draft/crane/volume', () => {
+    const ws = buildWorksheet(makeMatch(), undefined, undefined);
+    expect(ws).not.toBeNull();
+    expect(ws!.hardFilters.draft).toEqual({ pass: true });
+    expect(ws!.hardFilters.crane).toEqual({ pass: false, reason: 'crane required' });
+    expect(ws!.hardFilters.cargoVessel).toEqual({ pass: true });
+    expect(ws!.hardFilters.destDraft).toEqual({ pass: true });
+    expect(ws!.hardFilters.destCrane).toEqual({ pass: true });
+    expect(ws!.hardFilters.cargoWeight).toEqual({ pass: true });
+    expect(ws!.hardFilters.imsbc).toEqual({ pass: true });
+  });
+
+  test('carries sanctions from match', () => {
+    const ws = buildWorksheet(makeMatch(), undefined, undefined);
+    expect(ws!.sanctions).toEqual({ risk: 'LOW', blocking: false });
+  });
+
+  test('bucketReason is present and has bucket + reason', () => {
+    const ws = buildWorksheet(makeMatch(), undefined, undefined);
+    expect(ws!.bucketReason).toBeDefined();
+    expect(ws!.bucketReason!.bucket).toBeDefined();
+    expect(typeof ws!.bucketReason!.reason).toBe('string');
+  });
+
+  test('no readiness → returns null', () => {
+    const ws = buildWorksheet(makeMatch({ readiness: undefined }), undefined, undefined);
+    expect(ws).toBeNull();
+  });
+
+  test('missing hardFilters → falls back to pass:true defaults for all required gates', () => {
+    const ws = buildWorksheet(makeMatch({ hardFilters: undefined }), undefined, undefined);
+    expect(ws!.hardFilters.draft).toEqual({ pass: true });
+    expect(ws!.hardFilters.crane).toEqual({ pass: true });
+    expect(ws!.hardFilters.volume).toEqual({ pass: true });
+    expect(ws!.hardFilters.cargoVessel).toEqual({ pass: true });
+  });
+});
+
+describe('breakeven_tce_usd_per_day — persisted via createMatch (#959)', () => {
+  function freshDbWithBreakeven(): Database.Database {
+    const db = new Database(':memory:');
+    migration032.up(db);
+    migration033.up(db);
+    migration034.up(db);
+    migration035.up(db);
+    migration036.up(db);
+    migration041.up(db);
+    migration042.up(db);
+    migration044.up(db);
+    migration045.up(db);
+    migration046.up(db);
+    migration047.up(db);
+    migration050.up(db);
+    return db;
+  }
+
+  test('createMatch persists breakeven_tce_usd_per_day and listMatches returns it', () => {
+    const db = freshDbWithBreakeven();
+    try {
+      createMatch(db, {
+        cargo_id: 'cargo-1', vessel_id: 'vessel-1', cargo_item_index: 0, vessel_item_index: 0,
+        score: 80, reason: 'test', status: 'shortlist', user_id: null,
+        tce_usd_per_day: 6500, distance_nm: 400,
+        freight_rate_usd_per_mt: 28, freight_rate_source: 'index',
+        vessel_name: null, cargo_ref: null, fit_percent: 82, fit_breakdown: null,
+        breakeven_tce_usd_per_day: 5500,
+      });
+      const rows = listMatches(db, { user_id: null, sortBy: 'score', sortDir: 'desc' });
+      expect(rows).toHaveLength(1);
+      expect((rows[0] as Record<string, unknown>).breakeven_tce_usd_per_day).toBe(5500);
     } finally {
       db.close();
     }

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -44,6 +44,8 @@ import { seedPortDa, type BaselinePort } from '../seed-port-da';
 import { lookupCii } from '@/lib/imo/cii-lookup';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+import { deriveBucketReason } from '@/lib/matching/bucket-reason';
+import { breakevenTceByDwt } from '@/lib/economics/breakeven-thresholds';
 
 // ── CII hydration helper ──────────────────────────────────────────────────────
 
@@ -447,6 +449,59 @@ function matchToQuarantineInput(m: Match) {
   };
 }
 
+/** Build the worksheet object for a regen match, carrying the full filter passport.
+ *  Mirrors the live path in persist-session-matches.ts: full hardFilters (all gates),
+ *  sanctions, and bucketReason derived at persist-time. */
+export function buildWorksheet(m: Match, cargo: ParsedCargo | undefined, vessel: ParsedVessel | undefined): MatchWorksheet | null {
+  if (!m.readiness) return null;
+  const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? null) : null;
+  const bucketReason = deriveBucketReason({
+    verdict: m.readiness.verdict ?? 'unknown',
+    gapDays: m.readiness.gapDays ?? null,
+    matchLevel: m.matchLevel,
+    tceUsdPerDay: m.economics?.tceUsdPerDay ?? null,
+    vesselDwt,
+    issues: m.issues ?? [],
+  });
+  return {
+    readiness: {
+      ...m.readiness,
+      openPosition: vessel ? (cfValue(vessel.openPosition) ?? null) : null,
+    },
+    vessel: {
+      draftMax: vessel ? (cfValue(vessel.draftMax) ?? null) : null,
+      grainCapacity: vessel?.grainCapacity ?? null,
+      grainCapacityUnit: vessel?.grainCapacityUnit ?? null,
+      geared: vessel?.geared ?? null,
+      vesselType: vessel?.vesselType ?? null,
+      flag: vessel?.flag ?? null,
+      built: vessel?.built ?? null,
+      pandi: vessel?.pandi ?? null,
+      classSociety: vessel?.classSociety ?? null,
+      lastCargoes: vessel?.lastCargoes ?? null,
+      dwtSummer: vesselDwt,
+      dwcc: vessel ? (cfValue(vessel.dwcc) ?? null) : null,
+    },
+    cargo: {
+      weightMt: cargo ? (cfValue(cargo.weightMt) ?? null) : null,
+      cargoType: cargo ? cargoTypeStr(cargo) : null,
+      loadPort: cargo ? (cfValue(cargo.originPort) ?? null) : null,
+      dischargePort: cargo ? (cfValue(cargo.destinationPort) ?? null) : null,
+    },
+    hardFilters: m.hardFilters ?? {
+      draft: { pass: true },
+      crane: { pass: true },
+      volume: { pass: true },
+      cargoVessel: { pass: true },
+      destDraft: { pass: true },
+      destCrane: { pass: true },
+      cargoWeight: { pass: true },
+    },
+    sanctions: m.sanctions,
+    bucketReason,
+  };
+}
+
 async function main() {
   // --rebuild-worksheet / --dry-rebuild-worksheet: targeted worksheet rebuild mode.
   // Does NOT re-run analyzePairs — only patches worksheet_json for seed matches
@@ -627,8 +682,9 @@ async function main() {
 
   // ── 4. Write: replace the seed buckets (NULL + sentinels). Orphan per-session
   //        UUID copies are left for the app's deleteOrphanSessionMatches to prune. ──
-  const hasWorksheetCol = (db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>)
-    .some((c) => c.name === 'worksheet_json');
+  const _matchesCols = (db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>);
+  const hasWorksheetCol = _matchesCols.some((c) => c.name === 'worksheet_json');
+  const hasBreakevenCol = _matchesCols.some((c) => c.name === 'breakeven_tce_usd_per_day');
 
   const insert = db.prepare(`
     INSERT OR IGNORE INTO matches
@@ -636,44 +692,9 @@ async function main() {
        created_at, updated_at, reason_structured, cargo_type, load_port, discharge_port,
        laycan_start, laycan_end, vessel_dwt, tce_usd_per_day, distance_nm, vessel_name, cargo_ref,
        fit_percent, fit_breakdown,
-       freight_rate_usd_per_mt, freight_rate_source${hasWorksheetCol ? ', worksheet_json' : ''})
-    VALUES (?, ?, ?, ?, ?, ?, 'shortlist', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${hasWorksheetCol ? ', ?' : ''})
+       freight_rate_usd_per_mt, freight_rate_source${hasWorksheetCol ? ', worksheet_json' : ''}${hasBreakevenCol ? ', breakeven_tce_usd_per_day' : ''})
+    VALUES (?, ?, ?, ?, ?, ?, 'shortlist', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?${hasWorksheetCol ? ', ?' : ''}${hasBreakevenCol ? ', ?' : ''})
   `);
-
-  function buildWorksheet(m: Match, cargo: ParsedCargo | undefined, vessel: ParsedVessel | undefined): MatchWorksheet | null {
-    if (!m.readiness) return null;
-    return {
-      readiness: {
-        ...m.readiness,
-        openPosition: vessel ? (cfValue(vessel.openPosition) ?? null) : null,
-      },
-      vessel: {
-        draftMax: vessel ? (cfValue(vessel.draftMax) ?? null) : null,
-        grainCapacity: vessel?.grainCapacity ?? null,
-        grainCapacityUnit: vessel?.grainCapacityUnit ?? null,
-        geared: vessel?.geared ?? null,
-        vesselType: vessel?.vesselType ?? null,
-        flag: vessel?.flag ?? null,
-        built: vessel?.built ?? null,
-        pandi: vessel?.pandi ?? null,
-        classSociety: vessel?.classSociety ?? null,
-        lastCargoes: vessel?.lastCargoes ?? null,
-        dwtSummer: vessel ? (cfValue(vessel.dwtSummer) ?? null) : null,
-        dwcc: vessel ? (cfValue(vessel.dwcc) ?? null) : null,
-      },
-      cargo: {
-        weightMt: cargo ? (cfValue(cargo.weightMt) ?? null) : null,
-        cargoType: cargo ? cargoTypeStr(cargo) : null,
-        loadPort: cargo ? (cfValue(cargo.originPort) ?? null) : null,
-        dischargePort: cargo ? (cfValue(cargo.destinationPort) ?? null) : null,
-      },
-      hardFilters: {
-        draft: m.hardFilters?.draft ?? { pass: true },
-        crane: m.hardFilters?.crane ?? { pass: true },
-        volume: m.hardFilters?.volume ?? { pass: true },
-      },
-    };
-  }
 
   function writeBucket(matches: Match[], userId: string | null): number {
     let n = 0;
@@ -684,6 +705,7 @@ async function main() {
       const dischargePort = cargo ? cfValue(cargo.destinationPort) : null;
       const lay = cargo ? parseLaycan(cargo.laycan, refYear) : null;
       const voyage = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+      const vesselDwt = vessel ? (cfValue(vessel.dwtSummer) ?? null) : null;
       const ws = buildWorksheet(m, cargo, vessel);
       const args: Array<string | number | null> = [
         m.cargoEmailId, m.vesselEmailId, m.cargoItemIndex, m.vesselItemIndex,
@@ -694,7 +716,7 @@ async function main() {
         loadPort, dischargePort,
         lay ? lay.start.getTime() : null,
         lay ? lay.end.getTime() : null,
-        vessel ? (cfValue(vessel.dwtSummer) ?? null) : null,
+        vesselDwt,
         // #819 Phase B(b): stored tce_usd_per_day MUST come from the live
         // voyage-calculator path (buildMatchEconomics via pair-analyzer) so the
         // seed bucket and persistSessionMatches recompute agree numerically.
@@ -712,6 +734,7 @@ async function main() {
         m.economics?.freightRateSource ?? null,
       ];
       if (hasWorksheetCol) args.push(ws ? JSON.stringify(ws) : null);
+      if (hasBreakevenCol) args.push(vesselDwt ? breakevenTceByDwt(vesselDwt) : null);
       insert.run(...args);
       n++;
     }


### PR DESCRIPTION
## Summary

- `buildWorksheet` in `regenerate-matches.ts` now mirrors the live path (`persist-session-matches.ts`): uses full `m.hardFilters` (all 14 gates), adds `sanctions`, and computes `bucketReason` via `deriveBucketReason`
- `writeBucket` INSERT now writes `breakeven_tce_usd_per_day = breakevenTceByDwt(vesselDwt)` when migration 050 column is present
- `buildWorksheet` extracted to module-level export; no logic duplication (reuses `deriveBucketReason` and `breakevenTceByDwt`)

## Root cause

After #958/#959, the live path (`persistSessionMatches`) carried full hard-filter passport + breakeven, but the offline regen script (`regenerate-matches.ts`) still wrote only `{draft, crane, volume}` to `hardFilters`, skipped `sanctions`/`bucketReason`, and never wrote `breakeven_tce_usd_per_day`. Result: 0/77 seed matches had new fields post-regen.

## Test plan

- [ ] `npx jest __tests__/scripts/regenerate-matches-freight.test.ts` — 8 tests pass (2 existing + 6 new covering: full hardFilters gates, sanctions, bucketReason, fallback, null-readiness, breakeven persistence via migration 050)
- [ ] `npx jest --findRelatedTests scripts/demo-seed/regenerate-matches.ts` — 45 tests pass
- [ ] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)