### PR TITLE
feat: enable ready-but-off — ⌘K palette routes + TMI benchmark (chart + quote fallback)

### DIFF
--- a/__tests__/lib/market/benchmark.test.ts
+++ b/__tests__/lib/market/benchmark.test.ts
@@ -22,11 +22,41 @@ jest.mock('@/lib/market/toepfer-scraper', () => ({
   fetchToepferTmi: (...args: unknown[]) => mockFetchToepferTmi(...args),
 }));
 
+// ─── Mock session-store so DB fallback sees an empty DB ───────────────────────
+
+import Database from 'better-sqlite3';
+
+const mockGetStore = jest.fn();
+jest.mock('@/lib/session-store', () => ({
+  getStore: (...args: unknown[]) => mockGetStore(...args),
+}));
+
 // ─── Setup ───────────────────────────────────────────────────────────────────
+
+// Empty in-memory DB that has the two tables but no rows — so DB fallback returns null.
+let emptyDb: Database.Database;
 
 beforeEach(() => {
   _clearCacheForTesting();
   jest.clearAllMocks();
+  emptyDb = new Database(':memory:');
+  emptyDb.exec(`
+    CREATE TABLE IF NOT EXISTS market_indices (
+      id TEXT PRIMARY KEY NOT NULL, index_name TEXT NOT NULL, index_date TEXT NOT NULL,
+      value REAL NOT NULL, unit TEXT NOT NULL DEFAULT 'USD/day', source TEXT NOT NULL,
+      fetched_at TEXT NOT NULL DEFAULT (datetime('now')), UNIQUE(index_name, index_date)
+    );
+    CREATE TABLE IF NOT EXISTS baltic_indices (
+      index_code TEXT NOT NULL, value REAL NOT NULL, price_date TEXT NOT NULL,
+      source TEXT NOT NULL, fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(index_code, price_date)
+    );
+  `);
+  mockGetStore.mockReturnValue({ getDatabase: () => emptyDb });
+});
+
+afterEach(() => {
+  emptyDb.close();
 });
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -50,7 +80,8 @@ describe('getCurrentBenchmark — TOEPFER_TMI (scraper path)', () => {
     expect(result!.indicator).toBe('TOEPFER_TMI');
   });
 
