### PR TITLE
chore(demo-seed): #1021 #1023 backfill script for CBM volume + DWT-range in parsed_results

### DIFF
--- a/scripts/demo-seed/__tests__/backfill-1021-cargo-data.test.ts
+++ b/scripts/demo-seed/__tests__/backfill-1021-cargo-data.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Behavioral tests for backfill-1021-cargo-data.ts
+ *
+ * Data-half of #1033 (engine fixes for #1021 CBM volume + #1023 DWT-range).
+ * Tests run against a synthetic SQLite DB seeded so that the two in-scope cargo
+ * rows carry the pre-backfill (null) state:
+ *   - 19e07d7c0f5b66c5 item 0: volumeCbm=null         (#1021)
+ *   - 19e07cc3ba833475 item 0: minVesselDwtMt=null,
+ *                              maxVesselDwtMt=null     (#1023)
+ * The unrelated Egypt-Med salt email (19e07caab607dfe5) is seeded with
+ * volumeCbm=null and must stay null (out of scope).
+ */
+import Database from 'better-sqlite3';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as child_process from 'node:child_process';
+
+const CBM_EMAIL_ID = '19e07d7c0f5b66c5'; // #1021 — volumeCbm
+const DWT_EMAIL_ID = '19e07cc3ba833475'; // #1023 — min/maxVesselDwtMt
+const SALT_EMAIL_ID = '19e07caab607dfe5'; // out of scope — must stay null
+
+const SCRIPT_PATH = path.resolve(__dirname, '../backfill-1021-cargo-data.ts');
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+// Pre-backfill (null) item 0 for the CBM cargo (#1021).
+const CBM_STALE_ITEM_0 = {
+  emailId: CBM_EMAIL_ID,
+  itemIndex: 0,
+  originPort: { value: 'Chennai', confidence: 'interpreted', sourceText: 'Chennai' },
+  destinationPort: { value: 'Fujairah', confidence: 'interpreted', sourceText: 'Fujairah' },
+  cargoDescription: { value: 'General cargo ~12,000 net CBM', confidence: 'interpreted', sourceText: 'CBM' },
+  weightMt: null,
+  weightMtMin: null,
+  weightMtMax: null,
+  volumeCbm: null, // pre-#1021 state — to be backfilled to 12000
+  cargoType: 'BREAK_BULK',
+  laycan: 'Mid to end May 2026',
+  minVesselDwtMt: null,
+  maxVesselDwtMt: null,
+};
+
+// Pre-backfill (null) item 0 for the DWT-range cargo (#1023).
+const DWT_STALE_ITEM_0 = {
+  emailId: DWT_EMAIL_ID,
+  itemIndex: 0,
+  originPort: { value: 'Thisvi', confidence: 'confirmed', sourceText: 'Thisvi' },
+  destinationPort: { value: 'Monfalcone', confidence: 'confirmed', sourceText: 'Monfalcone' },
+  cargoDescription: { value: 'Cargo not specified', confidence: 'uncertain', sourceText: 'cargo' },
+  weightMt: null,
+  weightMtMin: null,
+  weightMtMax: null,
+  volumeCbm: null,
+  cargoType: 'OTHER',
+  laycan: '17-22 May 2026',
+  minVesselDwtMt: null, // pre-#1023 state — to be backfilled to 12000
+  maxVesselDwtMt: null, // pre-#1023 state — to be backfilled to 14000
+};
+
+// Out-of-scope salt email — volumeCbm intentionally null, must stay null.
+const SALT_ITEM_0 = {
+  emailId: SALT_EMAIL_ID,
+  itemIndex: 0,
+  originPort: { value: 'Egypt Med', confidence: 'interpreted', sourceText: 'Egypt Med' },
+  destinationPort: { value: 'POC', confidence: 'interpreted', sourceText: 'POC' },
+  cargoDescription: { value: 'Salt in big bags', confidence: 'interpreted', sourceText: 'salt' },
+  weightMt: { value: 5000, confidence: 'interpreted', sourceText: '5000' },
+  weightMtMin: 4500,
+  weightMtMax: 5500,
+  volumeCbm: null, // intentionally null — must NOT be touched
+  cargoType: 'BULK',
+  laycan: 'Spot',
+  minVesselDwtMt: null,
+  maxVesselDwtMt: null,
+};
+
+function createSyntheticDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS parsed_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      account_id TEXT NOT NULL DEFAULT 'demo',
+      gmail_message_id TEXT NOT NULL,
+      parse_type TEXT NOT NULL,
+      parser_version TEXT NOT NULL DEFAULT '1.0',
+      result_json TEXT NOT NULL,
+      parsed_at INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  const insert = db.prepare(
+    `INSERT INTO parsed_results (gmail_message_id, parse_type, result_json) VALUES (?, 'cargo', ?)`,
+  );
+  insert.run(CBM_EMAIL_ID, JSON.stringify([CBM_STALE_ITEM_0]));
+  insert.run(DWT_EMAIL_ID, JSON.stringify([DWT_STALE_ITEM_0]));
+  insert.run(SALT_EMAIL_ID, JSON.stringify([SALT_ITEM_0]));
+  db.close();
+}
+
+function runBackfill(dbPath: string, extraArgs: string[] = []): { stdout: string; stderr: string; exitCode: number } {
+  const result = child_process.spawnSync('npx', ['tsx', SCRIPT_PATH, '--db', dbPath, ...extraArgs], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
+  };
+}
+
+function readItems(dbPath: string, emailId: string): Record<string, unknown>[] {
+  const db = new Database(dbPath, { readonly: true });
+  const row = db
+    .prepare(`SELECT result_json FROM parsed_results WHERE gmail_message_id=? AND parse_type='cargo'`)
+    .get(emailId) as { result_json: string };
+  db.close();
+  return JSON.parse(row.result_json);
+}
+
+describe('backfill-1021-cargo-data', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-1021-test-'));
+    dbPath = path.join(tmpDir, 'demo-seed.db');
+    createSyntheticDb(dbPath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('live run: sets volumeCbm=12000 (#1021) on the CBM cargo item 0', () => {
+    const { exitCode } = runBackfill(dbPath);
+    expect(exitCode).toBe(0);
+    expect(readItems(dbPath, CBM_EMAIL_ID)[0].volumeCbm).toBe(12000);
+  });
+
+  it('live run: sets minVesselDwtMt=12000 / maxVesselDwtMt=14000 (#1023) on the DWT cargo item 0', () => {
+    const { exitCode } = runBackfill(dbPath);
+    expect(exitCode).toBe(0);
+    const item0 = readItems(dbPath, DWT_EMAIL_ID)[0];
+    expect(item0.minVesselDwtMt).toBe(12000);
+    expect(item0.maxVesselDwtMt).toBe(14000);
+  });
+
+  it('dry run: leaves DB unchanged but logs WOULD-UPDATE for both in-scope emails', () => {
+    const dbBefore = fs.readFileSync(dbPath);
+    const { stdout, stderr, exitCode } = runBackfill(dbPath, ['--dry']);
+    const output = stdout + stderr;
+
+    expect(exitCode).toBe(0);
+    // DB file must be byte-for-byte identical (no writes)
+    expect(dbBefore.equals(fs.readFileSync(dbPath))).toBe(true);
+    expect(output).toMatch(/WOULD-UPDATE/);
+    expect(output).toMatch(CBM_EMAIL_ID);
+    expect(output).toMatch(DWT_EMAIL_ID);
+    // Values must still be null after a dry run
+    expect(readItems(dbPath, CBM_EMAIL_ID)[0].volumeCbm).toBeNull();
+    expect(readItems(dbPath, DWT_EMAIL_ID)[0].minVesselDwtMt).toBeNull();
+  });
+
+  it('does NOT touch the out-of-scope salt email (volumeCbm stays null)', () => {
+    runBackfill(dbPath);
+    expect(readItems(dbPath, SALT_EMAIL_ID)[0].volumeCbm).toBeNull();
+  });
+
+  it('leaves unrelated fields on in-scope rows untouched', () => {
+    runBackfill(dbPath);
+    const cbm = readItems(dbPath, CBM_EMAIL_ID)[0];
+    expect(cbm.cargoType).toBe('BREAK_BULK');
+    expect((cbm.originPort as { value: string }).value).toBe('Chennai');
+    // #1023 fields not in this row's target set stay null
+    expect(cbm.minVesselDwtMt).toBeNull();
+
+    const dwt = readItems(dbPath, DWT_EMAIL_ID)[0];
+    expect(dwt.cargoType).toBe('OTHER');
+    // #1021 field not in this row's target set stays null
+    expect(dwt.volumeCbm).toBeNull();
+  });
+
+  it('idempotent: second run produces 0 updates', () => {
+    const r1 = runBackfill(dbPath);
+    expect(r1.exitCode).toBe(0);
+
+    const r2 = runBackfill(dbPath);
+    const output = r2.stdout + r2.stderr;
+    expect(r2.exitCode).toBe(0);
+    expect(output).not.toMatch(/\bUPDATED emailId=/);
+    expect(output).toMatch(/updated=0/i);
+  });
+
+  it('summary always includes updated / skipped-already-correct / skipped-missing', () => {
+    const { stdout, stderr } = runBackfill(dbPath);
+    const output = stdout + stderr;
+    expect(output).toMatch(/updated=\d+/);
+    expect(output).toMatch(/skipped-already-correct=\d+/);
+    expect(output).toMatch(/skipped-missing=\d+/);
+  });
+
+  it('counts a missing row as skipped-missing (no crash) when an in-scope email is absent', () => {
+    // Drop the CBM email row entirely → SKIPPED-MISSING for that target.
+    const db = new Database(dbPath);
+    db.prepare(`DELETE FROM parsed_results WHERE gmail_message_id=?`).run(CBM_EMAIL_ID);
+    db.close();
+
+    const { stdout, stderr, exitCode } = runBackfill(dbPath);
+    const output = stdout + stderr;
+    expect(exitCode).toBe(0);
+    expect(output).toMatch(/SKIPPED-MISSING/);
+    expect(output).toMatch(/skipped-missing=1/);
+    // The DWT email is still present and gets updated.
+    expect(readItems(dbPath, DWT_EMAIL_ID)[0].maxVesselDwtMt).toBe(14000);
+  });
+});

--- a/scripts/demo-seed/backfill-1021-cargo-data.ts
+++ b/scripts/demo-seed/backfill-1021-cargo-data.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * backfill-1021-cargo-data.ts — surgical backfill of the cargo fields the T5
+ * graft (commit f2999b67) updated only in the create-path JSON
+ * (lib/sample-data/demo-parsed-cargoes.json), but never wrote back into the
+ * parsed_results.result_json rows that hydrate-demo-session.ts and
+ * regenerate-matches.ts read.
+ *
+ * This is the DATA half of #1033 (engine fixes for #1021 + #1023):
+ *   - #1021  CBM volume dropped: 19e07d7c0f5b66c5 item 0 needs volumeCbm=12000
+ *   - #1023  DWT-range ignored:  19e07cc3ba833475 item 0 needs
+ *            minVesselDwtMt=12000 and maxVesselDwtMt=14000
+ *
+ * Canonical values are READ from lib/sample-data/demo-parsed-cargoes.json — this
+ * script never invents numbers, it only propagates the create-path truth into
+ * the DB rows. Only the fields listed in TARGETS are touched; everything else
+ * (including the unrelated Egypt-Med salt email 19e07caab607dfe5, whose
+ * volumeCbm is intentionally null) is left exactly as-is.
+ *
+ * Usage:
+ *   npx tsx scripts/demo-seed/backfill-1021-cargo-data.ts --db data/demo-seed.db [--dry]
+ *
+ * --dry  Preview only — logs WOULD-UPDATE lines, writes nothing.
+ *
+ * Summary line (always printed):
+ *   done — updated=N skipped-already-correct=M skipped-missing=K
+ *
+ * Idempotent: re-run on an already-patched DB produces 0 changes.
+ *
+ * NOTE: this script only writes to the DB passed via --db. Running the actual
+ * prod backfill (and the downstream regenerate-matches) is a separate,
+ * orchestrator-sanctioned prod-write step — NOT performed here.
+ */
+
+import Database from 'better-sqlite3';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface Target {
+  emailId: string;
+  itemIndex: number;
+  fields: string[];
+}
+
+/**
+ * The exact (emailId, itemIndex, fields) tuples to backfill. Field VALUES are
+ * not hard-coded here — they are read from the canonical fixture below.
+ */
+const TARGETS: Target[] = [
+  { emailId: '19e07d7c0f5b66c5', itemIndex: 0, fields: ['volumeCbm'] }, // #1021
+  { emailId: '19e07cc3ba833475', itemIndex: 0, fields: ['minVesselDwtMt', 'maxVesselDwtMt'] }, // #1023
+];
+
+interface FixtureItem {
+  emailId: string;
+  itemIndex: number;
+  [key: string]: unknown;
+}
+
+type ParsedItem = Record<string, unknown>;
+
+function arg(k: string): string | undefined {
+  const i = process.argv.indexOf(k);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+const DRY = process.argv.includes('--dry');
+const dbPath = arg('--db') ?? path.resolve(process.cwd(), 'data/demo-seed.db');
+const fixturePath = path.resolve(process.cwd(), 'lib/sample-data/demo-parsed-cargoes.json');
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+async function main() {
+  console.log(`[backfill-1021] db=${dbPath}${DRY ? ' (DRY)' : ''}`);
+
+  if (!fs.existsSync(dbPath)) {
+    console.error(`[backfill-1021] ERROR: db not found: ${dbPath}`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(fixturePath)) {
+    console.error(`[backfill-1021] ERROR: fixture not found: ${fixturePath}`);
+    process.exit(1);
+  }
+
+  const fixture: FixtureItem[] = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+  // canonical[emailId][itemIndex] → fixture item
+  const canonical = new Map<string, Map<number, FixtureItem>>();
+  for (const item of fixture) {
+    const byIndex = canonical.get(item.emailId) ?? new Map<number, FixtureItem>();
+    byIndex.set(item.itemIndex, item);
+    canonical.set(item.emailId, byIndex);
+  }
+
+  const db = new Database(dbPath, DRY ? { readonly: true } : {});
+  if (!DRY) db.pragma('journal_mode = WAL');
+
+  const selectRow = db.prepare<[string]>(
+    `SELECT result_json FROM parsed_results WHERE gmail_message_id=? AND parse_type='cargo'`,
+  );
+  const updateRow = DRY
+    ? null
+    : db.prepare<[string, string]>(
+        `UPDATE parsed_results SET result_json=? WHERE gmail_message_id=? AND parse_type='cargo'`,
+      );
+
+  let updates = 0;
+  let skipped = 0;
+  let skippedMissing = 0;
+
+  // Group targets by emailId so each row is read/written once.
+  const byEmail = new Map<string, Target[]>();
+  for (const t of TARGETS) {
+    const arr = byEmail.get(t.emailId) ?? [];
+    arr.push(t);
+    byEmail.set(t.emailId, arr);
+  }
+
+  for (const [emailId, targets] of byEmail) {
+    const row = selectRow.get(emailId) as { result_json: string } | undefined;
+    if (!row) {
+      for (const t of targets) {
+        console.log(`[backfill-1021] SKIPPED-MISSING emailId=${emailId} itemIndex=${t.itemIndex} (no parsed_results row)`);
+        skippedMissing++;
+      }
+      continue;
+    }
+
+    const items: ParsedItem[] = JSON.parse(row.result_json);
+    let rowChanged = false;
+
+    for (const t of targets) {
+      const target = items[t.itemIndex];
+      if (!target) {
+        console.log(`[backfill-1021] SKIPPED-MISSING emailId=${emailId} itemIndex=${t.itemIndex} (item not in result_json)`);
+        skippedMissing++;
+        continue;
+      }
+
+      const source = canonical.get(emailId)?.get(t.itemIndex);
+      if (!source) {
+        console.log(`[backfill-1021] SKIPPED-MISSING emailId=${emailId} itemIndex=${t.itemIndex} (no canonical fixture item)`);
+        skippedMissing++;
+        continue;
+      }
+
+      const changed: string[] = [];
+      const oldVals: Record<string, unknown> = {};
+      const newVals: Record<string, unknown> = {};
+
+      for (const field of t.fields) {
+        const canonicalVal = source[field];
+        const currentVal = target[field];
+        if (!jsonEqual(currentVal, canonicalVal)) {
+          changed.push(field);
+          oldVals[field] = currentVal;
+          newVals[field] = canonicalVal;
+          target[field] = canonicalVal;
+          rowChanged = true;
+        }
+      }
+
+      if (changed.length > 0) {
+        const prefix = DRY ? 'WOULD-UPDATE' : 'UPDATED';
+        const oldStr = changed.map((f) => `${f}: ${JSON.stringify(oldVals[f])}`).join(', ');
+        const newStr = changed.map((f) => `${f}: ${JSON.stringify(newVals[f])}`).join(', ');
+        console.log(
+          `[backfill-1021] ${prefix} emailId=${emailId} itemIndex=${t.itemIndex} fields=[${changed.join(',')}] ${oldStr} → ${newStr}`,
+        );
+        updates++;
+      } else {
+        skipped++;
+      }
+    }
+
+    if (rowChanged && !DRY && updateRow) {
+      updateRow.run(JSON.stringify(items), emailId);
+    }
+  }
+
+  console.log(
+    `[backfill-1021] done — updated=${updates} skipped-already-correct=${skipped} skipped-missing=${skippedMissing}`,
+  );
+}
+
+main().catch((err) => {
+  console.error('[backfill-1021] fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

New one-off backfill script `scripts/demo-seed/backfill-1021-cargo-data.ts` (+ behavioral test).
This is the **data half** of #1033 — the engine fixes for #1021 (CBM volume) and #1023 (DWT-range) are already merged on `main` (`fit-breakdown.ts scoreVolume`, `match-filters.ts checkVesselDwtRange`, `pair-analyzer.ts DWT_OUT_OF_BAND_PENALTY`). They consume DB fields that, in prod, are still `null`.

## Why

The T5 graft (commit `f2999b67`) updated only the **create-path** JSON `lib/sample-data/demo-parsed-cargoes.json`, not the `parsed_results.result_json` DB rows that `hydrate-demo-session.ts` and `regenerate-matches.ts` read. So prod `parsed_results` still has `volumeCbm=null` and `min/maxVesselDwtMt=null`, and the merged engine has nothing to consume.

## What the script does

Modelled exactly on `scripts/demo-seed/backfill-815-weights.ts` (arg parsing `--db`/`--dry`, WAL-safe open, idempotent WOULD-UPDATE/UPDATE logging). Reads canonical values from the fixture and patches:

| emailId | itemIndex | field(s) | value | issue |
|---|---|---|---|---|
| `19e07d7c0f5b66c5` | 0 | `volumeCbm` | `12000` | #1021 |
| `19e07cc3ba833475` | 0 | `minVesselDwtMt`, `maxVesselDwtMt` | `12000` / `14000` | #1023 |

- **Idempotent**: re-run after apply = 0 changes (skips rows already correct).
- **`--dry`**: prints `WOULD-UPDATE` lines, writes nothing.
- Summary: `updated=N skipped-already-correct=N skipped-missing=N`.
- Out-of-scope salt email `19e07caab607dfe5` (Egypt Med, `volumeCbm` intentionally null) is **not** touched.

## NOT in this PR

The **actual prod backfill** (`--db <prod>`) and the downstream `regenerate-matches` are a **separate, orchestrator-sanctioned prod-write step** — deliberately not run here. This PR only adds the tooling + test.

This is the CBM/DWT-range data half only; #1021's second example (cement `5.000/5.500mts` MT-format) is out of this script's scope, so no issues are auto-closed here.

## Tests

- `npx jest --findRelatedTests` on the new script → **8 passed** (live set, dry no-op, idempotent 0-changes, out-of-scope salt untouched, missing-row → skipped-missing).
- `npx tsc --noEmit` → exit 0 (needs `--max-old-space-size=8192` on VPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)