### PR TITLE
chore(ci): ignore tailwindcss major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@sentry/nextjs"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Closes the recurrence of #996. Tailwind v4 = JS→CSS config rewrite; mechanical dependabot major bumps break Build+TypeCheck. Pin to v3, revisit via dedicated migration PR if needed. Same policy as next/react/react-dom/@sentry/nextjs.

Config-only change (.github/dependabot.yml). No runtime/prod impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)