### PR TITLE
fix: qa-backlog #968 (demo session rehydrate) + #787 (dedup) + #793 (capacity/weight)

### DIFF
--- a/__tests__/lib/parse-vessel-capacity-guard-793.test.ts
+++ b/__tests__/lib/parse-vessel-capacity-guard-793.test.ts
@@ -1,0 +1,83 @@
+/**
+ * #793 — capacity plausibility guard in preNormalizeRawVessel.
+ *
+ * When cbm < 0.5 × DWT (both positive), grain/bale capacity is implausible
+ * and should be nulled. Plausible values (cbm >= 0.5 × DWT) are kept.
+ */
+import { parseVesselAIResponse } from '@/lib/parsing/parse-vessel-helpers';
+
+describe('#793 — vessel capacity plausibility guard', () => {
+  it('nulls grain/bale capacity when cbm is implausibly small (< 0.5 × DWT)', () => {
+    // IMO 8605480 scenario: DWT 2570, grain/bale 81 cbm (81 < 0.5 * 2570 = 1285)
+    const raw = JSON.stringify({
+      vessel_name: 'MV SEAGULL 2',
+      imo: '8605480',
+      dwt_summer: 2570,
+      grain_capacity: 81,
+      bale_capacity: 81,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].grainCapacity).toBeNull();
+    expect(vessels[0].baleCapacity).toBeNull();
+  });
+
+  it('keeps plausible grain/bale capacity (cbm >= 0.5 × DWT)', () => {
+    // 3200 cbm on 2570 DWT: 3200 >= 0.5 * 2570 = 1285 → plausible
+    const raw = JSON.stringify({
+      vessel_name: 'MV PLAUSIBLE',
+      imo: '1234567',
+      dwt_summer: 2570,
+      grain_capacity: 3200,
+      bale_capacity: 3000,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].grainCapacity).toBe(3200);
+    expect(vessels[0].baleCapacity).toBe(3000);
+  });
+
+  it('does not null capacity when DWT is absent (no guard without both values)', () => {
+    const raw = JSON.stringify({
+      vessel_name: 'MV NO_DWT',
+      imo: '1234567',
+      grain_capacity: 81,
+      bale_capacity: 81,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    // Without DWT, cannot apply guard → keep the value as-is
+    expect(vessels[0].grainCapacity).toBe(81);
+    expect(vessels[0].baleCapacity).toBe(81);
+  });
+
+  it('does not null capacity when cbm is 0 (zero-guard already handles that)', () => {
+    // Zero cbm is already null'd by nullIfZeroNumeric — guard only for positive implausible values
+    const raw = JSON.stringify({
+      vessel_name: 'MV ZERO_CAP',
+      imo: '1234567',
+      dwt_summer: 10000,
+      grain_capacity: { value: 0, confidence: 'uncertain', source_text: '' },
+      bale_capacity: { value: 0, confidence: 'uncertain', source_text: '' },
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    // Zero values already null'd by existing zero-guard — no additional change
+    expect(vessels[0].grainCapacity).toBeNull();
+  });
+
+  it('applies guard independently: nulls grain but keeps bale when only grain is implausible', () => {
+    // grain = 50 cbm (implausible), bale = 3000 cbm (plausible), DWT = 2570
+    const raw = JSON.stringify({
+      vessel_name: 'MV SPLIT',
+      imo: '1234567',
+      dwt_summer: 2570,
+      grain_capacity: 50,
+      bale_capacity: 3000,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].grainCapacity).toBeNull();
+    expect(vessels[0].baleCapacity).toBe(3000);
+  });
+});

--- a/__tests__/match-weight-unit-793.test.ts
+++ b/__tests__/match-weight-unit-793.test.ts
@@ -1,37 +1,66 @@
 /**
  * #793 — cargo weight SourceAttributionSection must show unit "mt".
  *
- * Static source analysis: the Weight field passed to SourceAttributionSection
- * must include the unit (e.g. `${cargo.weightMt} mt`) instead of a bare number.
+ * Runtime assertion: spreading cargo.weightMt with a formatted .value must
+ * produce a ConfidenceField<string> with:
+ *   - .value = "<number> mt"  (not "[object Object] mt")
+ *   - .confidence preserved from the original field
+ *   - .sourceText preserved from the original field
  */
 
-import fs from 'fs';
-import path from 'path';
+import type { ConfidenceField } from '@/lib/types';
 
-const ROOT = path.resolve(__dirname, '..');
-const pagePath = path.join(ROOT, 'app/match/[id]/page.tsx');
+/** Mirrors the spread expression in app/match/[id]/page.tsx */
+function buildWeightField(
+  weightMt: ConfidenceField<number>,
+): ConfidenceField<string> {
+  return { ...weightMt, value: `${weightMt.value} mt` };
+}
 
 describe('#793 — weight unit in SourceAttributionSection', () => {
-  it('Weight field includes "mt" unit in the displayed value', () => {
-    const src = fs.readFileSync(pagePath, 'utf-8');
-    // The template literal must include " mt" unit suffix
-    expect(src).toMatch(/weightMt.*mt|`\$\{.*weightMt.*\}\s*mt/);
+  const sample: ConfidenceField<number> = {
+    value: 55000,
+    confidence: 'interpreted',
+    sourceText: '55,000 mt grain',
+  };
+
+  it('renders a real number + " mt", not "[object Object] mt"', () => {
+    const field = buildWeightField(sample);
+    expect(field.value).toBe('55000 mt');
+    expect(field.value).not.toContain('[object Object]');
   });
 
-  it('Weight label exists with mt unit string in SourceAttributionSection fields', () => {
-    const src = fs.readFileSync(pagePath, 'utf-8');
-    // Must have the string "mt" near the Weight label
-    const weightIdx = src.indexOf("'Weight'");
-    expect(weightIdx).toBeGreaterThan(-1);
-    // Look at the surrounding 200 chars for "mt"
-    const surrounding = src.substring(weightIdx, weightIdx + 200);
-    expect(surrounding).toMatch(/mt/);
+  it('preserves original confidence (does not hardcode "confirmed")', () => {
+    const field = buildWeightField(sample);
+    expect(field.confidence).toBe('interpreted');
   });
 
-  it('Weight value is wrapped in a ConfidenceField-compatible object (not a bare number)', () => {
-    const src = fs.readFileSync(pagePath, 'utf-8');
-    // The value must use a ConfidenceField shape { value: ..., confidence: ... }
-    // to satisfy SourceAttributionSection type requirements
-    expect(src).toMatch(/Weight.*confidence|confidence.*Weight/);
+  it('preserves sourceText so SourceAttributionSection shows the row', () => {
+    const field = buildWeightField(sample);
+    expect(field.sourceText).toBe('55,000 mt grain');
+  });
+
+  it('works when sourceText is absent', () => {
+    const noSource: ConfidenceField<number> = { value: 12000, confidence: 'confirmed' };
+    const field = buildWeightField(noSource);
+    expect(field.value).toBe('12000 mt');
+    expect(field.sourceText).toBeUndefined();
+  });
+
+  it('page.tsx uses the spread pattern (source guard)', () => {
+    // Belt-and-suspenders: verify the page source uses the spread, not a bare template literal
+     
+    const fs = require('fs') as typeof import('fs');
+     
+    const path = require('path') as typeof import('path');
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../app/match/[id]/page.tsx'),
+      'utf-8',
+    );
+    // Must use spread: { ...cargo.weightMt, value: `${cargo.weightMt.value} mt` }
+    expect(src).toMatch(/\.\.\.\s*cargo\.weightMt/);
+    expect(src).toMatch(/cargo\.weightMt\.value.*mt/);
+    // Must NOT interpolate the raw ConfidenceField object as a whole
+    expect(src).not.toMatch(/`\$\{cargo\.weightMt\}\s*mt`/);
   });
 });

--- a/__tests__/match-weight-unit-793.test.ts
+++ b/__tests__/match-weight-unit-793.test.ts
@@ -1,0 +1,37 @@
+/**
+ * #793 — cargo weight SourceAttributionSection must show unit "mt".
+ *
+ * Static source analysis: the Weight field passed to SourceAttributionSection
+ * must include the unit (e.g. `${cargo.weightMt} mt`) instead of a bare number.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '..');
+const pagePath = path.join(ROOT, 'app/match/[id]/page.tsx');
+
+describe('#793 — weight unit in SourceAttributionSection', () => {
+  it('Weight field includes "mt" unit in the displayed value', () => {
+    const src = fs.readFileSync(pagePath, 'utf-8');
+    // The template literal must include " mt" unit suffix
+    expect(src).toMatch(/weightMt.*mt|`\$\{.*weightMt.*\}\s*mt/);
+  });
+
+  it('Weight label exists with mt unit string in SourceAttributionSection fields', () => {
+    const src = fs.readFileSync(pagePath, 'utf-8');
+    // Must have the string "mt" near the Weight label
+    const weightIdx = src.indexOf("'Weight'");
+    expect(weightIdx).toBeGreaterThan(-1);
+    // Look at the surrounding 200 chars for "mt"
+    const surrounding = src.substring(weightIdx, weightIdx + 200);
+    expect(surrounding).toMatch(/mt/);
+  });
+
+  it('Weight value is wrapped in a ConfidenceField-compatible object (not a bare number)', () => {
+    const src = fs.readFileSync(pagePath, 'utf-8');
+    // The value must use a ConfidenceField shape { value: ..., confidence: ... }
+    // to satisfy SourceAttributionSection type requirements
+    expect(src).toMatch(/Weight.*confidence|confidence.*Weight/);
+  });
+});

--- a/__tests__/matches-dedup-787.test.ts
+++ b/__tests__/matches-dedup-787.test.ts
@@ -1,10 +1,12 @@
 /**
  * #787 — dedupMatches: dedup by economic identity, not paraphrased cargo_ref.
  *
- * Two rows with the same vessel+cargo_type+load_port+discharge_port+laycan_start
+ * Two rows with the same vessel+cargo_type+load_port+discharge_port+laycan_start+laycan_end+fit_percent
  * but different cargo_ref text must collapse to one.
  * Rows differing in any discriminator (discharge_port, cargo_type, laycan_start,
- * vessel_name) must NOT collapse (no over-collapse regression).
+ * vessel_name, fit_percent) must NOT collapse (no over-collapse regression).
+ * fit_percent added after prod-data analysis showed 17 same-route rows with different
+ * fit values (genuinely distinct matches) were being wrongly merged.
  */
 
 import { dedupMatches } from '../app/matches/page';
@@ -29,7 +31,7 @@ function makeRow(overrides: Partial<StoredMatch> & { id: number }): StoredMatch 
     load_port: overrides.load_port ?? 'UAODS',
     discharge_port: overrides.discharge_port ?? 'CNSHA',
     laycan_start: overrides.laycan_start ?? 1748908800000,
-    laycan_end: null,
+    laycan_end: overrides.laycan_end ?? null,
     cargo_ref: overrides.cargo_ref ?? null,
     vessel_dwt: null,
     freight_rate_usd_per_mt: null,
@@ -37,7 +39,7 @@ function makeRow(overrides: Partial<StoredMatch> & { id: number }): StoredMatch 
     distance_nm: null,
     tce_usd_per_day: null,
     consumption_estimated: null,
-    fit_percent: null,
+    fit_percent: overrides.fit_percent ?? null,
     fit_breakdown: null,
     worksheet_json: null,
     breakeven_tce_usd_per_day: null,
@@ -107,5 +109,27 @@ describe('dedupMatches — economic identity key (#787)', () => {
     ];
     const result = dedupMatches(rows);
     expect(result).toHaveLength(2);
+  });
+
+  it('keeps rows identical except for different fit_percent (no over-collapse)', () => {
+    // Prod data: 17 rows with same vessel/cargo_type/route/laycan but different fit_percent —
+    // these are genuinely distinct matches and must not be merged.
+    const rows = [
+      makeRow({ id: 1, vessel_name: 'SEAGULL', cargo_type: 'grain', load_port: 'UAODS', discharge_port: 'CNSHA', laycan_start: 1748908800000, laycan_end: 1749081600000, fit_percent: 61.2 }),
+      makeRow({ id: 2, vessel_name: 'SEAGULL', cargo_type: 'grain', load_port: 'UAODS', discharge_port: 'CNSHA', laycan_start: 1748908800000, laycan_end: 1749081600000, fit_percent: 74.5 }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(2);
+  });
+
+  it('collapses rows with same route/laycan AND same fit_percent (true re-circulated dup)', () => {
+    // e.g. SEAGULL 60 appearing twice with same fit_percent 61.2 — these ARE true dups
+    const rows = [
+      makeRow({ id: 1, cargo_ref: 'grain shipment A', vessel_name: 'SEAGULL', fit_percent: 61.2, laycan_end: 1749081600000 }),
+      makeRow({ id: 2, cargo_ref: 'grain shipment B', vessel_name: 'SEAGULL', fit_percent: 61.2, laycan_end: 1749081600000 }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
   });
 });

--- a/__tests__/matches-dedup-787.test.ts
+++ b/__tests__/matches-dedup-787.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #787 — dedupMatches: dedup by economic identity, not paraphrased cargo_ref.
+ *
+ * Two rows with the same vessel+cargo_type+load_port+discharge_port+laycan_start
+ * but different cargo_ref text must collapse to one.
+ * Rows differing in any discriminator (discharge_port, cargo_type, laycan_start,
+ * vessel_name) must NOT collapse (no over-collapse regression).
+ */
+
+import { dedupMatches } from '../app/matches/page';
+import type { StoredMatch } from '@/lib/matching/matches-repository';
+
+function makeRow(overrides: Partial<StoredMatch> & { id: number }): StoredMatch {
+  return {
+    id: overrides.id,
+    user_id: 'u1',
+    cargo_id: overrides.cargo_id ?? 'c1',
+    vessel_id: overrides.vessel_id ?? 'v1',
+    cargo_item_index: null,
+    vessel_item_index: null,
+    score: 80,
+    reason: '',
+    reason_structured: null,
+    status: 'shortlist',
+    created_at: 1748908800,
+    updated_at: 1748908800,
+    vessel_name: overrides.vessel_name ?? 'MV ALPHA',
+    cargo_type: overrides.cargo_type ?? 'grain',
+    load_port: overrides.load_port ?? 'UAODS',
+    discharge_port: overrides.discharge_port ?? 'CNSHA',
+    laycan_start: overrides.laycan_start ?? 1748908800000,
+    laycan_end: null,
+    cargo_ref: overrides.cargo_ref ?? null,
+    vessel_dwt: null,
+    freight_rate_usd_per_mt: null,
+    freight_rate_source: null,
+    distance_nm: null,
+    tce_usd_per_day: null,
+    consumption_estimated: null,
+    fit_percent: null,
+    fit_breakdown: null,
+    worksheet_json: null,
+    breakeven_tce_usd_per_day: null,
+  } as StoredMatch;
+}
+
+describe('dedupMatches — economic identity key (#787)', () => {
+  it('collapses two rows with same economic identity but paraphrased cargo_ref', () => {
+    const rows = [
+      makeRow({ id: 1, cargo_ref: 'max 2 tiers' }),
+      makeRow({ id: 2, cargo_ref: 'tier limit 2' }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1); // first-wins
+  });
+
+  it('keeps rows that differ in discharge_port (no over-collapse)', () => {
+    const rows = [
+      makeRow({ id: 1, discharge_port: 'CNSHA' }),
+      makeRow({ id: 2, discharge_port: 'CNNGB' }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps rows that differ in cargo_type (no over-collapse)', () => {
+    const rows = [
+      makeRow({ id: 1, cargo_type: 'grain' }),
+      makeRow({ id: 2, cargo_type: 'coal' }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps rows that differ in laycan_start (no over-collapse)', () => {
+    const rows = [
+      makeRow({ id: 1, laycan_start: 1748908800000 }),
+      makeRow({ id: 2, laycan_start: 1749000000000 }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps rows that differ in vessel_name (no over-collapse)', () => {
+    const rows = [
+      makeRow({ id: 1, vessel_name: 'MV ALPHA' }),
+      makeRow({ id: 2, vessel_name: 'MV BETA' }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(2);
+  });
+
+  it('handles null fields gracefully (uses empty string for null)', () => {
+    const rows = [
+      makeRow({ id: 1, vessel_name: null, cargo_type: null, load_port: null, discharge_port: null, laycan_start: null }),
+      makeRow({ id: 2, vessel_name: null, cargo_type: null, load_port: null, discharge_port: null, laycan_start: null }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps rows with same economic identity that differ only in load_port', () => {
+    const rows = [
+      makeRow({ id: 1, load_port: 'UAODS' }),
+      makeRow({ id: 2, load_port: 'EGPSD' }),
+    ];
+    const result = dedupMatches(rows);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/__tests__/matches-page.test.tsx
+++ b/__tests__/matches-page.test.tsx
@@ -267,32 +267,33 @@ describe('app/matches/page.tsx — content dedup (#787)', () => {
     expect(src).toMatch(/dedupMatches/);
   });
 
-  it('dedup key includes vessel_name, cargo_ref, load_port, laycan_start', () => {
+  it('dedup key uses economic identity: vessel_name, cargo_type, load_port, discharge_port, laycan_start (#787)', () => {
     const src = readSource(pagePath);
     expect(src).toMatch(/vessel_name/);
-    expect(src).toMatch(/cargo_ref/);
+    expect(src).toMatch(/cargo_type/);
     expect(src).toMatch(/load_port/);
+    expect(src).toMatch(/discharge_port/);
     expect(src).toMatch(/laycan_start/);
   });
 
-  it('behavioral: identical vessel+cargo+port+laycan rows collapse to one', () => {
-    type Row = { id: number; vessel_name: string | null; cargo_ref: string | null; cargo_id: string; load_port: string | null; laycan_start: number | null };
-    function dedupMatches(rows: Row[]): Row[] {
+  it('behavioral: identical economic-identity rows collapse to one; differing vessel_name kept distinct', () => {
+    type Row = { id: number; vessel_name: string | null; cargo_type: string | null; load_port: string | null; discharge_port: string | null; laycan_start: number | null };
+    function dedupMatchesLocal(rows: Row[]): Row[] {
       const seen = new Map<string, Row>();
       for (const r of rows) {
-        const k = `${r.vessel_name ?? ''}|${r.cargo_ref ?? r.cargo_id}|${r.load_port ?? ''}|${r.laycan_start ?? ''}`;
+        const k = `${r.vessel_name ?? ''}|${r.cargo_type ?? ''}|${r.load_port ?? ''}|${r.discharge_port ?? ''}|${r.laycan_start ?? ''}`;
         if (!seen.has(k)) seen.set(k, r);
       }
       return [...seen.values()];
     }
 
-    const base = { vessel_name: 'MV ALPHA', cargo_ref: 'GRAIN-001', cargo_id: 'c1', load_port: 'UAODS', laycan_start: 1748908800000 };
+    const base = { vessel_name: 'MV ALPHA', cargo_type: 'grain', load_port: 'UAODS', discharge_port: 'CNSHA', laycan_start: 1748908800000 };
     const rows: Row[] = [
       { ...base, id: 1 },
       { ...base, id: 2 },
       { ...base, id: 3, vessel_name: 'MV BETA' },
     ];
-    const result = dedupMatches(rows);
+    const result = dedupMatchesLocal(rows);
     expect(result.length).toBe(2);
     expect(result[0].id).toBe(1);
     expect(result[1].vessel_name).toBe('MV BETA');

--- a/__tests__/pages/demo-session-rehydrate-redirect.test.ts
+++ b/__tests__/pages/demo-session-rehydrate-redirect.test.ts
@@ -1,0 +1,87 @@
+/**
+ * #968 — demo session-eviction rehydrate redirect.
+ *
+ * When getSession returns null AND isDemoMode() is true, matches/page.tsx and
+ * dashboard/page.tsx must redirect to /api/demo/rehydrate?next=<page> instead
+ * of rendering the "No emails yet" empty state.
+ *
+ * Strategy: static source-analysis (no SQLite, no Next.js runtime).
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '../..');
+
+function read(relPath: string): string {
+  return fs.readFileSync(path.join(ROOT, relPath), 'utf-8');
+}
+
+describe('#968 — matches page: demo rehydrate on null session', () => {
+  it('imports isDemoMode from @/lib/demo-mode', () => {
+    const src = read('app/matches/page.tsx');
+    expect(src).toMatch(/isDemoMode/);
+    expect(src).toMatch(/@\/lib\/demo-mode/);
+  });
+
+  it('imports redirect from next/navigation', () => {
+    const src = read('app/matches/page.tsx');
+    expect(src).toMatch(/redirect/);
+    expect(src).toMatch(/next\/navigation/);
+  });
+
+  it('calls redirect with /api/demo/rehydrate?next=/matches inside the !session branch', () => {
+    const src = read('app/matches/page.tsx');
+    // The redirect call must be inside the !session block and use the correct URL
+    expect(src).toMatch(/\/api\/demo\/rehydrate\?next=\/matches/);
+  });
+
+  it('isDemoMode() guards the redirect (non-demo fallback preserved)', () => {
+    const src = read('app/matches/page.tsx');
+    // isDemoMode() must precede the redirect for /matches
+    const isDemoModeIdx = src.indexOf('isDemoMode()');
+    const rehydrateIdx = src.indexOf('/api/demo/rehydrate?next=/matches');
+    expect(isDemoModeIdx).toBeGreaterThan(-1);
+    expect(rehydrateIdx).toBeGreaterThan(-1);
+    // isDemoMode check must come before the redirect call
+    expect(isDemoModeIdx).toBeLessThan(rehydrateIdx);
+  });
+
+  it('still contains the "No emails yet" non-demo fallback', () => {
+    const src = read('app/matches/page.tsx');
+    expect(src).toMatch(/No emails yet/);
+  });
+});
+
+describe('#968 — dashboard page: demo rehydrate on null session', () => {
+  it('imports isDemoMode from @/lib/demo-mode', () => {
+    const src = read('app/dashboard/page.tsx');
+    expect(src).toMatch(/isDemoMode/);
+    expect(src).toMatch(/@\/lib\/demo-mode/);
+  });
+
+  it('imports redirect from next/navigation', () => {
+    const src = read('app/dashboard/page.tsx');
+    expect(src).toMatch(/redirect/);
+    expect(src).toMatch(/next\/navigation/);
+  });
+
+  it('calls redirect with /api/demo/rehydrate?next=/dashboard inside the !session branch', () => {
+    const src = read('app/dashboard/page.tsx');
+    expect(src).toMatch(/\/api\/demo\/rehydrate\?next=\/dashboard/);
+  });
+
+  it('isDemoMode() guards the redirect (non-demo fallback preserved)', () => {
+    const src = read('app/dashboard/page.tsx');
+    const isDemoModeIdx = src.indexOf('isDemoMode()');
+    const rehydrateIdx = src.indexOf('/api/demo/rehydrate?next=/dashboard');
+    expect(isDemoModeIdx).toBeGreaterThan(-1);
+    expect(rehydrateIdx).toBeGreaterThan(-1);
+    expect(isDemoModeIdx).toBeLessThan(rehydrateIdx);
+  });
+
+  it('still contains the "No emails yet" non-demo fallback', () => {
+    const src = read('app/dashboard/page.tsx');
+    expect(src).toMatch(/No emails yet/);
+  });
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,8 @@
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { getSession } from '@/lib/session';
+import { isDemoMode } from '@/lib/demo-mode';
 import { getStore } from '@/lib/session-store';
 import { filterByCategory } from '@/lib/dashboard-queries';
 import { countAwaitingApproval } from '@/lib/auto-prequote/queue';
@@ -23,6 +25,9 @@ export default async function DashboardPage() {
   const session = sessionId ? getSession(sessionId) : null;
 
   if (!session) {
+    if (isDemoMode()) {
+      redirect('/api/demo/rehydrate?next=/dashboard');
+    }
     return (
       <div className="min-h-screen bg-ds-bg flex items-center justify-center px-4">
         <div className="max-w-md w-full text-center space-y-4">

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -306,7 +306,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   <SourceAttributionSection
                     fields={[
                       ...(cargo.cargoDescription ? [{ label: 'Cargo', value: cargo.cargoDescription }] : []),
-                      ...(cargo.weightMt ? [{ label: 'Weight', value: cargo.weightMt }] : []),
+                      ...(cargo.weightMt != null ? [{ label: 'Weight', value: { value: `${cargo.weightMt} mt`, confidence: 'confirmed' as const } }] : []),
                       ...(cargo.originPort ? [{ label: 'Load Port', value: cargo.originPort }] : []),
                       ...(cargo.destinationPort ? [{ label: 'Discharge Port', value: cargo.destinationPort }] : []),
                       ...(laycanDisplay

--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -306,7 +306,7 @@ export default async function MatchDetailPage({ params }: Props) {
                   <SourceAttributionSection
                     fields={[
                       ...(cargo.cargoDescription ? [{ label: 'Cargo', value: cargo.cargoDescription }] : []),
-                      ...(cargo.weightMt != null ? [{ label: 'Weight', value: { value: `${cargo.weightMt} mt`, confidence: 'confirmed' as const } }] : []),
+                      ...(cargo.weightMt != null ? [{ label: 'Weight', value: { ...cargo.weightMt, value: `${cargo.weightMt.value} mt` } }] : []),
                       ...(cargo.originPort ? [{ label: 'Load Port', value: cargo.originPort }] : []),
                       ...(cargo.destinationPort ? [{ label: 'Discharge Port', value: cargo.destinationPort }] : []),
                       ...(laycanDisplay

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -129,11 +129,15 @@ export default async function MatchesPage() {
   );
 }
 
-/** Keep one row per vessel_name+cargo_ref+load_port+laycan_start key (#787). */
-function dedupMatches(rows: StoredMatch[]): StoredMatch[] {
+/**
+ * Dedup by economic identity: vessel_name|cargo_type|load_port|discharge_port|laycan_start (#787).
+ * Paraphrased cargo_ref text ("max 2 tiers" vs "tier limit 2") no longer creates duplicate rows;
+ * rows differing in discharge_port, cargo_type, laycan_start, or vessel_name are kept distinct.
+ */
+export function dedupMatches(rows: StoredMatch[]): StoredMatch[] {
   const seen = new Map<string, StoredMatch>();
   for (const r of rows) {
-    const k = `${r.vessel_name ?? ''}|${r.cargo_ref ?? r.cargo_id}|${r.load_port ?? ''}|${r.laycan_start ?? ''}`;
+    const k = `${r.vessel_name ?? ''}|${r.cargo_type ?? ''}|${r.load_port ?? ''}|${r.discharge_port ?? ''}|${r.laycan_start ?? ''}`;
     if (!seen.has(k)) seen.set(k, r);
   }
   return [...seen.values()];

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -130,14 +130,16 @@ export default async function MatchesPage() {
 }
 
 /**
- * Dedup by economic identity: vessel_name|cargo_type|load_port|discharge_port|laycan_start (#787).
+ * Dedup by economic identity: vessel_name|cargo_type|load_port|discharge_port|laycan_start|laycan_end|fit_percent (#787).
  * Paraphrased cargo_ref text ("max 2 tiers" vs "tier limit 2") no longer creates duplicate rows;
- * rows differing in discharge_port, cargo_type, laycan_start, or vessel_name are kept distinct.
+ * rows differing in discharge_port, cargo_type, laycan_start, vessel_name, or fit_percent are kept
+ * distinct (fit_percent added to prevent over-collapse of genuinely different matches, prod data
+ * showed 17 rows with identical route/laycan but different fit — they must remain separate).
  */
 export function dedupMatches(rows: StoredMatch[]): StoredMatch[] {
   const seen = new Map<string, StoredMatch>();
   for (const r of rows) {
-    const k = `${r.vessel_name ?? ''}|${r.cargo_type ?? ''}|${r.load_port ?? ''}|${r.discharge_port ?? ''}|${r.laycan_start ?? ''}`;
+    const k = `${r.vessel_name ?? ''}|${r.cargo_type ?? ''}|${r.load_port ?? ''}|${r.discharge_port ?? ''}|${r.laycan_start ?? ''}|${r.laycan_end ?? ''}|${r.fit_percent ?? ''}`;
     if (!seen.has(k)) seen.set(k, r);
   }
   return [...seen.values()];

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { getSession } from '@/lib/session';
+import { isDemoMode } from '@/lib/demo-mode';
 import { getStore } from '@/lib/session-store';
 import { listMatches, type StoredMatch } from '@/lib/matching/matches-repository';
 import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
@@ -23,6 +25,9 @@ export default async function MatchesPage() {
   const session = sessionId ? getSession(sessionId) : null;
 
   if (!session) {
+    if (isDemoMode()) {
+      redirect('/api/demo/rehydrate?next=/matches');
+    }
     return (
       <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
         <div className="max-w-md w-full text-center space-y-4">

--- a/docs/superpowers/plans/2026-06-13-qa-backlog-968-787-793.md
+++ b/docs/superpowers/plans/2026-06-13-qa-backlog-968-787-793.md
@@ -1,0 +1,59 @@
+# QA backlog fixes #968 / #787 / #793 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: subagent-driven-development. Steps use `- [ ]`.
+> Before using Next.js/React APIs changed after v14 — WebFetch the relevant nextjs.org/react.dev page first.
+
+**Goal:** Fix three open qa-walker bugs verified still-live against prod (2026-06-13 triage): #968 demo session-eviction empty board (HIGH), #787 duplicate re-circulated match (medium), #793 capacity outlier + unit-less weight (low).
+
+**Tech:** Next.js 16 + React 19 + TS + Jest + better-sqlite3.
+
+**Ground truth (verified this session — do NOT re-derive):**
+
+- `app/matches/page.tsx:25-38` and `app/dashboard/page.tsx:25-43` both render a "No emails yet" empty state when `getSession(sessionId)` returns null. In DEMO_MODE this fires for a PRESENT-but-stale `session_id` cookie (DB row evicted/wiped by regen while the 30-day cookie survives), because middleware only rehydrates when the cookie is ABSENT.
+- `app/api/demo/rehydrate/route.ts` EXISTS: `GET ?next=<path>` → if no valid `demo_auth` → 302 /login; else `createSession('demo-seed', ttl)` (loads the seeded demo data) → sets `session_id` cookie → 302 back to `next` (sanitised to a relative path). So redirecting a stale-session page hit here yields a fresh, data-backed session and the board renders.
+- `isDemoMode()` is exported from `lib/demo-mode.ts:8`.
+- `dedupMatches` at `app/matches/page.tsx:128-135` keys on `vessel_name|cargo_ref??cargo_id|load_port|laycan_start`. The re-circulated-cargo dup survives because two emails give paraphrased `cargo_ref` ("max 2 tiers" vs "tier limit 2") → different key. `StoredMatch` (lib/matching/matches-repository.ts) has fields: `cargo_type`, `load_port`, `discharge_port`, `laycan_start`, `vessel_name`, `cargo_ref` (all nullable).
+- #793: prod parsed_results for IMO 8605480 (M/V SEAGULL 2, DWT 2570) has `grain:81, bale:81` cbm (~40× too small). Render: `components/match/VesselsTab.tsx:147` shows `{vessel.baleCapacity.toLocaleString()} CBM` with no plausibility guard. Unit-less weight: `app/match/[id]/page.tsx:309` feeds `{label:'Weight', value: cargo.weightMt}` into `SourceAttributionSection` which renders the raw number with no unit. `lib/parsing/parse-vessel-helpers.ts` `preNormalizeRawVessel` is where capacity normalization lives (has zero-guard / CBFT→CBM conversion today).
+
+**Sanctioned spec changes:** none change existing tested behavior except: dedupMatches key changes (Task 2) — update any test pinning the old key; capacity normalizer nulls implausible cbm (Task 3) — update any test asserting the old pass-through.
+
+---
+
+### Task 1: #968 — demo session-eviction rehydrate (HIGH)
+
+**Files:** Modify `app/matches/page.tsx`, `app/dashboard/page.tsx`. Test: `__tests__/` (mirror existing page tests; check for an existing matches-page / dashboard-page test first).
+
+- [ ] **Step 1: Failing test** — render the page (or extract the guard) with `getSession` mocked to return null, `isDemoMode` mocked true, and `next/navigation` `redirect` mocked: assert `redirect` is called with `/api/demo/rehydrate?next=/matches` (resp. `/dashboard`). Second case: `isDemoMode` false → `redirect` NOT called, "No emails yet" renders.
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** — in the `if (!session) {` branch of BOTH pages, before returning the "No emails yet" JSX: `if (isDemoMode()) { redirect('/api/demo/rehydrate?next=/matches'); }` (dashboard → `next=/dashboard`). Import `redirect` from `next/navigation`, `isDemoMode` from `@/lib/demo-mode`. Leave the "No emails yet" return as the non-demo fallback. Rationale: the rehydrate route self-guards auth (302→/login if no demo_auth) and createSession('demo-seed') always yields data, so no redirect loop. Do NOT touch middleware (edge runtime, no sqlite).
+- [ ] **Step 4: Run, pass.**
+- [ ] **Step 5: Commit** — `fix(demo): rehydrate evicted demo session instead of 'No emails yet' (#968)`.
+
+### Task 2: #787 — dedup re-circulated cargo by economic identity (medium)
+
+**Files:** Modify `app/matches/page.tsx` (`dedupMatches`). Test: a new/extended unit test for `dedupMatches` (export it if needed, or test via the page — prefer exporting `dedupMatches` for direct testing).
+
+- [ ] **Step 1: Failing test** — `dedupMatches` collapses two rows that share `vessel_name + cargo_type + load_port + discharge_port + laycan_start` but differ only in `cargo_ref` text ("max 2 tiers" vs "tier limit 2") → 1 row. AND does NOT collapse rows differing in ANY of: discharge_port, cargo_type, laycan_start, vessel_name → all kept (no over-collapse regression).
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** — change the dedup key to the economic identity: `` `${r.vessel_name ?? ''}|${r.cargo_type ?? ''}|${r.load_port ?? ''}|${r.discharge_port ?? ''}|${r.laycan_start ?? ''}` ``. Keep first-wins (`if (!seen.has(k)) seen.set(k, r)`). Update the doc comment to describe the economic key + #787. Export `dedupMatches` if the test needs it.
+- [ ] **Step 4: Run, pass.**
+- [ ] **Step 5: Commit** — `fix(matches): dedup re-circulated cargo by economic identity, not paraphrased ref (#787)`.
+
+### Task 3: #793 — capacity-plausibility guard + weight unit (low)
+
+**Files:** Modify `lib/parsing/parse-vessel-helpers.ts` (`preNormalizeRawVessel`), `app/match/[id]/page.tsx` (Weight field). Tests: extend the existing parse-vessel-helpers test + add a render/assert for the weight unit.
+
+- [ ] **Step 1: Failing test** — `preNormalizeRawVessel` nulls `grainCapacity`/`baleCapacity` when the cbm value is implausibly small relative to DWT (cbm < 0.5 × dwtSummer) — e.g. input grain/bale 81 cbm on dwtSummer 2570 → null; a plausible value (e.g. 3200 cbm on 2570 DWT) is kept. Read the function first to match how it currently reads DWT + capacity + their units.
+- [ ] **Step 2: Run, fail.**
+- [ ] **Step 3: Implement** — in `preNormalizeRawVessel`, after capacity is resolved to cbm and DWT is known, if `capacityCbm > 0 && dwt > 0 && capacityCbm < 0.5 * dwt` → null that capacity (grain and/or bale). Guard only when both numbers are present and positive; don't touch the zero-guard / CBFT conversion already there.
+- [ ] **Step 4: Weight unit** — in `app/match/[id]/page.tsx` where `{label:'Weight', value: cargo.weightMt}` is built for SourceAttribution, render the value WITH its unit (e.g. value `cargo.weightMt != null ? \`${cargo.weightMt} mt\` : null`). Keep null/empty handling. (If `SourceAttributionSection` is the cleaner place for a per-field unit, do it there — but the minimal surgical fix is at the call site.)
+- [ ] **Step 5: Run tests, pass.** `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit`.
+- [ ] **Step 6: Commit** — `fix(parse): null implausible vessel capacity + add unit to cargo weight (#793)`.
+
+---
+
+## Self-review
+
+- #968: redirect only in DEMO_MODE; rehydrate self-guards auth + always seeds data → no loop. Non-demo "No emails yet" unchanged. Both pages fixed.
+- #787: economic key drops paraphrased cargo_ref but keeps discharge_port/cargo_type/laycan/vessel discriminators → no over-collapse (tested).
+- #793: plausibility guard only fires when both cbm & DWT positive; weight unit is display-only.

--- a/lib/parsing/parse-vessel-helpers.ts
+++ b/lib/parsing/parse-vessel-helpers.ts
@@ -139,6 +139,24 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
     }
   }
 
+  // CAPACITY_PLAUSIBILITY: null grain/bale capacity when cbm < 0.5 × DWT (#793).
+  // Only fires when both capacity and DWT are present and positive.
+  const dwtRaw = out['dwt_summer'];
+  const dwt = isConfField(dwtRaw)
+    ? (typeof dwtRaw.value === 'number' ? dwtRaw.value : null)
+    : (typeof dwtRaw === 'number' ? dwtRaw : null);
+  if (dwt !== null && dwt > 0) {
+    for (const capKey of ['grain_capacity', 'bale_capacity']) {
+      const capRaw = out[capKey];
+      const cbm = isConfField(capRaw)
+        ? (typeof capRaw.value === 'number' ? capRaw.value : null)
+        : (typeof capRaw === 'number' ? capRaw : null);
+      if (cbm !== null && cbm > 0 && cbm < 0.5 * dwt) {
+        out[capKey] = null;
+      }
+    }
+  }
+
   // BUILT_FROM_DATE: null out when source_text contains a month name
   if ('built' in out) out['built'] = nullBuiltIfCalendarDate(out['built']);
 


### PR DESCRIPTION
## What

Fixes 3 open qa-walker bugs verified still-live against prod (2026-06-13 triage):

- **#968 (HIGH)** — `/matches` + `/dashboard` showed "No emails yet" when a demo `session_id` cookie survived but its DB row was evicted/wiped (regen / MAX_SESSIONS). Now in `DEMO_MODE` the empty-session branch redirects to `/api/demo/rehydrate?next=…` (self-guards auth, re-seeds a fresh demo session) instead of the dead-end empty state. Non-demo unchanged.
- **#787 (medium)** — re-circulated cargo (two broker emails, paraphrased descriptions, different `cargo_id`) rendered as a visually-identical duplicate row (e.g. SEAGULL 60 Hereke→Constanța ×2). `dedupMatches` now keys on economic identity `vessel_name|cargo_type|load_port|discharge_port|laycan_start|laycan_end|fit_percent` instead of the paraphrasable `cargo_ref`. `fit_percent` added after prod-data analysis (session rows: collapses 691→672, catches true dups which share fit, **preserves 17 fit-distinct rows** the naive key would over-collapse).
- **#793 (low)** — implausible vessel capacity (81 CBM on 2,570 DWT) now nulled in `preNormalizeRawVessel` when cbm < 0.5×DWT; cargo Weight now renders with its `mt` unit (preserving real confidence + sourceText).

## Quality
Cold-QA (adversarial, fresh agent) returned **BLOCK** on 2 HIGH introduced by the first pass — `[object Object] mt` weight render + dedup over-collapsing fit-distinct rows — both fixed (commit fixing them included). All affected suites green (67/67).

Also closed 4 backlog issues verified already-fixed/not-a-bug: #589 (#717), #784 (#797), #668 (Sentry telemetry, not errors), #667 (#830).

Addresses #968 #787 #793. Plan: `docs/superpowers/plans/2026-06-13-qa-backlog-968-787-793.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)