### PR TITLE
fix: convert grain/bale cbft→cbm at engine/regen intake (3rd reader) + single-owner util

### DIFF
--- a/__tests__/engine-cbft-grain-conversion.test.ts
+++ b/__tests__/engine-cbft-grain-conversion.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Engine/regen intake: CBFT→CBM conversion of vessels BEFORE they reach the
+ * matching engine's volume readers (checkVolume / scoreVolume).
+ *
+ * ROOT (#984 follow-up): #984 converted cbft→cbm only at parse-time (new LLM
+ * parses) and at hydrate (LIVE display). The matching ENGINE / regen path was a
+ * THIRD reader — it loads cached raw cbft from parsed_results and fed the RAW
+ * value straight to checkVolume/scoreVolume, which read grainCapacity as m³. So
+ * a 220577 cbft vessel was treated as ~220577 m³ (~35× inflated) and the volume
+ * gate never bound.
+ *
+ * FIX: normalizeVesselCapacityToCbm (shared single-owner util) runs at engine/
+ * regen intake. Oracle: 220577 cbft → 6247 cbm. A vessel already cbm (3994) must
+ * stay 3994 (no double-convert).
+ *
+ * Behavioral: feeds the normalized capacity through the REAL checkVolume and
+ * scoreVolume — not a string assertion.
+ */
+import {
+  normalizeVesselCapacityToCbm,
+  CBFT_TO_CBM,
+} from '@/lib/parsing/vessel-capacity-units';
+import { checkVolume } from '@/lib/sailing/match-filters';
+import { scoreVolume } from '@/lib/sailing/fit-breakdown';
+import type { ParsedVessel } from '@/lib/types';
+
+function makeVessel(over: Partial<ParsedVessel>): ParsedVessel {
+  return {
+    emailId: 'v', itemIndex: 0,
+    vesselName: null, imo: null, flag: null, built: null, classSociety: null, pandi: null,
+    dwtSummer: null, dwcc: null, draftMax: null, loa: null, beam: null, grt: null, nrt: null,
+    holdsCount: null, hatchesCount: null,
+    grainCapacity: null, grainCapacityUnit: null, baleCapacity: null,
+    holdDimensions: null, hatchDimensions: null, tankTopStrength: null, geared: null,
+    craneCapacity: null, hatchType: null, vesselType: null, openPosition: null, openDate: null,
+    direction: null, restrictions: [], lastCargoes: null, speedLaden: null, speedBallast: null,
+    consumption: null, deckCapacity: null, specialFeatures: [], ciiRating: null,
+    verificationWarning: null,
+    ...over,
+  } as ParsedVessel;
+}
+
+describe('engine intake converts cbft grain capacity before the volume readers', () => {
+  it('220577 cbft → ~6247 cbm at intake (oracle)', () => {
+    const v = makeVessel({ grainCapacity: 220577, grainCapacityUnit: 'cbft' });
+    normalizeVesselCapacityToCbm(v);
+    expect(v.grainCapacityUnit).toBe('cbm');
+    expect(v.grainCapacity!).toBeGreaterThanOrEqual(6240);
+    expect(v.grainCapacity!).toBeLessThanOrEqual(6250);
+    // sanity vs the documented factor
+    expect(v.grainCapacity).toBe(Math.round(220577 / CBFT_TO_CBM));
+  });
+
+  it('checkVolume BINDS on a real overflow once cbft is converted (gate would never bind on raw cbft)', () => {
+    // 6000 mt grain (sf 1.35 → ~8100 m³ required) vs a 6247 m³ hold → overflow.
+    const v = makeVessel({ grainCapacity: 220577, grainCapacityUnit: 'cbft' });
+    normalizeVesselCapacityToCbm(v);
+
+    const fail = checkVolume({
+      weightMt: 6000,
+      grainCapacity: v.grainCapacity,
+      cargoDescription: 'grain',
+      stowageFactor: null,
+    });
+    expect(fail.pass).toBe(false);
+
+    // Against the RAW (unconverted) cbft the same cargo trivially "fits" — proving
+    // the bug: the gate never binds when grainCapacity is read as 220577 m³.
+    const rawPass = checkVolume({
+      weightMt: 6000,
+      grainCapacity: 220577,
+      cargoDescription: 'grain',
+      stowageFactor: null,
+    });
+    expect(rawPass.pass).toBe(true);
+  });
+
+  it('scoreVolume sees ~6247 m³ not 220577 (ratio reflects the real hold)', () => {
+    const v = makeVessel({ grainCapacity: 220577, grainCapacityUnit: 'cbft' });
+    normalizeVesselCapacityToCbm(v);
+
+    // 4000 mt grain × 1.35 sf = 5400 m³ required vs 6247 m³ hold → ~86% → ideal fill.
+    const converted = scoreVolume(4000, 'grain', v.grainCapacity, null);
+    expect(converted.bracketData).toBe('86% of grain');
+
+    // Same cargo against raw cbft reads as ~2% — the inflated-capacity bug.
+    const raw = scoreVolume(4000, 'grain', 220577, null);
+    expect(raw.bracketData).toBe('2% of grain');
+  });
+
+  it('a vessel already cbm (3994) stays 3994 — no double-convert', () => {
+    const v = makeVessel({ grainCapacity: 3994, grainCapacityUnit: 'cbm' });
+    normalizeVesselCapacityToCbm(v);
+    expect(v.grainCapacity).toBe(3994);
+    expect(v.grainCapacityUnit).toBe('cbm');
+  });
+
+  it('is idempotent — a second pass after conversion does not re-divide', () => {
+    const v = makeVessel({ grainCapacity: 220577, grainCapacityUnit: 'cbft', baleCapacity: 210000 });
+    normalizeVesselCapacityToCbm(v);
+    const grainAfterFirst = v.grainCapacity;
+    const baleAfterFirst = v.baleCapacity;
+    normalizeVesselCapacityToCbm(v);
+    expect(v.grainCapacity).toBe(grainAfterFirst);
+    expect(v.baleCapacity).toBe(baleAfterFirst);
+  });
+
+  it('converts bale capacity under the shared grain unit (no separate bale unit)', () => {
+    const v = makeVessel({ grainCapacity: 220577, grainCapacityUnit: 'cbft', baleCapacity: 210000 });
+    normalizeVesselCapacityToCbm(v);
+    expect(v.baleCapacity).toBe(Math.round(210000 / CBFT_TO_CBM));
+  });
+});

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -7,6 +7,7 @@ import { deleteOrphanSessionMatches } from '@/lib/matching/matches-repository';
 import { logger } from '@/lib/logger';
 import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
