### PR TITLE
docs(recon): #1021 #1023 root-cause + code-merged status + prod backfill plan

### DIFF
--- a/recon-1021-1023.md
+++ b/recon-1021-1023.md
@@ -1,0 +1,280 @@
+# Recon Report — #1021 #1023 (Group B cargo-data-truth)
+
+Generated: 2026-06-17 · Branch: claude/1781692212-recon-1021-1023 (read-only)
+
+---
+
+## TL;DR
+
+**Code is fully merged** (PR #1033). **Data is NOT patched** in prod `parsed_results`.
+Fix is data-only: patch 2 rows in `parsed_results` + re-run `regenerate-matches.ts`.
+
+---
+
+## Bug #1021 — CBM volume dropped (SEAGULL 69, Chennai→Sohar MDF)
+
+### Root Cause
+
+Email `19e07d7c0f5b66c5` idx=0 was parsed by the LLM but the LLM did NOT extract
+`volumeCbm` from "Qty: about 12,000 net CBM / 13,500 gross CBM". Output: `volumeCbm=null`.
+
+T5 surgical graft (commit f2999b67, Jun 17 07:40) updated `demo-parsed-cargoes.json`
+to add `volumeCbm=12000`. But `parsed_results` DB (which `hydrate-demo-session.ts`
+and `regenerate-matches.ts` BOTH read from) was NOT updated.
+
+### Code-Merged Status
+
+PR #1033 (`feat(match): Group B phase-2`) merged **all three engine fixes**:
+
+| File | Change |
+|------|--------|
+| `lib/sailing/fit-breakdown.ts` | `scoreVolume(null, type, grain, sf, volumeCbm)` — uses CBM when weight null |
+| `lib/sailing/match-filters.ts` | `checkVesselDwtRange()` + `VESSEL_DWT_RANGE_TOLERANCE=5%` |
+| `lib/matching/pair-analyzer.ts` | Reads `cargo.minVesselDwtMt/maxVesselDwtMt`; applies `DWT_OUT_OF_BAND_PENALTY=25` |
+| `scripts/demo-seed/regenerate-matches.ts` | `buildWorksheet` carries `volumeCbm`, `minVesselDwtMt`, `maxVesselDwtMt` |
+| `lib/types.ts` | `ParsedCargo.volumeCbm`, `minVesselDwtMt`, `maxVesselDwtMt` fields |
+
+All 3 test files pass:
+- `__tests__/sample-data/demo-cargo-data-truth.test.ts` — 3/3 ✓
+- `lib/sailing/__tests__/fit-breakdown.test.ts` — 71/71 ✓
+- `lib/sailing/__tests__/match-filters.test.ts` — 75/75 ✓
+
+### Data Gap (why prod still broken)
+
+```
+demo-parsed-cargoes.json (repo)      ← T5 graft added volumeCbm=12000 ✓
+         ≠
+parsed_results (prod DB)             ← still volumeCbm=null ✗
+         ↓ (regenerate-matches reads from DB)
+matches.worksheet_json.cargo.volumeCbm  = null ✗
+matches.fit_breakdown.volume.rationale  = "not stated" ✗
+```
+
+`hydrate-demo-session.ts:93` reads `SELECT parse_type, result_json FROM parsed_results` →
+`parsedCargos` for the session → `volumeCbm=null` → scoring uses fallback "not stated".
+
+TRACE_READ confirmation via `qd-golden` DB (pre-T5 state, mirrors prod):
+```sql
+-- qd-golden: email 19e07d7c0f5b66c5 idx=0 → volumeCbm=None
+SELECT result_json FROM parsed_results
+WHERE gmail_message_id='19e07d7c0f5b66c5' AND parse_type='cargo';
+-- → item.volumeCbm = null (confirmed)
+```
+
+---
+
+## Bug #1023 — DWT range requirement ignored (GRAIN TRADER P vs SEAGULL 71)
+
+### Root Cause
+
+Email `19e07cc3ba833475` idx=0 (Thisvi→Monfalcone): "any 12,000-14,000 dwt vsl".
+LLM parse output: `minVesselDwtMt=null, maxVesselDwtMt=null`.
+
+T5 graft added `minVesselDwtMt=12000, maxVesselDwtMt=14000` to `demo-parsed-cargoes.json`.
+`parsed_results` in prod: still `null`.
+
+Engine path when `minVesselDwtMt=null`:
+```
+checkVesselDwtRange({ vesselDwt: 8100, minVesselDwtMt: null, maxVesselDwtMt: null })
+→ { stated: false, inRange: true }   // early return, no penalty
+```
+
+Engine path AFTER fix:
+```
+checkVesselDwtRange({ vesselDwt: 8100, minVesselDwtMt: 12000, maxVesselDwtMt: 14000 })
+lo = 12000 * 0.95 = 11400
+hi = 14000 * 1.05 = 14700
+8100 < 11400  → { stated: true, inRange: false, reason: "Vessel 8100 DWT outside required DWT 12000-14000" }
+→ fitPercent -= DWT_OUT_OF_BAND_PENALTY (25)   // e.g. 78% → 53%
+```
+
+Note: **SOFT gate** (founder decision). Vessel still appears in results but with penalty
++ "outside required DWT" in issues. No hard exclusion, no forced bucket demotion.
+
+### Data Gap
+
+```
+demo-parsed-cargoes.json (repo)      ← T5 graft: minVesselDwtMt=12000 ✓
+         ≠
+parsed_results (prod DB)             ← minVesselDwtMt=null ✗
+         ↓
+checkVesselDwtRange → stated=false → no penalty ✗
+```
+
+---
+
+## What's ALREADY Correct in DB
+
+SEAGULL 71 cement (`19e07c837ba011a2` idx=0, Al Arish→Latakia):
+- `weightMtMin=5000, weightMtMax=5500` **already in `parsed_results`** (qd-golden confirms)
+- The original LLM parse captured this correctly → no patch needed for this case
+
+---
+
+## Prod-Write Plan (Data-Only Fix)
+
+### Pre-conditions
+- Code from PR #1033 must be deployed (deploy at 12:18 today confirmed)
+- Run from `/root/work/quantika-demo` with `main` branch checked out
+
+### Step A — WAL-safe backup (NOT `cp`)
+```bash
+DB=/root/work/quantika-demo/data/demo-seed.db
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+sqlite3 "$DB" ".backup ${DB}.bak.${TS}"
+ls -la "${DB}.bak.${TS}"
+```
+
+### Step B — Dry-run backfill
+Use a new script `scripts/demo-seed/backfill-1021-cargo-data.ts`
+(modelled on `backfill-815-weights.ts`; patches `volumeCbm`, `minVesselDwtMt`,
+`maxVesselDwtMt` from `demo-parsed-cargoes.json` into `parsed_results`).
+
+```bash
+npx tsx scripts/demo-seed/backfill-1021-cargo-data.ts \
+  --db data/demo-seed.db --dry
+```
+
+Expected dry output:
+```
+WOULD-UPDATE emailId=19e07d7c0f5b66c5 itemIndex=0 fields=[volumeCbm] null → 12000
+WOULD-UPDATE emailId=19e07cc3ba833475 itemIndex=0 fields=[minVesselDwtMt,maxVesselDwtMt] null,null → 12000,14000
+done — updated=2 skipped-already-correct=N skipped-missing=0
+```
+
+### Step C — Live backfill
+```bash
+npx tsx scripts/demo-seed/backfill-1021-cargo-data.ts \
+  --db data/demo-seed.db
+```
+
+### Step D — Verify parsed_results
+```bash
+sqlite3 data/demo-seed.db "
+SELECT gmail_message_id,
+       json_extract(value, '$.itemIndex') idx,
+       json_extract(value, '$.volumeCbm') vol,
+       json_extract(value, '$.minVesselDwtMt') min_dwt,
+       json_extract(value, '$.maxVesselDwtMt') max_dwt
+FROM parsed_results,
+     json_each(result_json)
+WHERE gmail_message_id IN ('19e07d7c0f5b66c5','19e07cc3ba833475')
+  AND parse_type = 'cargo'
+ORDER BY gmail_message_id, idx;
+"
+```
+Pass criteria:
+- `19e07d7c0f5b66c5 idx=0`: `vol=12000`
+- `19e07cc3ba833475 idx=0`: `min_dwt=12000, max_dwt=14000`
+
+### Step E — Dry-run regenerate-matches
+```bash
+npx tsx scripts/demo-seed/regenerate-matches.ts --dry \
+  > /tmp/regen-1021-dry.log 2>&1
+tail -30 /tmp/regen-1021-dry.log
+```
+Inspect planned DELETE/INSERT counts. **Founder approval before Step F.**
+
+### Step F — Live regenerate-matches
+```bash
+npx tsx scripts/demo-seed/regenerate-matches.ts \
+  > /tmp/regen-1021-live.log 2>&1
+tail -30 /tmp/regen-1021-live.log
+```
+
+### Step G — Verify matches (before/after oracle)
+
+**SEAGULL 69 CBM oracle** (expect `ws_vol=12000` after regen):
+```sql
+SELECT m.id, m.vessel_name, m.fit_percent,
+       json_extract(m.worksheet_json, '$.cargo.volumeCbm') ws_vol,
+       json_extract(
+         json_extract(m.fit_breakdown, '$.components'),
+         '$[6].rationale'
+       ) vol_rationale
+FROM matches m
+WHERE m.cargo_id = '19e07d7c0f5b66c5'
+  AND m.cargo_item_index = 0
+  AND m.user_id IS NULL
+LIMIT 3;
+```
+Before: `ws_vol=null`, `vol_rationale` contains "not stated"
+After:  `ws_vol=12000`, `vol_rationale` contains "% of … grain capacity"
+
+**SEAGULL 71 DWT-filter oracle** (expect `min_dwt=12000`, fit penalized):
+```sql
+SELECT m.id, m.vessel_name, m.vessel_dwt, m.fit_percent,
+       json_extract(m.worksheet_json, '$.cargo.minVesselDwtMt') min_dwt,
+       json_extract(m.worksheet_json, '$.cargo.maxVesselDwtMt') max_dwt
+FROM matches m
+WHERE m.cargo_id = '19e07cc3ba833475'
+  AND m.cargo_item_index = 0
+  AND m.user_id IS NULL
+ORDER BY m.fit_percent DESC
+LIMIT 3;
+```
+Before: `min_dwt=null`, SEAGULL 71 (8100 DWT) has `fit_percent~78`
+After:  `min_dwt=12000`, SEAGULL 71 (8100 DWT) has `fit_percent~53` (78-25 penalty)
+
+### Step H — Restart app
+```bash
+systemctl restart quantika-demo
+journalctl -u quantika-demo --lines 30
+```
+
+### Step I — Invalidate stale demo sessions
+`regenerate-matches.ts` calls `invalidateActiveDemoSessions()` automatically.
+Stale sessions are cleared; next login re-hydrates from fresh NULL bucket.
+
+---
+
+## Expected Value Deltas
+
+### SEAGULL 69 (Chennai→Sohar MDF)
+| Field | Before | After |
+|-------|--------|-------|
+| `parsed_results.volumeCbm` | null | 12000 |
+| `matches.worksheet_json.cargo.volumeCbm` | null | 12000 |
+| `fit_breakdown.volume.rationale` | "not stated, scored conservatively" | "Cargo volume ~92% of ship's grain capacity (12000 cbm vs 13000 cbm)" |
+| `fit_breakdown.volume.score` | 0 (floor) | >0 (honest) |
+
+### GRAIN TRADER P (Thisvi→Monfalcone) vs SEAGULL 71 (8100 DWT)
+| Field | Before | After |
+|-------|--------|-------|
+| `parsed_results.minVesselDwtMt` | null | 12000 |
+| `matches.worksheet_json.cargo.minVesselDwtMt` | null | 12000 |
+| `checkVesselDwtRange.stated` | false | true |
+| `checkVesselDwtRange.inRange` | true | false |
+| `fit_percent` for 8100 DWT vessel | ~78% | ~53% (78-25 penalty) |
+| `issues` | [] | ["Vessel 8100 DWT outside required DWT 12000-14000"] |
+
+---
+
+## New Script Required: `backfill-1021-cargo-data.ts`
+
+Follows `backfill-815-weights.ts` pattern exactly. Patches from `demo-parsed-cargoes.json`:
+- Fields: `volumeCbm`, `minVesselDwtMt`, `maxVesselDwtMt`
+- Only 2 rows need patching (confirmed via qd-golden)
+- Idempotent; re-run produces 0 changes after first apply
+
+Also: 1 new email `19e07caab607dfe5` is in `demo-parsed-cargoes.json` but NOT in
+`parsed_results` (qd-golden reference). This email (Egypt Med salt, 5000mt, no CBM/DWT)
+is NOT related to #1021/#1023 and is non-critical; can be skipped or handled separately.
+
+---
+
+## Acceptance Criteria Status
+
+| Issue | Criterion | Status | Evidence |
+|-------|-----------|--------|----------|
+| #1021 | CBM volume captured in `volumeCbm` | ✓ code | `demo-parsed-cargoes.json:122 volumeCbm=12000`; `fit-breakdown.ts:scoreVolume` uses it |
+| #1021 | `scoreVolume` uses CBM when weight null | ✓ merged | `lib/sailing/fit-breakdown.ts:424-432`, test 71/71 ✓ |
+| #1021 | `parsed_results` has volumeCbm=12000 | ✗ NOT YET | needs `backfill-1021-cargo-data.ts` + regen |
+| #1021 | prod demo shows honest volume factor | ✗ NOT YET | blocked on data patch |
+| #1023 | DWT range parsed into `minVesselDwtMt` | ✓ code | `demo-parsed-cargoes.json:26 minVesselDwtMt=12000` |
+| #1023 | `checkVesselDwtRange` as soft gate | ✓ merged | `match-filters.ts:439`, `pair-analyzer.ts:763`, test 75/75 ✓ |
+| #1023 | `parsed_results` has minVesselDwtMt=12000 | ✗ NOT YET | needs backfill + regen |
+| #1023 | SEAGULL 71 (8100 DWT) penalized -25% | ✗ NOT YET | blocked on data patch |
+
+**Both issues: code merged, data not yet applied to prod.**
+Fix = `backfill-1021-cargo-data.ts` + `regenerate-matches.ts` run on prod.


### PR DESCRIPTION
## Summary

Recon-only PR (read-only investigation, no code changes). Delivers structured findings for Group B bugs #1021 and #1023.

- **#1021** (SEAGULL 69, CBM dropped): Engine code fully merged (PR #1033 `scoreVolume(volumeCbm)`). Root cause: `parsed_results` in prod still has `volumeCbm=null` for email `19e07d7c0f5b66c5 idx=0`. Fix = data-only backfill.
- **#1023** (DWT range ignored): Engine code fully merged (PR #1033 `checkVesselDwtRange` soft gate, `DWT_OUT_OF_BAND_PENALTY=25`). Root cause: `parsed_results` has `minVesselDwtMt=null` for `19e07cc3ba833475 idx=0`. Fix = data-only backfill.
- SEAGULL 71 cement (`weightMtMin=5000/5500`) already correct in `parsed_results` — no patch needed.

## What's needed next

New script `scripts/demo-seed/backfill-1021-cargo-data.ts` (modelled on `backfill-815-weights.ts`) patches `volumeCbm`, `minVesselDwtMt`, `maxVesselDwtMt` from `demo-parsed-cargoes.json` into `parsed_results`. Then `regenerate-matches.ts` rebuilds matches. Full procedure in `recon-1021-1023.md`.

## Test plan
- [x] All findings are read-only — no code changes
- [x] `__tests__/sample-data/demo-cargo-data-truth.test.ts` — 3/3 ✓
- [x] `lib/sailing/__tests__/match-filters.test.ts` — 75/75 ✓
- [x] `lib/sailing/__tests__/fit-breakdown.test.ts` — 71/71 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)