### PR TITLE
chore(ci): ignore eslint major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "tailwindcss"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Closes the recurrence of #997. ESLint v10 is blocked upstream — eslint-config-next bundles an eslint-plugin-react calling the removed context.getFilename() API → crash on v10. Pin to v9; revisit via dedicated migration once Next ships a v10-compatible eslint-config-next.

Config-only (.github/dependabot.yml). No runtime/prod impact. Same policy as next/react/react-dom/@sentry/nextjs/tailwindcss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)