### PR TITLE
feat(economics): commission row in calculation waterfall

### DIFF
--- a/components/economics/CalculationWaterfall.tsx
+++ b/components/economics/CalculationWaterfall.tsx
@@ -35,6 +35,8 @@ export function CalculationWaterfall({ breakdown, warRiskBreakdown }: Props) {
     bunker_consumption_mt_per_day,
     bunker_price_usd_per_mt,
     gross_freight_usd,
+    commission_pct,
+    commission_usd,
     bunker_usd,
     canal_usd,
     da_usd,
@@ -80,6 +82,16 @@ export function CalculationWaterfall({ breakdown, warRiskBreakdown }: Props) {
           <span data-testid="gross-freight">{fmtUsd(gross_freight_usd)}</span>
         </div>
       </section>
+
+      {/* ── COMMISSION ─────────────────────────────────────── */}
+      {commission_usd != null && commission_usd > 0 && (
+        <div className="space-y-0.5" data-testid="cost-commission">
+          <div className="flex justify-between">
+            <span>📋 Commission {commission_pct}% TTL</span>
+            <span>{fmtUsd(-commission_usd)}</span>
+          </div>
+        </div>
+      )}
 
       {/* ── MINUS VOYAGE COSTS ─────────────────────────────── */}
       <section className="space-y-2">

--- a/components/economics/__tests__/CalculationWaterfall.test.tsx
+++ b/components/economics/__tests__/CalculationWaterfall.test.tsx
@@ -173,4 +173,35 @@ describe('CalculationWaterfall', () => {
     render(<CalculationWaterfall breakdown={FIXTURE} warRiskBreakdown={zeroBreakdown} />);
     expect(screen.queryByTestId('war-risk-breakdown')).not.toBeInTheDocument();
   });
+
+  it('renders commission row with amount and pct label when commission_usd > 0', () => {
+    const withCommission: TCEBreakdown = {
+      ...FIXTURE,
+      commission_pct: 3.75,
+      commission_usd: 56_250,
+      net_freight_usd: 1_443_750,
+    };
+    render(<CalculationWaterfall breakdown={withCommission} />);
+    const commRow = screen.getByTestId('cost-commission');
+    expect(commRow).toBeInTheDocument();
+    expect(commRow).toHaveTextContent('-$56,250');
+    expect(commRow).toHaveTextContent('3.75%');
+  });
+
+  it('hides commission row when commission_usd is 0', () => {
+    const noCommission: TCEBreakdown = {
+      ...FIXTURE,
+      commission_pct: 0,
+      commission_usd: 0,
+      net_freight_usd: FIXTURE.gross_freight_usd,
+    };
+    render(<CalculationWaterfall breakdown={noCommission} />);
+    expect(screen.queryByTestId('cost-commission')).not.toBeInTheDocument();
+  });
+
+  it('hides commission row when commission_usd is absent', () => {
+    const noCommission: TCEBreakdown = { ...FIXTURE };
+    render(<CalculationWaterfall breakdown={noCommission} />);
+    expect(screen.queryByTestId('cost-commission')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `Commission X% TTL — -$N` row in `CalculationWaterfall` between gross freight and voyage costs
- Row is hidden when `commission_usd` is 0 or absent (no visual noise on routes without commission)
- Reads `commission_pct` / `commission_usd` from existing `TCEBreakdown` — no engine changes, pure presentation

## Test plan

- [x] RED test: `renders commission row with amount and pct label when commission_usd > 0`
- [x] GREEN: row renders with correct `-$56,250` and `3.75%` label
- [x] Hide-zero: row absent when `commission_usd === 0`
- [x] Hide-absent: row absent when `commission_usd` not in breakdown
- [x] 128 related tests all pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)