### PR TITLE
fix: null implausibly-large grain/bale capacity (>2.5x DWT) — qa #976

### DIFF
--- a/__tests__/lib/parse-vessel-capacity-guard-793.test.ts
+++ b/__tests__/lib/parse-vessel-capacity-guard-793.test.ts
@@ -80,4 +80,34 @@ describe('#793 — vessel capacity plausibility guard', () => {
     expect(vessels[0].grainCapacity).toBeNull();
     expect(vessels[0].baleCapacity).toBe(3000);
   });
+
+  it('nulls grain/bale capacity when cbm is implausibly LARGE (> 2.5 x DWT) #976', () => {
+    // MV BBA LARISA scenario: DWT 5007, grain 220577 cbm (220577 > 2.5 * 5007 = 12517.5)
+    const raw = JSON.stringify({
+      vessel_name: 'MV BBA LARISA',
+      imo: '9166510',
+      dwt_summer: 5007,
+      grain_capacity: 220577,
+      bale_capacity: 213000,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].grainCapacity).toBeNull();
+    expect(vessels[0].baleCapacity).toBeNull();
+  });
+
+  it('keeps grain/bale capacity at the plausible upper end (<= 2.5 x DWT) #976', () => {
+    // Legit large-cube vessel: 12000 cbm on 5007 DWT (ratio 2.40 < 2.5 -> plausible)
+    const raw = JSON.stringify({
+      vessel_name: 'MV LEGIT MPP',
+      imo: '1234568',
+      dwt_summer: 5007,
+      grain_capacity: 12000,
+      bale_capacity: 11500,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].grainCapacity).toBe(12000);
+    expect(vessels[0].baleCapacity).toBe(11500);
+  });
 });

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -111,6 +111,19 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
     if (v.grainCapacityUnit && v.grainCapacityUnit !== 'cbm') {
       v.grainCapacityUnit = 'cbm';
     }
+    // CAPACITY_PLAUSIBILITY upper bound: same rule as preNormalizeRawVessel (#976).
+    // Fixes already-persisted CBFT-as-CBM values in demo-seed.db.
+    const dwtVal = typeof v.dwtSummer === 'object' && v.dwtSummer !== null
+      ? (v.dwtSummer as { value?: number }).value ?? null
+      : (typeof v.dwtSummer === 'number' ? v.dwtSummer : null);
+    if (dwtVal !== null && dwtVal > 0) {
+      if (v.grainCapacity !== null && v.grainCapacity !== undefined && v.grainCapacity > 2.5 * dwtVal) {
+        v.grainCapacity = null;
+      }
+      if (v.baleCapacity !== null && v.baleCapacity !== undefined && v.baleCapacity > 2.5 * dwtVal) {
+        v.baleCapacity = null;
+      }
+    }
   }
 
   const colNames = new Set((db.prepare(`PRAGMA table_info(matches)`).all() as Array<{name:string}>).map((c) => c.name));

--- a/lib/parsing/parse-vessel-helpers.ts
+++ b/lib/parsing/parse-vessel-helpers.ts
@@ -139,8 +139,8 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
     }
   }
 
-  // CAPACITY_PLAUSIBILITY: null grain/bale capacity when cbm < 0.5 × DWT (#793).
-  // Only fires when both capacity and DWT are present and positive.
+  // CAPACITY_PLAUSIBILITY: null grain/bale capacity outside 0.5x-2.5x DWT range (#793/#976).
+  // Both bounds fire only when capacity and DWT are present and positive.
   const dwtRaw = out['dwt_summer'];
   const dwt = isConfField(dwtRaw)
     ? (typeof dwtRaw.value === 'number' ? dwtRaw.value : null)
@@ -151,7 +151,7 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
       const cbm = isConfField(capRaw)
         ? (typeof capRaw.value === 'number' ? capRaw.value : null)
         : (typeof capRaw === 'number' ? capRaw : null);
-      if (cbm !== null && cbm > 0 && cbm < 0.5 * dwt) {
+      if (cbm !== null && cbm > 0 && (cbm < 0.5 * dwt || cbm > 2.5 * dwt)) {
         out[capKey] = null;
       }
     }


### PR DESCRIPTION
## Root cause

`220.577` in the source email (European thousands separator) = **220,577 cbft** with no unit keyword. Without a unit keyword, `convertCbftToCbm()` doesn't fire and the value is stored as-is: **220,577 cbm** on a 5,007 DWT vessel (ratio 44× physical max).

The #793 guard at `parse-vessel-helpers.ts:154` had only a **lower bound** (`cbm < 0.5×DWT`). The upper bound was missing.

**17 additional vessels** in demo-seed.db share the same root cause (confirmed via session query).

## Fix (2 parts)

### Part 1 — normalizer (catches future parses)
`lib/parsing/parse-vessel-helpers.ts:154` — extended condition:
```
cbm < 0.5 * dwt   →   cbm < 0.5 * dwt || cbm > 2.5 * dwt
```

### Part 2 — runtime fixup for persisted data
`lib/demo-mode/hydrate-demo-session.ts` — added upper-bound null pass inside the existing unit-fixup loop. Nulls the stored 220,577 (and the 17 peers) on session hydrate. **No DB write** — session-only, no demo-seed.db / prod touch.

## K=2.5 justification

- Dry bulk grain: 1.0–1.6 cbm/DWT
- MPP / general cargo: up to ~2.0 cbm/DWT
- Conservative ceiling that never false-zeros a real vessel
- 220,577÷35.315/5007 = 1.25 cbm/DWT → correct value safely passes (1.25 < 2.5 ✓)
- Mirrors the existing lower bound (K=0.5) in symmetry

## Tests

Extended `__tests__/lib/parse-vessel-capacity-guard-793.test.ts` with 2 new cases:
- `nulls grain/bale capacity when cbm is implausibly LARGE (> 2.5 x DWT) #976` — red before fix, green after
- `keeps grain/bale capacity at the plausible upper end (<= 2.5 x DWT) #976` — verifies K=2.5 doesn't false-zero 2.40× vessels
- All 5 existing #793 tests remain green

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)