### PR TITLE
fix(port-da): resolve vague discharge ports in list DA so list==detail (#1004)

### DIFF
--- a/lib/port-da/__tests__/match-da.test.ts
+++ b/lib/port-da/__tests__/match-da.test.ts
@@ -28,6 +28,10 @@ function makeDb(opts?: { altConfidence?: string }): Database.Database {
   ins.run('ROCND', 0, 100000, 10000, 5000, 3000, 2, 'general', opts?.altConfidence ?? 'verified', 'seed');
   // Marmara (TRMAR): 8k + 4k + 2k = 14k fixed
   ins.run('TRMAR', 0, 100000, 8000, 4000, 2000, 2, 'general', 'verified', 'seed');
+  // Rotterdam (NLRTM): 9k + 6k + 4k = 19k fixed. ARA / "European Continent" vague
+  // descriptors resolve to NLRTM via resolveVaguePort — the discharge DA the LIST
+  // path used to silently drop (only resolvePort, no vague fallback).
+  ins.run('NLRTM', 0, 100000, 9000, 6000, 4000, 2, 'general', 'verified', 'seed');
   return db;
 }
 
@@ -38,6 +42,24 @@ describe('sumMatchPortDaUsd', () => {
     // against 'general' rows regardless, matching the detail-route behaviour.
     const result = sumMatchPortDaUsd(['constanta', 'marmara'], 30000, 'bulk', db);
     expect(result.totalUsd).toBe(18000 + 14000);
+    db.close();
+  });
+
+  // #1004 parity: LIST path must mirror DETAIL (resolvePortOrPassthrough) and resolve
+  // vague discharge descriptors via resolveVaguePort, else discharge DA is dropped and
+  // list TCE underestimates vs the voyage detail page.
+  //
+  // NB: a real range descriptor ("European Continent" / "ARA range") is used here, not
+  // bare "ARA" — resolvePort('ARA') fuzzy-matches the substring "ara" in "Mtwara" (TZMYW)
+  // and returns a non-null (wrong) port, so the ?? fallback never fires for it. The prod
+  // descriptors that actually trigger the dropped-DA bug (resolvePort → null) are the
+  // range forms below; those are what resolveVaguePort rescues.
+  test('vague descriptor "European Continent" resolves via resolveVaguePort → Rotterdam DA included', () => {
+    const db = makeDb();
+    // Marmara (TRMAR, exact) = 14k ; "European Continent" → Rotterdam (NLRTM, vague) = 19k.
+    const result = sumMatchPortDaUsd(['Marmara', 'European Continent'], 30000, null, db);
+    // Must include the vague-resolved discharge DA, not just the load port.
+    expect(result.totalUsd).toBe(14000 + 19000);
     db.close();
   });
 

--- a/lib/port-da/match-da.ts
+++ b/lib/port-da/match-da.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import { getPortDa } from './repository';
 import { resolvePort } from '@/lib/ports/resolve';
+import { resolveVaguePort } from '@/lib/ports/resolve-vague';
 import type { PortDaBreakdown } from './types';
 
 /** Confidence ordering for min-aggregation: lower index = lower confidence */
@@ -55,7 +56,10 @@ export function sumMatchPortDaUsd(
   for (const name of portNames) {
     if (!name) continue;
     try {
-      const resolved = resolvePort(name);
+      // Exact match first; fall back to vague-descriptor resolution (ARA, "European
+      // Continent", etc.) exactly as resolvePortOrPassthrough does in the detail route,
+      // so the LIST path no longer silently drops discharge DA for range descriptors.
+      const resolved = resolvePort(name) ?? resolveVaguePort(name);
       if (!resolved) continue;
       // Pass cargoType=undefined → getPortDa resolves to 'general' (the only seed
       // cargo type).  This mirrors resolveDaUsd in the detail route and guarantees


### PR DESCRIPTION
## Problem

`sumMatchPortDaUsd` (match-LIST TCE path) resolved port names with **only** `resolvePort` (exact/alias). Vague range descriptors — `"European Continent"`, `"ARA range"`, `"East Coast Greece"`, `"1 safe port Sweden"`, etc. — return `null` from `resolvePort`, so their discharge DA was **silently dropped** ($0 contribution).

The DETAIL path (`app/api/voyage/tce/route.ts` → `resolvePortOrPassthrough`) already falls back to `resolveVaguePort`, mapping those descriptors to a representative basin port (e.g. ARA range → Rotterdam/NLRTM). Result: **list TCE underestimated DA vs the voyage P&L** for vague-discharge routes — part of the #1004 "one number" divergence.

## Fix (one line + import)

`lib/port-da/match-da.ts` — mirror the detail path:
```ts
const resolved = resolvePort(name) ?? resolveVaguePort(name);
```
Additive: exact-port names resolve first and are unaffected. Vague ports that previously dropped now contribute their real DA, matching DETAIL.

## Recon correction worth noting

The recon used bare `"ARA"` as the example, claiming `resolvePort("ARA") → null`. **Not true in this codebase** — `resolvePort('ARA')` fuzzy-matches the substring `"ara"` in **"Mtwara" (TZMYW)** and returns a (wrong) non-null port, so the `??` fallback never fires for bare `"ARA"`. The descriptors that *actually* trigger the dropped-DA bug (and that prod stores) are the **range forms** — `"ARA range"`, `"European Continent"` — which `resolvePort` correctly returns `null` for. The parity test therefore uses `"European Continent"`, the real prod-shaped descriptor. (Bare `"ARA"` mis-resolving to Mtwara is a separate latent `resolvePort` fuzzy-match landmine, out of scope here — it has parity since both list & detail call `resolvePort` first.)

## Tests

- Added failing-first parity test in `lib/port-da/__tests__/match-da.test.ts`: seed NLRTM row, `sumMatchPortDaUsd(['Marmara','European Continent'], 30000, null, db)` must equal `marmara_da + rotterdam_da` (33000), not just `marmara_da` (14000). RED before fix → GREEN after.
- `match-da` 9/9 · DA-parity + economics suites 23/23 · findRelatedTests on changed files: 102 suites / 757 passed, 1 skipped · `tsc --noEmit` clean.

## No backfill

`tce_usd_per_day` is recomputed live every `/matches` render via `persistSessionMatches` → `computeStoredMatchEconomics`. The frozen column auto-converges on next render. No migration.

## Scope

DA axis of #1004 only — **partial**. Bunker (#1002), Recalculate override (#1000), scoring labels (#1003) are separate sub-issues of the epic. Not closing #1004.

Refs #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)