### PR TITLE
ci(test): run jest with --maxWorkers=2 to use both runner cores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm ci
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      - run: npm test
+      - run: npm test -- --maxWorkers=2
         env:
           NODE_OPTIONS: --max-old-space-size=6144
       # Critical regression locks live in tests/regression/ (jest-ignored from the

--- a/docs/superpowers/plans/2026-06-17-qd-jest-workers.md
+++ b/docs/superpowers/plans/2026-06-17-qd-jest-workers.md
@@ -1,0 +1,73 @@
+# Plan — Speed up CI Test job via jest `--maxWorkers=2`
+
+Date: 2026-06-17
+Branch: `qd-jest-workers`
+Type: CI performance experiment (orchestrator merges only if real CI is faster)
+
+## Root cause
+
+CI `Test` job runs ~5m41s. Breakdown:
+
+- `npm test` (bare `jest`) = ~310s (91% of job)
+- `npm ci` = ~0s (node_modules cache hit)
+- `npm run test:regression` = ~8s
+
+`jest.config.mjs` sets **no** `maxWorkers`, and the `test` package script is bare
+`jest`. GitHub's `ubuntu-latest` runner has **2 cores**. jest's default worker
+count is `cores - 1` = **1 worker** → the suite runs effectively serial, using
+only half the runner.
+
+## Lever
+
+Use both runner cores: pass `--maxWorkers=2` to the CI `npm test` invocation.
+
+## Change (one line, CI-only)
+
+`.github/workflows/ci.yml`, `test` job:
+
+```diff
+-      - run: npm test
++      - run: npm test -- --maxWorkers=2
+```
+
+- **CI-only.** Do NOT edit `package.json` `test` script — bare `jest` keeps
+  jest's adaptive default locally (devs with more cores aren't capped at 2).
+- `test:regression` left unchanged.
+- `jest.config.mjs` untouched (no `maxWorkers` baked in) unless a race fix
+  genuinely requires per-worker isolation.
+- No job renamed (`Test` / `TypeCheck + Audit` / `Build` are required checks).
+
+## Parallel-safety verification (dev-vps, foreground/blocking)
+
+1->2 workers can surface shared-state races (sqlite/test DB, ports, global
+mocks/singletons, fixture paths, ordering). Verify at 2-worker concurrency:
+
+1. `npm test -- --maxWorkers=2 --forceExit` — **run 1**, must be GREEN
+2. `npm test -- --maxWorkers=2 --forceExit` — **run 2** (consecutive), must be GREEN
+3. `npm run test:regression` — once, must be GREEN
+
+(`--forceExit` is a LOCAL-only safety wrapper: dev-vps jest hangs on open
+handles after the run completes — known behavior. It forces process exit AFTER
+tests finish, so it does not mask races, which manifest as failures *during*
+execution. CI's bare jest already exits cleanly in ~310s, so the CI line does
+not need it.)
+
+dev-vps has 6 cores → `--maxWorkers=2` here is for **race detection at 2-worker
+concurrency**, NOT a timing measurement. The timing verdict is the **real CI
+run** (orchestrator validates after merge-candidate CI).
+
+Any race found → fix PROPERLY: per-worker isolation keyed on
+`process.env.JEST_WORKER_ID` (unique temp dir / sqlite per worker) or proper
+mock reset. Never edit test expectations to fit impl; never skip/mask a race.
+
+## Gates
+
+- `npm run lint` — pass
+- `npx tsc --noEmit` — pass
+- 2x green under `--maxWorkers=2` + test:regression green
+
+## Out of scope
+
+- package.json `test` script (local dev speed).
+- Sharding the Test job via matrix (`jest --shard`) — premature at this scale.
+- typecheck/build/node-version/caches; any job rename.


### PR DESCRIPTION
## Root cause

CI `Test` job runs **~5m41s**. Breakdown (recon):

| step | time |
|------|------|
| `npm test` (bare `jest`) | **~310s (91%)** |
| `npm ci` | ~0s (node_modules cache hit) |
| `npm run test:regression` | ~8s |

`jest.config.mjs` sets **no** `maxWorkers`, and the `test` package script is bare `jest`. GitHub's `ubuntu-latest` runner has **2 cores**, and jest's default worker count is `cores − 1` = **1 worker** → the suite runs effectively serial, using only half the runner.

## The change (one line, CI-only)

```diff
-      - run: npm test
+      - run: npm test -- --maxWorkers=2
```

- **CI-only.** `package.json` `test` script stays bare `jest` — keeps jest's adaptive default for local dev (devs with more cores aren't capped at 2).
- `test:regression` and `jest.config.mjs` left unchanged.
- No job renamed (`Test` / `TypeCheck + Audit` / `Build` remain the required checks).

Also adds the plan doc `docs/superpowers/plans/2026-06-17-qd-jest-workers.md`.

## Race fixes

**None needed.** 1→2 workers can surface shared-state races (sqlite/test DB, ports, global mocks/singletons, fixture paths, ordering). Verified at 2-worker concurrency on dev-vps — **no race surfaced** (two consecutive full-suite runs identical and green). No code change beyond the one CI line.

## 2× green proof — `npm test -- --maxWorkers=2` (dev-vps, race detection)

Run on dev-vps (6 cores) twice consecutively, foreground/blocking. `--forceExit` added **for the local run only** (dev-vps jest hangs on open handles after completion — known behavior; it forces exit *after* tests finish, so it does not mask races). CI's bare jest already exits cleanly in ~310s and does not need it.

| run | result | suites | tests |
|-----|--------|--------|-------|
| #1 | ✅ exit 0 | 1 skipped, **949 passed** / 950 | 33 skipped, **10120 passed** / 10153 |
| #2 | ✅ exit 0 | 1 skipped, **949 passed** / 950 | 33 skipped, **10120 passed** / 10153 |
| `test:regression` | ✅ exit 0 | **56 passed** / 56 | **802 passed** / 802 |

Gates: `npm run lint` → exit 0 (0 errors, 44 pre-existing warnings); `npx tsc --noEmit` → exit 0 (no output).

> The error lines in jest stdout (`audit write failed`, `network error`, `AI text call failed`) are **expected test-internal error-path output** — suites like `ai-llm-timeout-graceful`, `fetch-persists`, and `compare-routes-da` deliberately drive failure paths and assert graceful fallback. They are counted in the 949 passed; **0 failed** in both runs.

## ⚠️ Timing verdict = real CI, not dev-vps

dev-vps has 6 cores, so the `--maxWorkers=2` runs here are for **race detection at 2-worker concurrency only** — the ~915s wall times are NOT a speedup measurement (they're inflated vs CI and were run under `--forceExit`). **The speedup verdict is the real GitHub Actions CI run on this PR** (2-core runner): compare this PR's `Test` job duration against `main`. Merge only if real CI is actually faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
