### PR TITLE
fix(demo): #1024 strip false laycan [¹] footnote in hydrate path

### DIFF
--- a/app/match/[id]/page.tsx
+++ b/app/match/[id]/page.tsx
@@ -379,7 +379,10 @@ export default async function MatchDetailPage({ params }: Props) {
                       ...(cargo.originPort ? [{ label: 'Load Port', value: cargo.originPort }] : []),
                       ...(cargo.destinationPort ? [{ label: 'Discharge Port', value: cargo.destinationPort }] : []),
                       ...(laycanDisplay
-                    ? [{ label: 'Laycan', value: { value: laycanDisplay, confidence: 'confirmed' as const, sourceText: cargo.preferredDates?.sourceText } }]
+                    // #1024: laycanDisplay is synthesized/shifted — do NOT carry
+                    // sourceText (the original email date quote), else a false [¹]
+                    // citation renders. Defense-in-depth over Fix A in hydrate.
+                    ? [{ label: 'Laycan', value: { value: laycanDisplay, confidence: 'confirmed' as const } }]
                     : cargo.preferredDates
                       ? [{ label: 'Laycan', value: cargo.preferredDates }]
                       : []),

--- a/lib/demo-mode/__tests__/hydrate-demo-session-laycan-source.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session-laycan-source.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test (#1024): the hydrate path (PROD login) must strip
+ * preferredDates.sourceText so a synthesized/shifted laycan does NOT render a
+ * false [¹] Source-Attribution footnote.
+ *
+ * Two write-paths exist:
+ *   - createDemoSession → rebaseParsedCargoes (dropLaycanSource) — already strips.
+ *   - hydrateDemoSession → buildDemoSessionBlob — loaded parsed_results AS-IS and
+ *     preserved the original email date quote (sourceText), while the displayed
+ *     laycan is the synthesized value → false [¹].
+ *
+ * After Fix A both paths behave the same: preferredDates.sourceText === undefined.
+ */
+import Database from 'better-sqlite3';
+import { buildDemoSessionBlob } from '../hydrate-demo-session';
+
+const EMAIL_ID = '19e0cafef00dba1';
+const ITEM_INDEX = 0;
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE emails (
+      account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+      from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+      body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+    );
+    CREATE TABLE parsed_results (
+      account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+      result_json TEXT, parsed_at INTEGER
+    );
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+      reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+      reason_structured TEXT
+    );
+  `);
+
+  db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, from_name, from_email, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+    VALUES ('demo',?,?,?,?,?,'me@demo.local','Cargo Nemrut/Berbera','2026-05-20','L/C 07/10 May','snip','["INBOX"]',0)`)
+    .run(EMAIL_ID, `t-${EMAIL_ID}`, `Sender <sender@demo.local>`, 'Sender', 'sender@demo.local');
+
+  // A cargo whose preferredDates carries the ORIGINAL email date quote in
+  // sourceText ('07/10 May') while .value is the synthesized/shifted laycan.
+  const cargoRow = JSON.stringify([{
+    emailId: EMAIL_ID, itemIndex: ITEM_INDEX,
+    cargoDescription: '2,800 mt steel',
+    laycan: '2026-06-03 to 2026-06-06',
+    preferredDates: {
+      value: '2026-06-03 to 2026-06-06',
+      confidence: 'confirmed',
+      sourceText: '07/10 May',
+    },
+  }]);
+
+  db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at) VALUES ('demo',?,?,?,?,?)`)
+    .run(EMAIL_ID, 'cargo', 'v1', cargoRow, 0);
+
+  return db;
+}
+
+describe('buildDemoSessionBlob — strip false laycan [¹] footnote (#1024)', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = makeDb(); });
+  afterEach(() => { db.close(); });
+
+  it('drops preferredDates.sourceText for a shifted laycan (no false [¹])', () => {
+    const blob = buildDemoSessionBlob(db);
+    const cargo = blob.parsedCargos.find(
+      (c) => c.emailId === EMAIL_ID && c.itemIndex === ITEM_INDEX,
+    );
+    expect(cargo).toBeDefined();
+    expect(cargo!.preferredDates).not.toBeNull();
+    // sourceText stripped → SourceAttributionSection renders no [¹] for laycan.
+    expect(cargo!.preferredDates!.sourceText).toBeUndefined();
+    // displayed value is preserved.
+    expect(cargo!.preferredDates!.value).toBe('2026-06-03 to 2026-06-06');
+  });
+});

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -107,7 +107,16 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   }
 
   const dedupedVessels = dedupByKey(parsedVessels);
-  const dedupedCargos  = dedupByKey(parsedCargos);
+  // #1024: the displayed laycan is synthesized/shifted to keep the demo current,
+  // but preferredDates.sourceText still carries the ORIGINAL email date quote —
+  // SourceAttributionSection would render a false [¹] citation. Strip it here,
+  // mirroring rebaseParsedCargoes' dropLaycanSource (the createDemoSession path),
+  // so both write-paths behave the same. Read-time only — no prod-data write.
+  const dedupedCargos = dedupByKey(parsedCargos).map((c) =>
+    c.preferredDates
+      ? { ...c, preferredDates: { ...c.preferredDates, sourceText: undefined } }
+      : c,
+  );
   for (const v of dedupedVessels) {
     // CBFT→CBM: code is the single owner of the conversion — shared util, the
     // SAME one the engine/regen intake calls (#984 follow-up), so all readers


### PR DESCRIPTION
## Problem (#1024)
PROD login uses `hydrateDemoSession` → `buildDemoSessionBlob` (lib/demo-mode/hydrate-demo-session.ts), which loaded `parsed_results` AS-IS and **never stripped** `preferredDates.sourceText`. The displayed laycan is synthesized/shifted (to keep the demo current), but `sourceText` still carried the **original email date quote** → `SourceAttributionSection` (`:29`, renders `[¹]` when `value.sourceText` truthy) showed a **false citation** as if the date came verbatim from the source email.

**TWO-WRITE-PATHS recurrence:** the `dropLaycanSource` fix (commit `7f903f05`) was applied only in `lib/sample-data/rebase-parsed.ts`, which runs for `createDemoSession` — not for the prod hydrate path.

## Fix
- **Fix A (primary):** strip `preferredDates.sourceText` on `dedupedCargos` in `hydrate-demo-session.ts`, mirroring `rebaseParsedCargoes`' `dropLaycanSource` exactly. Both write-paths now behave the same. Read-time only — **no migration, no prod-data write**.
- **Fix B (defense-in-depth):** drop `sourceText` from the synthesized `laycanDisplay` branch in `app/match/[id]/page.tsx`. The `else` branch (where `cargo.preferredDates` IS the real source) keeps its `sourceText` intact.

## Scope
- **Laycan footnote ONLY.** Vessel-open-date is **out of scope**: it is synthesized but **no source is claimed** for it → no false footnote → untouched.

## Test
New behavioral test `hydrate-demo-session-laycan-source.test.ts`: builds a session blob from an in-memory DB whose cargo carries a shifted laycan + original-quote `sourceText`, asserts `preferredDates.sourceText === undefined` (and `.value` preserved). FAILS on current code, passes after Fix A.

## Parity
After this, `createDemoSession` (rebaseParsedCargoes) and `hydrateDemoSession` both strip the synthesized-laycan citation.

Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)