### PR TITLE
fix: normalize swapped weight range at parser site (min>max → swap)

### DIFF
--- a/__tests__/parsing/parse-cargo-ai-weight-range.test.ts
+++ b/__tests__/parsing/parse-cargo-ai-weight-range.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Behavioral test: swapped weight range from LLM must be normalized at parse time.
+ *
+ * VALUE_CHECK oracle (PI2): a cargo with a swapped weight range must produce the
+ * same resolveCargoWeight result as the equivalent non-swapped range, ensuring
+ * the OVERLOAD verdict is correct in both cases.
+ */
+import { parseCargoAIResponse } from '@/lib/parsing/parse-cargo-ai';
+import { resolveCargoWeight } from '@/lib/sailing/cargo-weight';
+
+function parseOne(item: Record<string, unknown>) {
+  return parseCargoAIResponse(JSON.stringify({ items: [item] }), 'email-test')[0];
+}
+
+describe('parseCargoAIResponse — weight range ordering', () => {
+  it('swapped range: weightMtMin < weightMtMax after parse (min=30000, max=25000 → min=25000, max=30000)', () => {
+    const cargo = parseOne({
+      cargo_type: 'BULK',
+      weight_mt_min: 30000,
+      weight_mt_max: 25000,
+    });
+    expect(cargo.weightMtMin).toBe(25000);
+    expect(cargo.weightMtMax).toBe(30000);
+  });
+
+  it('swapped range: quantity.min < quantity.max after parse', () => {
+    const cargo = parseOne({
+      cargo_type: 'BULK',
+      weight_mt_min: 30000,
+      weight_mt_max: 25000,
+    });
+    expect(cargo.quantity).toEqual({ min: 25000, max: 30000 });
+  });
+
+  it('normal range: preserved as-is (min=25000, max=30000)', () => {
+    const cargo = parseOne({
+      cargo_type: 'BULK',
+      weight_mt_min: 25000,
+      weight_mt_max: 30000,
+    });
+    expect(cargo.weightMtMin).toBe(25000);
+    expect(cargo.weightMtMax).toBe(30000);
+    expect(cargo.quantity).toEqual({ min: 25000, max: 30000 });
+  });
+
+  it('VALUE_CHECK: swapped-range OVERLOAD verdict matches non-swapped equivalent', () => {
+    // LLM returns min=30000, max=25000 (swapped). resolveCargoWeight must return 30000,
+    // same as the correctly-ordered range (min=25000, max=30000).
+    const swapped = parseOne({ cargo_type: 'BULK', weight_mt_min: 30000, weight_mt_max: 25000 });
+    const normal  = parseOne({ cargo_type: 'BULK', weight_mt_min: 25000, weight_mt_max: 30000 });
+    expect(resolveCargoWeight(swapped)).toBe(resolveCargoWeight(normal));
+    expect(resolveCargoWeight(swapped)).toBe(30000);
+  });
+
+  it('equal min/max: treated as single value (falls through to quantity scalar)', () => {
+    const cargo = parseOne({
+      cargo_type: 'BULK',
+      weight_mt_min: 5000,
+      weight_mt_max: 5000,
+      quantity: 5000,
+    });
+    // wMin === wMax → no range, falls through to extractNum(quantity)
+    expect(cargo.quantity).toBe(5000);
+  });
+
+  it('only min present: no range created', () => {
+    const cargo = parseOne({
+      cargo_type: 'BULK',
+      weight_mt_min: 5000,
+    });
+    expect(cargo.weightMtMax).toBeNull();
+    // quantity falls through to scalar
+    expect(typeof cargo.quantity === 'object' && cargo.quantity !== null).toBe(false);
+  });
+});

