### PR TITLE
fix(economics): single-sourced EUR→USD for ETS/FuelEU/bunker-carbon (audit #14)

### DIFF
--- a/app/api/voyage/compare-routes/route.ts
+++ b/app/api/voyage/compare-routes/route.ts
@@ -128,13 +128,19 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Single-sourced EUR→USD (as-of frozen/real clock) so compare-routes ETS USD matches
+  // the voyage TCE detail page. Lazy import keeps better-sqlite3 out of this route's
+  // static module graph (compare-routes-perf: import < 1000ms).
+  const { getEurToUsd } = await import('@/lib/economics/fx-rate-source');
+  const eurToUsdRate = getEurToUsd().rate;
+
   try {
     const result = await compareRoutes(
       body.origin,
       body.destination,
       body.vessel,
       body.cargo,
-      body.marketRates,
+      { ...body.marketRates, eurToUsdRate },
       daResolver,
       jwcSystemContext,
     );

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -19,6 +19,7 @@ import { resolvePort, type ResolvedPort } from '@/lib/ports/resolve';
 import { resolveVaguePort } from '@/lib/ports/resolve-vague';
 import { getDistance } from '@/lib/knowledge/distances/lookup';
 import { getStore } from '@/lib/session-store';
+import { getEurToUsd } from '@/lib/economics/fx-rate-source';
 import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { isEuCountry } from '@/lib/validation/sanctions';
@@ -408,6 +409,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     cargo: data.cargo,
     bunkerPriceUsdPerMt,
     euaPriceEur,
+    // EUR→USD as-of the (demo-frozen or real) clock date — single source: fx-rate.ts.
+    eurToUsdRate: getEurToUsd(getStore().getDb()).rate,
     durationDays: data.durationDays,
     euLegPercent: resolvedEuLegPercent,
     originEu: data.includeEuETS ? originEu : undefined,

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -410,7 +410,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     bunkerPriceUsdPerMt,
     euaPriceEur,
     // EUR→USD as-of the (demo-frozen or real) clock date — single source: fx-rate.ts.
-    eurToUsdRate: getEurToUsd(getStore().getDb()).rate,
+    // No db arg: getEurToUsd() resolves getDb() INTERNALLY inside its own try/catch, so an
+    // unavailable FX DB degrades to the estimated constant instead of 500-ing the route.
+    // Same db source as compare-routes/route.ts (global getDb) → list and detail can't diverge.
+    eurToUsdRate: getEurToUsd().rate,
     durationDays: data.durationDays,
     euLegPercent: resolvedEuLegPercent,
     originEu: data.includeEuETS ? originEu : undefined,

--- a/lib/economics/__tests__/fx-rate.test.ts
+++ b/lib/economics/__tests__/fx-rate.test.ts
@@ -1,0 +1,155 @@
+/**
+ * fx-rate.ts — single sourced EUR→USD for voyage economics (audit finding 14).
+ *
+ * Covers:
+ *  - as-of-date resolution + 'live' tier
+ *  - demo-frozen-date determinism (clock mocked → stable across calls / wall-clock)
+ *  - 'estimated' fallback when the FX feed is unavailable
+ *  - all three EU-cost call-sites read the SAME injected rate (no private literal)
+ */
+import Database from 'better-sqlite3';
+
+// Freeze the clock so the as-of date is deterministic (mirrors DEMO_MODE behaviour).
+const mockToday = jest.fn<string, []>(() => '2026-05-28');
+jest.mock('@/lib/clock', () => ({
+  today: () => mockToday(),
+  now: () => new Date('2026-05-28T00:00:00.000Z'),
+  demoNow: () => new Date('2026-05-28T12:00:00.000Z').getTime(),
+}));
+
+import { getEurToUsd } from '../fx-rate-source';
+import { EUR_USD_FALLBACK } from '../fx-rate';
+import { computeBunkerComparison } from '../bunker-comparison';
+import { calculateFuelEu } from '../fueleu';
+import { computeTce, type TceInputs } from '../compute-tce';
+
+function buildFxDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE fx_rates (
+      base_currency TEXT NOT NULL, quote_currency TEXT NOT NULL,
+      rate REAL NOT NULL, rate_date TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'frankfurter', fetched_at TEXT NOT NULL,
+      PRIMARY KEY (base_currency, quote_currency, rate_date)
+    );
+  `);
+  return db;
+}
+
+function seedRate(db: Database.Database, rate: number, rateDate: string): void {
+  db.prepare(
+    `INSERT INTO fx_rates (base_currency, quote_currency, rate, rate_date, source, fetched_at)
+     VALUES ('EUR','USD',?,?,'frankfurter','2026-05-28T00:00:00Z')`,
+  ).run(rate, rateDate);
+}
+
+beforeEach(() => {
+  mockToday.mockReturnValue('2026-05-28');
+});
+
+describe('getEurToUsd', () => {
+  it('returns the latest rate as-of the clock date, tier=live (ignores future-dated rows)', () => {
+    const db = buildFxDb();
+    seedRate(db, 1.1, '2026-05-01');
+    seedRate(db, 1.16, '2026-05-25'); // latest <= frozen 2026-05-28
+    seedRate(db, 1.2, '2026-06-10'); // future vs frozen — must be ignored
+
+    const result = getEurToUsd(db);
+    expect(result.rate).toBe(1.16);
+    expect(result.tier).toBe('live');
+    expect(result.rateDate).toBe('2026-05-25');
+    // Real EUR/USD (~1.16) — materially above the old hardcoded 1.08.
+    expect(result.rate).toBeGreaterThan(EUR_USD_FALLBACK);
+  });
+
+  it('is deterministic under the frozen clock — repeated calls return the same row', () => {
+    const db = buildFxDb();
+    seedRate(db, 1.16, '2026-05-25');
+
+    const a = getEurToUsd(db);
+    const b = getEurToUsd(db);
+    expect(a).toEqual(b);
+    expect(a.rateDate).toBe('2026-05-25');
+
+    // A different frozen date would resolve a different as-of row — proving the
+    // rate tracks the clock (frozen in demo) rather than wall-clock drift.
+    seedRate(db, 1.1, '2026-04-10');
+    mockToday.mockReturnValue('2026-04-15');
+    expect(getEurToUsd(db).rate).toBe(1.1);
+  });
+
+  it('falls back to EUR_USD_FALLBACK with tier=estimated when no rate is available', () => {
+    const db = buildFxDb(); // empty fx_rates
+    const result = getEurToUsd(db);
+    expect(result.rate).toBe(EUR_USD_FALLBACK);
+    expect(result.tier).toBe('estimated');
+    expect(result.rateDate).toBeNull();
+  });
+
+  it('falls back to estimated on DB error (missing table)', () => {
+    const db = new Database(':memory:'); // no fx_rates table
+    const result = getEurToUsd(db);
+    expect(result.rate).toBe(EUR_USD_FALLBACK);
+    expect(result.tier).toBe('estimated');
+  });
+});
+
+describe('single source of truth — all EU-cost call-sites read the injected rate', () => {
+  const INJECTED = 2.16; // exactly 2× EUR_USD_FALLBACK → ratios are clean
+
+  it('bunker-comparison carbonCostUsd scales with eurToUsdRate (default = EUR_USD_FALLBACK)', () => {
+    const base = {
+      candidates: [{ port: 'NLRTM', grade: 'vlsfo', priceUsdPerMt: 600, deviationNm: 0 }],
+      vesselSpeedKn: 14,
+      dailyConsMtPerDay: 30,
+      liftTonnes: 2000,
+      vesselDayRateUsd: 20000,
+      euaPriceEur: 80,
+    };
+    const dflt = computeBunkerComparison(base)[0]!;
+    const injected = computeBunkerComparison({ ...base, eurToUsdRate: INJECTED })[0]!;
+
+    expect(dflt.carbonCostUsd).toBeGreaterThan(0);
+    // default path must use the single EUR_USD_FALLBACK constant (1.08), not a private literal
+    expect(injected.carbonCostUsd / dflt.carbonCostUsd).toBeCloseTo(INJECTED / EUR_USD_FALLBACK, 4);
+  });
+
+  it('fueleu penaltyUsd scales with eurToUsdRate (default = EUR_USD_FALLBACK)', () => {
+    const base = { fuelType: 'vlsfo', consumptionMtPerDay: 50, voyageDays: 30, year: 2025 };
+    const dflt = calculateFuelEu(base);
+    const injected = calculateFuelEu({ ...base, eurToUsdRate: INJECTED });
+
+    expect(dflt.penaltyEur).toBeGreaterThan(0);
+    expect(dflt.penaltyUsd).toBeCloseTo(dflt.penaltyEur * EUR_USD_FALLBACK, 4);
+    expect(injected.penaltyUsd / dflt.penaltyUsd).toBeCloseTo(INJECTED / EUR_USD_FALLBACK, 4);
+  });
+
+  it('compute-tce ets_usd scales with eurToUsdRate (default = EUR_USD_FALLBACK)', () => {
+    const base: TceInputs = {
+      dwt: 50000,
+      valueUsd: 25_000_000,
+      speedKts: 14,
+      consumptionMtPerDay: 30,
+      freightRateUsdPerMt: 25,
+      quantityMt: 45000,
+      distanceNm: 4000,
+      bunkerPriceUsdPerMt: 600,
+      euaPriceEur: 80,
+      canalUsd: 0,
+      daUsd: 0,
+      euLegPercent: 1,
+      originEu: true,
+      destEu: true,
+    };
+    const dflt = computeTce(base);
+    const injected = computeTce({ ...base, eurToUsdRate: INJECTED });
+
+    expect(dflt.breakdown.ets_eur).toBeGreaterThan(0);
+    expect(dflt.breakdown.ets_usd).toBeGreaterThan(0);
+    expect(dflt.breakdown.ets_usd).toBeCloseTo(dflt.breakdown.ets_eur * EUR_USD_FALLBACK, 0);
+    expect(injected.breakdown.ets_usd / dflt.breakdown.ets_usd).toBeCloseTo(
+      INJECTED / EUR_USD_FALLBACK,
+      2,
+    );
+  });
+});

--- a/lib/economics/bunker-comparison.ts
+++ b/lib/economics/bunker-comparison.ts
@@ -1,5 +1,6 @@
 import { cfForFuel } from './ets';
 import { isEuCountry } from '@/lib/validation/sanctions';
+import { EUR_USD_FALLBACK } from './fx-rate';
 
 export interface BunkerCandidateInput {
   port: string;
@@ -40,14 +41,14 @@ export interface BunkerComparisonInput {
   vesselDayRateUsd: number;
   /** EU ETS EUA price in EUR/tCO2. If omitted, carbon cost = 0 and euaUsedFallback = true. */
   euaPriceEur?: number;
+  /** EUR→USD for carbon-cost conversion. Resolve via getEurToUsd() at the async caller
+   *  and inject. Omitted → EUR_USD_FALLBACK (estimated). */
+  eurToUsdRate?: number;
 }
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }
-
-// EUR/USD rate — matches lib/economics/voyage-calculator.ts and lib/currency.ts
-const EUR_TO_USD = 1.08;
 
 // Ceuta is a Spanish territory (ES prefix) but outside the maritime EU ETS scope
 const NON_EU_ETS_OVERRIDE = new Set(['ESCEU']);
@@ -70,13 +71,14 @@ export function isEuEtsPort(locode: string): boolean {
  *   effectiveDeviationNm = max(0, deviationNm)
  *   deviationFuelUsd = devNm * (dailyConsT / (speedKn * 24)) * priceUsdPerMt
  *   timeCostUsd      = devNm / speedKn / 24 * vesselDayRateUsd
- *   carbonCostUsd    = euaPriceEur * EUR_TO_USD * Cf * liftTonnes  (EU ports only; 0 if euaPriceEur not provided)
+ *   carbonCostUsd    = euaPriceEur * eurToUsd * Cf * liftTonnes  (EU ports only; 0 if euaPriceEur not provided)
  *   effectiveUsdPerMt = (priceUsdPerMt * liftTonnes + deviationFuelUsd + timeCostUsd + carbonCostUsd) / liftTonnes
  *
  * Invariant: effectiveUsdPerMt = priceUsdPerMt + deviationFuelUsd/lift + timeCostUsd/lift + carbonUsdPerMt
  */
 export function computeBunkerComparison(input: BunkerComparisonInput): BunkerCandidateResult[] {
   const { candidates, vesselSpeedKn, dailyConsMtPerDay, liftTonnes, vesselDayRateUsd, euaPriceEur } = input;
+  const eurToUsd = input.eurToUsdRate ?? EUR_USD_FALLBACK;
 
   if (vesselSpeedKn <= 0 || dailyConsMtPerDay <= 0 || liftTonnes <= 0) return [];
 
@@ -92,7 +94,7 @@ export function computeBunkerComparison(input: BunkerComparisonInput): BunkerCan
     let carbonUsdPerMt = 0;
     if (!euaUsedFallback && isEuEtsPort(c.port)) {
       const cf = cfForFuel(c.grade);
-      carbonCostUsd = round2(euaPriceEur * EUR_TO_USD * cf * liftTonnes);
+      carbonCostUsd = round2(euaPriceEur * eurToUsd * cf * liftTonnes);
       carbonUsdPerMt = round2(carbonCostUsd / liftTonnes);
     }
 

--- a/lib/economics/bunker-routing.ts
+++ b/lib/economics/bunker-routing.ts
@@ -21,6 +21,7 @@ import { getLatestBunkerPrice } from '@/lib/market/bunker-repository';
 import { getLatestEuaPrice } from '@/lib/market/eua-repository';
 import { computeBunkerComparison } from '@/lib/economics/bunker-comparison';
 import type { BunkerCandidateResult } from '@/lib/economics/bunker-comparison';
+import { getEurToUsd } from '@/lib/economics/fx-rate-source';
 import { isCandidateInVoyageBasins } from '@/lib/sailing/voyage-basin';
 import { estimateBunkerLift } from '@/lib/economics/bunker-lift';
 import { resolveConsMtPerDay } from '@/lib/economics/vessel-consumption';
@@ -196,6 +197,7 @@ export function resolveOnRouteBunkerCandidates(
     liftTonnes,
     vesselDayRateUsd: DEFAULT_VESSEL_DAY_RATE_USD,
     euaPriceEur,
+    eurToUsdRate: getEurToUsd(db).rate,
   });
 
   return {

--- a/lib/economics/compute-tce.ts
+++ b/lib/economics/compute-tce.ts
@@ -25,8 +25,8 @@ import type { TCEBreakdown } from '@/lib/economics/voyage-calculator';
 import type { EcaZone } from '@/lib/knowledge/eca/parser';
 import type { ResolvedPort } from '@/lib/ports/resolve';
 import type { DataQuality } from '@/lib/data-quality/types';
+import { EUR_USD_FALLBACK } from './fx-rate';
 
-const EUR_TO_USD = 1.08;
 const ESTIMATED_DAYS_FALLBACK = 1;
 
 function safeNum(n: unknown): number {
@@ -55,6 +55,9 @@ export interface TceInputs {
   bunkerPriceUsdPerMt: number;
   /** EUA price EUR. Pass 0 when no EU routing. */
   euaPriceEur: number;
+  /** EUR→USD rate for EU-cost conversion (ETS, FuelEU). Resolve via getEurToUsd()
+   *  at the async caller and inject. Omitted → EUR_USD_FALLBACK (estimated). */
+  eurToUsdRate?: number;
 
   // Pre-resolved costs (canal / DA modules run upstream)
   canalUsd: number;
@@ -143,6 +146,9 @@ export function computeTce(inputs: TceInputs): TceResult {
   const valueUsd = safeNum(inputs.valueUsd);
   const euLegPercent = safeNum(inputs.euLegPercent);
   const euaPrice = safeNum(inputs.euaPriceEur);
+  // EUR→USD for EU-cost conversion (ETS + FuelEU). Single source: fx-rate.ts.
+  // Caller injects the live/as-of rate; fall back to the estimated constant.
+  const eurToUsd = inputs.eurToUsdRate ?? EUR_USD_FALLBACK;
   const daysInHraRaw = inputs.daysInHra;
   const daysInHra = typeof daysInHraRaw === 'number' && Number.isFinite(daysInHraRaw)
     ? daysInHraRaw
@@ -220,7 +226,7 @@ export function computeTce(inputs: TceInputs): TceResult {
     destEu: inputs.destEu,
   });
   const etsEur = etsResult.amountEur;
-  const etsUsd = Math.round(etsEur * EUR_TO_USD);
+  const etsUsd = Math.round(etsEur * eurToUsd);
   const etsApplicable = etsResult.applicable;
 
   // ── FuelEU Maritime (audit A.5, flag-gated) ───────────────────────────
@@ -239,6 +245,7 @@ export function computeTce(inputs: TceInputs): TceResult {
       fuelType,
       consumptionMtPerDay: consumption,
       voyageDays: duration,
+      eurToUsdRate: eurToUsd,
     });
     fueleuUsd = Math.round(fe.penaltyUsd * share);
   }

--- a/lib/economics/fueleu.ts
+++ b/lib/economics/fueleu.ts
@@ -3,6 +3,7 @@
  * Implements Well-to-Wake GHG intensity calculation per EU Regulation 2023/1805
  * Penalty: €2400/tCO2eq for non-compliance
  */
+import { EUR_USD_FALLBACK } from './fx-rate';
 
 // GHG intensity g CO2eq/MJ (Well-to-Wake, FuelEU Maritime Annex I)
 export const FUEL_GHG_INTENSITY: Record<string, number> = {
@@ -38,14 +39,14 @@ export const FUELEU_TARGET_2030 = 80.75; // -13%
 export const FUELEU_TARGET_2035 = 62.62; // -29%
 export const FUELEU_PENALTY_EUR_PER_T_CO2EQ = 2400;
 
-// EUR/USD fallback rate (from currency.ts or hardcoded)
-const EUR_USD_FALLBACK = 1.08;
-
 export interface FuelEuInput {
   fuelType: string; // key from FUEL_GHG_INTENSITY
   consumptionMtPerDay: number; // metric tons fuel per day
   voyageDays: number;
   year?: number; // for target selection (default: current year)
+  /** EUR→USD for penalty conversion. Resolve via getEurToUsd() at the async caller
+   *  and inject. Omitted → EUR_USD_FALLBACK (estimated). */
+  eurToUsdRate?: number;
 }
 
 export interface FuelEuResult {
@@ -53,7 +54,7 @@ export interface FuelEuResult {
   ghgIntensityTarget: number; // g CO2eq/MJ target for year
   complianceGapPct: number; // positive = non-compliant, negative = over-compliant
   penaltyEur: number; // €0 if compliant
-  penaltyUsd: number; // converted at ~1.08 rate
+  penaltyUsd: number; // penaltyEur × eurToUsdRate (single-sourced; default EUR_USD_FALLBACK)
   totalEnergyMj: number;
   isCompliant: boolean;
 }
@@ -124,7 +125,7 @@ export function calculateFuelEu(input: FuelEuInput): FuelEuResult {
     complianceGapPct = (gapGPerMj / ghgIntensityTarget) * 100;
   }
 
-  const penaltyUsd = penaltyEur * EUR_USD_FALLBACK;
+  const penaltyUsd = penaltyEur * (input.eurToUsdRate ?? EUR_USD_FALLBACK);
 
   return {
     ghgIntensityActual,

--- a/lib/economics/fx-rate-source.ts
+++ b/lib/economics/fx-rate-source.ts
@@ -1,0 +1,43 @@
+/**
+ * DB-backed EUR→USD resolver. Reads the FX subsystem (`fx_rates`, populated by the
+ * daily Frankfurter/ECB cron) AS-OF the clock date. In DEMO_MODE `today()` is the
+ * frozen date, so the rate is deterministic (never drifts day to day); outside demo
+ * it tracks the latest rate.
+ *
+ * Kept separate from `fx-rate.ts` so that the pure economics functions (which import
+ * only the EUR_USD_FALLBACK constant) do not transitively load better-sqlite3 / the
+ * clock at module-import time. Import this only from async request handlers.
+ */
+import type Database from 'better-sqlite3';
+import { getDb } from '@/lib/db/index';
+import { today } from '@/lib/clock';
+import { EUR_USD_FALLBACK, type EurToUsd } from './fx-rate';
+
+export type { EurToUsd } from './fx-rate';
+export { EUR_USD_FALLBACK } from './fx-rate';
+
+/**
+ * Resolve EUR→USD as-of the (demo-frozen or real) clock date.
+ * Synchronous — better-sqlite3 is sync, so request handlers can read the resolved
+ * `.rate` number and inject it into the (pure, synchronous) economics functions.
+ */
+export function getEurToUsd(db?: Database.Database): EurToUsd {
+  try {
+    const database = db ?? getDb();
+    const asOf = today();
+    const row = database
+      .prepare<[string], { rate: number; rate_date: string }>(
+        `SELECT rate, rate_date FROM fx_rates
+         WHERE base_currency = 'EUR' AND quote_currency = 'USD' AND rate_date <= ?
+         ORDER BY rate_date DESC
+         LIMIT 1`,
+      )
+      .get(asOf);
+    if (row && typeof row.rate === 'number' && row.rate > 0) {
+      return { rate: row.rate, tier: 'live', rateDate: row.rate_date };
+    }
+  } catch {
+    // FX source unavailable — fall through to the estimated constant.
+  }
+  return { rate: EUR_USD_FALLBACK, tier: 'estimated', rateDate: null };
+}

--- a/lib/economics/fx-rate.ts
+++ b/lib/economics/fx-rate.ts
@@ -1,0 +1,20 @@
+/**
+ * Single source of truth for the EUR→USD rate used across voyage economics
+ * (EU ETS, FuelEU penalty, bunker-carbon). Replaces the hardcoded `1.08`
+ * literals that previously lived in compute-tce.ts / fueleu.ts / bunker-comparison.ts.
+ *
+ * This module is intentionally dependency-light: the pure/synchronous economics
+ * functions import only `EUR_USD_FALLBACK` from here, so they must NOT transitively
+ * pull in better-sqlite3 / the clock. The DB-backed resolver lives in
+ * `fx-rate-source.ts` and is imported only by async request handlers.
+ */
+
+/** Fallback EUR/USD used only when the FX feed is unavailable. Tier: 'estimated'. */
+export const EUR_USD_FALLBACK = 1.08;
+
+export interface EurToUsd {
+  rate: number;
+  tier: 'live' | 'estimated';
+  /** rate_date of the sourced row, or null when falling back to the constant. */
+  rateDate: string | null;
+}

--- a/lib/economics/route-decision.ts
+++ b/lib/economics/route-decision.ts
@@ -147,7 +147,7 @@ const HRA_DAYS_FOR_SUEZ = 4; // approx Bab-el-Mandeb + Red Sea exposure
 interface CompareInput {
   vessel: VoyageInput['vessel'];
   cargo: VoyageInput['cargo'];
-  marketRates: { bunkerPriceUsdPerMt: number; euaPriceEur: number };
+  marketRates: { bunkerPriceUsdPerMt: number; euaPriceEur: number; eurToUsdRate?: number };
   daResolver?: DaResolver;
 }
 
@@ -199,6 +199,7 @@ function buildLeg(
     cargo,
     bunkerPriceUsdPerMt: marketRates.bunkerPriceUsdPerMt,
     euaPriceEur: marketRates.euaPriceEur,
+    eurToUsdRate: marketRates.eurToUsdRate,
     durationDays: dur,
     canalUsd: viaSuez ? SUEZ_CANAL_DUES_USD : 0,
     daUsd,
@@ -292,7 +293,7 @@ export async function compareRoutes(
   destination: string,
   vessel: VoyageInput['vessel'],
   cargo: VoyageInput['cargo'],
-  marketRates: { bunkerPriceUsdPerMt: number; euaPriceEur: number },
+  marketRates: { bunkerPriceUsdPerMt: number; euaPriceEur: number; eurToUsdRate?: number },
   daResolver?: DaResolver,
   jwcSystemContext?: string,
 ): Promise<RouteCompareResult> {

--- a/lib/economics/voyage-calculator.ts
+++ b/lib/economics/voyage-calculator.ts
@@ -44,6 +44,9 @@ export interface VoyageInput {
   };
   bunkerPriceUsdPerMt: number;
   euaPriceEur: number;
+  /** EUR→USD for EU-cost conversion (ETS/FuelEU). Resolve via getEurToUsd() and inject;
+   *  omitted → EUR_USD_FALLBACK (estimated). */
+  eurToUsdRate?: number;
   durationDays: number;
   /** EU leg percentage (0–1). Default 0 (no ETS). */
   euLegPercent?: number;
@@ -122,6 +125,7 @@ export function calculateTCE(input: VoyageInput): TCEResult {
     // Prices
     bunkerPriceUsdPerMt: safeNum(input.bunkerPriceUsdPerMt),
     euaPriceEur: safeNum(input.euaPriceEur),
+    eurToUsdRate: input.eurToUsdRate,
     // Pre-resolved costs
     canalUsd: safeNum(input.canalUsd),
     daUsd: safeNum(input.daUsd),

--- a/lib/matching/stored-match-economics.ts
+++ b/lib/matching/stored-match-economics.ts
@@ -209,6 +209,10 @@ export function computeStoredMatchEconomics(
       ballastDistanceNm: ballastDistanceNm ?? undefined,
       bunkerPriceUsdPerMt: resolvedBunkerBk,
       euaPriceEur: euaForBreakdown,
+      // NOTE: eurToUsdRate intentionally omitted here → EUR_USD_FALLBACK. The match
+      // tce_usd_per_day parity chain (matching engine computeEstimatedTce ↔ this stored
+      // recompute) must move to the sourced rate together; wiring only one side would
+      // re-introduce list≠detail divergence (#1002/#1004 class). Follow-up.
       canalUsd: canalUsdBk,
       daUsd: daUsd > 0 ? daUsd : 0,
       euLegPercent,


### PR DESCRIPTION
## Audit finding 14 — EUR→USD was a hardcoded literal, not a sourced rate

`EUR→USD = 1.08` was hardcoded in **three** places and used at three call-sites:

| file | const | used at |
|---|---|---|
| `lib/economics/compute-tce.ts` | `EUR_TO_USD` | EU ETS `ets_usd` |
| `lib/economics/bunker-comparison.ts` | `EUR_TO_USD` | bunker `carbonCostUsd` |
| `lib/economics/fueleu.ts` | `EUR_USD_FALLBACK` | FuelEU `penaltyUsd` |

Meanwhile `lib/currency.ts` (daily ECB/Frankfurter feed + 24h cache + `fx_rates` DB) had **zero** economics callers. Real EUR/USD is ~1.16, so every EU-cost USD figure ran **~7% low**.

## One source of truth
- **`lib/economics/fx-rate.ts`** — `EUR_USD_FALLBACK` constant + `EurToUsd` type. Intentionally dependency-light: the pure/synchronous economics functions import **only the constant**, so they don't transitively pull `better-sqlite3`/the clock into their module graph.
- **`lib/economics/fx-rate-source.ts`** — `getEurToUsd(db?)`: reads `fx_rates` **as-of `today()`** with `WHERE base='EUR' AND quote='USD' AND rate_date <= ? ORDER BY rate_date DESC LIMIT 1`. Falls back to `EUR_USD_FALLBACK` with tier `'estimated'` (never silently `'live'`) when the feed is unavailable.

The three pure functions now take optional `eurToUsdRate?` (default `EUR_USD_FALLBACK`). Async request handlers inject `getEurToUsd(db).rate`:
- `app/api/voyage/tce/route.ts` (standalone TCE calculator)
- `lib/economics/bunker-routing.ts` (voyage bunker-recommendation + `matches/[id]` reco)
- `app/api/voyage/compare-routes/route.ts` (lazy `await import` — keeps `better-sqlite3` out of the route's static graph)

## Demo determinism (hard constraint) ✅
The rate is keyed to the **frozen clock date** (`lib/clock.ts` `today()` → frozen in `DEMO_MODE`), never a per-request live value — demo numbers don't drift day to day. Live (non-demo) tracks the latest rate.

## Out of scope / follow-ups
- **Match `tce_usd_per_day` parity chain** (matching-engine `computeEstimatedTce` ↔ `stored-match-economics` recompute) intentionally **left on `EUR_USD_FALLBACK`** — wiring only one side would re-introduce list≠detail divergence (#1002/#1004 class). They must migrate together in a follow-up. No regression (both still 1.08).
- **Re-seeding the demo `fx_rates` table** across the frozen date is a separate ops concern; if no `EUR/USD` row ≤ frozen date exists, the helper falls back to estimated 1.08.

## Tests
`lib/economics/__tests__/fx-rate.test.ts` (7 cases): as-of resolution + `live` tier, frozen-date determinism, `estimated` fallback (empty table + DB error), and all three call-sites scaling with the injected rate.

- `npx tsc --noEmit` — clean
- 139 passed across 13 affected suites (fx-rate, compute-tce, fueleu, bunker, ets-wiring, stored-match, voyage tce route, bunker-rec, route-decision)
- Note: `__tests__/api/compare-routes-perf.test.ts` "import < 1000ms" fails on this VPS **on clean HEAD too** (baseline 1182ms; environmental cold-compile — the heavy static cost is the LLM stack in `route-decision`, not FX). Should pass on faster CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)