### PR TITLE
fix: convert grain/bale cbft→cbm (code single owner) before capacity clamp

### DIFF
--- a/__tests__/hydrate-cbft-grain-conversion.test.ts
+++ b/__tests__/hydrate-cbft-grain-conversion.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Demo hydrate: CBFT→CBM conversion of seeded parsed_results before the
+ * CAPACITY_PLAUSIBILITY clamp.
+ *
+ * ROOT (prod-confirmed): 8 seed vessels store grainCapacityUnit="cbft" with the
+ * RAW cbft value (e.g. 220577). The previous hydrate relabelled unit→cbm WITHOUT
+ * converting the value, so the raw cbft (read as cbm, ~35x too large) tripped the
+ * >2.5x DWT clamp and the legit capacity was nulled → volume constraint dropped.
+ *
+ * FIX: buildDemoSessionBlob converts the VALUE (÷35.314667) and sets unit="cbm"
+ * BEFORE the clamp. Oracle: 220577 cbft → 6247 cbm.
+ *
+ * NOTE: read-time, in-memory recovery only — does NOT write/reseed prod.
+ */
+import Database from 'better-sqlite3';
+import { buildDemoSessionBlob } from '@/lib/demo-mode/hydrate-demo-session';
+import type { ParsedVessel } from '@/lib/types';
+
+function makeSeedDb(vessel: Partial<ParsedVessel>): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE emails (
+      account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+      from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+      body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+    );
+    CREATE TABLE parsed_results (
+      account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+      result_json TEXT, parsed_at INTEGER
+    );
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+      reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+      reason_structured TEXT
+    );
+  `);
+  const full: ParsedVessel = {
+    emailId: 'v-cbft', itemIndex: 0,
+    vesselName: null, imo: null, flag: null, built: null, classSociety: null, pandi: null,
+    dwtSummer: { value: 8000, confidence: 'confirmed', source_text: 'DWT 8000' } as unknown as ParsedVessel['dwtSummer'],
+    dwcc: null, draftMax: null, loa: null, beam: null, grt: null, nrt: null,
+    holdsCount: null, hatchesCount: null,
+    grainCapacity: 220577, grainCapacityUnit: 'cbft', baleCapacity: null,
+    holdDimensions: null, hatchDimensions: null, tankTopStrength: null, geared: null,
+    craneCapacity: null, hatchType: null, vesselType: null, openPosition: null, openDate: null,
+    direction: null, restrictions: [], lastCargoes: null, speedLaden: null, speedBallast: null,
+    consumption: null, deckCapacity: null, specialFeatures: [], ciiRating: null,
+    verificationWarning: null,
+    ...vessel,
+  };
+  db.prepare(`INSERT INTO parsed_results (parse_type, result_json) VALUES ('vessel', ?)`)
+    .run(JSON.stringify([full]));
+  return db;
+}
+
+describe('hydrate converts seeded cbft grain capacity before the clamp', () => {
+  it('220577 cbft → ~6247 cbm, unit cbm, NOT nulled by the >2.5x DWT clamp', () => {
+    const db = makeSeedDb({});
+    const blob = buildDemoSessionBlob(db);
+    db.close();
+
+    expect(blob.parsedVessels).toHaveLength(1);
+    const v = blob.parsedVessels[0];
+    expect(v.grainCapacity).not.toBeNull();
+    expect(v.grainCapacity!).toBeGreaterThanOrEqual(6240);
+    expect(v.grainCapacity!).toBeLessThanOrEqual(6250);
+    expect(v.grainCapacityUnit).toBe('cbm');
+  });
+
+  it('already-cbm seed value is left untouched (no double-convert)', () => {
+    const db = makeSeedDb({ grainCapacity: 6247, grainCapacityUnit: 'cbm' });
+    const blob = buildDemoSessionBlob(db);
+    db.close();
+    expect(blob.parsedVessels[0].grainCapacity).toBe(6247);
+    expect(blob.parsedVessels[0].grainCapacityUnit).toBe('cbm');
+  });
+});

--- a/__tests__/lib/parse-vessel-cbft-explicit-unit.test.ts
+++ b/__tests__/lib/parse-vessel-cbft-explicit-unit.test.ts
@@ -66,4 +66,37 @@ describe('CBFT explicit-unit conversion — code is the single owner', () => {
     expect(v.grainCapacity).toBe(6247);
     expect(v.grainCapacityUnit).toBe('cbm');
   });
+
+  // ── cold-QA #984 R2 breaker: BALE double-convert ──────────────────────────
+  // The source_text pass (convertCbftToCbm) converts a bale ConfidenceField whose
+  // source_text contains "cbft". Unlike grain, that pass did NOT relabel the shared
+  // grain_capacity_unit, so when grain is absent / not source_text-converted the
+  // unit stays 'cbft' and the explicit-unit pass RE-CONVERTS bale → ÷35.314667²
+  // ≈ 168 (or null after the clamp). CODE must be the single owner per field.
+  it('ConfidenceField bale (cbft source_text) + grain absent: converts ONCE → ~5947, NOT double → 168', () => {
+    // No dwt_summer → no plausibility clamp, so a double-convert leaves a visible 168.
+    const raw = rawVessel({
+      bale_capacity: { value: 210000, confidence: 'confirmed', source_text: 'BALE 210000 CBFT' },
+      grain_capacity_unit: 'cbft',
+    });
+    const [v] = parseVesselAIResponse(raw, 'e5');
+    // 210000 / 35.314667 ≈ 5947 (single). Double-convert ≈ 168.
+    expect(v.baleCapacity).toBeGreaterThanOrEqual(5940);
+    expect(v.baleCapacity).toBeLessThanOrEqual(5955);
+    expect(v.baleCapacity).not.toBe(168);
+  });
+
+  it('mixed shape: grain via explicit unit + bale ConfidenceField via source_text each convert ONCE', () => {
+    const raw = rawVessel({
+      grain_capacity: 220577, // plain number → converts via the explicit-unit pass
+      bale_capacity: { value: 210000, confidence: 'confirmed', source_text: 'BALE 210000 CBFT' }, // → source_text pass
+      grain_capacity_unit: 'cbft',
+      dwt_summer: { value: 8000, confidence: 'confirmed', source_text: 'DWT 8000' },
+    });
+    const [v] = parseVesselAIResponse(raw, 'e6');
+    expect(v.grainCapacity).toBeGreaterThanOrEqual(6240);
+    expect(v.grainCapacity).toBeLessThanOrEqual(6250);
+    expect(v.baleCapacity).toBeGreaterThanOrEqual(5940);
+    expect(v.baleCapacity).toBeLessThanOrEqual(5955);
+  });
 });

--- a/__tests__/lib/parse-vessel-cbft-explicit-unit.test.ts
+++ b/__tests__/lib/parse-vessel-cbft-explicit-unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * CBFT→CBM conversion via the EXPLICIT grain_capacity_unit field.
+ *
+ * ROOT (prod-confirmed): the LLM emits the RAW cbft number + grain_capacity_unit="cbft"
+ * (it does NOT pre-convert). Downstream scoreVolume/checkVolumeFit read grainCapacity as
+ * cbm unconditionally; the CAPACITY_PLAUSIBILITY clamp (cbm > 2.5x DWT → null) then NULLS
+ * the legit capacity because a raw cbft value reads ~35x too large.
+ *
+ * FIX: code is the single owner of the cbft→cbm conversion. parseVesselAIResponse must
+ * convert the VALUE (÷35.314667 ≈ ×0.0283168) and relabel unit="cbm" BEFORE the clamp.
+ * Oracle: 220577 cbft → 6247 cbm.
+ */
+import { parseVesselAIResponse } from '@/lib/parsing/parse-vessel-helpers';
+
+function rawVessel(extra: Record<string, unknown>): string {
+  return JSON.stringify({ vessel_name: 'MV CBFT TEST', ...extra });
+}
+
+describe('CBFT explicit-unit conversion — code is the single owner', () => {
+  it('plain-number grain 220577 cbft → ~6247 cbm, unit relabelled, NOT nulled by clamp', () => {
+    // dwt 8000: raw 220577 > 2.5*8000 (20000) would clamp; 6247 is in [4000, 20000] → survives.
+    const raw = rawVessel({
+      grain_capacity: 220577,
+      grain_capacity_unit: 'cbft',
+      dwt_summer: { value: 8000, confidence: 'confirmed', source_text: 'DWT 8000' },
+    });
+    const [v] = parseVesselAIResponse(raw, 'e1');
+    expect(v.grainCapacity).not.toBeNull();
+    expect(v.grainCapacity).toBeGreaterThanOrEqual(6240);
+    expect(v.grainCapacity).toBeLessThanOrEqual(6250);
+    expect(v.grainCapacityUnit).toBe('cbm');
+  });
+
+  it('ConfidenceField grain 220577 cbft → ~6247 cbm, unit cbm', () => {
+    const raw = rawVessel({
+      grain_capacity: { value: 220577, confidence: 'confirmed', source_text: 'grain 220577' },
+      grain_capacity_unit: 'cbft',
+      dwt_summer: { value: 8000, confidence: 'confirmed', source_text: 'DWT 8000' },
+    });
+    const [v] = parseVesselAIResponse(raw, 'e2');
+    expect(v.grainCapacity).toBeGreaterThanOrEqual(6240);
+    expect(v.grainCapacity).toBeLessThanOrEqual(6250);
+    expect(v.grainCapacityUnit).toBe('cbm');
+  });
+
+  it('bale capacity converts under the shared cbft unit', () => {
+    const raw = rawVessel({
+      grain_capacity: 220577,
+      bale_capacity: 210000,
+      grain_capacity_unit: 'cbft',
+      dwt_summer: { value: 8000, confidence: 'confirmed', source_text: 'DWT 8000' },
+    });
+    const [v] = parseVesselAIResponse(raw, 'e3');
+    // 210000 / 35.314667 ≈ 5947
+    expect(v.baleCapacity).toBeGreaterThanOrEqual(5940);
+    expect(v.baleCapacity).toBeLessThanOrEqual(5955);
+  });
+
+  it('no double-convert: value already cbm stays put', () => {
+    const raw = rawVessel({
+      grain_capacity: 6247,
+      grain_capacity_unit: 'cbm',
+      dwt_summer: { value: 8000, confidence: 'confirmed', source_text: 'DWT 8000' },
+    });
+    const [v] = parseVesselAIResponse(raw, 'e4');
+    expect(v.grainCapacity).toBe(6247);
+    expect(v.grainCapacityUnit).toBe('cbm');
+  });
+});

--- a/lib/demo-mode/__tests__/hydrate-demo-session-dedup.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session-dedup.test.ts
@@ -36,11 +36,13 @@ function makeDb(): Database.Database {
     VALUES ('demo',?,?,?,?,?,'me@demo.local','Vessel YUCATAN','2026-05-20','body','snip','["INBOX"]',0)`)
     .run(EMAIL_ID, `t-${EMAIL_ID}`, `Sender <sender@demo.local>`, 'Sender', 'sender@demo.local');
 
