### PR TITLE
fix(quote): #1034 worker resolves cargo by match item-index

### DIFF
--- a/lib/quote-jobs/__tests__/select-parsed-cargo.test.ts
+++ b/lib/quote-jobs/__tests__/select-parsed-cargo.test.ts
@@ -1,0 +1,79 @@
+import Database from 'better-sqlite3';
+import type { ParsedCargo } from '@/lib/types';
+import { selectParsedCargo } from '../../../scripts/quote-workshop/worker';
+
+// #1034: a multi-cargo email has several parsedCargos that share one emailId,
+// distinguished only by itemIndex. The worker must pick the cargo that the JOB's
+// match is actually for (match.cargo_item_index), NOT just the first item.
+
+function buildMatchesDb(cargoItemIndex: number | null): {
+  db: Database.Database;
+  matchId: string;
+} {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cargo_id TEXT NOT NULL DEFAULT '',
+      vessel_id TEXT NOT NULL DEFAULT '',
+      score INTEGER NOT NULL DEFAULT 0,
+      reason TEXT NOT NULL DEFAULT '',
+      user_id TEXT,
+      created_at INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL DEFAULT 0,
+      cargo_item_index INTEGER,
+      vessel_item_index INTEGER
+    )
+  `);
+  const r = db
+    .prepare(`INSERT INTO matches (cargo_item_index, vessel_item_index) VALUES (?, 0)`)
+    .run(cargoItemIndex);
+  return { db, matchId: String(r.lastInsertRowid) };
+}
+
+const EMAIL = 'email-X';
+
+function cargo(itemIndex: number, dest: string, weightMt: number): ParsedCargo {
+  return {
+    emailId: EMAIL,
+    itemIndex,
+    destinationPort: { value: dest, confidence: 'high' },
+    weightMt: { value: weightMt, confidence: 'high' },
+  } as unknown as ParsedCargo;
+}
+
+// item0 = Djibouti/Tadjourah ~8500 MT sibling; item1 = Berbera 2800 MT.
+const item0 = cargo(0, 'Djibouti', 8500);
+const item1 = cargo(1, 'Berbera', 2800);
+const session = { parsedCargos: [item0, item1] };
+
+it('picks the Berbera 2800 cargo (itemIndex=1) when the match is for item 1', () => {
+  const { db, matchId } = buildMatchesDb(1);
+  const job = { email_id: EMAIL, match_id: matchId, session_id: 's1' };
+  const picked = selectParsedCargo(db, session, job);
+  expect(picked).toBe(item1);
+  expect(picked!.itemIndex).toBe(1);
+  expect(picked!.destinationPort!.value).toBe('Berbera');
+  expect(picked!.weightMt!.value).toBe(2800);
+});
+
+it('picks item 0 when the match is for item 0', () => {
+  const { db, matchId } = buildMatchesDb(0);
+  const job = { email_id: EMAIL, match_id: matchId, session_id: 's1' };
+  const picked = selectParsedCargo(db, session, job);
+  expect(picked).toBe(item0);
+  expect(picked!.itemIndex).toBe(0);
+});
+
+it('falls back to item 0 when the job has no numeric match_id', () => {
+  const { db } = buildMatchesDb(1);
+  const job = { email_id: EMAIL, match_id: null, session_id: 's1' };
+  const picked = selectParsedCargo(db, session, job);
+  expect(picked).toBe(item0);
+});
+
+it('returns undefined when no parsedCargo matches the resolved item index', () => {
+  const { db, matchId } = buildMatchesDb(5);
+  const job = { email_id: EMAIL, match_id: matchId, session_id: 's1' };
+  expect(selectParsedCargo(db, session, job)).toBeUndefined();
+});

--- a/scripts/quote-workshop/worker.ts
+++ b/scripts/quote-workshop/worker.ts
@@ -3,12 +3,37 @@
  * Serial drain: claims one job, calls callClaudeCliRaw (blocking spawnSync), notifies Next, repeat.
  * Exits when queue is empty.
  */
+import type Database from 'better-sqlite3';
 import { getStore } from '@/lib/session-store';
 import { callClaudeCliRaw } from '@/lib/ai-provider';
 import { claimNextJob, completeJob, failJob, reapStaleJobs, heartbeatJob } from '@/lib/quote-jobs/store';
 import { buildQuotePrompt } from '@/lib/quote-jobs/prompt';
+import { getMatch } from '@/lib/matching/matches-repository';
 import { isRagEnabled } from '@/lib/knowledge/flags';
 import { today } from '@/lib/clock';
+import type { ParsedCargo } from '@/lib/types';
+
+/**
+ * #1034: a multi-cargo email yields several parsedCargos that share one emailId,
+ * distinguished only by itemIndex. Resolving by emailId ALONE returns item 0
+ * regardless of which item the match is for. Mirror the (emailId|itemIndex)
+ * keying used by persist-session-matches.ts:50 and app/match/[id]/page.tsx:85 —
+ * read the target item index from the job's match (migration 049 stores match_id).
+ */
+export function selectParsedCargo(
+  db: Database.Database,
+  session: { parsedCargos?: ParsedCargo[] } | null | undefined,
+  job: { email_id: string; match_id: string | null },
+): ParsedCargo | undefined {
+  let targetItemIndex = 0;
+  if (job.match_id && /^[0-9]+$/.test(job.match_id)) {
+    const m = getMatch(db, Number(job.match_id));
+    if (m?.cargo_item_index != null) targetItemIndex = m.cargo_item_index;
+  }
+  return (session?.parsedCargos ?? []).find(
+    (r) => r.emailId === job.email_id && r.itemIndex === targetItemIndex,
+  );
+}
 
 const MODEL = process.env.DRAFT_QUOTE_CLI_MODEL ?? 'claude-sonnet-4-6';
 const BUDGET = Number(process.env.DRAFT_QUOTE_CLI_BUDGET_USD) || 0.20;
@@ -37,7 +62,7 @@ async function main() {
     if (!job) break;
 
     const session = store.getSession(job.session_id);
-    const parsedCargo = (session?.parsedCargos ?? []).find((r: { emailId: string }) => r.emailId === job.email_id);
+    const parsedCargo = selectParsedCargo(db, session, job);
     if (!parsedCargo) {
       failJob(db, job.id, 'session or parsed cargo no longer available');
       await notify(job.session_id, { id: job.id, status: 'error', email_id: job.email_id, error: 'session expired' });
@@ -73,4 +98,9 @@ async function main() {
   }
 }
 
-main().then(() => process.exit(0)).catch((e) => { console.error('[quote-worker] fatal:', e); process.exit(1); });
+// Entry guard: `npm run quote:workshop` (tsx) drains the queue; under jest
+// (NODE_ENV=test) the module is imported to unit-test selectParsedCargo, so we
+// must NOT spawn the drain loop / process.exit on import.
+if (process.env.NODE_ENV !== 'test') {
+  main().then(() => process.exit(0)).catch((e) => { console.error('[quote-worker] fatal:', e); process.exit(1); });
+}


### PR DESCRIPTION
## Problem (#1034, HIGH, Class B — wrong commercial doc)
On a multi-cargo email, Draft Quote was generated for the **wrong cargo item**. Prod repro (2026-06-17): match *M/V SEAGULL 41 · Nemrut Bay → Berbera · Steel 2800 MT* produced a quote for *Nemrut Bay → Djibouti/Tadjourah · Steel 8,000–9,000 MT* — the sibling item from the same email.

## Root cause
`scripts/quote-workshop/worker.ts:40` resolved the cargo by **emailId alone**:
```ts
const parsedCargo = (session?.parsedCargos ?? []).find(r => r.emailId === job.email_id);
```
For a multi-cargo email that returns `itemIndex=0` (Djibouti 8-9k) regardless of which item the match is for. The match was for `itemIndex=1` (Berbera 2800 MT).

## Fix (Fix 1 — surgical, NO migration)
Read the target item index from the job's match (`getMatch(db, match_id).cargo_item_index`, stored since migration 049) and key the lookup on `(emailId|itemIndex)`:
```ts
const parsedCargo = selectParsedCargo(db, session, job);
```
Mirrors the correct keying already used in `persist-session-matches.ts:50` and `app/match/[id]/page.tsx:85`. Extracted `selectParsedCargo()` + a `NODE_ENV !== 'test'` entry guard so the drain loop is unit-testable without spawning on import.

## Tests
`lib/quote-jobs/__tests__/select-parsed-cargo.test.ts` (TDD — written failing first):
- picks Berbera/2800 (itemIndex=1) when match.cargo_item_index=1 — the #1034 repro
- picks item 0 when match is for item 0
- falls back to item 0 when job has no numeric match_id
- returns undefined when no cargo matches the resolved index

`npx jest lib/quote-jobs` → 47/47 green · `tsc --noEmit` clean.

## Deferred follow-up
**Fix 2 (dedup key in `lib/quote-jobs/store.ts`)** is intentionally **deferred** per founder decision — NOT included here, no migration added. Tracked as a follow-up.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)