### PR TITLE
fix(matches): distinguish bucket label from quality tier + demotion reason (#1003)

### DIFF
--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -19,6 +19,7 @@ import { MatchWorksheet } from '@/components/match/MatchWorksheet';
 import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
 import { cfValue } from '@/lib/types';
 import { getPortDistance } from '@/lib/sailing/port-distances';
+import { demotionReason } from '@/lib/sailing/match-scoring';
 import { getBalticDayRate } from '@/lib/market/baltic-freight';
 import { lookupCii } from '@/lib/imo/cii-lookup';
 
@@ -98,6 +99,17 @@ export default async function MatchDetailPage({ params }: Props) {
 
   const badgeCfg = sessionMatch
     ? (MATCH_LEVEL_BADGE[sessionMatch.matchLevel] ?? MATCH_LEVEL_BADGE.possible)
+    : null;
+
+  // Why does an 87%-fit match read as "Possible"? The ballast/size cap can demote a
+  // high-fit match below its fit-implied tier (#1003). Surface that reason so the
+  // pill, the fit-%, and the bucket label stop reading as a contradiction.
+  const demotionNote = sessionMatch
+    ? demotionReason(
+        sessionMatch.fitPercent ?? storedMatch.fit_percent ?? null,
+        sessionMatch.matchLevel,
+        sessionMatch.issues ?? [],
+      )
     : null;
 
   let worksheet: MatchWorksheetType | null = null;
@@ -219,11 +231,19 @@ export default async function MatchDetailPage({ params }: Props) {
                   {storedMatch.vessel_name ?? 'TBN'}
                 </h1>
                 {badgeCfg && (
-                  <Badge className="bg-ds-accent-soft text-ds-accent-soft-fg border-0 text-xs">
+                  <Badge
+                    className="bg-ds-accent-soft text-ds-accent-soft-fg border-0 text-xs"
+                    title={demotionNote ?? undefined}
+                  >
                     {badgeCfg.label}
                   </Badge>
                 )}
               </div>
+              {demotionNote && (
+                <p className="text-xs text-amber-300/90 mt-0.5 truncate" title={demotionNote}>
+                  Capped: {demotionNote}
+                </p>
+              )}
               {routeMeta && (
                 <p className="text-sm text-slate-300 truncate">{routeMeta}</p>
               )}

--- a/components/match/BucketReasonCard.tsx
+++ b/components/match/BucketReasonCard.tsx
@@ -2,7 +2,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import type { BucketReason } from '@/lib/matching/bucket-reason';
 
 const BUCKET_LABEL: Record<BucketReason['bucket'], { title: string; cls: string }> = {
-  main:             { title: 'Main match',      cls: 'text-emerald-600' },
+  main:             { title: 'Main list',       cls: 'text-emerald-600' },
   lowConfidence:    { title: 'Manual review',   cls: 'text-amber-600' },
   insufficientData: { title: 'Not enough data', cls: 'text-slate-500' },
   blocked:          { title: 'Blocked',          cls: 'text-red-500' },

--- a/components/match/__tests__/BucketReasonCard.test.tsx
+++ b/components/match/__tests__/BucketReasonCard.test.tsx
@@ -12,6 +12,15 @@ test('renders bucket label + reason', () => {
   expect(screen.getByText(/below the \$5,500\/day breakeven/)).toBeInTheDocument();
 });
 
+test('main bucket reads as a list partition, not a quality verdict (#1003)', () => {
+  // The bucket label must not contain the word "Match" — it is conflated with the
+  // quality-tier pill ("Possible Match") and reads as a contradiction (#1003).
+  render(<BucketReasonCard bucketReason={{ bucket: 'main',
+    reason: 'Passed all hard filters and economic thresholds.' }} />);
+  expect(screen.getByText('Main list')).toBeInTheDocument();
+  expect(screen.queryByText(/Main match/i)).not.toBeInTheDocument();
+});
+
 test('renders nothing when bucketReason absent (pre-this-PR data)', () => {
   const { container } = render(<BucketReasonCard bucketReason={undefined} />);
   expect(container).toBeEmptyDOMElement();

--- a/lib/sailing/__tests__/demotion-reason.test.ts
+++ b/lib/sailing/__tests__/demotion-reason.test.ts
@@ -1,0 +1,33 @@
+import { demotionReason } from '@/lib/sailing/match-scoring';
+
+describe('demotionReason', () => {
+  const ballast = 'BALLAST: 5400nm exceeds panamax ballast radius 3000nm — uneconomic, capped to possible';
+  const size = 'SIZE: cargo fills only 38% of vessel (deadfreight) — disproportion, capped to possible';
+
+  it('returns the ballast reason when a high-fit match was demoted below "good"', () => {
+    // fit 87% would derive "good", but ballast cap demoted it to "possible".
+    expect(demotionReason(87, 'possible', [ballast])).toBe(
+      '5400nm exceeds panamax ballast radius 3000nm — uneconomic, capped to possible',
+    );
+  });
+
+  it('returns the size reason when present', () => {
+    expect(demotionReason(82, 'possible', ['Some unrelated note', size])).toBe(
+      'cargo fills only 38% of vessel (deadfreight) — disproportion, capped to possible',
+    );
+  });
+
+  it('returns null when the level matches what the fit implies (no demotion)', () => {
+    // fit 87% → "good" and matchLevel is "good": nothing was demoted.
+    expect(demotionReason(87, 'good', [ballast])).toBeNull();
+  });
+
+  it('returns null when there is no cap issue to explain the demotion', () => {
+    expect(demotionReason(87, 'possible', ['Sanctions: medium risk'])).toBeNull();
+  });
+
+  it('returns null when fitPercent is null/undefined', () => {
+    expect(demotionReason(null, 'possible', [ballast])).toBeNull();
+    expect(demotionReason(undefined, 'possible', [ballast])).toBeNull();
+  });
+});

--- a/lib/sailing/match-scoring.ts
+++ b/lib/sailing/match-scoring.ts
@@ -171,6 +171,28 @@ export function deriveMatchLevelFromFit(fit: number): MatchLevel {
   return 'weak';
 }
 
+const MATCH_LEVEL_RANK: Record<MatchLevel, number> = { good: 3, possible: 2, weak: 1 };
+
+/**
+ * Broker-facing explanation of why a match sits below the tier its fit-% implies.
+ * A high fit-% can still be demoted to 'possible'/'weak' by the ballast/size cap
+ * (applyBallastSizeCap) — e.g. 87% fit but "Possible Match". This conflict reads as
+ * a contradiction (#1003) unless the cap reason is surfaced. Returns the cap issue
+ * text (BALLAST:/SIZE:, tag stripped) when a demotion happened, else null.
+ */
+export function demotionReason(
+  fitPercent: number | null | undefined,
+  matchLevel: MatchLevel,
+  issues: string[],
+): string | null {
+  if (fitPercent == null) return null;
+  const impliedRank = MATCH_LEVEL_RANK[deriveMatchLevelFromFit(fitPercent)];
+  if (impliedRank <= MATCH_LEVEL_RANK[matchLevel]) return null; // not demoted
+  const capIssue = (issues ?? []).find((i) => i.startsWith('BALLAST:') || i.startsWith('SIZE:'));
+  if (!capIssue) return null;
+  return capIssue.slice(capIssue.indexOf(':') + 1).trim();
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Ballast + size realism cap (Wave C — levers 3 + 4, handover 2026-05-30)
 //


### PR DESCRIPTION
## Problem (#1003)

Match detail showed **two scoring systems disagreeing** on one page:
`87% fit · "Possible Match" pill · "MAIN MATCH" bucket note`. The bucket
label "Main **match**" read like a third, conflicting quality verdict
next to the "Possible Match" pill.

## Fix (surgical, no scope creep)

1. **Bucket label** `Main match` → `Main list` (`BucketReasonCard.tsx`).
   It is a list partition, not a quality tier — so it no longer competes
   with the matchLevel pill.
2. **`demotionReason()`** (`lib/sailing/match-scoring.ts`): when the
   fit-% implies a higher tier than the assigned `matchLevel`, return the
   ballast/size cap issue (`BALLAST:`/`SIZE:`) that demoted it. Match
   detail now renders `Capped: <reason>`, so "87% fit but Possible" reads
   as **explained**, not contradictory.

## Out of scope (deferred)

- No DB column drop, no legacy `computeScoreBreakdown` change — the
  legacy scorer still runs in pair-analyzer. Removing it is a larger
  cross-cutting change; deferred per #1003 intent (low-severity clarity
  fix, no expectation rewrite).

## Tests

- New `lib/sailing/__tests__/demotion-reason.test.ts` (5 behavioral cases:
  ballast/size demotion, no-demotion null, no-cap-issue null, null fit).
- `BucketReasonCard.test.tsx`: asserts label reads "Main list", not
  "Main match".
- Affected suite: **877 passed / 1 skipped (95 suites)** · `tsc --noEmit` clean.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)