-  // Three duplicate rows for the same emailId|itemIndex: first has correct cbft value that maps
-  // to 3994 cbm; second and third carry a previously-double-converted 113 cbm value.
+  // Three duplicate rows for the same emailId|itemIndex: first carries the RAW cbft value
+  // (141050) the LLM emits with unit='cbft' — code is the single owner of the cbft→cbm
+  // conversion, so hydrate converts it to 3994 cbm (141050 ÷ 35.314667). Second and third
+  // carry a previously-double-converted 113 cbm value (already-cbm dupes, dropped by dedup).
   const row1 = JSON.stringify([{
     emailId: EMAIL_ID, itemIndex: ITEM_INDEX,
-    vesselName: 'YUCATAN', grainCapacity: 3994, grainCapacityUnit: 'cbft',
+    vesselName: 'YUCATAN', grainCapacity: 141050, grainCapacityUnit: 'cbft',
     dwt: 3176,
   }]);
   const row2 = JSON.stringify([{

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -18,6 +18,10 @@ type DemoBlob = Pick<
   | 'lowConfidenceMatches' | 'insufficientData'
 >;
 
+// cbft→cbm: 1 cbft = 0.0283168 m³, i.e. divide by 35.314667. Single conversion
+// constant shared with lib/parsing/parse-vessel-helpers.ts (CBFT_TO_CBM_PROD).
+const CBFT_TO_CBM = 35.314667;
+
 interface EmailRow {
   gmail_message_id: string; thread_id: string; from_addr: string; from_name: string | null;
   from_email: string | null; to_addr: string; subject: string; date: string;
@@ -108,7 +112,21 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   const dedupedVessels = dedupByKey(parsedVessels);
   const dedupedCargos  = dedupByKey(parsedCargos);
   for (const v of dedupedVessels) {
-    if (v.grainCapacityUnit && v.grainCapacityUnit !== 'cbm') {
+    // CBFT→CBM: code is the single owner of the conversion (mirrors
+    // preNormalizeRawVessel). Seeded parsed_results store the RAW cbft value +
+    // grainCapacityUnit='cbft' (LLM does NOT pre-convert). Convert the VALUE here
+    // BEFORE relabelling and BEFORE the capacity clamp below — else a legit
+    // ~6247 cbm hidden as a raw ~220577 cbft trips the >2.5x DWT clamp and the
+    // volume constraint is silently dropped. Read-time only — no prod write.
+    if (v.grainCapacityUnit && v.grainCapacityUnit.toLowerCase() === 'cbft') {
+      if (typeof v.grainCapacity === 'number' && v.grainCapacity > 0) {
+        v.grainCapacity = Math.round(v.grainCapacity / CBFT_TO_CBM);
+      }
+      if (typeof v.baleCapacity === 'number' && v.baleCapacity > 0) {
+        v.baleCapacity = Math.round(v.baleCapacity / CBFT_TO_CBM);
+      }
+      v.grainCapacityUnit = 'cbm';
+    } else if (v.grainCapacityUnit && v.grainCapacityUnit !== 'cbm') {
       v.grainCapacityUnit = 'cbm';
     }
     // CAPACITY_PLAUSIBILITY upper bound: same rule as preNormalizeRawVessel (#976).

--- a/lib/parsing/parse-vessel-helpers.ts
+++ b/lib/parsing/parse-vessel-helpers.ts
@@ -127,7 +127,7 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
   // SPEED_AS_DRAFT: draft_max from speed source (e.g. "13 knts") → null
   if ('draft_max' in out) out['draft_max'] = nullIfSpeedAsDraft(out['draft_max']);
 
-  // CBFT→CBM: grain/bale capacity unit conversion
+  // CBFT→CBM: grain/bale capacity unit conversion from source_text.
   for (const k of ['grain_capacity', 'bale_capacity']) {
     if (k in out) {
       const before = out[k];
@@ -137,6 +137,29 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
         out['grain_capacity_unit'] = 'cbm';
       }
     }
+  }
+
+  // CBFT→CBM via the EXPLICIT grain_capacity_unit field — CODE is the single
+  // owner of the conversion. Prod LLM emits the RAW cbft number + unit='cbft'
+  // (it does NOT pre-convert), so convert the VALUE here and relabel unit→cbm.
+  // The single unit governs both grain and bale. Runs AFTER the source_text
+  // pass (so an already-relabelled 'cbm' is skipped — no double-convert) and
+  // BEFORE the CAPACITY_PLAUSIBILITY clamp below, which otherwise nulls a legit
+  // ~6247 cbm hidden as a raw ~220577 cbft (reads as >2.5x DWT).
+  const unitRaw = out['grain_capacity_unit'];
+  const unitStr = (isConfField(unitRaw)
+    ? (typeof unitRaw.value === 'string' ? unitRaw.value : '')
+    : (typeof unitRaw === 'string' ? unitRaw : '')).toLowerCase();
+  if (unitStr === 'cbft') {
+    for (const k of ['grain_capacity', 'bale_capacity']) {
+      const cf = out[k];
+      if (isConfField(cf) && typeof cf.value === 'number' && cf.value > 0) {
+        out[k] = { ...cf, value: Math.round(cf.value / CBFT_TO_CBM_PROD), confidence: 'interpreted' };
+      } else if (typeof cf === 'number' && cf > 0) {
+        out[k] = Math.round(cf / CBFT_TO_CBM_PROD);
+      }
+    }
+    out['grain_capacity_unit'] = 'cbm';
   }
 
   // CAPACITY_PLAUSIBILITY: null grain/bale capacity outside 0.5x-2.5x DWT range (#793/#976).

--- a/lib/parsing/parse-vessel-helpers.ts
+++ b/lib/parsing/parse-vessel-helpers.ts
@@ -127,14 +127,20 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
   // SPEED_AS_DRAFT: draft_max from speed source (e.g. "13 knts") → null
   if ('draft_max' in out) out['draft_max'] = nullIfSpeedAsDraft(out['draft_max']);
 
-  // CBFT→CBM: grain/bale capacity unit conversion from source_text.
+  // CBFT→CBM: grain/bale capacity unit conversion from source_text. Track which
+  // keys this pass converts so the explicit-unit pass below does NOT re-fire on
+  // them (single owner PER FIELD). Grain additionally relabels the shared unit→cbm,
+  // but bale has no such relabel, so without this set a bale ConfidenceField with
+  // cbft source_text would convert here AND again in the unit pass → ÷35² ≈ 168.
+  const cbftConvertedKeys = new Set<string>();
   for (const k of ['grain_capacity', 'bale_capacity']) {
     if (k in out) {
       const before = out[k];
       out[k] = convertCbftToCbm(out[k]);
-      // If ConfidenceField was converted, the value is now CBM → relabel unit defensively
-      if (k === 'grain_capacity' && out[k] !== before && isConfField(out[k])) {
-        out['grain_capacity_unit'] = 'cbm';
+      if (out[k] !== before && isConfField(out[k])) {
+        cbftConvertedKeys.add(k);
+        // If ConfidenceField was converted, the value is now CBM → relabel unit defensively
+        if (k === 'grain_capacity') out['grain_capacity_unit'] = 'cbm';
       }
     }
   }
@@ -152,6 +158,7 @@ function preNormalizeRawVessel(item: RawVesselItem): RawVesselItem {
     : (typeof unitRaw === 'string' ? unitRaw : '')).toLowerCase();
   if (unitStr === 'cbft') {
     for (const k of ['grain_capacity', 'bale_capacity']) {
+      if (cbftConvertedKeys.has(k)) continue; // already converted by source_text pass — single owner
       const cf = out[k];
       if (isConfField(cf) && typeof cf.value === 'number' && cf.value > 0) {
         out[k] = { ...cf, value: Math.round(cf.value / CBFT_TO_CBM_PROD), confidence: 'interpreted' };

--- a/lib/prompts/parse-vessel.ts
+++ b/lib/prompts/parse-vessel.ts
@@ -256,14 +256,14 @@ CARGO / BAG DIMENSIONS:
   ✗ loa=1.1 from "ABT 110X110X65 CM" (centimeters divided by 100) → correct: loa=null, beam=null
 
 GRAIN/BALE CAPACITY UNITS:
-  grain_capacity and bale_capacity are ALWAYS in cubic meters (CBM/cbm).
-  When source says "cbft", "CBFT", "cuft", "ft³" → it is in cubic feet — convert to CBM: divide by 35.315.
-  ✗ grain_capacity=140000 from "GRAIN 140,000CBFT" (wrong — not converted)
-  ✓ grain_capacity=3963 from "GRAIN 140,000CBFT" (140000 ÷ 35.315 ≈ 3963 cbm), confidence='interpreted', source_text="GRAIN 140,000CBFT"
-  When source says "CBM" or "cbm" → use the number directly.
-  "GRAIN/BALE 3000/2950 CBM" → grain_capacity=3000, bale_capacity=2950
-  ALWAYS set grain_capacity_unit="cbm" — the value you output is already in CBM regardless of source unit.
-  NEVER set grain_capacity_unit="cbft" — conversion to CBM must happen before output.
+  Output grain_capacity and bale_capacity as the RAW number written in the email — do NOT convert.
+  Set grain_capacity_unit to the unit exactly as the source states it:
+    - source says "CBM"/"cbm" → grain_capacity_unit="cbm"
+    - source says "cbft"/"CBFT"/"cuft"/"ft³" → grain_capacity_unit="cbft"
+  Conversion from cubic feet to CBM (÷ 35.315) is done in CODE after parsing — code is the single
+  owner of the conversion. Never pre-convert here; just report the number and its unit faithfully.
+  ✓ grain_capacity=140000, grain_capacity_unit="cbft" from "GRAIN 140,000CBFT" (code converts → ~3963 cbm)
+  ✓ grain_capacity=3000, bale_capacity=2950, grain_capacity_unit="cbm" from "GRAIN/BALE 3000/2950 CBM"
 
 GRAIN CAPACITY ANTI-FABRICATION:
   Extract grain_capacity ONLY from text explicitly labeled "grain", "grain cap", "grain cubic", "GKC", or "GRAIN/BALE X/Y" format.
@@ -273,7 +273,7 @@ GRAIN CAPACITY ANTI-FABRICATION:
   ✓ grain_capacity=null when only bale capacity is present in the email
   ✓ grain_capacity=3000, bale_capacity=2950 from "GRAIN/BALE 3000/2950 CBM"
   EXCEPTION — COMBINED GRAIN/BALE FORMAT: When source says "grain/bale X" (single figure for both), grain = bale = X. Both MUST be populated.
-  ✓ grain_capacity=2851, bale_capacity=2851 from "hold cap. grain/bale abt 100682 cbft" (100682 ÷ 35.315 ≈ 2851 cbm)
+  ✓ grain_capacity=100682, bale_capacity=100682, grain_capacity_unit="cbft" from "hold cap. grain/bale abt 100682 cbft" (raw cbft; code converts → ~2851 cbm)
   ✗ grain_capacity=null from "hold cap. grain/bale abt 100682 cbft" → WRONG (combined notation = both equal)
 
 For numeric fields (DWT, DWCC, LOA, beam, draft, built-year, grain capacity, etc.):


### PR DESCRIPTION
## Problem
Vessels with grain capacity in **CBFT** lost their grain/volume-fit constraint.

ROOT (prod-confirmed): the LLM emits the RAW cbft number + `grainCapacityUnit='cbft'` (does **not** pre-convert). Downstream `scoreVolume`/`checkVolumeFit` read `grainCapacity` as cbm unconditionally, and `hydrate-demo-session` relabelled unit→cbm **without converting the value**. Raw cbft read as cbm is ~35× too large, so the `>2.5×DWT` plausibility clamp **nulled the legit capacity** → volume constraint silently dropped. 8 seed vessels affected (incl. 220577 cbft).

## Fix — code is the single owner of cbft→cbm
- **`lib/parsing/parse-vessel-helpers.ts`** — convert by explicit `grain_capacity_unit='cbft'` (value ÷35.314667, grain + bale), relabel unit→cbm, **before** the capacity clamp. Runs after the source_text pass → no double-convert.
- **`lib/demo-mode/hydrate-demo-session.ts`** — same conversion before relabel + clamp (read-time, **no prod write**); seeded raw-cbft vessels recover (220577 → 6247 cbm).
- **`lib/prompts/parse-vessel.ts`** — reconcile audit flag: LLM emits raw value + unit as-seen, code converts (removed the contradictory pre-converted `3963` example).

## VALUE_CHECK (oracle = 8 prod cbft vessels)
expected cbm = raw_cbft × 0.0283168 → **220577 → 6247** ✓ (verdict: PASS)

## Tests
- New: `__tests__/lib/parse-vessel-cbft-explicit-unit.test.ts`, `__tests__/hydrate-cbft-grain-conversion.test.ts` (behavioral — real parser + `buildDemoSessionBlob`).
- Existing `#884` dedup test: **fixture input** corrected to raw cbft (141050 → 3994); assertions unchanged.
- `npx tsc --noEmit` clean; 65 related suites green (631 passed).

## Out of scope (follow-up)
Re-hydrating already-nulled prod `parsed_results` is a **prod-write** requiring founder authorization — NOT done here. Flag: reseed/prod re-hydrate to recover the 8 cached vessels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)