### PR TITLE
fix(low-a): laytime 1440 round + dwt=0 ballast guard + charterer-tier comment

### DIFF
--- a/__tests__/lib/fit-breakdown-dwt0-ballast.test.ts
+++ b/__tests__/lib/fit-breakdown-dwt0-ballast.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression lock: scoreBallast with vesselDwt=0 must return conservative unknown,
+ * not classify as handysize (which was the pre-fix behavior via classifyVesselByDwt(0)).
+ * Mirrors scoreClassFit guard at line 259: `vesselDwt <= 0`.
+ */
+
+import { scoreBallast } from '@/lib/sailing/fit-breakdown';
+import { FIT_WEIGHTS } from '@/lib/sailing/fit-breakdown';
+
+const UNKNOWN_SHARE = 0.6; // matches UNKNOWN_SHARE constant in fit-breakdown
+
+describe('scoreBallast — dwt=0 guard', () => {
+  it('returns conservative unknown score for vesselDwt=0', () => {
+    const result = scoreBallast(200, 0);
+    // conservative = 60% of weight, not a full class-based score
+    const expectedScore = Math.round(FIT_WEIGHTS.ballast * UNKNOWN_SHARE * 10) / 10;
+    expect(result.score).toBe(expectedScore);
+    expect(result.factor).toBe('ballast');
+  });
+
+  it('returns a rationale string (not handysize class label) for vesselDwt=0', () => {
+    const result = scoreBallast(200, 0);
+    expect(result.rationale).toContain('DWT not stated');
+  });
+
+  it('still scores normally for a valid handysize vessel (15000 DWT)', () => {
+    // This ensures the guard does NOT affect legitimate small vessels
+    const result = scoreBallast(200, 15000);
+    const maxScore = FIT_WEIGHTS.ballast;
+    expect(result.score).toBeGreaterThan(maxScore * UNKNOWN_SHARE);
+  });
+});

--- a/__tests__/lib/laytime-full-day-round.test.ts
+++ b/__tests__/lib/laytime-full-day-round.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression lock: laytime full day must be exactly 1440 minutes (24h).
+ * Before fix: dayEnd=23:59:59.999 → 86399999ms/day → 1439.9998... minutes.
+ * After fix: Math.round applied → 1440 exactly.
+ */
+
+import { calculateLaytime } from '@/lib/laytime/calculator';
+
+describe('calculateLaytime — full-day minute rounding', () => {
+  it('counts exactly 1440 minutes for a full calendar day (SHINC, no exclusions)', () => {
+    // commencedAt midnight → completedAt next midnight = exactly 1 day
+    const result = calculateLaytime({
+      allowedLaytimeDays: 2,
+      mode: 'SHINC',
+      commencedAt: '2026-05-01T00:00:00.000Z',
+      completedAt: '2026-05-02T00:00:00.000Z',
+    });
+
+    const day1 = result.breakdown.find(e => e.date === '2026-05-01');
+    expect(day1).toBeDefined();
+    // hours must be exactly 24, not 23.9999...
+    expect(day1!.hours).toBe(24);
+  });
+
+  it('usedLaytimeHours is exactly 24 for one full SHINC day', () => {
+    const result = calculateLaytime({
+      allowedLaytimeDays: 2,
+      mode: 'SHINC',
+      commencedAt: '2026-05-01T00:00:00.000Z',
+      completedAt: '2026-05-02T00:00:00.000Z',
+    });
+
+    expect(result.usedLaytimeHours).toBe(24);
+  });
+});

--- a/lib/laytime/calculator.ts
+++ b/lib/laytime/calculator.ts
@@ -165,5 +165,5 @@ function calculateMinutesInDay(
   }
 
   const minutes = (effectiveEnd.getTime() - effectiveStart.getTime()) / (1000 * 60);
-  return Math.max(0, minutes);
+  return Math.max(0, Math.round(minutes));
 }

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -66,6 +66,7 @@ const TOTAL_WEIGHT = Object.values(FIT_WEIGHTS).reduce((a, b) => a + b, 0);
 // Charterer credit-tier penalty (founder-calibrated; DEFAULT). Counterparty-side,
 // kept OUT of vessel vetting. weak → soft fit hit; second/blue-chip → none.
 // STRONGER: { weak: 8, second: 3 }. SOFTER: { weak: 2, second: 0 }.
+// DEFAULT: { weak: 4, second: 0 }
 export const CHARTERER_TIER_PENALTY: Record<'blue-chip' | 'second' | 'weak', number> = {
   'blue-chip': 0,
   second: 0,
@@ -215,7 +216,7 @@ export function scoreBallast(
   if (distanceNm == null || !Number.isFinite(distanceNm)) {
     return unknown('ballast', 'Ballast distance', 'Distance to load port unknown — vessel position or port not mapped, scored conservatively.');
   }
-  if (vesselDwt == null || !Number.isFinite(vesselDwt)) {
+  if (vesselDwt == null || !Number.isFinite(vesselDwt) || vesselDwt <= 0) {
     return unknown('ballast', 'Ballast distance', 'Vessel DWT not stated — cannot determine class range, scored conservatively.');
   }
   const cls = classifyVesselByDwt(vesselDwt);


### PR DESCRIPTION
## Summary

- **laytime float** (`lib/laytime/calculator.ts:168`): `Math.round()` on per-day minutes — full calendar day was returning 1439.9998 min instead of 1440 due to `dayEnd.setUTCHours(23,59,59,999)=86399999ms`
- **dwt=0 ballast guard** (`lib/sailing/fit-breakdown.ts:218`): add `|| vesselDwt <= 0` to `scoreBallast` guard — mirrors existing `scoreClassFit:259` guard; without it `dwt=0` fell through to `classifyVesselByDwt(0)='handysize'` → wrong score
- **charterer-tier comment** (`lib/sailing/fit-breakdown.ts:68`): add `// DEFAULT: { weak: 4, second: 0 }` annotation to CHARTERER_TIER_PENALTY

## Tests

- `__tests__/lib/laytime-full-day-round.test.ts` — full-day = exactly 24h (1440 min); 2 cases
- `__tests__/lib/fit-breakdown-dwt0-ballast.test.ts` — dwt=0 → conservative unknown score, not handysize; 3 cases
- 79 related test suites, 703 tests — all green

## VALUE check

- `VALUE: laytime full-day=1440 (expect 1440); dwt0-ballast=guarded (conservative unknown score, not handysize)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)