--- a/lib/parsing/parse-cargo-ai.ts
+++ b/lib/parsing/parse-cargo-ai.ts
@@ -94,6 +94,15 @@ export function parseCargoAIResponse(raw: string, emailId: string): ParsedCargo[
   const parsed: ParsedCargo[] = [];
 
   items.forEach((item, idx) => {
+    const rawWMin = extractNum(item.weight_mt_min);
+    const rawWMax = extractNum(item.weight_mt_max);
+    // Swap if the LLM returned a reversed range (e.g. "25/30000" → min=30000, max=25000).
+    // resolveCargoWeight uses weightMtMax as the hard-overload upper bound, so a swapped
+    // range would either miss a real overload or fabricate a false one.
+    const wSwapped = rawWMin !== null && rawWMax !== null && rawWMin > rawWMax;
+    const normWMin = wSwapped ? rawWMax : rawWMin;
+    const normWMax = wSwapped ? rawWMin : rawWMax;
+
     parsed.push(calibrateAll({
       emailId,
       itemIndex: idx,
@@ -103,8 +112,8 @@ export function parseCargoAIResponse(raw: string, emailId: string): ParsedCargo[
       destinationCountry: extractStr(item.destination_country),
       cargoDescription: toConfidence<string>(item.cargo_description),
       weightMt: toConfidence<number>(item.weight_mt),
-      weightMtMin: extractNum(item.weight_mt_min),
-      weightMtMax: extractNum(item.weight_mt_max),
+      weightMtMin: normWMin,
+      weightMtMax: normWMax,
       // extractNum is NaN-safe and preserves a legitimate zero (unlike `x || null`,
       // which nullifies 0). Prior commit introduced a 0-commission bug by using the
       // antipattern — see ROADMAP_MVP.md W1.8.
@@ -118,10 +127,8 @@ export function parseCargoAIResponse(raw: string, emailId: string): ParsedCargo[
       })(),
       containerType: extractStr(item.container_type),
       quantity: (() => {
-        const wMin = extractNum(item.weight_mt_min);
-        const wMax = extractNum(item.weight_mt_max);
-        if (wMin !== null && wMax !== null && wMin !== wMax) {
-          return { min: wMin, max: wMax } as Range<number>;
+        if (normWMin !== null && normWMax !== null && normWMin !== normWMax) {
+          return { min: normWMin, max: normWMax } as Range<number>;
         }
         return extractNum(item.quantity);
       })(),


### PR DESCRIPTION
## Problem

When the LLM parses a range like `"25/30000"`, it can return `weight_mt_min=30000, weight_mt_max=25000` (swapped). `resolveCargoWeight` uses `weightMtMax` as the upper bound for the hard OVERLOAD gate — a swapped range makes this the *smaller* value, silently missing real overloads or fabricating false ones downstream in `match-scoring.ts`.

## Fix

Single-site fix in `lib/parsing/parse-cargo-ai.ts`: extract `rawWMin`/`rawWMax` before the `calibrateAll` object literal, swap if `min > max`, then use `normWMin`/`normWMax` for both `weightMtMin`, `weightMtMax` fields and the `quantity` Range. All consumers receive a correctly-ordered range.

## Tests

New test suite `__tests__/parsing/parse-cargo-ai-weight-range.test.ts`:
- Swapped range → `weightMtMin < weightMtMax` after parse
- Swapped range → `quantity.min < quantity.max` after parse  
- **VALUE_CHECK oracle**: `resolveCargoWeight(swappedCargo) === resolveCargoWeight(normalCargo) === 30000`
- Normal range preserved as-is
- Edge cases: equal min/max, only min present

## Test plan
- [ ] `npx jest __tests__/parsing/parse-cargo-ai-weight-range --no-coverage --forceExit` → 6 passed
- [ ] `npx jest __tests__/adversarial/cargo-weight-adversarial --no-coverage --forceExit` → 13 passed (no regression)
- [ ] `npx jest __tests__/matching/overload-guard-regression __tests__/matching/utilization-overload-guard --no-coverage --forceExit` → 18 passed (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)