### PR TITLE
fix(dd-panel): counter.info reconciles hero breakdown + weight=0→inactive

### DIFF
--- a/__tests__/components/match/DueDiligencePanel-counter-info.test.ts
+++ b/__tests__/components/match/DueDiligencePanel-counter-info.test.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = process.cwd();
+const panelPath = path.join(ROOT, 'components/match/DueDiligencePanel.tsx');
+
+describe('DueDiligencePanel.tsx — info counter rendering', () => {
+  it('references counter.info in the render output', () => {
+    const src = fs.readFileSync(panelPath, 'utf8');
+    expect(src).toMatch(/counter\.info/);
+  });
+
+  it('guards info segment with counter.info > 0 so it hides when zero', () => {
+    const src = fs.readFileSync(panelPath, 'utf8');
+    expect(src).toMatch(/counter\.info\s*>\s*0/);
+  });
+});

--- a/components/match/DueDiligencePanel.tsx
+++ b/components/match/DueDiligencePanel.tsx
@@ -64,7 +64,7 @@ export function DueDiligencePanel({ model }: { model: DDModel }) {
           <p className="text-sm text-ds-text mt-1">
             Прогнали <span className="font-semibold">{counter.ran}</span> проверок
             <span className="text-ds-text-muted">
-              {' · '}{counter.pass} ✓ · {counter.caution} ⚠ · критичных стопов {criticalText}
+              {' · '}{counter.pass} ✓ · {counter.caution} ⚠{counter.info > 0 && <> · <Info className="inline h-3.5 w-3.5 align-text-bottom text-sky-600" aria-hidden /> {counter.info}</>} · критичных стопов {criticalText}
             </span>
           </p>
         </div>

--- a/lib/matching/__tests__/due-diligence.test.ts
+++ b/lib/matching/__tests__/due-diligence.test.ts
@@ -154,6 +154,22 @@ describe('buildDueDiligence', () => {
     expect(m.counter.ran).toBe(checks.filter((c) => c.state !== 'inactive').length);
   });
 
+  it('counter.info: breakdown reconciles — pass+caution+info === ran', () => {
+    const m = buildDueDiligence(fullArgs());
+    expect(m.counter).toHaveProperty('info');
+    expect(m.counter.pass + m.counter.caution + m.counter.info).toBe(m.counter.ran);
+    expect(m.counter.info).toBe(flat(m).filter((c) => c.state === 'info').length);
+  });
+
+  it('weight=0 component → inactive, not pass', () => {
+    const fb = fullFb();
+    const zeroWeightComp = fb.components.find((c) => c.factor === 'utilisation')!;
+    zeroWeightComp.weight = 0;
+    zeroWeightComp.score = 0;
+    const m = buildDueDiligence(fullArgs({ fitBreakdown: fb }));
+    expect(byLabel(m, 'Утилизация DWT')?.state).toBe('inactive');
+  });
+
   it('parity: fitPercent echoes the passed value, never recomputes from fitBreakdown', () => {
     // fb.fitPercent is 94 but the stored fit_percent is 87 → must use 87.
     const m = buildDueDiligence(fullArgs({ fitPercent: 87 }));

--- a/lib/matching/due-diligence.ts
+++ b/lib/matching/due-diligence.ts
@@ -43,7 +43,7 @@ export interface DDCategory {
 
 export interface DDModel {
   categories: DDCategory[];
-  counter: { ran: number; pass: number; caution: number; flagsCritical: number };
+  counter: { ran: number; pass: number; caution: number; info: number; flagsCritical: number };
   /** Echoes the passed stored fit-% verbatim — never recomputed (parity invariant). */
   fitPercent: number | null;
 }
@@ -75,7 +75,8 @@ function findComponent(
 /** Map a fit-breakdown component to a state by its earned-vs-weight ratio. */
 function componentState(c: FitBreakdownComponent | undefined): DDState {
   if (!c) return 'inactive';
-  const ratio = c.weight > 0 ? c.score / c.weight : 1;
+  if (c.weight === 0) return 'inactive';
+  const ratio = c.score / c.weight;
   return ratio >= PASS_THRESHOLD ? 'pass' : 'caution';
 }
 
@@ -331,6 +332,7 @@ export function buildDueDiligence(args: BuildDDArgs): DDModel {
     ran: active.length,
     pass: allChecks.filter((c) => c.state === 'pass').length,
     caution: allChecks.filter((c) => c.state === 'caution').length,
+    info: allChecks.filter((c) => c.state === 'info').length,
     // A blocking sanction would have removed this pair from the board — rare on a
     // detail page (the row exists because it survived), usually 0.
     flagsCritical: args.sanctions?.blocking ? 1 : 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16282,6 +16282,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## What

Fixes two bugs in the Due Diligence panel shipped in #1020:

**Bug 1 — Hero counter breakdown doesn't sum to N**
- Counter shows `Прогнали N проверок · X ✓ · Y ⚠` but `X+Y ≠ N` because info(ℹ) checks are counted in `ran` but not displayed
- Fix: add `counter.info` to `DDModel` builder; render `· ℹ {N}` segment in panel hero when `info > 0`

**Bug 2 (LOW-1) — Zero-weight component falsely shows `pass`**
- `componentState()` used `ratio = c.weight > 0 ? c.score / c.weight : 1` — when weight=0, ratio=1 ≥ 0.7 → `'pass'`
- Fix: guard `if (c.weight === 0) return 'inactive'`

## Files

- `lib/matching/due-diligence.ts` — `DDModel.counter` gains `info: number`; `componentState()` weight=0 guard; counter builder includes `info` count
- `components/match/DueDiligencePanel.tsx` — render `· ℹ N` when `counter.info > 0`
- `lib/matching/__tests__/due-diligence.test.ts` — 2 new tests: reconciliation + weight=0
- `__tests__/components/match/DueDiligencePanel-counter-info.test.ts` — 2 static-source tests for panel

## Verification

- `npx tsc --noEmit` → clean (0 errors)
- `jest --findRelatedTests due-diligence.ts DueDiligencePanel.tsx` → 26/26 passed + 2/2 panel tests = **28/28 green**
- `npm run build` → compiled ✓, `/match/[id]` server-rendered (ƒ), `DueDiligencePanel.tsx` in SSR chunks

## How to verify manually

Open `/match/<id>` → hero counter: `N проверок · X ✓ · Y ⚠ · ℹ Z` where `X+Y+Z = N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)