### PR TITLE
fix(dashboard): unify KPI count + match lists on one deduped DB-row source

### DIFF
--- a/__tests__/pages/dashboard-dbid-fallback-600.test.tsx
+++ b/__tests__/pages/dashboard-dbid-fallback-600.test.tsx
@@ -8,11 +8,21 @@
  * dbId is undefined → `?? 0` produces id=0 → DashboardFreshMatches renders
  * href="/match/0" → re-introduces original /match/0 bug from #588.
  *
- * Fix: filter out goodMatches where dbId is null before building freshMatchesData.
+ * Original fix: filter out goodMatches where dbId is null before building
+ * freshMatchesData.
+ *
+ * Superseded by the single-source refactor (fix-dashboard-divergence): both the
+ * KPI count and the lists now derive from deriveDashboardSurfaces ->
+ * listQualifyingMatches, mapping over real StoredMatch DB rows. Every row carries
+ * a real `sm.id`, so a missing/`0` id is structurally impossible — the #600
+ * guarantee is stronger than the old `.filter(dbId != null)` and no longer lives
+ * as a literal in page.tsx.
  *
  * Tests:
- * 1. Static: page.tsx freshMatchesData section must NOT have `?? 0` fallback.
- * 2. Static: page.tsx freshMatchesData section MUST filter matches before map.
+ * 1. Static: the id assigned to each fresh-match row is the row's real DB id
+ *    (sm.id), never a `?? 0` fallback.
+ * 2. Static: fresh-match rows are sourced from the deduped qualifying DB rows
+ *    (listQualifyingMatches), not from an id-map lookup that can miss.
  * 3. Behavioral: DashboardFreshMatches never renders /match/0 when given valid ids.
  */
 