+import { normalizeVesselCapacityToCbm } from '@/lib/parsing/vessel-capacity-units';
 import type {
   Email, Classification, ParsedCargo, ParsedVessel, ParsedFixtureRecap, Match, ScoreBreakdown, SessionData,
 } from '@/lib/types';
@@ -17,10 +18,6 @@ type DemoBlob = Pick<
   | 'parsedFixtureRecaps' | 'processedEmails' | 'matches' | 'isSampleData' | 'accountId'
   | 'lowConfidenceMatches' | 'insufficientData'
 >;
-
-// cbft→cbm: 1 cbft = 0.0283168 m³, i.e. divide by 35.314667. Single conversion
-// constant shared with lib/parsing/parse-vessel-helpers.ts (CBFT_TO_CBM_PROD).
-const CBFT_TO_CBM = 35.314667;
 
 interface EmailRow {
   gmail_message_id: string; thread_id: string; from_addr: string; from_name: string | null;
@@ -112,23 +109,14 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   const dedupedVessels = dedupByKey(parsedVessels);
   const dedupedCargos  = dedupByKey(parsedCargos);
   for (const v of dedupedVessels) {
-    // CBFT→CBM: code is the single owner of the conversion (mirrors
-    // preNormalizeRawVessel). Seeded parsed_results store the RAW cbft value +
-    // grainCapacityUnit='cbft' (LLM does NOT pre-convert). Convert the VALUE here
-    // BEFORE relabelling and BEFORE the capacity clamp below — else a legit
-    // ~6247 cbm hidden as a raw ~220577 cbft trips the >2.5x DWT clamp and the
-    // volume constraint is silently dropped. Read-time only — no prod write.
-    if (v.grainCapacityUnit && v.grainCapacityUnit.toLowerCase() === 'cbft') {
-      if (typeof v.grainCapacity === 'number' && v.grainCapacity > 0) {
-        v.grainCapacity = Math.round(v.grainCapacity / CBFT_TO_CBM);
-      }
-      if (typeof v.baleCapacity === 'number' && v.baleCapacity > 0) {
-        v.baleCapacity = Math.round(v.baleCapacity / CBFT_TO_CBM);
-      }
-      v.grainCapacityUnit = 'cbm';
-    } else if (v.grainCapacityUnit && v.grainCapacityUnit !== 'cbm') {
-      v.grainCapacityUnit = 'cbm';
-    }
+    // CBFT→CBM: code is the single owner of the conversion — shared util, the
+    // SAME one the engine/regen intake calls (#984 follow-up), so all readers
+    // agree. Seeded parsed_results store the RAW cbft value + grainCapacityUnit=
+    // 'cbft' (LLM does NOT pre-convert). The util converts the VALUE BEFORE the
+    // capacity clamp below — else a legit ~6247 cbm hidden as a raw ~220577 cbft
+    // trips the >2.5x DWT clamp and the volume constraint is silently dropped.
+    // Read-time only — no prod write.
+    normalizeVesselCapacityToCbm(v);
     // CAPACITY_PLAUSIBILITY upper bound: same rule as preNormalizeRawVessel (#976).
     // Fixes already-persisted CBFT-as-CBM values in demo-seed.db.
     const dwtVal = typeof v.dwtSummer === 'object' && v.dwtSummer !== null

--- a/lib/parsing/parse-vessel-helpers.ts
+++ b/lib/parsing/parse-vessel-helpers.ts
@@ -3,6 +3,7 @@ import { extractNum, toConfidence } from '@/lib/parsing-utils';
 import { validateImo } from '@/lib/validation/imo';
 import { calibrateAll } from '@/lib/validation/confidence-calibration';
 import { extractLastCargoesFromBody } from '@/lib/parsing/lastcargoes-fallback';
+import { CBFT_TO_CBM } from '@/lib/parsing/vessel-capacity-units';
 
 interface RawVesselItem {
   vessel_name?: unknown;
@@ -74,7 +75,8 @@ const SQM_OR_CM_PROD_RE = /sqm|sq\.?m\b|\bcm\b|cbm/i;
 const SPEED_UNIT_PROD_RE = /\bknts?\b|\bknots?\b|\bkts?\b/i;
 const THREE_DIM_PROD_RE = /\d+\s*[Xx×]\s*\d+\s*[Xx×]\s*\d+/;
 const CBFT_PROD_RE = /\bcbft\b|\bcuft\b|ft³|ft3/i;
-const CBFT_TO_CBM_PROD = 35.314667;
+// Single-owner conversion factor (shared with hydrate + engine/regen intake).
+const CBFT_TO_CBM_PROD = CBFT_TO_CBM;
 
 function nullIfSqmOrCmDimension(v: unknown): unknown {
   if (!isConfField(v)) return v;

--- a/lib/parsing/vessel-capacity-units.ts
+++ b/lib/parsing/vessel-capacity-units.ts
@@ -1,0 +1,39 @@
+import type { ParsedVessel } from '@/lib/types';
+
+// cbft→cbm: 1 cbft = 0.0283168 m³, i.e. divide by 35.314667. SINGLE shared
+// constant — previously duplicated as CBFT_TO_CBM_PROD (parse-vessel-helpers)
+// and CBFT_TO_CBM (hydrate-demo-session). Code is the single owner of the
+// conversion factor (principle #4, shared-root). (#984 follow-up)
+export const CBFT_TO_CBM = 35.314667;
+
+/**
+ * Normalize a ParsedVessel's grain/bale capacity to cbm IN PLACE, unit-aware.
+ *
+ * `grainCapacityUnit` is the single unit field governing BOTH grain and bale —
+ * there is no separate `baleCapacityUnit`. When it is 'cbft' the raw value(s) are
+ * divided by 35.314667 and the unit relabelled 'cbm'. Any other non-cbm/non-null
+ * label is normalised to 'cbm' WITHOUT touching the value (already cbm — e.g. a
+ * post-#984 parse).
+ *
+ * IDEMPOTENT: once relabelled 'cbm' a re-run never re-converts — so calling it at
+ * multiple readers (parse-time, hydrate, engine/regen intake) cannot double-convert.
+ * This is what lets all three readers agree on a single conversion (#984 fixed
+ * parse-time + hydrate; the engine/regen path was a third, unconverted reader).
+ *
+ * Does NOT apply the >2.5×DWT capacity-plausibility clamp (#793/#976) — that stays
+ * a separate concern at each reader so this util has one job: the unit conversion.
+ */
+export function normalizeVesselCapacityToCbm(v: ParsedVessel): void {
+  const unit = v.grainCapacityUnit;
+  if (unit && unit.toLowerCase() === 'cbft') {
+    if (typeof v.grainCapacity === 'number' && v.grainCapacity > 0) {
+      v.grainCapacity = Math.round(v.grainCapacity / CBFT_TO_CBM);
+    }
+    if (typeof v.baleCapacity === 'number' && v.baleCapacity > 0) {
+      v.baleCapacity = Math.round(v.baleCapacity / CBFT_TO_CBM);
+    }
+    v.grainCapacityUnit = 'cbm';
+  } else if (unit && unit !== 'cbm') {
+    v.grainCapacityUnit = 'cbm';
+  }
+}

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -38,6 +38,7 @@ import { parseLaycan } from '@/lib/sailing/date-parsing';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import { calculateReadinessGap, detectSpot } from '@/lib/sailing/readiness-gap';
 import { cfValue, type ParsedCargo, type ParsedVessel, type Match, type MatchWorksheet } from '@/lib/types';
+import { normalizeVesselCapacityToCbm } from '@/lib/parsing/vessel-capacity-units';
 import { seedCharterersWithDb } from '../knowledge/seeds/seed-charterers';
 import { seedPscHistoryWithDb } from '../knowledge/seeds/seed-psc-history';
 import { seedPortDa, type BaselinePort } from '../seed-port-da';
@@ -570,6 +571,20 @@ async function main() {
     if (changed && !DRY) { updateParsed.run(JSON.stringify(items), r.id, r.parse_type); normalizedRows++; }
   }
   console.log(`[regen] frozen=${frozen} refYear=${refYear} · cargos=${cargos.length} vessels=${vessels.length} · normalized parsed rows=${normalizedRows}`);
+
+  // CBFT→CBM at ENGINE INTAKE (#984 follow-up): seeded parsed_results store the
+  // RAW cbft value + grainCapacityUnit='cbft'. analyzePairs' volume readers
+  // (checkVolume/scoreVolume) read grainCapacity as m³, so without this the
+  // engine scored the 8 cbft vessels with ~35x inflated volume capacity and the
+  // volume gate never bound. Same single-owner util as parse-time + hydrate, so
+  // all three readers agree. In-memory only — the raw cbft stays in parsed_results
+  // (read-time conversion is the contract, mirroring #984); this normalises the
+  // in-memory vessels used for BOTH analyzePairs AND the downstream worksheet.
+  const cbftVesselCount = vessels.filter(
+    (v) => v.grainCapacityUnit && String(v.grainCapacityUnit).toLowerCase() === 'cbft',
+  ).length;
+  for (const v of vessels) normalizeVesselCapacityToCbm(v);
+  console.log(`[regen] cbft→cbm engine-intake conversion applied to ${cbftVesselCount} vessel(s)`);
 
   await hydrateCiiRatings(vessels);
   console.log(`[regen] CII hydrated for ${vessels.filter((v) => v.ciiRating != null).length}/${vessels.length} vessels`);


### PR DESCRIPTION
## Problem
The matching **ENGINE / regen path** is a THIRD cbft reader that #984 missed.
`scripts/demo-seed/regenerate-matches.ts` loads cached **RAW cbft** from
`parsed_results` and feeds `v.grainCapacity` straight to `analyzePairs`, whose
volume readers (`checkVolume` / `scoreVolume`) read `grainCapacity` as **m³**.

So the 8 cbft vessels were scored with **~35× inflated** volume capacity → the
volume gate never bound. #984 only converted at **parse-time** (new LLM parses)
and **hydrate** (LIVE display); the engine/regen reader bypassed both and read
cached raw cbft.

## Fix — single owner (principle #4, shared-root)
The cbft→cbm unit-aware conversion was **duplicated** in `parse-vessel-helpers` +
`hydrate`. Extracted into ONE shared util:

- **`lib/parsing/vessel-capacity-units.ts`** (new) — `normalizeVesselCapacityToCbm(v)`
  + the single-owner `CBFT_TO_CBM` constant. Unit-aware (`grainCapacityUnit==='cbft'`
  → ÷35.314667 + relabel `cbm`; else already cbm → untouched). **Idempotent** — once
  relabelled `cbm`, re-runs never re-convert → no double-convert across the 3 readers.
- **`scripts/demo-seed/regenerate-matches.ts`** — calls the util at the vessel-load
  (engine intake), so the in-memory vessels feeding BOTH `analyzePairs` AND the
  worksheet are cbm. **In-memory only** — raw cbft stays in `parsed_results`
  (read-time conversion is the #984 contract). **No regen run, no prod write.**
- **`lib/demo-mode/hydrate-demo-session.ts`** — now calls the shared util (dropped its
  inline copy + local constant). Behaviour identical (clamp ordering preserved).
- **`lib/parsing/parse-vessel-helpers.ts`** — shares the single `CBFT_TO_CBM` constant
  (its ConfidenceField/source_text logic is a different layer, unchanged).

## VALUE_CHECK (oracle)
`220577 cbft × 0.0283168 → 6247 m³` at engine intake ✓ (verdict: PASS)

## Tests
- New `__tests__/engine-cbft-grain-conversion.test.ts` (behavioral — real `checkVolume`
  + `scoreVolume`): cbft vessel through intake → `checkVolume` **binds** / `scoreVolume`
  sees ~6247 m³ (raw cbft reads 220577 → never binds); cbm **3994 stays 3994** (no
  double-convert); idempotency; shared-unit bale conversion.
- `npx tsc --noEmit` clean; 29 related suites green (200 passed, 1 skipped) — existing
  `#984` hydrate + parse-vessel cbft tests unchanged (PI3).

## Out of scope
Re-running regen / re-seeding prod `parsed_results` is a separate **gated** step after
this merges (prod-write, founder auth). `scripts/progong-harness.ts` keeps its own
standalone constant (cold-eval harness, intentionally self-contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)