-  it('T-2: returns null when scraper returns null', async () => {
+  it('T-2: returns null when scraper returns null AND no DB data', async () => {
+    // emptyDb has the tables but no rows, so DB fallback returns null too
     mockFetchToepferTmi.mockResolvedValue(null);
     const result = await getCurrentBenchmark('TOEPFER_TMI');
     expect(result).toBeNull();

--- a/design-system/patterns/PaletteTabs/NavigateTab.tsx
+++ b/design-system/patterns/PaletteTabs/NavigateTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 
-const ROUTES = [
+const ALL_ROUTES = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/matches', label: 'Matches' },
   { href: '/cargo', label: 'Cargo' },
@@ -9,15 +9,22 @@ const ROUTES = [
   { href: '/market', label: 'Market' },
   { href: '/charterers', label: 'Charterers' },
   { href: '/recap', label: 'Recap' },
+  { href: '/laytime', label: 'Laytime' },
+  { href: '/psc', label: 'PSC' },
+  { href: '/commission', label: 'Commission' },
+  { href: '/clauses', label: 'Clauses' },
   { href: '/email', label: 'Email' },
   { href: '/settings', label: 'Settings' },
   { href: '/upgrade', label: 'Upgrade' },
 ];
 
 export function NavigateTab({ query, onSelect }: { query: string; onSelect: () => void }) {
+  const routes = ALL_ROUTES.filter(
+    (r) => r.href !== '/laytime' || process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED === 'true',
+  );
   const filtered = query
-    ? ROUTES.filter((r) => r.label.toLowerCase().includes(query.toLowerCase()))
-    : ROUTES;
+    ? routes.filter((r) => r.label.toLowerCase().includes(query.toLowerCase()))
+    : routes;
   if (filtered.length === 0) {
     return <div className="p-4 text-ds-text-subtle text-sm">No matching pages</div>;
   }

--- a/design-system/patterns/PaletteTabs/__tests__/NavigateTab.test.tsx
+++ b/design-system/patterns/PaletteTabs/__tests__/NavigateTab.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for NavigateTab — verifies that all expected routes are surfaced in the
+ * command-palette navigate tab, including the laytime flag gate.
+ *
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { NavigateTab } from '../NavigateTab';
+
+// next/link renders as <a> in tests via the jest/next mocks
+describe('NavigateTab', () => {
+  const noOp = () => {};
+
+  describe('with NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED unset', () => {
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED;
+    });
+
+    it('renders /clauses link', () => {
+      render(<NavigateTab query="" onSelect={noOp} />);
+      expect(screen.getByRole('link', { name: /clauses/i })).toBeInTheDocument();
+    });
+
+    it('renders /psc link', () => {
+      render(<NavigateTab query="" onSelect={noOp} />);
+      expect(screen.getByRole('link', { name: /psc/i })).toBeInTheDocument();
+    });
+
+    it('renders /commission link', () => {
+      render(<NavigateTab query="" onSelect={noOp} />);
+      expect(screen.getByRole('link', { name: /commission/i })).toBeInTheDocument();
+    });
+
+    it('does NOT render /laytime when flag is unset', () => {
+      render(<NavigateTab query="" onSelect={noOp} />);
+      expect(screen.queryByRole('link', { name: /laytime/i })).toBeNull();
+    });
+  });
+
+  describe('with NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED=true', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED;
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED = 'true';
+    });
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED;
+      } else {
+        process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED = originalEnv;
+      }
+    });
+
+    it('renders /laytime link when flag is true', () => {
+      render(<NavigateTab query="" onSelect={noOp} />);
+      expect(screen.getByRole('link', { name: /laytime/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('query filtering still works', () => {
+    it('filters to show only matching routes', () => {
+      render(<NavigateTab query="psc" onSelect={noOp} />);
+      // PSC should be visible
+      expect(screen.getByRole('link', { name: /psc/i })).toBeInTheDocument();
+      // Dashboard should not be visible
+      expect(screen.queryByRole('link', { name: /dashboard/i })).toBeNull();
+    });
+  });
+});

--- a/docs/superpowers/plans/2026-06-13-enable-nav-palette-tmi.md
+++ b/docs/superpowers/plans/2026-06-13-enable-nav-palette-tmi.md
@@ -1,0 +1,75 @@
+# Enable ready-but-off: command-palette nav + TMI benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development. Steps use `- [ ]`.
+> Before using Next.js/React APIs introduced or changed after v14 — WebFetch the relevant nextjs.org/react.dev docs page first.
+
+**Goal:** Surface three already-built-but-dark capabilities: (1) `/clauses /laytime /psc /commission` in the ⌘K command palette; (2) the TMI chart on `/market` (seed `market_indices.tmi`); (3) the Toepfer-TMI line in the quote prompt + `/api/market/benchmark` (DB fallback when the scraper returns null).
+
+**Architecture:** Next.js 16 + React 19. Nav lives in `design-system/patterns/`. Market data in `market_indices` (chart) + `baltic_indices` (quote benchmark anchor). Seed scripts mirror `scripts/demo-seed/seed-charterers.ts`.
+
+**Ground truth (verified this session, do NOT re-derive):**
+
+- `design-system/patterns/PaletteTabs/NavigateTab.tsx` — `ROUTES` array (lines 4-15) currently lists dashboard/matches/cargo/vessels/market/charterers/recap/email/settings/upgrade. Missing: clauses, laytime, psc, commission.
+- `design-system/patterns/TopNav.tsx` `MORE_ITEMS` already lists all four + gates laytime on `process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED === 'true'` (MoreDropdown filter, lines 75-77). Mirror that gating in the palette.
+- `lib/market/market-indices-repository.ts`: `MarketIndexRow = {id,index_name,index_date,value,unit,source,fetched_at}`; `upsertIndex(db,row)` is idempotent `ON CONFLICT(index_name,index_date)`, validates `value>=0` finite, requires id/index_name/index_date/source. `getLatestIndex(db,name)`, `getIndexHistory(db,name,days)` ORDER BY index_date DESC LIMIT days.
+- `app/api/market/indices/route.ts:80` serves `getIndexHistory(db,'tmi',days)` behind `MARKET_BENCHMARK_FULL_ENABLED==='true'` (TRUE on prod). `/market` page fetches `?name=tmi&days=30` (page.tsx:143) and renders `MarketBenchmarkChart` only when `tmiData.length>0` (page.tsx:337).
+- Prod `market_indices.tmi` = 0 rows (chart silently absent); `baltic_indices` has one `TOEPFER_TMI = 12683 @ 2026-05-09 (static-seed)` from migration 020; migration 043 anchors $/day rates to TOEPFER_TMI≈12,683. **Oracle = 12683 USD/day.**
+- `demo_seed_meta(id=1, frozen_date TEXT, ...)` holds the demo "today" (local=2026-05-10; prod newer — read from the target DB at apply time).
+- `lib/market/benchmark.ts` `getCurrentBenchmark('TOEPFER_TMI')` → scraper `fetchToepferTmi()` only; returns null on prod (no network) → quote line dropped (`lib/quote-jobs/match-context.ts:32,41`) + `/api/market/benchmark?indicator=TOEPFER_TMI` 404. NO DB path today. Callers (non-test): benchmark.ts, quote-jobs/match-context.ts, app/api/market/benchmark/route.ts.
+- `MarketBenchmark = {indicator, value, unit, period, sourceUrl, fetchedAt, stale?}` (lib/types.ts:136).
+
+**Sanctioned spec changes:** none of these change existing tested behavior except where listed — only ADD palette entries, ADD a seed script, and ADD a DB fallback that fires only when the scraper returns null (the no-network prod path). Existing scraper-success behavior is unchanged. Tests that pin the old "scraper null → getCurrentBenchmark null with empty cache" must be updated to the new "scraper null → DB fallback" behavior (Task 3).
+
+---
+
+### Task 1: Command-palette routes (UI, low risk)
+
+**Files:**
+
+- Modify: `design-system/patterns/PaletteTabs/NavigateTab.tsx`
+- Test: `design-system/patterns/PaletteTabs/__tests__/NavigateTab.test.tsx` (create if absent; check for an existing test first)
+
+- [ ] **Step 1: Failing test** — render `<NavigateTab query="" onSelect={()=>{}} />`, assert links for `/clauses`, `/psc`, `/commission` present; assert `/laytime` present when `process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED==='true'` and absent when unset (set/restore env in the test).
+- [ ] **Step 2: Run, see fail.**
+- [ ] **Step 3: Implement** — add to `ROUTES` (keep grouping consistent with `MORE_ITEMS` labels): `{href:'/charterers'...}` already present; ADD `{href:'/laytime',label:'Laytime'}`, `{href:'/psc',label:'PSC'}`, `{href:'/commission',label:'Commission'}`, `{href:'/clauses',label:'Clauses'}`. Filter `/laytime` out when `process.env.NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED!=='true'` (mirror TopNav MoreDropdown). Keep the existing `query` filter behavior.
+- [ ] **Step 4: Run, pass.** Plus run any existing palette/CmdK tests so the change doesn't break them.
+- [ ] **Step 5: Commit** — `feat(nav): surface clauses/laytime/psc/commission in ⌘K palette`.
+
+### Task 2: Seed TMI into market_indices (data — the /market 3rd chart)
+
+**Files:**
+
+- Create: `scripts/demo-seed/tmi-fixture.ts` (pure, testable)
+- Create: `scripts/demo-seed/seed-tmi.ts` (CLI, mirrors `seed-charterers.ts`)
+- Test: `scripts/demo-seed/__tests__/tmi-fixture.test.ts`
+
+- [ ] **Step 1: Failing test** for `buildTmiRows(frozenDate: string, count=30): MarketIndexRow[]`: returns `count` rows; every `value` in `[12000,13500]` and finite; `index_name==='tmi'`, `unit==='USD/day'`, `source==='demo-seed'`; dates are consecutive daily, ascending, the LAST equal to `frozenDate`; ids unique & stable (`tmi-<date>`); deterministic (two calls equal) so re-seeding is idempotent; values centred near 12683 (assert mean within ±800 of 12683).
+- [ ] **Step 2: Run, see fail.**
+- [ ] **Step 3: Implement `tmi-fixture.ts`** — deterministic series (no Math.random): `value = round(12683 + 600*sin(i*0.5) + 120*((i%5)-2))` clamped to `[12000,13500]`; daily dates ending at `frozenDate` (use a pure date helper, UTC, no `Date.now()` baked into values); `fetched_at = frozenDate + 'T12:00:00.000Z'`.
+- [ ] **Step 4: Implement `seed-tmi.ts`** — CLI mirroring `seed-charterers.ts`: read `frozen_date` from `demo_seed_meta` (fallback to latest `market_indices` date, then today) of the target DB; build rows; `seedTmiWithDb(db)` wraps `upsertIndex` per row in a single `db.transaction`; `--dry-run` opens readonly and reports existing `tmi` count + what would be written (no writes); `--db` arg, default `data/demo-seed.db`; print `done — upserted N tmi row(s), table now M`. Export `seedTmiWithDb` + `buildTmiRows` re-export for tests.
+- [ ] **Step 5: Run test, pass.** `npx tsc --noEmit` for the two new files (NODE_OPTIONS=--max-old-space-size=8192).
+- [ ] **Step 6: Commit** — `feat(seed): targeted tmi market-index seed (does not touch bhsi/drewry)`.
+
+### Task 3: Quote/benchmark TMI DB fallback (value-bearing code)
+
+**Files:**
+
+- Create: `lib/market/tmi-benchmark-fallback.ts` (DB reader → `MarketBenchmark`)
+- Modify: `lib/market/benchmark.ts` (use fallback when scraper null)
+- Test: `lib/__tests__/benchmark-db-fallback.test.ts` (+ update any existing benchmark test pinning the old null behavior)
+
+- [ ] **Step 1: Failing test** — with a temp DB seeded with `baltic_indices` TOEPFER_TMI=12683@2026-05-09 (and optionally a recent `market_indices.tmi` row), mock `fetchToepferTmi` to return null, `_clearCacheForTesting()`, then `getCurrentBenchmark('TOEPFER_TMI')` resolves to a `MarketBenchmark` with `value===12683` (or the latest `market_indices.tmi` value if present), `indicator==='TOEPFER_TMI'`, `unit==='USD/day'`, `stale===true`, non-empty `period`. Also assert: scraper SUCCESS still wins over DB; non-TMI indicators with scraper null + no cache still return null (unchanged).
+- [ ] **Step 2: Run, see fail.**
+- [ ] **Step 3: Implement `tmi-benchmark-fallback.ts`** — `getTmiBenchmarkFromDb(db): MarketBenchmark | null`: prefer `getLatestIndex(db,'tmi')`; else latest `baltic_indices` row WHERE index_code='TOEPFER_TMI' (ORDER BY price_date DESC LIMIT 1); map to `MarketBenchmark` (`value`, `unit:'USD/day'`, `period` = "Mon YYYY" from the date, `sourceUrl:''`, `fetchedAt:` row's date ISO, `stale:true`); return null if neither exists. Pure read, guarded.
+- [ ] **Step 4: Modify `benchmark.ts`** — in `getCurrentBenchmark`, for `indicator==='TOEPFER_TMI'`, after the scraper returns null AND before returning the final `null`, try `getTmiBenchmarkFromDb(getStore().getDatabase())` inside try/catch (DB failure → continue to existing null/stale-cache path). Do NOT change the scraper-success or fresh-cache paths. Keep `getStore` import lazy-safe.
+- [ ] **Step 5: Run tests, pass** — new test + the existing benchmark test suite (update the pinned-null case per Sanctioned spec changes). `npx tsc --noEmit`.
+- [ ] **Step 6: Commit** — `feat(market): DB fallback for Toepfer-TMI benchmark when scraper is unavailable`.
+
+---
+
+## Self-review checklist
+
+- Palette mirrors `MORE_ITEMS` (laytime gated identically). ✓ type-consistent `{href,label}`.
+- `buildTmiRows` deterministic + idempotent (re-seed converges via `ON CONFLICT`). ✓ does not write bhsi/drewry.
+- benchmark DB fallback fires only on scraper-null TOEPFER_TMI; other indicators + scraper-success unchanged. ✓ value = real 12683 anchor (oracle).
+- No `Date.now()` baked into seeded values (frozen-date anchored → no ROI-style aging time-bomb).

--- a/lib/__tests__/benchmark-db-fallback.test.ts
+++ b/lib/__tests__/benchmark-db-fallback.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for benchmark.ts DB fallback — when fetchToepferTmi() returns null,
+ * getCurrentBenchmark('TOEPFER_TMI') should fall back to the DB value.
+ *
+ * Covers:
+ *   1. market_indices.tmi row → used as fallback (stale=true)
+ *   2. No tmi row → falls back to baltic_indices TOEPFER_TMI (stale=true)
+ *   3. Neither → returns null (existing behaviour)
+ *   4. Scraper success → still wins over DB (unchanged path)
+ *   5. Non-TMI indicator with scraper null → still returns null (unchanged)
+ */
+import Database from 'better-sqlite3';
+
+// We mock the module BEFORE importing getCurrentBenchmark
+jest.mock('../market/toepfer-scraper', () => ({
+  fetchToepferTmi: jest.fn(),
+}));
+jest.mock('../session-store', () => ({
+  getStore: jest.fn(),
+}));
+
+import { fetchToepferTmi } from '../market/toepfer-scraper';
+import { getStore } from '../session-store';
+import { getCurrentBenchmark, _clearCacheForTesting } from '../market/benchmark';
+import type { MarketBenchmark } from '../types';
+
+const mockFetchToepferTmi = fetchToepferTmi as jest.MockedFunction<typeof fetchToepferTmi>;
+const mockGetStore = getStore as jest.MockedFunction<typeof getStore>;
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS market_indices (
+      id          TEXT PRIMARY KEY NOT NULL,
+      index_name  TEXT NOT NULL,
+      index_date  TEXT NOT NULL,
+      value       REAL NOT NULL,
+      unit        TEXT NOT NULL DEFAULT 'USD/day',
+      source      TEXT NOT NULL,
+      fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(index_name, index_date)
+    );
+    CREATE TABLE IF NOT EXISTS baltic_indices (
+      index_code  TEXT NOT NULL,
+      value       REAL NOT NULL,
+      price_date  TEXT NOT NULL,
+      source      TEXT NOT NULL,
+      fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(index_code, price_date)
+    );
+  `);
+  return db;
+}
+
+function seedBalticToepfer(db: Database.Database, value = 12683, date = '2026-05-09'): void {
+  db.prepare(
+    `INSERT INTO baltic_indices (index_code, value, price_date, source) VALUES (?,?,?,?)`,
+  ).run('TOEPFER_TMI', value, date, 'static-seed');
+}
+
+function seedMarketTmi(db: Database.Database, value = 12900, date = '2026-05-10'): void {
+  db.prepare(
+    `INSERT INTO market_indices (id, index_name, index_date, value, unit, source, fetched_at)
+     VALUES (?,?,?,?,?,?,?)`,
+  ).run(`tmi-${date}`, 'tmi', date, value, 'USD/day', 'demo-seed', date + 'T12:00:00.000Z');
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('getCurrentBenchmark — DB fallback for TOEPFER_TMI', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    _clearCacheForTesting();
+    db = makeDb();
+    mockFetchToepferTmi.mockResolvedValue(null);
+    mockGetStore.mockReturnValue({ getDatabase: () => db } as ReturnType<typeof getStore>);
+  });
+
+  afterEach(() => {
+    db.close();
+    jest.clearAllMocks();
+  });
+
+  it('falls back to market_indices.tmi when scraper returns null', async () => {
+    seedMarketTmi(db, 12900, '2026-05-10');
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe(12900);
+    expect(result!.indicator).toBe('TOEPFER_TMI');
+    expect(result!.unit).toBe('USD/day');
+    expect(result!.stale).toBe(true);
+    expect(result!.period).toBeTruthy();
+  });
+
+  it('falls back to baltic_indices TOEPFER_TMI when no tmi in market_indices', async () => {
+    seedBalticToepfer(db, 12683, '2026-05-09');
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe(12683);
+    expect(result!.indicator).toBe('TOEPFER_TMI');
+    expect(result!.unit).toBe('USD/day');
+    expect(result!.stale).toBe(true);
+    expect(result!.period).toBeTruthy();
+  });
+
+  it('market_indices.tmi takes priority over baltic_indices when both present', async () => {
+    seedMarketTmi(db, 12900, '2026-05-10');
+    seedBalticToepfer(db, 12683, '2026-05-09');
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result!.value).toBe(12900);
+  });
+
+  it('returns null when neither DB source exists', async () => {
+    // Empty DB, no rows
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result).toBeNull();
+  });
+
+  it('scraper success still wins over DB (unchanged path)', async () => {
+    const scraperResult: MarketBenchmark = {
+      indicator: 'TOEPFER_TMI',
+      value: 13100,
+      unit: 'USD/day',
+      period: 'Jun 2026',
+      sourceUrl: 'https://example.com',
+      fetchedAt: new Date().toISOString(),
+    };
+    mockFetchToepferTmi.mockResolvedValue(scraperResult);
+    seedMarketTmi(db, 12900, '2026-05-10');
+
+    const result = await getCurrentBenchmark('TOEPFER_TMI');
+    expect(result!.value).toBe(13100);
+    expect(result!.stale).toBeUndefined();
+  });
+
+  it('non-TMI indicator with scraper null still returns null', async () => {
+    // BHSI, DREWRY_BREAKBULK, etc — no DB fallback for these
+    const result = await getCurrentBenchmark('BHSI');
+    expect(result).toBeNull();
+  });
+});

--- a/lib/market/benchmark.ts
+++ b/lib/market/benchmark.ts
@@ -1,5 +1,7 @@
 import type { MarketBenchmark, MarketIndicator } from '@/lib/types';
 import { fetchToepferTmi } from './toepfer-scraper';
+import { getTmiBenchmarkFromDb } from './tmi-benchmark-fallback';
+import { getStore } from '@/lib/session-store';
 
 /** TTL for cached market benchmark entries: 7 days in milliseconds. */
 const BENCHMARK_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -41,6 +43,18 @@ export async function getCurrentBenchmark(
   // Return stale cache if available rather than null
   if (cached) {
     return cached.benchmark;
+  }
+
+  // For TOEPFER_TMI: fall back to DB value when scraper is unavailable
+  if (indicator === 'TOEPFER_TMI') {
+    try {
+      const dbFallback = getTmiBenchmarkFromDb(getStore().getDatabase());
+      if (dbFallback) {
+        return dbFallback;
+      }
+    } catch {
+      // DB unavailable — continue to null
+    }
   }
 
   return null;

--- a/lib/market/tmi-benchmark-fallback.ts
+++ b/lib/market/tmi-benchmark-fallback.ts
@@ -1,0 +1,66 @@
+/**
+ * tmi-benchmark-fallback.ts — read the latest TMI value from the DB and
+ * return it as a MarketBenchmark when the live scraper is unavailable.
+ *
+ * Priority:
+ *   1. market_indices WHERE index_name='tmi' (demo-seeded rows)
+ *   2. baltic_indices WHERE index_code='TOEPFER_TMI' (migration 020 static-seed)
+ *
+ * Returns null if neither exists. Always sets stale=true (it's a DB fallback,
+ * not a fresh fetch).
+ */
+
+import type Database from 'better-sqlite3';
+import type { MarketBenchmark } from '@/lib/types';
+
+function formatPeriod(isoDate: string): string {
+  // '2026-05-09' → 'May 2026'
+  const d = new Date(isoDate + 'T00:00:00Z');
+  return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+}
+
+export function getTmiBenchmarkFromDb(db: Database.Database): MarketBenchmark | null {
+  try {
+    // 1. Prefer market_indices.tmi (demo-seeded, most recent)
+    const miRow = db
+      .prepare<[], { value: number; index_date: string }>(
+        `SELECT value, index_date FROM market_indices WHERE index_name='tmi' ORDER BY index_date DESC LIMIT 1`,
+      )
+      .get();
+
+    if (miRow) {
+      return {
+        indicator: 'TOEPFER_TMI',
+        value: miRow.value,
+        unit: 'USD/day',
+        period: formatPeriod(miRow.index_date),
+        sourceUrl: '',
+        fetchedAt: miRow.index_date + 'T00:00:00.000Z',
+        stale: true,
+      };
+    }
+
+    // 2. Fall back to baltic_indices TOEPFER_TMI (migration 020 static-seed)
+    const biRow = db
+      .prepare<[], { value: number; price_date: string }>(
+        `SELECT value, price_date FROM baltic_indices WHERE index_code='TOEPFER_TMI' ORDER BY price_date DESC LIMIT 1`,
+      )
+      .get();
+
+    if (biRow) {
+      return {
+        indicator: 'TOEPFER_TMI',
+        value: biRow.value,
+        unit: 'USD/day',
+        period: formatPeriod(biRow.price_date),
+        sourceUrl: '',
+        fetchedAt: biRow.price_date + 'T00:00:00.000Z',
+        stale: true,
+      };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/demo-seed/__tests__/tmi-fixture.test.ts
+++ b/scripts/demo-seed/__tests__/tmi-fixture.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for tmi-fixture.ts — deterministic TMI row generator for demo seed.
+ */
+import { buildTmiRows } from '../tmi-fixture';
+import type { MarketIndexRow } from '@/lib/market/market-indices-repository';
+
+const FROZEN_DATE = '2026-05-10';
+const COUNT = 30;
+
+describe('buildTmiRows', () => {
+  let rows: MarketIndexRow[];
+
+  beforeEach(() => {
+    rows = buildTmiRows(FROZEN_DATE, COUNT);
+  });
+
+  it('returns exactly count rows', () => {
+    expect(rows).toHaveLength(COUNT);
+  });
+
+  it('every value is in [12000, 13500] and finite', () => {
+    for (const r of rows) {
+      expect(Number.isFinite(r.value)).toBe(true);
+      expect(r.value).toBeGreaterThanOrEqual(12000);
+      expect(r.value).toBeLessThanOrEqual(13500);
+    }
+  });
+
+  it('every row has index_name === "tmi"', () => {
+    for (const r of rows) {
+      expect(r.index_name).toBe('tmi');
+    }
+  });
+
+  it('every row has unit === "USD/day"', () => {
+    for (const r of rows) {
+      expect(r.unit).toBe('USD/day');
+    }
+  });
+
+  it('every row has source === "demo-seed"', () => {
+    for (const r of rows) {
+      expect(r.source).toBe('demo-seed');
+    }
+  });
+
+  it('dates are consecutive daily ascending, last date === frozenDate', () => {
+    const dates = rows.map((r) => r.index_date);
+    // ascending order
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i] > dates[i - 1]).toBe(true);
+    }
+    // last date is frozenDate
+    expect(dates[dates.length - 1]).toBe(FROZEN_DATE);
+    // consecutive daily: each pair differs by exactly 1 day
+    for (let i = 1; i < dates.length; i++) {
+      const prev = new Date(dates[i - 1] + 'T00:00:00Z');
+      const curr = new Date(dates[i] + 'T00:00:00Z');
+      const diffDays = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diffDays).toBe(1);
+    }
+  });
+
+  it('ids are unique and stable (tmi-<date> pattern)', () => {
+    const ids = rows.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const r of rows) {
+      expect(r.id).toBe(`tmi-${r.index_date}`);
+    }
+  });
+
+  it('is deterministic — two calls produce equal output', () => {
+    const rows2 = buildTmiRows(FROZEN_DATE, COUNT);
+    expect(rows).toEqual(rows2);
+  });
+
+  it('values are centred near 12683 (mean within ±800)', () => {
+    const mean = rows.reduce((s, r) => s + r.value, 0) / rows.length;
+    expect(Math.abs(mean - 12683)).toBeLessThan(800);
+  });
+});

--- a/scripts/demo-seed/seed-tmi.ts
+++ b/scripts/demo-seed/seed-tmi.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * seed-tmi.ts — targeted idempotent seed of ~30 tmi rows into market_indices.
+ *
+ * Mirrors seed-charterers.ts patterns:
+ *   - reads frozen_date from demo_seed_meta (fallback: latest market_indices date, then today)
+ *   - builds rows via buildTmiRows (deterministic, no Math.random)
+ *   - wraps upsertIndex calls in a single db.transaction
+ *   - --dry-run: opens readonly, reports existing tmi count + what would be written
+ *   - --db: path to target database (default: data/demo-seed.db)
+ *   - does NOT touch bhsi/drewry or any other index
+ *
+ * Usage:
+ *   npx tsx scripts/demo-seed/seed-tmi.ts [--db data/demo-seed.db] [--dry-run]
+ */
+
+import Database from 'better-sqlite3';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { upsertIndex } from '@/lib/market/market-indices-repository';
+import { buildTmiRows } from './tmi-fixture';
+
+export { buildTmiRows };
+
+function getFrozenDate(db: Database.Database): string {
+  // 1. Try demo_seed_meta
+  const meta = db
+    .prepare(`SELECT frozen_date FROM demo_seed_meta WHERE id=1`)
+    .get() as { frozen_date?: string } | undefined;
+  if (meta?.frozen_date) return meta.frozen_date;
+
+  // 2. Try latest market_indices date
+  const latest = db
+    .prepare(`SELECT MAX(index_date) d FROM market_indices`)
+    .get() as { d?: string } | undefined;
+  if (latest?.d) return latest.d;
+
+  // 3. Fall back to today (UTC)
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Seed TMI rows into an explicit db handle.
+ * Idempotent: upsertIndex uses ON CONFLICT(index_name,index_date) DO UPDATE.
+ * Does NOT touch bhsi/drewry or any other index.
+ */
+export function seedTmiWithDb(db: Database.Database, count = 30): { upserted: number } {
+  const frozenDate = getFrozenDate(db);
+  const rows = buildTmiRows(frozenDate, count);
+
+  const run = db.transaction(() => {
+    for (const row of rows) {
+      upsertIndex(db, row);
+    }
+    return { upserted: rows.length };
+  });
+
+  return run();
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+function arg(k: string): string | undefined {
+  const i = process.argv.indexOf(k);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+function main(): void {
+  const dryRun = process.argv.includes('--dry-run');
+  const dbPath = arg('--db') ?? path.resolve(process.cwd(), 'data/demo-seed.db');
+
+  console.log(`[seed-tmi] db=${dbPath}${dryRun ? ' (DRY RUN — no writes)' : ''}`);
+
+  if (!fs.existsSync(dbPath)) {
+    console.error(`[seed-tmi] ERROR: db not found: ${dbPath}`);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    const db = new Database(dbPath, { readonly: true });
+    const existingCount = (
+      db.prepare(`SELECT COUNT(*) c FROM market_indices WHERE index_name='tmi'`).get() as { c: number }
+    ).c;
+    const frozenDate = getFrozenDate(db);
+    const rows = buildTmiRows(frozenDate, 30);
+    console.log(`[seed-tmi] existing tmi rows: ${existingCount}`);
+    console.log(`[seed-tmi] frozen_date: ${frozenDate}`);
+    console.log(`[seed-tmi] would write ${rows.length} rows (${rows[0].index_date} → ${rows[rows.length - 1].index_date})`);
+    db.close();
+    console.log('[seed-tmi] dry run complete — no rows written.');
+    return;
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  const { upserted } = seedTmiWithDb(db);
+  const total = (
+    db.prepare(`SELECT COUNT(*) c FROM market_indices WHERE index_name='tmi'`).get() as { c: number }
+  ).c;
+  db.close();
+
+  console.log(`[seed-tmi] done — upserted ${upserted} tmi row(s), table now ${total}.`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/demo-seed/seed-tmi.ts
+++ b/scripts/demo-seed/seed-tmi.ts
@@ -24,17 +24,25 @@ import { buildTmiRows } from './tmi-fixture';
 export { buildTmiRows };
 
 function getFrozenDate(db: Database.Database): string {
-  // 1. Try demo_seed_meta
-  const meta = db
-    .prepare(`SELECT frozen_date FROM demo_seed_meta WHERE id=1`)
-    .get() as { frozen_date?: string } | undefined;
-  if (meta?.frozen_date) return meta.frozen_date;
+  // 1. Try demo_seed_meta (may not exist on fresh DBs — guard against missing table)
+  try {
+    const meta = db
+      .prepare(`SELECT frozen_date FROM demo_seed_meta WHERE id=1`)
+      .get() as { frozen_date?: string } | undefined;
+    if (meta?.frozen_date) return meta.frozen_date;
+  } catch {
+    // Table doesn't exist — fall through to next fallback
+  }
 
-  // 2. Try latest market_indices date
-  const latest = db
-    .prepare(`SELECT MAX(index_date) d FROM market_indices`)
-    .get() as { d?: string } | undefined;
-  if (latest?.d) return latest.d;
+  // 2. Try latest tmi date in market_indices (anchored to tmi, not bhsi/drewry)
+  try {
+    const latest = db
+      .prepare(`SELECT MAX(index_date) AS d FROM market_indices WHERE index_name='tmi'`)
+      .get() as { d?: string } | undefined;
+    if (latest?.d) return latest.d;
+  } catch {
+    // Table doesn't exist — fall through to today
+  }
 
   // 3. Fall back to today (UTC)
   return new Date().toISOString().slice(0, 10);

--- a/scripts/demo-seed/tmi-fixture.ts
+++ b/scripts/demo-seed/tmi-fixture.ts
@@ -1,0 +1,44 @@
+/**
+ * tmi-fixture.ts — deterministic TMI series for demo-seed.
+ *
+ * Generates `count` daily rows ending at `frozenDate`, values centred near
+ * 12683 USD/day using a deterministic sine formula — no Math.random(), no
+ * Date.now() baked into values. Re-seeding is idempotent via the
+ * upsertIndex ON CONFLICT(index_name, index_date) constraint.
+ */
+
+import type { MarketIndexRow } from '@/lib/market/market-indices-repository';
+
+/**
+ * Build an array of `count` consecutive daily TMI rows.
+ * Dates run from (frozenDate - count + 1) to frozenDate (inclusive), ascending.
+ * value = round(12683 + 600*sin(i*0.5) + 120*((i%5)-2)), clamped to [12000,13500].
+ * fetched_at is frozenDate + 'T12:00:00.000Z'.
+ */
+export function buildTmiRows(frozenDate: string, count = 30): MarketIndexRow[] {
+  const end = new Date(frozenDate + 'T00:00:00Z');
+  const fetchedAt = frozenDate + 'T12:00:00.000Z';
+  const rows: MarketIndexRow[] = [];
+
+  for (let i = 0; i < count; i++) {
+    // i=0 is the earliest date, i=count-1 is frozenDate
+    const dayOffset = count - 1 - i;
+    const date = new Date(end.getTime() - dayOffset * 24 * 60 * 60 * 1000);
+    const isoDate = date.toISOString().slice(0, 10);
+
+    const raw = 12683 + 600 * Math.sin(i * 0.5) + 120 * ((i % 5) - 2);
+    const value = Math.round(Math.max(12000, Math.min(13500, raw)));
+
+    rows.push({
+      id: `tmi-${isoDate}`,
+      index_name: 'tmi',
+      index_date: isoDate,
+      value,
+      unit: 'USD/day',
+      source: 'demo-seed',
+      fetched_at: fetchedAt,
+    });
+  }
+
+  return rows;
+}

--- a/tests/regression/no-meta-seed.test.ts
+++ b/tests/regression/no-meta-seed.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test for FIX 2: seedTmiWithDb must NOT throw when called on a DB
+ * that lacks the `demo_seed_meta` table (e.g. a fresh DB with only market_indices).
+ *
+ * Before the fix, getFrozenDate() would throw:
+ *   SqliteError: no such table: demo_seed_meta
+ */
+import Database from 'better-sqlite3';
+import { seedTmiWithDb } from '../../scripts/demo-seed/seed-tmi';
+
+function makeDbWithoutMeta(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE market_indices (
+      id          TEXT PRIMARY KEY NOT NULL,
+      index_name  TEXT NOT NULL,
+      index_date  TEXT NOT NULL,
+      value       REAL NOT NULL,
+      unit        TEXT NOT NULL DEFAULT 'USD/day',
+      source      TEXT NOT NULL,
+      fetched_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(index_name, index_date)
+    );
+  `);
+  // NOTE: demo_seed_meta intentionally NOT created
+  return db;
+}
+
+describe('seedTmiWithDb — no demo_seed_meta table (FIX 2 regression)', () => {
+  it('does not throw when demo_seed_meta table is absent', () => {
+    const db = makeDbWithoutMeta();
+    expect(() => seedTmiWithDb(db, 5)).not.toThrow();
+    db.close();
+  });
+
+  it('writes tmi rows when demo_seed_meta is absent', () => {
+    const db = makeDbWithoutMeta();
+    const { upserted } = seedTmiWithDb(db, 5);
+    expect(upserted).toBe(5);
+
+    const count = (
+      db.prepare(`SELECT COUNT(*) AS c FROM market_indices WHERE index_name='tmi'`).get() as { c: number }
+    ).c;
+    expect(count).toBe(5);
+    db.close();
+  });
+});


### PR DESCRIPTION
## What

Surfaces three already-built-but-dark capabilities found in the ready-but-off audit:

1. **⌘K command palette** (`NavigateTab.tsx`) — adds `/clauses /laytime /psc /commission` to the Navigate list (they were in the desktop `MORE_ITEMS` top-nav but missing from the palette). `/laytime` gated on `NEXT_PUBLIC_LAYTIME_ENGINE_ENABLED` exactly like TopNav.
2. **TMI chart on `/market`** — `scripts/demo-seed/{tmi-fixture,seed-tmi}.ts` targeted, idempotent seed of ~30 `market_indices.tmi` rows (frozen-date anchored, values centred on the real TOEPFER_TMI anchor 12,683 $/day). Does **not** touch bhsi/drewry. Applied to prod by formula post-deploy. The 3rd benchmark chart was silently absent (0 tmi rows) though `MARKET_BENCHMARK_FULL_ENABLED=true`.
3. **TMI quote line + `/api/market/benchmark`** — `lib/market/benchmark.ts` DB fallback (`tmi-benchmark-fallback.ts`) when the live scraper returns null (the prod no-network path): reads latest `market_indices.tmi`, else `baltic_indices TOEPFER_TMI=12683`. Restores the "Market benchmark (Toepfer TMI): USD X/day TCE" line in the quote prompt.

## Ground truth / oracle
- TMI oracle = **12,683 USD/day** (`baltic_indices TOEPFER_TMI`, migration 020; migration 043 anchors $/day rates to it).
- Scraper-success and non-TMI benchmark paths unchanged; fallback fires only on scraper-null TOEPFER_TMI.
- No `Date.now()` baked into seeded values (frozen-date anchored → no ROI-style aging time-bomb).

## Tests
91/91 green across `design-system/patterns` + benchmark + tmi-fixture suites. New: NavigateTab palette test, tmi-fixture test, benchmark DB-fallback test.

Plan: `docs/superpowers/plans/2026-06-13-enable-nav-palette-tmi.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)