@@ -36,17 +46,22 @@ jest.mock('next/link', () => {
 describe('app/dashboard/page.tsx — issue #600 fallback guard', () => {
   let src: string;
   beforeAll(() => {
-    src = fs.readFileSync(path.join(ROOT, 'app/dashboard/page.tsx'), 'utf8');
+    // The fresh-match id now comes from the single-source helper, not page.tsx.
+    src = fs.readFileSync(path.join(ROOT, 'lib/matching/dashboard-surfaces.ts'), 'utf8');
   });
 
-  it('freshMatchesData section does NOT use `?? 0` fallback for dbId', () => {
-    const freshSection = src.match(/freshMatchesData[\s\S]{0,400}/)?.[0] ?? '';
-    expect(freshSection).not.toMatch(/\?\?\s*0/);
+  it('fresh-match id is the row real DB id, not a `?? 0` fallback', () => {
+    const block = src.match(/const freshMatchesData[\s\S]{0,400}/)?.[0] ?? '';
+    expect(block).toMatch(/id:\s*sm\.id/);
+    // no `id: <x> ?? 0` style fallback for the rendered id
+    expect(block).not.toMatch(/id:[^\n]*\?\?\s*0/);
   });
 
-  it('freshMatchesData section filters out matches with missing dbId before map', () => {
-    const freshSection = src.match(/freshMatchesData[\s\S]{0,400}/)?.[0] ?? '';
-    expect(freshSection).toMatch(/\.filter\(/);
+  it('fresh-match rows are sourced from the deduped qualifying DB rows', () => {
+    // qualifying = listQualifyingMatches(...) — no id-map lookup that can miss.
+    expect(src).toMatch(/listQualifyingMatches/);
+    const block = src.match(/const freshMatchesData[\s\S]{0,200}/)?.[0] ?? '';
+    expect(block).toMatch(/qualifying\.map/);
   });
 });
 

--- a/__tests__/pages/dashboard-divergence.test.tsx
+++ b/__tests__/pages/dashboard-divergence.test.tsx
@@ -1,0 +1,106 @@
+/** @jest-environment jsdom */
+/**
+ * Behavioral regression — dashboard KPI count must equal rendered list length.
+ *
+ * Divergence bug: the "open matches" KPI used countQualifyingMatches (deduped DB
+ * rows, fit>=60) while the lists below it used session.matches filtered by
+ * session-time matchLevel (not deduped, not re-checked against the re-patched DB
+ * fit_percent). So a "possible" match that re-patched below 60, or a duplicate
+ * row, made headline N != list M.
+ *
+ * Fix: both surfaces derive from deriveDashboardSurfaces -> listQualifyingMatches
+ * (one deduped, fit>=60 source). This test pins: a session whose re-patch crosses
+ * the 60 boundary AND contains a duplicate => KPI count === rendered list length.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Database from 'better-sqlite3';
+import migration032 from '@/lib/migrations/032-matches';
+import migration033 from '@/lib/migrations/033-matches-score-breakdown';
+import migration034 from '@/lib/migrations/034-matches-unique-constraint';
+import migration035 from '@/lib/migrations/035-matches-tce-distance';
+import migration036 from '@/lib/migrations/036-matches-freight-rate';
+import migration041 from '@/lib/migrations/041-matches-vessel-name';
+import migration042 from '@/lib/migrations/042-matches-fit';
+import { createMatch } from '@/lib/matching/matches-repository';
+import { countQualifyingMatches } from '@/lib/matching/count-qualifying';
+import { deriveDashboardSurfaces } from '@/lib/matching/dashboard-surfaces';
+import { DashboardFreshMatches } from '@/components/dashboard/DashboardFreshMatches';
+import type { Match } from '@/lib/types';
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  for (const m of [migration032, migration033, migration034, migration035, migration036, migration041, migration042]) {
+    m.up(db);
+  }
+  return db;
+}
+
+// Minimal session Match for enrichment — only the fields deriveDashboardSurfaces reads.
+function sessionMatch(over: Partial<Match> & { cargoEmailId: string; vesselEmailId: string }): Match {
+  return {
+    cargoItemIndex: 0,
+    vesselItemIndex: 0,
+    matchLevel: 'possible',
+    matchReasons: ['session reason'],
+    score: 80,
+    ...over,
+  } as unknown as Match;
+}
+
+const USER = 'sess-1';
+
+it('KPI count equals rendered list length when a re-patch crosses 60 AND a duplicate exists', () => {
+  const db = freshDb();
+
+  // (A) Duplicate pair: two DB rows sharing the dedup key (vessel/cargo/port/laycan),
+  // both fit>=60 -> dedup collapses to ONE qualifying row.
+  createMatch(db, {
+    cargo_id: 'cA1', vessel_id: 'vA1', score: 82, reason: 'dup A', user_id: USER,
+    fit_percent: 75, vessel_name: 'MV ALPHA', cargo_ref: 'GRAIN-1', load_port: 'UAODS', laycan_start: 1748908800000,
+  });
+  createMatch(db, {
+    cargo_id: 'cA2', vessel_id: 'vA2', score: 80, reason: 'dup A', user_id: USER,
+    fit_percent: 70, vessel_name: 'MV ALPHA', cargo_ref: 'GRAIN-1', load_port: 'UAODS', laycan_start: 1748908800000,
+  });
+
+  // (B) Boundary cross: labelled "possible" at session time, but re-patch dropped
+  // its DB fit_percent to 58 (<60) -> must be excluded from BOTH count and list.
+  createMatch(db, {
+    cargo_id: 'cB', vessel_id: 'vB', score: 64, reason: 'dropped below 60', user_id: USER,
+    fit_percent: 58, vessel_name: 'MV BETA', cargo_ref: 'COAL-9', load_port: 'AUPHE', laycan_start: 1749000000000,
+  });
+
+  // (C) A normal qualifying row.
+  createMatch(db, {
+    cargo_id: 'cC', vessel_id: 'vC', score: 90, reason: 'clean match', user_id: USER,
+    fit_percent: 88, vessel_name: 'MV GAMMA', cargo_ref: 'IRON-3', load_port: 'BRTUB', laycan_start: 1749100000000,
+  });
+
+  const sessionMatches: Match[] = [
+    sessionMatch({ cargoEmailId: 'cA1', vesselEmailId: 'vA1', matchLevel: 'good' }),
+    sessionMatch({ cargoEmailId: 'cA2', vesselEmailId: 'vA2', matchLevel: 'good' }),
+    sessionMatch({ cargoEmailId: 'cB', vesselEmailId: 'vB', matchLevel: 'possible' }), // session says possible — but DB says <60
+    sessionMatch({ cargoEmailId: 'cC', vesselEmailId: 'vC', matchLevel: 'good' }),
+  ];
+
+  const kpiCount = countQualifyingMatches(db, { user_id: USER });
+  const { openMatchCount, priorityCards, freshMatchesData } = deriveDashboardSurfaces(db, sessionMatches, USER);
+
+  // dedup collapses A1/A2 -> 1; B excluded (<60); C -> 1 ==> 2 qualifying.
+  expect(kpiCount).toBe(2);
+  expect(openMatchCount).toBe(kpiCount);
+
+  // Both lists are exactly the qualifying set — count === list length (the invariant).
+  expect(freshMatchesData).toHaveLength(openMatchCount);
+  expect(priorityCards).toHaveLength(openMatchCount);
+
+  // The dropped (<60) row appears in NEITHER surface.
+  expect(freshMatchesData.some((m) => m.matchReasons.includes('dropped below 60'))).toBe(false);
+
+  // Render the actual list component — rendered rows === headline count.
+  render(<DashboardFreshMatches matches={freshMatchesData} />);
+  const renderedLinks = screen.getAllByRole('link').filter((a) => a.getAttribute('href')?.startsWith('/match/'));
+  expect(renderedLinks).toHaveLength(openMatchCount);
+});

--- a/__tests__/pages/dashboard-match-href.test.ts
+++ b/__tests__/pages/dashboard-match-href.test.ts
@@ -7,8 +7,15 @@
  *
  * These tests ensure:
  * 1. DashboardFreshMatches uses match.id (DB id) not match.index in href.
- * 2. dashboard/page.tsx builds a matchIdMap via persistSessionMatches + listMatches.
- * 3. No hardcoded /match/0 or /match/${i} (loop index) in either file.
+ * 2. The dashboard list rows resolve their href from a real DB id.
+ * 3. No hardcoded /match/0 or /match/${i} (loop index) anywhere.
+ *
+ * Single-source refactor (fix-dashboard-divergence): the id-resolution mechanism
+ * moved from page.tsx (matchIdMap + listMatches lookup, which could MISS and fall
+ * back to /matches) into lib/matching/dashboard-surfaces.ts, which maps over real
+ * StoredMatch rows — `id: sm.id` is always a real DB id, so /match/0 is now
+ * structurally impossible. The page.tsx-source assertions below were re-pointed to
+ * that helper; the DashboardFreshMatches.tsx component guards are unchanged.
  */
 
 import * as fs from 'fs';
@@ -18,6 +25,7 @@ const ROOT = process.cwd();
 
 const freshMatchesPath = path.join(ROOT, 'components/dashboard/DashboardFreshMatches.tsx');
 const dashboardPagePath = path.join(ROOT, 'app/dashboard/page.tsx');
+const surfacesPath = path.join(ROOT, 'lib/matching/dashboard-surfaces.ts');
 
 describe('Dashboard match href — issue #588 regression', () => {
   describe('DashboardFreshMatches.tsx', () => {
@@ -52,23 +60,31 @@ describe('Dashboard match href — issue #588 regression', () => {
       expect(src).toMatch(/import.*persistSessionMatches.*from/);
     });
 
-    it('imports listMatches to retrieve stored matches with DB ids', () => {
-      expect(src).toMatch(/import.*listMatches.*from/);
+    it('derives its list surfaces from the single-source helper', () => {
+      expect(src).toMatch(/deriveDashboardSurfaces/);
     });
 
-    it('builds matchIdMap to resolve session match → DB id', () => {
-      expect(src).toMatch(/matchIdMap/);
-    });
-
-    it('priorityCards href falls back to /matches (not /match/0) when DB id missing', () => {
-      expect(src).toMatch(/\/matches/);
+    it('does not hardcode /match/0 or a loop-index href', () => {
+      expect(src).not.toMatch(/\/match\/0/);
       expect(src).not.toMatch(/href:\s*`\/match\/\$\{i\}`/);
     });
+  });
 
-    it('freshMatchesData uses id field not index', () => {
-      const freshSection = src.match(/freshMatchesData[\s\S]{0,300}/)?.[0] ?? '';
-      expect(freshSection).toMatch(/\bid\b/);
-      expect(freshSection).not.toMatch(/\bindex\s*:/);
+  describe('lib/matching/dashboard-surfaces.ts (id-resolution home)', () => {
+    let src: string;
+    beforeAll(() => {
+      src = fs.readFileSync(surfacesPath, 'utf8');
+    });
+
+    it('resolves list rows from the deduped qualifying DB rows', () => {
+      expect(src).toMatch(/listQualifyingMatches/);
+    });
+
+    it('hrefs and ids use the real DB id (sm.id), never /match/0 or a loop index', () => {
+      expect(src).toMatch(/href:\s*`\/match\/\$\{sm\.id\}`/);
+      expect(src).toMatch(/id:\s*sm\.id/);
+      expect(src).not.toMatch(/\/match\/0/);
+      expect(src).not.toMatch(/`\/match\/\$\{i\}`/);
     });
   });
 });

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,8 +6,6 @@ import { isDemoMode } from '@/lib/demo-mode';
 import { getStore } from '@/lib/session-store';
 import { filterByCategory } from '@/lib/dashboard-queries';
 import { countAwaitingApproval } from '@/lib/auto-prequote/queue';
-import { classifyPriority } from '@/lib/sailing/priority-classifier';
-import type { PriorityLevel } from '@/lib/sailing/priority-classifier';
 import { AnalyticsTracker } from '@/lib/analytics-tracker';
 import { DashboardKpiStrip } from '@/components/dashboard/DashboardKpiStrip';
 import { DashboardTodoSection } from '@/components/dashboard/DashboardTodoSection';
@@ -15,9 +13,7 @@ import { DashboardFreshMatches } from '@/components/dashboard/DashboardFreshMatc
 import { MorningHeader } from '@/components/dashboard/MorningHeader';
 import { Badge } from '@/design-system/primitives';
 import { persistSessionMatches } from '@/lib/matching/persist-session-matches';
-import { listMatches } from '@/lib/matching/matches-repository';
-import { countQualifyingMatches } from '@/lib/matching/count-qualifying';
-const PRIORITY_ORDER: Record<PriorityLevel, number> = { urgent: 0, attention: 1, ok: 2 };
+import { deriveDashboardSurfaces } from '@/lib/matching/dashboard-surfaces';
 
 export default async function DashboardPage() {
   const cookieStore = await cookies();
@@ -76,48 +72,19 @@ export default async function DashboardPage() {
 
   const cargoRows = filterByCategory(emails, processedEmails, 'CARGO_INQUIRY');
 
-  const goodMatches = matches.filter(
-    (m) => m.matchLevel === 'good' || m.matchLevel === 'possible',
-  );
-
   const db = getStore().getDatabase();
   if (matches.length > 0) {
     persistSessionMatches(db, sessionId!, matches, session.parsedCargos, session.parsedVessels);
   }
-  const storedMatches = listMatches(db, { user_id: sessionId!, sortBy: 'score', sortDir: 'desc' });
-  // Item-aware key (audit C.5, migration 051): two items of the same email pair
-  // are distinct rows — a 2-part (cargo_id, vessel_id) key would collapse them.
-  // ?? 0 covers StoredMatch's optional item columns (pre-044 rows).
-  const storedKey = (cargoId: string, cargoIdx: number | null | undefined, vesselId: string, vesselIdx: number | null | undefined) =>
-    `${cargoId}|${cargoIdx ?? 0}|${vesselId}|${vesselIdx ?? 0}`;
-  const matchIdMap = new Map(storedMatches.map((sm) => [storedKey(sm.cargo_id, sm.cargo_item_index, sm.vessel_id, sm.vessel_item_index), sm.id]));
-  const storedByKey = new Map(storedMatches.map((sm) => [storedKey(sm.cargo_id, sm.cargo_item_index, sm.vessel_id, sm.vessel_item_index), sm]));
-  const openMatchCount = countQualifyingMatches(db, { user_id: sessionId! });
-
-  const priorityCards = goodMatches
-    .map((match, i) => {
-      const readinessGap =
-        match.readiness?.gapDays !== null && match.readiness?.gapDays !== undefined
-          ? match.readiness.gapDays * 24
-          : undefined;
-      const priority = classifyPriority({ confidence: match.confidence, readinessGap });
-      const matchSummary = match.matchReasons[0] || `Match #${i + 1}`;
-      const keyInsight = match.readiness?.explanation || `Level: ${match.matchLevel}`;
-      const dbId = matchIdMap.get(storedKey(match.cargoEmailId, match.cargoItemIndex, match.vesselEmailId, match.vesselItemIndex));
-      const href = dbId != null ? `/match/${dbId}` : '/matches';
-      return { priority, matchSummary, keyInsight, href };
-    })
-    .sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
-
-  const freshMatchesData = goodMatches
-    .filter((m) => matchIdMap.get(storedKey(m.cargoEmailId, m.cargoItemIndex, m.vesselEmailId, m.vesselItemIndex)) != null)
-    .map((m) => ({
-      id: matchIdMap.get(storedKey(m.cargoEmailId, m.cargoItemIndex, m.vesselEmailId, m.vesselItemIndex))!,
-      score: m.score,
-      fit_percent: storedByKey.get(storedKey(m.cargoEmailId, m.cargoItemIndex, m.vesselEmailId, m.vesselItemIndex))?.fit_percent ?? null,
-      matchLevel: m.matchLevel,
-      matchReasons: m.matchReasons,
-    }));
+  // Single source of truth: KPI count AND both lists derive from the same deduped,
+  // fit>=60 DB rows. Guarantees the headline count === rendered list length even
+  // when a session "possible" match re-patches below 60 or a duplicate row exists
+  // (see dashboard-surfaces.ts). Session matches only enrich rows (confidence).
+  const { openMatchCount, priorityCards, freshMatchesData } = deriveDashboardSurfaces(
+    db,
+    matches,
+    sessionId!,
+  );
 
   const rawName = session.accountId?.split('@')[0] ?? '';
   const userName = rawName ? rawName.charAt(0).toUpperCase() + rawName.slice(1) : '';

--- a/lib/matching/count-qualifying.ts
+++ b/lib/matching/count-qualifying.ts
@@ -15,13 +15,30 @@ export interface CountQualifyingOpts extends Omit<ListMatchesOptions, 'sortBy' |
   fitFloor?: number;
 }
 
+/**
+ * The deduped, qualifying match rows for a user — the single source of truth that
+ * BOTH the dashboard "open matches" KPI and the match lists below it must derive
+ * from. Rows are deduped by vessel/cargo/port/laycan (same key as the count),
+ * filtered to fit_percent >= fitFloor (null excluded), ordered by fit_percent DESC.
+ *
+ * Using one function for count and lists keeps them in lockstep: a session match
+ * that re-patches below 60, or a duplicate row, is dropped from both surfaces
+ * identically, so `listQualifyingMatches(...).length === countQualifyingMatches(...)`.
+ */
+export function listQualifyingMatches(
+  db: Database.Database,
+  opts: CountQualifyingOpts,
+): StoredMatch[] {
+  const floor = opts.fitFloor ?? 60;
+  const raw = listMatches(db, { ...opts, sortBy: 'fit_percent', sortDir: 'desc' });
+  const deduped = dedupMatches(raw);
+  return deduped.filter((m) => m.fit_percent != null && m.fit_percent >= floor);
+}
+
 /** Count qualifying matches for a user: deduped, fit_percent >= fitFloor, null excluded. */
 export function countQualifyingMatches(
   db: Database.Database,
   opts: CountQualifyingOpts,
 ): number {
-  const floor = opts.fitFloor ?? 60;
-  const raw = listMatches(db, { ...opts, sortBy: 'fit_percent', sortDir: 'desc' });
-  const deduped = dedupMatches(raw);
-  return deduped.filter((m) => m.fit_percent != null && m.fit_percent >= floor).length;
+  return listQualifyingMatches(db, opts).length;
 }

--- a/lib/matching/dashboard-surfaces.ts
+++ b/lib/matching/dashboard-surfaces.ts
@@ -1,0 +1,97 @@
+import type Database from 'better-sqlite3';
+import type { Match, MatchWorksheet } from '@/lib/types';
+import { classifyPriority, type PriorityLevel } from '@/lib/sailing/priority-classifier';
+import { listQualifyingMatches } from './count-qualifying';
+import type { StoredMatch } from './matches-repository';
+import type { TodoCard } from '@/components/dashboard/DashboardTodoSection';
+import type { FreshMatchItem } from '@/components/dashboard/DashboardFreshMatches';
+
+const PRIORITY_ORDER: Record<PriorityLevel, number> = { urgent: 0, attention: 1, ok: 2 };
+
+export interface DashboardSurfaces {
+  /** Headline KPI: count of deduped, qualifying (fit >= 60) match rows. */
+  openMatchCount: number;
+  /** "To do today" cards — one per qualifying row, sorted by priority. */
+  priorityCards: TodoCard[];
+  /** "Fresh matches" rows — one per qualifying row, fit DESC. */
+  freshMatchesData: FreshMatchItem[];
+}
+
+// Item-aware key (audit C.5, migration 051): aligns a session Match with its
+// persisted StoredMatch row so list rows can be enriched with session-only data
+// (confidence/readiness) that is never persisted to the matches table.
+// ?? 0 covers StoredMatch's optional item columns (pre-044 rows).
+function storedKey(
+  cargoId: string,
+  cargoIdx: number | null | undefined,
+  vesselId: string,
+  vesselIdx: number | null | undefined,
+): string {
+  return `${cargoId}|${cargoIdx ?? 0}|${vesselId}|${vesselIdx ?? 0}`;
+}
+
+function parseWorksheet(json: string | null | undefined): MatchWorksheet | null {
+  if (!json) return null;
+  try {
+    return JSON.parse(json) as MatchWorksheet;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive ALL three dashboard match surfaces (KPI count + both lists) from one
+ * deduped DB-row source so they can never diverge. The KPI count and the rendered
+ * list length are guaranteed equal — `openMatchCount === priorityCards.length ===
+ * freshMatchesData.length` — because all three come from the same
+ * `listQualifyingMatches` result.
+ *
+ * Session matches are used only to enrich rows with confidence/readiness (not
+ * persisted to the matches table); they never widen or narrow the row set.
+ */
+export function deriveDashboardSurfaces(
+  db: Database.Database,
+  sessionMatches: Match[],
+  userId: string,
+): DashboardSurfaces {
+  const qualifying = listQualifyingMatches(db, { user_id: userId });
+
+  const sessionByKey = new Map(
+    sessionMatches.map((m) => [
+      storedKey(m.cargoEmailId, m.cargoItemIndex, m.vesselEmailId, m.vesselItemIndex),
+      m,
+    ]),
+  );
+
+  const enrich = (sm: StoredMatch) =>
+    sessionByKey.get(storedKey(sm.cargo_id, sm.cargo_item_index, sm.vessel_id, sm.vessel_item_index));
+
+  const priorityCards: TodoCard[] = qualifying
+    .map((sm) => {
+      const sMatch = enrich(sm);
+      const worksheet = parseWorksheet(sm.worksheet_json);
+      const gapDays = sMatch?.readiness?.gapDays ?? worksheet?.readiness?.gapDays ?? null;
+      const readinessGap = gapDays != null ? gapDays * 24 : undefined;
+      const priority = classifyPriority({ confidence: sMatch?.confidence, readinessGap });
+      const matchSummary = sMatch?.matchReasons?.[0] || sm.reason || `Match #${sm.id}`;
+      const keyInsight =
+        sMatch?.readiness?.explanation ||
+        worksheet?.readiness?.explanation ||
+        `${Math.round(sm.fit_percent ?? 0)}% fit`;
+      return { priority, matchSummary, keyInsight, href: `/match/${sm.id}` };
+    })
+    .sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
+
+  const freshMatchesData: FreshMatchItem[] = qualifying.map((sm) => {
+    const sMatch = enrich(sm);
+    return {
+      id: sm.id,
+      score: sm.score,
+      fit_percent: sm.fit_percent ?? null,
+      matchLevel: sMatch?.matchLevel ?? 'good',
+      matchReasons: sMatch?.matchReasons?.length ? sMatch.matchReasons : [sm.reason],
+    };
+  });
+
+  return { openMatchCount: qualifying.length, priorityCards, freshMatchesData };
+}


### PR DESCRIPTION
## Problem
Dashboard headline KPI **"open matches"** diverged from the match lists below it.

- KPI tile used `countQualifyingMatches` → DB rows, `fit_percent>=60`, **deduped** by vessel/cargo/port/laycan.
- "To do today" + "Fresh matches" used `session.matches.filter(matchLevel ∈ {good,possible})` → **session-time** matchLevel, **not deduped**, **not re-checked** against the DB.

`persistSessionMatches` re-patches DB `fit_percent` with the live bunker price, so a session match labelled `possible` (fit 60–70 at session time) can land **below 60** after re-patch. Result: headline says *N*, list shows *M≠N*, and duplicate rows inflate the list.

## Fix
Both surfaces now derive from **one** deduped DB-row source — `listQualifyingMatches` (single source of truth):

`openMatchCount === priorityCards.length === freshMatchesData.length` **by construction** (same array → `.length` + `.map`).

- `count-qualifying.ts` — extract `listQualifyingMatches` (deduped, fit>=60, fit DESC); `countQualifyingMatches` = `.length` (count semantics unchanged).
- `lib/matching/dashboard-surfaces.ts` (new) — `deriveDashboardSurfaces` maps the qualifying rows into both lists, enriching each with session-only `confidence`/`readiness` (never persisted) without widening/narrowing the set.
- `app/dashboard/page.tsx` — replace the `goodMatches` / `matchIdMap` path with the helper.

**Out of scope (unchanged):** the 60 threshold, the dedup keys.

## Tests
- **New behavioral** (`dashboard-divergence.test.tsx`): a session where a re-patch crosses the 60 boundary **AND** a duplicate exists → asserts KPI count === rendered `DashboardFreshMatches` link count, against a real migrated SQLite DB.
- **#588/#600 source guards** re-pointed to the id-resolution new home (`dashboard-surfaces.ts`). The id-map-miss → `/match/0` bug is now *structurally impossible* (every list row is a real `StoredMatch` with `sm.id`). Behavioral/component assertions in both files are **unchanged**; only obsolete source-string assertions (greps for the removed `matchIdMap`/`listMatches`) were updated.

> ⚠️ Reviewer note: the two `#588`/`#600` guard files were updated because the single-source refactor removes the exact mechanism they pinned (`matchIdMap` lookup + `.filter(dbId != null)`). Behavior is preserved & strengthened, plus a new behavioral test was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)