### PR TITLE
fix(demo-seed): anchor TMI headline (frozen-date row) to 12683 oracle (audit #16)

### DIFF
--- a/scripts/demo-seed/__tests__/tmi-fixture.test.ts
+++ b/scripts/demo-seed/__tests__/tmi-fixture.test.ts
@@ -78,4 +78,19 @@ describe('buildTmiRows', () => {
     const mean = rows.reduce((s, r) => s + r.value, 0) / rows.length;
     expect(Math.abs(mean - 12683)).toBeLessThan(800);
   });
+
+  it('headline (last / frozen-date row) === 12683 oracle', () => {
+    // The displayed TMI benchmark is the LAST row (frozenDate). It MUST equal
+    // the canonical 12683 oracle the broker compares TCE against — not the
+    // series mean. (audit finding 16)
+    const last = rows[rows.length - 1];
+    expect(last.index_date).toBe(FROZEN_DATE);
+    expect(last.value).toBe(12683);
+  });
+
+  it('series is not flattened — keeps oscillation amplitude', () => {
+    const values = rows.map((r) => r.value);
+    const spread = Math.max(...values) - Math.min(...values);
+    expect(spread).toBeGreaterThan(500);
+  });
 });

--- a/scripts/demo-seed/tmi-fixture.ts
+++ b/scripts/demo-seed/tmi-fixture.ts
@@ -12,7 +12,11 @@ import type { MarketIndexRow } from '@/lib/market/market-indices-repository';
 /**
  * Build an array of `count` consecutive daily TMI rows.
  * Dates run from (frozenDate - count + 1) to frozenDate (inclusive), ascending.
- * value = round(12683 + 600*sin(i*0.5) + 120*((i%5)-2)), clamped to [12000,13500].
+ * value = round(12683 + deviation*taper), clamped to [12000,13500], where
+ * deviation = 600*sin(i*0.5) + 120*((i%5)-2) and taper -> 0 over the final
+ * days so the HEADLINE (last / frozen-date row) lands exactly on the 12683
+ * oracle the broker compares TCE against, while earlier rows keep their
+ * plausible oscillation. (audit finding 16)
  * fetched_at is frozenDate + 'T12:00:00.000Z'.
  */
 export function buildTmiRows(frozenDate: string, count = 30): MarketIndexRow[] {
@@ -26,7 +30,12 @@ export function buildTmiRows(frozenDate: string, count = 30): MarketIndexRow[] {
     const date = new Date(end.getTime() - dayOffset * 24 * 60 * 60 * 1000);
     const isoDate = date.toISOString().slice(0, 10);
 
-    const raw = 12683 + 600 * Math.sin(i * 0.5) + 120 * ((i % 5) - 2);
+    // Anchor the displayed (frozen-date) row to the 12683 oracle: taper the
+    // deviation to 0 as we approach the frozen date (dayOffset === 0 => 0),
+    // converging like a spot quote without a one-day cliff or flattening.
+    const deviation = 600 * Math.sin(i * 0.5) + 120 * ((i % 5) - 2);
+    const taper = Math.min(1, dayOffset / 4);
+    const raw = 12683 + deviation * taper;
     const value = Math.round(Math.max(12000, Math.min(13500, raw)));
 
     rows.push({


### PR DESCRIPTION
## Audit finding 16 — inflated TMI headline benchmark

The seeded TMI **headline / current value** (the last row at the frozen date)
landed on **13484**, but the canonical oracle everywhere else (tests, migrations,
artifacts, `lib/market/benchmark.ts`) is **12683** — a ~6% inflated market
benchmark the broker compares TCE against.

### Root cause
`scripts/demo-seed/tmi-fixture.ts`: the sine series was centered on 12683 **on
average**, but the displayed value is the **last row** (frozen date), which by the
formula `12683 + 600·sin(i·0.5) + 120·((i%5)−2)` lands at `i=count-1` on 13484.

### Fix
Taper the deviation to 0 as the series approaches the frozen date
(`taper = min(1, dayOffset/4)`, `dayOffset===0 ⇒ 0`). The headline now lands
**exactly on 12683**, converging like a spot quote — while earlier rows keep their
plausible oscillation:

- last (frozen-date) row: **12683** (was 13484)
- day-over-day jump into headline: **−179** (no cliff)
- spread: **1469** (not flattened) · mean: **~12696** (still centered) · no new clamping

### Tests (TDD)
RED → GREEN in `scripts/demo-seed/__tests__/tmi-fixture.test.ts`:
- new: headline (last / frozen-date row) === 12683 oracle (was 13484)
- new: series is not flattened (spread > 500)
- existing 9 still green (mean ±800, dates, ids, determinism, range)

`npx jest scripts/demo-seed/__tests__/tmi-fixture.test.ts` → **11 passed**. `tsc --noEmit` clean.

### ⚠️ Re-seed required to propagate to prod
TMI lives in **seeded data**. This PR fixes the **generator**; the prod
`demo-seed.db` top row still shows 13484 until a **TMI re-seed** runs
(`npx tsx scripts/demo-seed/seed-tmi.ts` — idempotent upsert). Market indices may
live in `sessions.db` on prod; verify the target before re-seeding. **Not re-seeded
in this PR** (per scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)