### PR TITLE
fix(route-decision): round-trip voyage duration so Suez/Cape modal matches card (audit #7)

### DIFF
--- a/__tests__/economics/compare-routes-roundtrip.test.ts
+++ b/__tests__/economics/compare-routes-roundtrip.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Audit finding #7: Suez-vs-Cape route comparison computed voyage duration
+ * ONE-WAY while the canonical TCE path (compute-tce.ts → estimateRoundTripDays)
+ * uses round-trip (ladenDays*2 + 2). Result: the modal bunker burn + TCE/day
+ * were ~2x off vs the same vessel match card.
+ *
+ * These tests pin compareRoutes leg duration + bunker burn to the SAME
+ * round-trip formula the match card uses, so the modal matches the card.
+ *
+ * AI reason path is mocked offline (route-decision routes through
+ * @/lib/ai-provider; pin AI_PROVIDER=openai to delegate to the mocked layer).
+ */
+
+jest.mock('@/lib/openai', () => ({
+  callAiText: jest.fn(),
+  callAiJson: jest.fn(),
+}));
+
+import { callAiText } from '@/lib/openai';
+import { compareRoutes } from '@/lib/economics/route-decision';
+import { computeTce } from '@/lib/economics/compute-tce';
+import { estimateRoundTripDays } from '@/lib/economics/voyage-days';
+
+const mockedCallAiText = callAiText as jest.MockedFunction<typeof callAiText>;
+
+const VESSEL = {
+  dwt: 76_000,
+  valueUsd: 22_000_000,
+  speedKts: 13.5,
+  consumptionMtPerDay: 29,
+};
+const CARGO = { quantityMt: 65_000, freightRateUsdPerMt: 28 };
+const MARKET = { bunkerPriceUsdPerMt: 620, euaPriceEur: 75 };
+
+// Singapore|Rotterdam laden distances from DISTANCE_TABLE (rotterdam|singapore).
+const SUEZ_NM = 8_300;
+const CAPE_NM = 11_800;
+
+describe('compareRoutes — round-trip duration parity (audit #7)', () => {
+  beforeEach(() => {
+    mockedCallAiText.mockReset();
+    mockedCallAiText.mockResolvedValue('ok');
+    process.env.AI_PROVIDER = 'openai';
+  });
+
+  it('suez leg duration uses round-trip (ladenDays*2+2), not one-way', async () => {
+    const r = await compareRoutes('Singapore', 'Rotterdam', VESSEL, CARGO, MARKET);
+    expect(r.suez.durationDays).toBeCloseTo(estimateRoundTripDays(SUEZ_NM, VESSEL.speedKts), 5);
+    expect(r.suez.breakdown.duration_days).toBeCloseTo(
+      estimateRoundTripDays(SUEZ_NM, VESSEL.speedKts),
+      5,
+    );
+  });
+
+  it('cape leg duration uses round-trip (ladenDays*2+2), not one-way', async () => {
+    const r = await compareRoutes('Singapore', 'Rotterdam', VESSEL, CARGO, MARKET);
+    expect(r.cape.durationDays).toBeCloseTo(estimateRoundTripDays(CAPE_NM, VESSEL.speedKts), 5);
+  });
+
+  it('suez bunker burn matches the canonical card TCE for the same laden leg', async () => {
+    const r = await compareRoutes('Singapore', 'Rotterdam', VESSEL, CARGO, MARKET);
+
+    // Canonical card basis: computeTce derives round-trip duration internally
+    // (no overrideDurationDays). Bunker = consumption * round-trip-days * price.
+    const card = computeTce({
+      dwt: VESSEL.dwt,
+      valueUsd: VESSEL.valueUsd,
+      speedKts: VESSEL.speedKts,
+      consumptionMtPerDay: VESSEL.consumptionMtPerDay,
+      freightRateUsdPerMt: CARGO.freightRateUsdPerMt,
+      quantityMt: CARGO.quantityMt,
+      distanceNm: SUEZ_NM,
+      bunkerPriceUsdPerMt: MARKET.bunkerPriceUsdPerMt,
+      euaPriceEur: 0,
+      canalUsd: 0,
+      daUsd: 0,
+    });
+
+    expect(r.suez.breakdown.bunker_usd).toBe(card.breakdown.bunker_usd);
+  });
+
+  it('cape leg is still slower than suez (winner-selection basis unchanged)', async () => {
+    const r = await compareRoutes('Singapore', 'Rotterdam', VESSEL, CARGO, MARKET);
+    expect(r.cape.durationDays).toBeGreaterThan(r.suez.durationDays);
+  });
+});

--- a/lib/economics/route-decision.ts
+++ b/lib/economics/route-decision.ts
@@ -14,6 +14,7 @@
  */
 
 import { calculateTCE, type VoyageInput, type TCEBreakdown } from './voyage-calculator';
+import { estimateRoundTripDays } from './voyage-days';
 import { callAiText } from '@/lib/ai-provider';
 
 // βf3-06: LLM reason timeout — cap the AI explain call so cold-start ≤5s.
@@ -134,13 +135,6 @@ function lookupDistances(origin: string, destination: string): DistancePair {
   return DISTANCE_TABLE[key] ?? DEFAULT_DISTANCE;
 }
 
-function durationDays(distanceNm: number, speedKts: number): number {
-  if (!Number.isFinite(distanceNm) || !Number.isFinite(speedKts) || speedKts <= 0) {
-    return 0;
-  }
-  return Math.round((distanceNm / (speedKts * 24)) * 10) / 10;
-}
-
 const SUEZ_CANAL_DUES_USD = 480_000; // matches scenario narrative
 const HRA_DAYS_FOR_SUEZ = 4; // approx Bab-el-Mandeb + Red Sea exposure
 
@@ -169,7 +163,12 @@ function buildLeg(
   { vessel, cargo, marketRates, daResolver }: CompareInput,
 ): RouteCompareLeg {
   const speed = vessel.speedKts > 0 ? vessel.speedKts : 13;
-  const dur = durationDays(distanceNm, speed);
+  // Audit #7: use the canonical round-trip formula (ladenDays*2 + 2 port days),
+  // the SAME one compute-tce.ts uses for the match card, so the modal bunker burn
+  // and TCE/day match the card instead of being ~2x off (one-way vs round-trip).
+  // estimateRoundTripDays falls back to 12 kn on bad speed; speed is already
+  // clamped to 13 above, so the 12-kn fallback only triggers on non-finite speed.
+  const dur = estimateRoundTripDays(distanceNm, speed);
 
   // safeResolve: NaN/negative → 0; resolver throw → 0.
   // Math.max(0, NaN) === NaN, so Number.isFinite guard is required.


### PR DESCRIPTION
## Audit finding #7 — Suez-vs-Cape modal used one-way duration

The Suez-vs-Cape route comparison computed voyage duration **one-way** while the
rest of the app uses **round-trip**, so the modal bunker burn + TCE/day were ~2x
off vs the same vessel match card.

### Root cause
- `lib/economics/compute-tce.ts` (canonical card path) derives duration via
  `estimateRoundTripDays` = `ladenDays*2 + 2` port days.
- `lib/economics/route-decision.ts` `buildLeg` used a local one-way helper
  `durationDays(dist, speed)` = `round(dist/(speed*24))`, passed as
  `overrideDurationDays` into `calculateTCE`. Bunker = `consumption × one-way-days`
  (~half) and TCE/day divided by one-way days → absolute USD ~2× off.

Winner selection was already correct (both legs shared the same one-way basis);
only the absolute USD diverged.

### Fix
Replace the local one-way `durationDays()` with the shared canonical
`estimateRoundTripDays()` (same formula the match card uses). Now the modal
bunker burn + TCE/day match the card. The now-dead local helper is removed
(module-private, no external callers — grep-verified).

### Tests (TDD RED→GREEN)
New `__tests__/economics/compare-routes-roundtrip.test.ts`:
- leg `durationDays` == `estimateRoundTripDays(distance, speed)` (suez + cape)
- suez `bunker_usd` == canonical `computeTce` card basis
  (**RED: 460288 one-way → GREEN: 957158 round-trip**)
- cape still slower than suez (winner-selection basis unchanged)

Verification:
- `npx tsc --noEmit` — clean (needs `--max-old-space-size=6144` on this VPS)
- 33 passed / 2 skipped across 7 related suites (`--findRelatedTests route-decision.ts`)
- `__tests__/api/compare-routes-perf.test.ts` "import < 1000ms" is an environmental
  cold-compile flake (fails on clean HEAD too — documented in #1053; baseline
  measured 2704ms here without this change). Not caused by this PR.

Builds on #1053 (single-sourced EUR→USD), already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)