### PR TITLE
fix: qa-walker gamma-smoke followups — charterers column honesty, clause search dedup+OR, seed copy, IRS in IACS

### DIFF
--- a/__tests__/api/clauses-security.test.ts
+++ b/__tests__/api/clauses-security.test.ts
@@ -184,21 +184,20 @@ describe('adversarial — cold QA', () => {
   });
 
   // ADV-05: q=laytime+OR+cargo — mid-query boolean operator
-  // DOCUMENTED INTENTIONAL BEHAVIOR: escapeFts5Query wraps the full input in FTS5
-  // phrase quotes, so "laytime OR cargo" becomes '"laytime OR cargo"' in MATCH.
-  // Inside FTS5 phrase quotes, OR is literal text, not a boolean operator.
-  // Result: phrase match for the literal 3-word string — no boolean semantics.
-  // This is the designed behavior (see comment on escapeFts5Query).
-  it('ADV-05 (DOCUMENTED): mid-query OR is phrase-matched as literal text, not boolean', async () => {
+  // qa-smoke F3 (DOCUMENTED, updated): escapeFts5Query now quotes each
+  // whitespace token individually and joins them with OR, so
+  // "laytime OR cargo" becomes '"laytime" OR "OR" OR "cargo"'.
+  // The user-supplied "OR" token is STILL a quoted literal (injection-safe,
+  // never an operator), but multi-word queries match the union of tokens —
+  // the fixture row contains both "laytime" and "cargo", so it matches.
+  it('ADV-05 (DOCUMENTED): mid-query OR token stays a quoted literal; tokens are OR-unioned', async () => {
     const res = await GET(makeRequest('?q=laytime+OR+cargo'));
     // Must not crash (no SQLITE_ERROR)
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(Array.isArray(json.results)).toBe(true);
-    // Fixture row contains "Laytime" and "Cargo" as separate words, not the
-    // literal 3-word phrase "laytime OR cargo" — so boolean-as-literal gives 0 results.
-    expect(json.results).toHaveLength(0);
-    // Cross-check: plain "laytime" search DOES match (proves escaping is functional)
+    // Fixture row contains "laytime" and "cargo" tokens → matched once.
+    expect(json.results).toHaveLength(1);
   });
 
   // ADV-06 (FIXED): auth runs BEFORE flag check — unauthenticated caller gets 401

--- a/__tests__/api/clauses.test.ts
+++ b/__tests__/api/clauses.test.ts
@@ -284,6 +284,59 @@ describe('GET /api/knowledge/clauses', () => {
     expect(typeof meta.charterParty).toBe('string');
   });
 
+  // qa-smoke F2: chunked clauses must be deduplicated by clause number + charter party
+  it('returns a multi-chunk clause only once (dedup by clauseNumber + charterParty)', async () => {
+    process.env.BIMCO_RAG_ENABLED = 'true';
+
+    const stmt = db.prepare('INSERT INTO bimco_fts (content, metadata) VALUES (?, ?)');
+    // 3 chunks of the SAME clause (gencon2022 clause 8)
+    for (let chunk = 0; chunk < 3; chunk++) {
+      stmt.run(
+        `Laytime chunk ${chunk}: laytime shall commence upon tender of NOR`,
+        JSON.stringify({ charterParty: 'GENCON 2022', clauseNumber: '8', chunkIndex: chunk }),
+      );
+    }
+    // A different clause that also mentions laytime — must survive dedup
+    stmt.run(
+      'Laytime exceptions per clause 9',
+      JSON.stringify({ charterParty: 'GENCON 2022', clauseNumber: '9' }),
+    );
+
+    const { GET } = await import('@/app/api/knowledge/clauses/route');
+    const res = await GET(new NextRequest('http://localhost:3000/api/knowledge/clauses?q=laytime') as any);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const keys = json.results.map((r: any) => {
+      const m = JSON.parse(r.metadata);
+      return `${m.charterParty}::${m.clauseNumber}`;
+    });
+    expect(keys.filter((k: string) => k === 'GENCON 2022::8')).toHaveLength(1);
+    expect(keys).toContain('GENCON 2022::9');
+  });
+
+  // qa-smoke F3: multi-word query must return superset-or-equal of single-word results
+  it('multi-word query "ice clause" returns at least the results of "ice"', async () => {
+    process.env.BIMCO_RAG_ENABLED = 'true';
+
+    const stmt = db.prepare('INSERT INTO bimco_fts (content, metadata) VALUES (?, ?)');
+    stmt.run(
+      'Should the vessel be prevented by ice from reaching the port',
+      JSON.stringify({ charterParty: 'GENCON 2022', clauseNumber: '18' }),
+    );
+    stmt.run(
+      'Ice navigation: the master may deviate when ice conditions threaten',
+      JSON.stringify({ charterParty: 'NYPE 1946', clauseNumber: '21' }),
+    );
+
+    const { GET } = await import('@/app/api/knowledge/clauses/route');
+    const single = await (await GET(new NextRequest('http://localhost:3000/api/knowledge/clauses?q=ice') as any)).json();
+    const multi = await (await GET(new NextRequest('http://localhost:3000/api/knowledge/clauses?q=ice+clause') as any)).json();
+
+    expect(single.results.length).toBeGreaterThan(0);
+    expect(multi.results.length).toBeGreaterThanOrEqual(single.results.length);
+  });
+
   // TC-API-13: Behavioral — fixture data + cp filter returns only matching charter party
   it('returns only GENCON 2022 clauses when cp=GENCON+2022 with fixture data', async () => {
     process.env.BIMCO_RAG_ENABLED = 'true';

--- a/__tests__/charterers/charterers-page.test.tsx
+++ b/__tests__/charterers/charterers-page.test.tsx
@@ -36,11 +36,12 @@ const MOCK_CHARTERERS = [
 ];
 
 describe('CharterersTable column headers', () => {
-  it('renders exact reference header labels: Name / Email / Last Contact / Last Email Snippet / Status', async () => {
+  // qa-smoke F1: third column renders require_lc — header renamed to L/C Required
+  it('renders exact reference header labels: Name / Email / L/C Required / Last Email Snippet / Status', async () => {
     const { CharterersTable } = await import('@/components/charterers/CharterersTable');
     const { container } = render(<CharterersTable charterers={[]} />);
     const ths = Array.from(container.querySelectorAll('th')).map((th) => th.textContent?.trim());
-    expect(ths).toEqual(['Name', 'Email', 'Last Contact', 'Last Email Snippet', 'Status']);
+    expect(ths).toEqual(['Name', 'Email', 'L/C Required', 'Last Email Snippet', 'Status']);
   });
 });
 

--- a/app/api/knowledge/clauses/route.ts
+++ b/app/api/knowledge/clauses/route.ts
@@ -35,15 +35,23 @@ function isMalformedFts5Query(q: string): boolean {
 }
 
 /**
- * Escape a plain-text query for safe FTS5 MATCH binding (phrase match).
- * Mirrors lib/knowledge/embeddings/retriever-sqlite.ts.
+ * Escape a plain-text query for safe FTS5 MATCH binding.
  *
- * INTENTIONAL: mid-query boolean operators (e.g. "laytime OR cargo") become
- * literal text inside FTS5 phrase quotes — not boolean operators. All queries
- * are phrase-matched. Boolean search is not supported by design (simpler, safer).
+ * qa-smoke F3: each whitespace-separated token is individually quoted (FTS5
+ * string, injection-safe — same escaping as before) and tokens are joined
+ * with OR. Multi-word queries ("ice clause") now match the union of their
+ * tokens instead of requiring the literal phrase, so a multi-word query
+ * always returns a superset of any single token's results. User-supplied
+ * boolean operators are still neutralized: each token is inside FTS5 quotes,
+ * so "laytime OR cargo" becomes "laytime" OR "OR" OR "cargo" (literal "OR").
  */
 function escapeFts5Query(q: string): string {
-  return `"${q.replace(/"/g, '""')}"`;
+  return q
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((t) => `"${t.replace(/"/g, '""')}"`)
+    .join(' OR ');
 }
 
 export async function GET(request: NextRequest) {
@@ -101,15 +109,17 @@ export async function GET(request: NextRequest) {
         SELECT content, metadata
         FROM bimco_fts
         WHERE content MATCH ?
+        ORDER BY rank
         LIMIT ?
       `;
-      params = [query ? escapeFts5Query(query) : '*', limit];
+      params = [query.trim() ? escapeFts5Query(query) : '*', limit];
     } else if (query && query.trim() !== '') {
       // Search without charter party filter
       sql = `
         SELECT content, metadata
         FROM bimco_fts
         WHERE content MATCH ?
+        ORDER BY rank
         LIMIT ?
       `;
       params = [escapeFts5Query(query), limit];
@@ -138,6 +148,24 @@ export async function GET(request: NextRequest) {
         }
       });
     }
+
+    // qa-smoke F2: clauses are stored as multiple chunks — dedup by
+    // clauseNumber + charterParty, keeping the first (best-ranked, see
+    // ORDER BY rank) chunk per clause. Rows without a parseable dedup key
+    // are kept as-is.
+    const seen = new Set<string>();
+    results = results.filter((row) => {
+      try {
+        const meta = JSON.parse(row.metadata);
+        if (meta.clauseNumber == null || meta.charterParty == null) return true;
+        const key = `${meta.charterParty}::${meta.clauseNumber}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      } catch {
+        return true;
+      }
+    });
 
     return NextResponse.json({
       results,

--- a/components/charterers/CharterersTable.tsx
+++ b/components/charterers/CharterersTable.tsx
@@ -61,7 +61,9 @@ const TH_STYLE: React.CSSProperties = {
 const HEADERS: { label: string; align: 'left' | 'right' }[] = [
   { label: 'Name',               align: 'left'  },
   { label: 'Email',              align: 'left'  },
-  { label: 'Last Contact',       align: 'right' },
+  // qa-smoke F1: column renders require_lc (Yes/No), not a contact date —
+  // header renamed to match the value actually shown.
+  { label: 'L/C Required',       align: 'right' },
   { label: 'Last Email Snippet', align: 'left'  },
   { label: 'Status',             align: 'left'  },
 ];

--- a/lib/sanctions/__tests__/iacs-members.test.ts
+++ b/lib/sanctions/__tests__/iacs-members.test.ts
@@ -1,8 +1,9 @@
 import { IACS_MEMBERS, isIacs } from '../iacs-members';
 
 describe('IACS_MEMBERS', () => {
-  it('contains exactly 8 members', () => {
-    expect(IACS_MEMBERS).toHaveLength(8);
+  it('contains exactly 9 members', () => {
+    // qa-smoke F5: IRS (Indian Register of Shipping) is an IACS member — was missing
+    expect(IACS_MEMBERS).toHaveLength(9);
   });
 
   it('includes standard abbreviations', () => {
@@ -14,6 +15,7 @@ describe('IACS_MEMBERS', () => {
     expect(IACS_MEMBERS).toContain('KR');
     expect(IACS_MEMBERS).toContain('CCS');
     expect(IACS_MEMBERS).toContain('RINA');
+    expect(IACS_MEMBERS).toContain('IRS'); // qa-smoke F5
   });
 });
 
@@ -35,6 +37,8 @@ describe('isIacs', () => {
     expect(isIacs('China Classification Society')).toBe(true);
     expect(isIacs('Registro Italiano Navale')).toBe(true);
     expect(isIacs('American Bureau of Shipping')).toBe(true);
+    expect(isIacs('Indian Register of Shipping')).toBe(true); // qa-smoke F5
+    expect(isIacs('IRS')).toBe(true); // qa-smoke F5
   });
 
   it('returns false for unknown classification societies', () => {

--- a/lib/sanctions/iacs-members.ts
+++ b/lib/sanctions/iacs-members.ts
@@ -1,4 +1,5 @@
-export const IACS_MEMBERS = ['DNV', 'LR', 'ABS', 'BV', 'NKK', 'KR', 'CCS', 'RINA'] as const;
+// qa-smoke F5: IRS (Indian Register of Shipping) is an IACS member — was missing
+export const IACS_MEMBERS = ['DNV', 'LR', 'ABS', 'BV', 'NKK', 'KR', 'CCS', 'RINA', 'IRS'] as const;
 export type IacsMember = typeof IACS_MEMBERS[number];
 
 const ALIASES: Record<string, IacsMember> = {
@@ -14,6 +15,7 @@ const ALIASES: Record<string, IacsMember> = {
   'korean register of shipping': 'KR',
   'china classification society': 'CCS',
   'registro italiano navale': 'RINA',
+  'indian register of shipping': 'IRS', // qa-smoke F5
 };
 
 export function isIacs(className: string): boolean {

--- a/scripts/demo-seed/__tests__/seed-charterers.test.ts
+++ b/scripts/demo-seed/__tests__/seed-charterers.test.ts
@@ -86,6 +86,24 @@ describe('seedCharterersWithDb', () => {
     db.close();
   });
 
+  // qa-smoke F4: marker renamed (internal jargon leaked to UI) — old-marker rows must still be cleaned
+  it('removes rows seeded under the LEGACY demo marker (pre-rename migration)', () => {
+    const db = makeDb();
+    db.prepare(
+      `INSERT INTO charterers (id, name, tier, payment_history, require_lc, notes)
+       VALUES ('legacy-demo', 'LEGACY DEMO', 'second', '[]', 0, 'demo-universe rating (audit A.1)')`,
+    ).run();
+    seedCharterersWithDb(db);
+    const legacy = db.prepare(`SELECT 1 FROM charterers WHERE id = 'legacy-demo'`).get();
+    expect(legacy).toBeUndefined();
+    db.close();
+  });
+
+  // qa-smoke F4: notes surface in the demo UI — must be broker-friendly, no internal audit jargon
+  it('demo notes marker contains no internal jargon (audit refs)', () => {
+    expect(DEMO_NOTES).not.toMatch(/audit|demo-universe/i);
+  });
+
   it('does not touch rows without the demo notes marker', () => {
     const db = makeDb();
     db.prepare(

--- a/scripts/demo-seed/seed-charterers.ts
+++ b/scripts/demo-seed/seed-charterers.ts
@@ -30,7 +30,11 @@ import * as path from 'node:path';
 
 import { upsertCharterer, type ChartererRow } from '@/lib/market/charterers-repository';
 
-export const DEMO_NOTES = 'demo-universe rating (audit A.1)';
+// qa-smoke F4: marker is shown in the demo UI (list snippet + detail Notes) —
+// must read broker-friendly, no internal audit jargon.
+export const DEMO_NOTES = 'Demo rating — illustrative credit profile';
+// Previous marker (pre-rename) — rows seeded under it must still be cleaned.
+export const LEGACY_DEMO_NOTES = 'demo-universe rating (audit A.1)';
 
 export const CHARTERER_FIXTURE: Omit<ChartererRow, 'created_at'>[] = [
   {
@@ -75,7 +79,9 @@ export function seedCharterersWithDb(
   db: Database.Database,
 ): { deleted: number; inserted: number; adopted: number } {
   const run = db.transaction(() => {
-    const deleted = db.prepare(`DELETE FROM charterers WHERE notes = ?`).run(DEMO_NOTES).changes;
+    const deleted = db
+      .prepare(`DELETE FROM charterers WHERE notes IN (?, ?)`)
+      .run(DEMO_NOTES, LEGACY_DEMO_NOTES).changes; // qa-smoke F4: also migrate old-marker rows
     let adopted = 0;
     const byName = db.prepare(`SELECT id FROM charterers WHERE name = ?`);
     for (const row of CHARTERER_FIXTURE) {
@@ -125,7 +131,7 @@ function main(): void {
       .all() as Array<{ id: string; name: string; tier: string; notes: string | null }>;
     console.log(`[seed-charterers] existing rows: ${existing.length}`);
     for (const r of existing) {
-      console.log(`  · ${r.id} | ${r.name} | tier=${r.tier}${r.notes === DEMO_NOTES ? ' [demo — will be reseeded]' : ''}`);
+      console.log(`  · ${r.id} | ${r.name} | tier=${r.tier}${r.notes === DEMO_NOTES || r.notes === LEGACY_DEMO_NOTES ? ' [demo — will be reseeded]' : ''}`);
     }
     for (const row of CHARTERER_FIXTURE) {
       const clash = existing.find((r) => r.name === row.name && r.id !== row.id);


### PR DESCRIPTION
Followup-фиксы по находкам qa-walker смоука γ-страниц (волна D, решение фаундера «фиксить в составе волны»):

- **F1 (medium)**: /charterers — колонка «Last Contact» показывала Yes/No от require_lc → честный заголовок «L/C Required»
- **F2**: /clauses — результаты поиска дедуплицируются по charterParty::clauseNumber (было ×3 на чанк), лучший ранг сохраняется
- **F3**: /clauses — многословные запросы («ice clause») ищут OR по токенам вместо литеральной фразы; FTS5-экранирование потокенное, все security-пины зелёные (ADV-05 переписан осознанно — был behavior-пин)
- **F4**: сид-копия charterers без внутреннего жаргона «audit A.1» + миграция legacy-маркера в DELETE
- **F5**: IRS (Indian Register of Shipping) добавлен в IACS-список — фактическая поправка

Не фиксится кодом (data-quirks, в отчёте): спайк Drewry-BB в последней точке, grain capacity 144cbm у SEAGULL 7 (парс-значение).

После мержа: reseed charterers на проде по формуле (уберёт жаргон из живых notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)