### PR TITLE
fix(regen): full-regen worksheet carries worst-case weightMtEffective (audit #12)

### DIFF
--- a/__tests__/scripts/regenerate-matches-freight.test.ts
+++ b/__tests__/scripts/regenerate-matches-freight.test.ts
@@ -196,6 +196,20 @@ describe('buildWorksheet — cargo data-truth fields flow through (#1021 #1023)'
     expect(ws!.cargo.minVesselDwtMt).toBeNull();
     expect(ws!.cargo.maxVesselDwtMt).toBeNull();
   });
+
+  // Divergence audit finding 12: full-regen worksheet must carry worst-case
+  // weightMtEffective like the live engine (real-matches.ts) and rebuildWorksheets,
+  // else range-cargo util% silently drops to nominal and loses "max w/ option".
+  test('range cargo → weightMtEffective carries worst-case (resolveCargoWeight), not nominal', () => {
+    const ws = buildWorksheet(makeMatch(), cargoWithNewFields, undefined);
+    expect(ws!.cargo.weightMt).toBe(5000); // nominal (cfValue)
+    expect(ws!.cargo.weightMtEffective).toBe(5500); // worst-case (weightMtMax)
+  });
+
+  test('absent cargo → weightMtEffective null (no crash)', () => {
+    const ws = buildWorksheet(makeMatch(), undefined, undefined);
+    expect(ws!.cargo.weightMtEffective).toBeNull();
+  });
 });
 
 describe('breakeven_tce_usd_per_day — persisted via createMatch (#959)', () => {

--- a/scripts/demo-seed/regenerate-matches.ts
+++ b/scripts/demo-seed/regenerate-matches.ts
@@ -495,6 +495,10 @@ export function buildWorksheet(m: Match, cargo: ParsedCargo | undefined, vessel:
     },
     cargo: {
       weightMt: cargo ? (cfValue(cargo.weightMt) ?? null) : null,
+      // Worst-case (top-of-range) weight for util% gating — same resolver the live
+      // engine (real-matches.ts) and rebuildWorksheets use. Without this, full regen
+      // falls back to nominal and loses the "max w/ option" row (divergence audit #12).
+      weightMtEffective: cargo ? (resolveCargoWeight(cargo) ?? null) : null,
       volumeCbm: cargo ? (cargo.volumeCbm ?? null) : null,
       minVesselDwtMt: cargo ? (cargo.minVesselDwtMt ?? null) : null,
       maxVesselDwtMt: cargo ? (cargo.maxVesselDwtMt ?? null) : null,


### PR DESCRIPTION
## Divergence audit — finding 12

The full-regen worksheet builder `buildWorksheet` omitted `weightMtEffective`,
while **both** other write paths set it:

- live engine — `scripts/demo-seed/real-matches.ts:402` (`resolveCargoWeight(cargo)`)
- targeted rebuild — `rebuildWorksheets` (`scripts/demo-seed/regenerate-matches.ts:369`)

The render reads `weightMtEffective ?? weightMt`
(`components/match/MatchWorksheet.tsx:38,82,137`, `app/matches/MatchesClient.tsx:967`),
so after a **full regen** range cargoes whose worst-case (`weightMtMax`) != nominal
silently fell back to nominal util% and lost the **"max w/ option"** row.

## Fix

One field added to `buildWorksheet`'s cargo block, using the **same resolver**
(`resolveCargoWeight` / `lib/sailing/cargo-weight`) as the other two paths:

```ts
weightMtEffective: cargo ? (resolveCargoWeight(cargo) ?? null) : null,
```

## Tests

`__tests__/scripts/regenerate-matches-freight.test.ts` — buildWorksheet suite:
- range cargo (5000 / max 5500) → `weightMtEffective === 5500` (worst-case), not nominal
- absent cargo → `null` (no crash)

RED→GREEN confirmed. Full suite 12/12; `--findRelatedTests` 49/49; `tsc --noEmit` clean.

## Note

This is the **code fix only**. Prod propagation is a separate prod-regen step
(founder sanction) the orchestrator will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)