### PR TITLE
test(#976): lock ConfidenceField-shape dwt_summer in capacity guard

### DIFF
--- a/__tests__/lib/parse-vessel-capacity-guard-793.test.ts
+++ b/__tests__/lib/parse-vessel-capacity-guard-793.test.ts
@@ -110,4 +110,21 @@ describe('#793 — vessel capacity plausibility guard', () => {
     expect(vessels[0].grainCapacity).toBe(12000);
     expect(vessels[0].baleCapacity).toBe(11500);
   });
+
+  it('nulls implausibly-large grain/bale when dwt_summer is a ConfidenceField (real prod shape) #976', () => {
+    // Prod stores dwt_summer as a ConfidenceField object, not a plain number
+    // (see ParsedVessel.dwtSummer in lib/types.ts). Lock that path: DWT 5007,
+    // grain 220577 cbm (> 2.5 * 5007 = 12517.5) → both nulled.
+    const raw = JSON.stringify({
+      vessel_name: 'MV BBA LARISA CF',
+      imo: '9166511',
+      dwt_summer: { value: 5007, confidence: 'high', source_text: '5007 dwt' },
+      grain_capacity: 220577,
+      bale_capacity: 213000,
+    });
+    const vessels = parseVesselAIResponse(raw, 'test-email');
+    expect(vessels).toHaveLength(1);
+    expect(vessels[0].grainCapacity).toBeNull();
+    expect(vessels[0].baleCapacity).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

Adds **one coverage-only test** to `__tests__/lib/parse-vessel-capacity-guard-793.test.ts` that feeds `dwt_summer` as a **ConfidenceField object** (`{ value: 5007, confidence: 'high', source_text: '5007 dwt' }`) alongside an implausibly-large grain (220577) / bale (213000) capacity, asserting both are nulled.

## Why

Cold-QA of #977 (the #976 upper-bound guard, main `d7fa1f9a`) flagged a LOW, non-blocking coverage gap: the committed tests only feed `dwt_summer` as a **plain number**, but real prod data stores it as a **ConfidenceField** (`ParsedVessel.dwtSummer`, `lib/types.ts:261`). The normalizer already handles both shapes correctly (`isConfField` branch in `preNormalizeRawVessel`, `parse-vessel-helpers.ts:145-147`) — but nothing locked the actual prod path against regression. This test closes that gap.

## Risk

None. Test-only, no production code touched. Mirrors the exact harness/imports/call-signature of the existing tests in the file.

## Verification

`npx jest __tests__/lib/parse-vessel-capacity-guard-793.test.ts` → **8/8 passed** (was 7). Pre-commit eslint + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)