### PR TITLE
fix: enforce isRagEnabled() master switch in Vertex RAG retriever

### DIFF
--- a/__tests__/lib/knowledge/embeddings/retriever-vertex.test.ts
+++ b/__tests__/lib/knowledge/embeddings/retriever-vertex.test.ts
@@ -13,6 +13,10 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
 import { SearchServiceClient } from "@google-cloud/discoveryengine";
 
+// Ensure RAG is enabled for all tests that verify retriever behavior (not the gate test).
+// TC-VX-GATE tests temporarily override this.
+process.env.KNOWLEDGE_RAG_ENABLED = "true";
+
 // Replace prototype.search with a controllable mock — jest.mock factory
 // doesn't reliably apply for this package under next/jest + ts-jest stack.
 let _mockSearch: jest.Mock<(...args: unknown[]) => Promise<unknown[]>> = jest.fn(async () => []);
@@ -485,5 +489,62 @@ describe("retriever-vertex engine mapping", () => {
     });
 
     expect(_mockSearch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retriever-vertex RAG master-switch gate (TC-VX-GATE)", () => {
+  const ORIG = process.env.KNOWLEDGE_RAG_ENABLED;
+
+  beforeEach(() => {
+    _mockSearch = jest.fn();
+  });
+
+  afterEach(() => {
+    if (ORIG === undefined) {
+      delete process.env.KNOWLEDGE_RAG_ENABLED;
+    } else {
+      process.env.KNOWLEDGE_RAG_ENABLED = ORIG;
+    }
+  });
+
+  it("TC-VX-GATE-01: KNOWLEDGE_RAG_ENABLED unset → retrieve() throws 'RAG is not enabled', zero Vertex calls", async () => {
+    delete process.env.KNOWLEDGE_RAG_ENABLED;
+
+    await expect(
+      retrieve("bulk carrier cargo", {
+        vectorTable: "imsbc_vec",
+        ftsTable: "imsbc_fts",
+        topN: 5,
+      })
+    ).rejects.toThrow("RAG is not enabled");
+
+    expect(_mockSearch).not.toHaveBeenCalled();
+  });
+
+  it("TC-VX-GATE-02: KNOWLEDGE_RAG_ENABLED=false → retrieve() throws 'RAG is not enabled', zero Vertex calls", async () => {
+    process.env.KNOWLEDGE_RAG_ENABLED = "false";
+
+    await expect(
+      retrieve("dangerous goods stowage", {
+        vectorTable: "igc_vec",
+        ftsTable: "igc_fts",
+        topN: 3,
+      })
+    ).rejects.toThrow("RAG is not enabled");
+
+    expect(_mockSearch).not.toHaveBeenCalled();
+  });
+
+  it("TC-VX-GATE-03: KNOWLEDGE_RAG_ENABLED=true → retrieve() proceeds (no gate throw)", async () => {
+    process.env.KNOWLEDGE_RAG_ENABLED = "true";
+    _mockSearch.mockResolvedValue([]);
+
+    await expect(
+      retrieve("test query", {
+        vectorTable: "imsbc_vec",
+        ftsTable: "imsbc_fts",
+        topN: 1,
+      })
+    ).resolves.toEqual([]);
   });
 });

--- a/lib/knowledge/embeddings/retriever-vertex.ts
+++ b/lib/knowledge/embeddings/retriever-vertex.ts
@@ -16,6 +16,7 @@
 import { SearchServiceClient } from "@google-cloud/discoveryengine";
 import type { RetrievedChunk, ChunkMetadata } from "@/lib/knowledge/embeddings/chunks";
 import type { RetrieveOptions } from "@/lib/knowledge/embeddings/retriever-sqlite";
+import { isRagEnabled } from "@/lib/knowledge/flags";
 
 const ALLOWED_VEC_TABLES = ["imsbc_vec", "igc_vec", "jwc_vec", "bimco_vec"] as const;
 
@@ -45,6 +46,11 @@ export async function retrieve(
   query: string,
   opts: RetrieveOptions
 ): Promise<RetrievedChunk[]> {
+  // Guard: RAG master switch — mirrors SQLite contract
+  if (!isRagEnabled()) {
+    throw new Error("RAG is not enabled");
+  }
+
   // Guard: empty/null/undefined query (identical to sqlite version)
   if (!query || query.trim().length === 0) {
     return [];


### PR DESCRIPTION
## Summary

- `retriever-vertex.ts retrieve()` had no `isRagEnabled()` guard — with `KNOWLEDGE_RAG_ENABLED=false` + `KNOWLEDGE_BACKEND=vertex`, any caller reaching `retrieve()` would fire a live Vertex Search request and bill the account
- Added `if (!isRagEnabled()) throw new Error("RAG is not enabled")` as the **first line** of `retrieve()`, mirroring the SQLite contract exactly
- Added `KNOWLEDGE_RAG_ENABLED = "true"` to the test file global setup (required for all existing tests that exercise retriever behavior)
- Added `TC-VX-GATE` behavioral test suite: unset → throws + zero Vertex calls, false → throws + zero Vertex calls, true → proceeds

Closes path-scoped checklist item: `.claude/rules/retriever.md` — `KNOWLEDGE_RAG_ENABLED` checked before DB.

## Test plan

- [x] `TC-VX-GATE-01`: `KNOWLEDGE_RAG_ENABLED` unset → `retrieve()` throws `"RAG is not enabled"`, `_mockSearch` not called
- [x] `TC-VX-GATE-02`: `KNOWLEDGE_RAG_ENABLED=false` → same
- [x] `TC-VX-GATE-03`: `KNOWLEDGE_RAG_ENABLED=true` → proceeds normally
- [x] All 27 related test suites green (251 passed, 13 skipped, 0 failures)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)