### PR TITLE
feat(match): Group B phase-2 — consume recovered cargo data + honest residue (#1021 #1022 #1023)

### DIFF
--- a/components/match/MatchWorksheet.tsx
+++ b/components/match/MatchWorksheet.tsx
@@ -52,7 +52,13 @@ export function MatchWorksheet({ worksheet }: Props) {
     return parts.length > 0 ? parts.join(' → ') : '—';
   })();
 
-  const rows: Array<{ label: string; vessel: string; cargoPort: string; verdict: string; detail?: React.ReactNode }> = [
+  // #1022 honest residue: cargo weight is TRULY absent (no nominal, no worst-case).
+  const weightTrulyAbsent = c.weightMt == null && c.weightMtEffective == null;
+  // Volume is unverifiable when there is neither a weight to derive stowage from
+  // nor an explicit recovered CBM figure.
+  const volumeTrulyAbsent = weightTrulyAbsent && c.volumeCbm == null;
+
+  const rows: Array<{ label: string; vessel: string; cargoPort: string; verdict: string; detail?: React.ReactNode; testId?: string }> = [
     {
       label: '⏱ Time',
       vessel: [r.openDate ? `free ${r.openDate}` : null, r.openPosition ? `@ ${r.openPosition}` : null].filter(Boolean).join(' ') || '—',
@@ -70,21 +76,31 @@ export function MatchWorksheet({ worksheet }: Props) {
     },
     {
       label: '⚖️ Weight',
+      testId: 'worksheet-weight-row',
       vessel: v.dwtSummer != null ? `${v.dwtSummer.toLocaleString('en-US')} DWT${v.dwcc != null ? ` / ${v.dwcc.toLocaleString('en-US')} DWCC` : ''}` : '—',
       cargoPort: c.weightMt != null
           ? (c.weightMtEffective != null && c.weightMtEffective !== c.weightMt
               ? `${c.weightMt.toLocaleString('en-US')} mt (${c.weightMtEffective.toLocaleString('en-US')} max w/ option)`
               : `${c.weightMt.toLocaleString('en-US')} mt`)
           : '—',
+      // #1022: never show a green "✅ OK" verdict when the cargo weight was never
+      // stated — that is a green lie. Surface honest "not verified" (LOW) instead.
       verdict: util != null
         ? `${util}% utilisation${util > 100 ? ' ❌' : util >= 85 ? ' ✅' : util >= 70 ? ' ⚠️' : ' ❌'}`
-        : verdictBadge(hf.volume.pass, hf.volume.reason),
+        : weightTrulyAbsent
+          ? '⚠️ Cargo weight not verified'
+          : verdictBadge(hf.volume.pass, hf.volume.reason),
     },
     {
       label: '📦 Volume',
+      testId: 'worksheet-volume-row',
       vessel: v.grainCapacity != null ? `${v.grainCapacity.toLocaleString('en-US')} ${v.grainCapacityUnit ?? 'cbm'}` : '—',
-      cargoPort: '—',
-      verdict: verdictBadge(hf.volume.pass, hf.volume.reason),
+      // #1021: surface the recovered net CBM figure when present.
+      cargoPort: c.volumeCbm != null ? `${c.volumeCbm.toLocaleString('en-US')} cbm` : '—',
+      // #1022: no false "✅ OK" when there is nothing to verify volume against.
+      verdict: volumeTrulyAbsent
+        ? '⚠️ Volume not verified'
+        : verdictBadge(hf.volume.pass, hf.volume.reason),
     },
     {
       label: '🚢 Type',
@@ -156,7 +172,7 @@ export function MatchWorksheet({ worksheet }: Props) {
         <tbody>
           {rows.map((row) => (
             <React.Fragment key={row.label}>
-              <tr className="border-t border-ds-border hover:bg-ds-bg/50">
+              <tr className="border-t border-ds-border hover:bg-ds-bg/50" data-testid={row.testId}>
                 <td className="py-2 px-3 font-medium text-ds-text-muted whitespace-nowrap">{row.label}</td>
                 <td className="py-2 px-3 text-ds-text">{row.vessel}</td>
                 <td className="py-2 px-3 text-ds-text">{row.cargoPort}</td>

--- a/components/match/__tests__/MatchWorksheet-honest-residue.test.tsx
+++ b/components/match/__tests__/MatchWorksheet-honest-residue.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Behavioral tests — MatchWorksheet honest residue (#1022, founder decision).
+ * When cargo weight/volume is TRULY absent, the worksheet must NOT render a
+ * false "✅ OK" verdict; it shows an honest "not verified" flag instead. The
+ * card STAYS in the Main List (no bucket change here).
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MatchWorksheet } from '../MatchWorksheet';
+import type { MatchWorksheet as MatchWorksheetType } from '@/lib/types';
+
+function makeWorksheet(cargo: Partial<MatchWorksheetType['cargo']>): MatchWorksheetType {
+  return {
+    readiness: {
+      verdict: 'ideal', explanation: '', openDate: null, openPosition: null,
+      laycanStart: null, laycanEnd: null, distanceNm: null, sailingDays: null,
+      speedKn: null, arrivalDate: null, gapDays: null,
+    },
+    vessel: {
+      draftMax: null, grainCapacity: 13000, grainCapacityUnit: null, geared: null,
+      vesselType: null, flag: null, built: null, pandi: null, classSociety: null,
+      lastCargoes: null, dwtSummer: 10000, dwcc: null,
+    },
+    cargo: {
+      weightMt: null, cargoType: null, loadPort: null, dischargePort: null,
+      ...cargo,
+    },
+    hardFilters: {
+      draft: { pass: true }, crane: { pass: true }, volume: { pass: true },
+    },
+  };
+}
+
+describe('MatchWorksheet — honest residue (#1022)', () => {
+  it('does NOT show ✅ OK on Weight when cargo weight is truly unknown', () => {
+    render(<MatchWorksheet worksheet={makeWorksheet({ weightMt: null, weightMtEffective: null })} />);
+    const row = screen.getByTestId('worksheet-weight-row');
+    expect(row).not.toHaveTextContent('OK');
+    expect(row).toHaveTextContent(/not verified/i);
+  });
+
+  it('does NOT show ✅ OK on Volume when neither weight nor volumeCbm stated', () => {
+    render(<MatchWorksheet worksheet={makeWorksheet({ weightMt: null, weightMtEffective: null, volumeCbm: null })} />);
+    const row = screen.getByTestId('worksheet-volume-row');
+    expect(row).not.toHaveTextContent('OK');
+    expect(row).toHaveTextContent(/not verified/i);
+  });
+
+  it('shows recovered volumeCbm in the Volume row when present', () => {
+    render(<MatchWorksheet worksheet={makeWorksheet({ weightMt: null, weightMtEffective: null, volumeCbm: 12000 })} />);
+    const row = screen.getByTestId('worksheet-volume-row');
+    expect(row).toHaveTextContent(/12,000\s*cbm/i);
+    expect(row).not.toHaveTextContent(/not verified/i);
+  });
+});

--- a/lib/matching/pair-analyzer.ts
+++ b/lib/matching/pair-analyzer.ts
@@ -69,6 +69,11 @@ export const IDLE_HARD_MAX_GAP_DAYS = 21;
 // PSC detention lookback for the vetting signal: 3 years before refYear.
 const PSC_LOOKBACK_YEARS = 3;
 
+// #1023 SOFT vessel-DWT gate (founder decision): fit-% penalty applied when a
+// vessel falls outside the cargo's requested DWT band. Strong (knocks the pair
+// off the main board most of the time) but NOT a hard exclusion.
+const DWT_OUT_OF_BAND_PENALTY = 25;
+
 /** Outcome of the matching pipeline: the main "worth calling" list plus the
  *  preserved side-buckets (no pair is ever dropped — see the partition below). */
 export interface AnalyzePairsResult {
@@ -145,6 +150,9 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     cargoFlagRequired: c.flagRequired ?? null,
     cargoClassRequired: c.classRequired ?? null,
     vesselOpenPosition: cfValue(v.openPosition) ?? null,
+    // #1023 SOFT gate — required vessel DWT band
+    cargoMinVesselDwtMt: c.minVesselDwtMt ?? null,
+    cargoMaxVesselDwtMt: c.maxVesselDwtMt ?? null,
   });
 
   const hardFilters: MatchHardFilters = {
@@ -162,6 +170,7 @@ function analyzePair(c: ParsedCargo, v: ParsedVessel, refYear: number, today: Da
     voyage: hf.checks.voyage,
     flagClass: hf.checks.flagClass,
     warPositionVoyage: hf.checks.warPositionVoyage,
+    vesselDwtRange: hf.checks.vesselDwtRange,
   };
 
   const imsbcCheck = checkImsbcLoadability(cfValue(c.cargoDescription), { restrictions: v.restrictions ?? [] });
@@ -747,6 +756,15 @@ export async function analyzePairs(
       });
       m.fitPercent = fb.fitPercent;
       m.fitBreakdown = fb;
+      // #1023 SOFT vessel-DWT gate (founder decision): a vessel outside the cargo's
+      // requested DWT band still matches, but takes a strong fit penalty + a surfaced
+      // flag. NOT a hard exclusion and NOT a forced bucket demotion — the pair routes
+      // normally; the penalty just lowers its headline %.
+      const dwtRange = analysis?.hardFilters?.vesselDwtRange;
+      if (dwtRange?.stated && !dwtRange.inRange) {
+        m.fitPercent = Math.max(0, Math.round((m.fitPercent - DWT_OUT_OF_BAND_PENALTY) * 10) / 10);
+        if (dwtRange.reason) m.issues = [...(m.issues ?? []), dwtRange.reason];
+      }
       // Derive matchLevel from fitPercent (spec §3.4); safety demotions below may lower it.
       m.matchLevel = deriveMatchLevelFromFit(m.fitPercent);
       // Safety demotion: ballast + size cap may lower the fit-derived level.

--- a/lib/sailing/__tests__/fit-breakdown.test.ts
+++ b/lib/sailing/__tests__/fit-breakdown.test.ts
@@ -10,6 +10,7 @@ import {
   scoreTiming,
   scoreVetting,
   scoreDraft,
+  scoreVolume,
 } from '../fit-breakdown';
 import type { MatchReadiness, MatchSanctions, MatchHardFilters, ParsedCargo, ParsedVessel } from '@/lib/types';
 
@@ -699,5 +700,34 @@ describe('#884 — HRC cargo on corrected-capacity YUCATAN vessel is a comfortab
     expect(result.score).toBe(0);
     expect(result.rationale).toContain('laden');
     expect(result.rationale).toContain('12.9');
+  });
+});
+
+describe('scoreVolume — CBM-only cargo (#1021 Group B)', () => {
+  it('scores volume from volumeCbm when weight is null (CBM cargo)', () => {
+    // SEAGULL 69 MDF: 12,000 net CBM, no weight stated, vessel grain 13,000 cbm
+    const c = scoreVolume(null, 'MDF', 13000, null, 12000);
+    expect(c.factor).toBe('volume');
+    expect(c.rationale).not.toMatch(/not stated/i);
+    expect(c.score).toBeGreaterThan(0);
+  });
+
+  it('stays unknown when neither weight nor volumeCbm present', () => {
+    const c = scoreVolume(null, null, 13000, null, null);
+    expect(c.rationale).toMatch(/not stated/i);
+  });
+
+  it('weight path still wins when weight present (volumeCbm ignored)', () => {
+    const c = scoreVolume(5000, 'wheat', 7000, null, 12000);
+    expect(c.bracketData).not.toMatch(/CBM/);
+  });
+
+  it('computeFitBreakdown wires cargo.volumeCbm into the volume factor', () => {
+    const cargo = makeCargo({ weightMt: null, weightMtMax: null, volumeCbm: 12000 });
+    const vessel = makeVessel({ grainCapacity: 13000 });
+    const bd = computeFitBreakdown({ cargo, vessel, readiness: READY_IDEAL, sanctions: SANCTIONS_OK, hardFilters: HF_PASS });
+    const vol = bd.components.find((x) => x.factor === 'volume')!;
+    expect(vol.rationale).not.toMatch(/not stated/i);
+    expect(vol.score).toBeGreaterThan(0);
   });
 });

--- a/lib/sailing/__tests__/match-filters.test.ts
+++ b/lib/sailing/__tests__/match-filters.test.ts
@@ -5,6 +5,7 @@ import {
   checkCargoVesselCompat,
   checkCargoWeight,
   checkImsbc,
+  checkVesselDwtRange,
   runHardFilters,
   STOWAGE_FACTORS,
 } from '../match-filters';
@@ -715,5 +716,69 @@ describe('runHardFilters — laden-draft gate (M3)', () => {
     expect(r.checks.destDraft.pass).toBe(true);
     expect(r.checks.draft.portLimitM).toBeUndefined();
     expect(r.checks.destDraft.portLimitM).toBeUndefined();
+  });
+});
+
+describe('checkVesselDwtRange (soft gate — #1023)', () => {
+  it('flags vessel below the requested band', () => {
+    // GRAIN TRADER P wants 12-14k dwt; SEAGULL 71 is 8,100 dwt
+    const r = checkVesselDwtRange({ vesselDwt: 8100, minVesselDwtMt: 12000, maxVesselDwtMt: 14000 });
+    expect(r.stated).toBe(true);
+    expect(r.inRange).toBe(false);
+    expect(r.reason).toMatch(/outside required DWT/i);
+  });
+
+  it('flags vessel above the requested band', () => {
+    const r = checkVesselDwtRange({ vesselDwt: 20000, minVesselDwtMt: 12000, maxVesselDwtMt: 14000 });
+    expect(r.inRange).toBe(false);
+  });
+
+  it('passes a vessel inside the band', () => {
+    const r = checkVesselDwtRange({ vesselDwt: 13000, minVesselDwtMt: 12000, maxVesselDwtMt: 14000 });
+    expect(r.stated).toBe(true);
+    expect(r.inRange).toBe(true);
+  });
+
+  it('passes within 5% tolerance of the band edges', () => {
+    const r = checkVesselDwtRange({ vesselDwt: 11500, minVesselDwtMt: 12000, maxVesselDwtMt: 14000 });
+    expect(r.inRange).toBe(true); // 12000*0.95 = 11400 ≤ 11500
+  });
+
+  it('is neutral when no DWT band stated', () => {
+    const r = checkVesselDwtRange({ vesselDwt: 8100, minVesselDwtMt: null, maxVesselDwtMt: null });
+    expect(r.stated).toBe(false);
+    expect(r.inRange).toBe(true);
+  });
+
+  it('cannot disprove when vessel DWT unknown', () => {
+    const r = checkVesselDwtRange({ vesselDwt: null, minVesselDwtMt: 12000, maxVesselDwtMt: 14000 });
+    expect(r.stated).toBe(true);
+    expect(r.inRange).toBe(true);
+  });
+});
+
+describe('runHardFilters — vesselDwtRange is SOFT (does not exclude)', () => {
+  it('out-of-band vessel still passes hard filters but reports vesselDwtRange', () => {
+    const r = runHardFilters({
+      cargoType: 'BULK',
+      originPort: null,
+      destinationPort: null,
+      weightMt: null,
+      cargoDescription: 'grain',
+      stowageFactor: null,
+      vesselType: 'Handysize Bulker',
+      geared: true,
+      draftMax: null,
+      grainCapacity: null,
+      dwtSummer: 8100,
+      dwcc: null,
+      cargoMinVesselDwtMt: 12000,
+      cargoMaxVesselDwtMt: 14000,
+    });
+    expect(r.checks.vesselDwtRange?.stated).toBe(true);
+    expect(r.checks.vesselDwtRange?.inRange).toBe(false);
+    // SOFT: the out-of-band condition must NOT fail the overall hard-filter gate
+    expect(r.pass).toBe(true);
+    expect(r.failures).not.toContain(r.checks.vesselDwtRange?.reason);
   });
 });

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -402,14 +402,38 @@ export function scoreCranes(
 }
 
 /** Volume / hold fit — stowage ratio of cargo m³ to vessel grain capacity. */
+function volumeShare(ratio: number): { share: number; note: string } {
+  if (ratio <= 0.7) return { share: 0.85, note: 'comfortable fit, room to spare' };
+  if (ratio <= 0.9) return { share: 1.0, note: 'ideal fill' };
+  if (ratio <= 1.0) return { share: 0.85, note: 'a tight but workable fit' };
+  return { share: 0.25, note: 'cargo overflows the holds' };
+}
+
 export function scoreVolume(
   cargoWtMax: number | null,
   cargoDescription: string | null,
   grainCapacity: number | null,
   stowageFactor: string | null,
+  volumeCbm: number | null = null,
 ): FitBreakdownComponent {
   const w = FIT_WEIGHTS.volume;
-  if (!cargoWtMax || cargoWtMax <= 0 || !grainCapacity || grainCapacity <= 0) {
+  const haveGrain = !!grainCapacity && grainCapacity > 0;
+  const haveWeight = !!cargoWtMax && cargoWtMax > 0;
+  // #1021: CBM-only cargo (net CBM recovered by Claude re-parse, no weight stated)
+  // — score the direct volumetric fit instead of returning unknown.
+  if (!haveWeight && volumeCbm != null && volumeCbm > 0 && haveGrain) {
+    const ratio = volumeCbm / grainCapacity!;
+    const { share, note } = volumeShare(ratio);
+    return {
+      factor: 'volume',
+      label: 'Volume / hold fit',
+      weight: w,
+      score: Math.round(w * share * 10) / 10,
+      rationale: `Cargo volume ~${Math.round(ratio * 100)}% of the ship's grain capacity (${fmt(volumeCbm)} cbm vs ${fmt(grainCapacity!)} cbm) — ${note}.`,
+      bracketData: `${Math.round(ratio * 100)}% of grain (CBM)`,
+    };
+  }
+  if (!haveWeight || !haveGrain) {
     return unknown('volume', 'Volume / hold fit', 'Cargo weight or grain capacity not stated, scored conservatively.');
   }
   // Resolve stowage factor (explicit > keyword > default)
@@ -628,7 +652,7 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
     scoreClassFit(cargoWtNominal, dwt, partCargo),
     scoreCargoTypeQuality(cargo.cargoType, vessel.vesselType, vessel.lastCargoes),
     scoreCranes(vessel.geared, cfValue(cargo.originPort), cfValue(cargo.destinationPort)),
-    scoreVolume(cargoWtNominal, desc, vessel.grainCapacity, cargo.stowageFactor),
+    scoreVolume(cargoWtNominal, desc, vessel.grainCapacity, cargo.stowageFactor, cargo.volumeCbm),
     scoreDraft(hardFilters),
     scoreVetting(vessel, refYear, detentionCount),
     scoreEconomics(tceUsdPerDay, dwt),

--- a/lib/sailing/match-filters.ts
+++ b/lib/sailing/match-filters.ts
@@ -417,6 +417,44 @@ export function checkVesselDimensions(input: VesselDimensionsCheckInput): Filter
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Vessel-DWT range check — SOFT gate (#1023, founder decision).
+//
+//   The cargo inquiry may request a vessel SIZE BAND in DWT ("any 12,000-14,000
+//   dwt vsl"). A vessel outside that band STILL matches — this is NOT a hard
+//   filter. It returns a soft descriptor that drives a score penalty + flag in
+//   pair-analyzer. Conservative: no band stated, or vessel DWT unknown → neutral.
+//   5% tolerance mirrors checkCargoWeight ("abt").
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface VesselDwtRangeResult {
+  /** A DWT band was stated on the cargo (something to enforce). */
+  stated: boolean;
+  /** Vessel is inside the band (or band/vessel unknown → cannot disprove → true). */
+  inRange: boolean;
+  reason?: string;
+}
+
+const VESSEL_DWT_RANGE_TOLERANCE = 0.05; // 5% "abt" tolerance on each band edge
+
+export function checkVesselDwtRange(args: {
+  vesselDwt: number | null;
+  minVesselDwtMt: number | null;
+  maxVesselDwtMt: number | null;
+}): VesselDwtRangeResult {
+  const { vesselDwt, minVesselDwtMt, maxVesselDwtMt } = args;
+  if (minVesselDwtMt == null && maxVesselDwtMt == null) return { stated: false, inRange: true };
+  if (vesselDwt == null || !Number.isFinite(vesselDwt)) return { stated: true, inRange: true }; // can't disprove
+  const lo = minVesselDwtMt != null ? minVesselDwtMt * (1 - VESSEL_DWT_RANGE_TOLERANCE) : -Infinity;
+  const hi = maxVesselDwtMt != null ? maxVesselDwtMt * (1 + VESSEL_DWT_RANGE_TOLERANCE) : Infinity;
+  if (vesselDwt >= lo && vesselDwt <= hi) return { stated: true, inRange: true };
+  return {
+    stated: true,
+    inRange: false,
+    reason: `Vessel ${Math.round(vesselDwt)} DWT outside required DWT ${minVesselDwtMt ?? '?'}-${maxVesselDwtMt ?? '?'}`,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // War-risk open position + tiny vessel + intercontinental voyage gate
 //
 // A sub-handy vessel (DWT < SUB_HANDY_DWT_THRESHOLD) open in a JWC HRA zone
@@ -510,6 +548,9 @@ export interface HardFilterInput {
   cargoFlagRequired?: string | null;
   cargoClassRequired?: string | null;
   vesselOpenPosition?: string | null;
+  // #1023 SOFT gate — required vessel DWT band (not a hard filter)
+  cargoMinVesselDwtMt?: number | null;
+  cargoMaxVesselDwtMt?: number | null;
 }
 
 export interface HardFilterResult {
@@ -531,6 +572,8 @@ export interface HardFilterResult {
     voyage?: FilterResult;
     flagClass?: FilterResult;
     warPositionVoyage?: FilterResult;
+    /** #1023 SOFT gate — out-of-band vessel does NOT add to failures; drives penalty+flag downstream. */
+    vesselDwtRange?: VesselDwtRangeResult;
   };
 }
 
@@ -595,6 +638,12 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
     originPort: input.originPort,
     destinationPort: input.destinationPort ?? null,
   });
+  // #1023 SOFT gate — computed but intentionally NOT added to `failures` below.
+  const vesselDwtRange = checkVesselDwtRange({
+    vesselDwt: input.dwtSummer ?? null,
+    minVesselDwtMt: input.cargoMinVesselDwtMt ?? null,
+    maxVesselDwtMt: input.cargoMaxVesselDwtMt ?? null,
+  });
 
   const failures: string[] = [];
   if (!draft.pass && draft.reason) failures.push(draft.reason);
@@ -618,6 +667,7 @@ export function runHardFilters(input: HardFilterInput): HardFilterResult {
     checks: {
       draft, crane, volume, cargoVessel, destDraft, destCrane, cargoWeight, imsbc,
       vesselAge, dimensions, gearRequired, voyage, flagClass, warPositionVoyage,
+      vesselDwtRange,
     },
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -441,6 +441,17 @@ export interface MatchHardFilters {
   voyage?: HardFilterCheck;
   flagClass?: HardFilterCheck;
   warPositionVoyage?: HardFilterCheck;
+  /** #1023 SOFT gate — required vessel-DWT band check. NOT a hard filter:
+   *  out-of-band vessel still matches but is penalised + flagged downstream. */
+  vesselDwtRange?: VesselDwtRangeCheck;
+}
+
+/** SOFT vessel-DWT band descriptor (#1023). Distinct from HardFilterCheck —
+ *  carries stated/inRange instead of pass, because it never excludes a pair. */
+export interface VesselDwtRangeCheck {
+  stated: boolean;
+  inRange: boolean;
+  reason?: string;
 }
 
 /** Sanctions screening (see lib/validation/sanctions.ts). */


### PR DESCRIPTION
## Group B — Cargo-Data Truth, Phase 2 (consume + honest-UI layer)

Phase 1 (parser rules + `volumeCbm`/`minVesselDwtMt`/`maxVesselDwtMt` fields + re-parsed demo data) is already on `main`. This PR **consumes** those recovered fields and makes the residue render honestly. Plan: `docs/superpowers/plans/2026-06-16-plan-B-cargo-data-truth.md` (Tasks 6–10).

### Tasks

- **Task 6 — `scoreVolume` consumes `volumeCbm` (#1021).** CBM-only cargo (net CBM recovered by the Claude re-parse, no weight stated) now gets a real volumetric fit score (`volumeCbm` ÷ grain capacity) instead of falling through to `unknown()`. `lib/sailing/fit-breakdown.ts`.
- **Task 7 — soft `checkVesselDwtRange` (#1023, founder decision).** New SOFT gate in `lib/sailing/match-filters.ts`. A vessel outside the cargo's requested DWT band (e.g. GRAIN TRADER P wants 12–14k dwt, SEAGULL 71 is 8.1k) **still matches** — it is **not** hard-filtered and **not** force-demoted to a bucket. It takes a strong fit-% penalty (`DWT_OUT_OF_BAND_PENALTY = 25`) + a surfaced `outside required DWT` issue. 5% edge tolerance. Wired through `HardFilterInput` → `runHardFilters` (kept OUT of `failures`) → `MatchHardFilters.vesselDwtRange` → `pair-analyzer.ts` penalty.
- **Task 8 — honest residue (#1022, founder decision).** `MatchWorksheet` no longer renders a false `✅ OK` on Weight/Volume when the cargo value is truly absent — it shows `⚠️ … not verified`. Recovered `volumeCbm` is surfaced in the Volume row. **Card stays in the Main List** (no new bucket, no re-routing). `components/match/MatchWorksheet.tsx`.
- **Task 9 — null → "not stated", no false footnote (#1021).** Already landed via Group A (`#1027` display tail): `app/match/[id]/page.tsx:378` guards `weightMt.value != null`, `SourceAttributionSection` filters `value != null`. Verified green, **not re-touched** (PI3).
- **Task 10 — prod-verify (post-merge).** Browser verification of the 3 demo examples is deferred to post-merge deploy (see TEST_STEP / verify checklist below).

### Founder decisions honoured (diverge from literal issue asks — do NOT "fix" back)
- #1023 = **SOFT** gate (flag + penalty), not a hard filter / exclusion.
- #1022 = honest LOW "not verified", card **stays in Main List** (no separate lead bucket).

### Tests
- `npx tsc --noEmit` → exit 0 (needs `--max-old-space-size=6144` on VPS).
- `findRelatedTests` over changed source files → **106 suites, 1064 passed, 1 skipped**.
- pair-analyzer related suite → **45 suites, 362 passed**.
- New behavioral tests: `scoreVolume` CBM path, `checkVesselDwtRange` (6 cases) + `runHardFilters` SOFT integration, `MatchWorksheet` honest-residue (3 cases).

### Post-merge browser verify (Task 10)
- SEAGULL 69 (MDF) → Volume row shows `12,000 cbm` (not `—`).
- SEAGULL 71 (cement) → Weight `5,000–5,500 mt`, no `null mt[¹]`.
- GRAIN TRADER P × SEAGULL 71 (8.1k) → `outside required DWT` flag + lowered fit, NOT `✅ OK`, still listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
