### PR TITLE
fix(sailing): month-only laycan honours stated year (audit #10)

### DIFF
--- a/__tests__/cargo-laycan-render.test.ts
+++ b/__tests__/cargo-laycan-render.test.ts
@@ -32,10 +32,11 @@ describe('cargo laycan render — parse+format pipeline', () => {
     expect(result).toMatch(/Jun\s+25.+Jun\s+30|Jun 2[5-9]/);
   });
 
-  // "June 2019" bare month-year → whole-month range at refYear (founder 2026-06-02:
-  // month-year → range). Stale 2019 stripped like the "End June 2019" phrase case
-  // above — never a single day, never a stale-year raw passthrough.
-  it('bare "June 2019" → whole-month range at refYear (stale year stripped)', () => {
+  // "June 2019" bare month-year → whole-month range. The parser now HONOURS the
+  // stated year (audit finding 10: it parses to June 2019, not refYear June 2026),
+  // but the display omits the year, so the rendered string is the same whole-month
+  // window — never a single day, never a stale-year raw passthrough.
+  it('bare "June 2019" → whole-month range (year honoured, display omits it)', () => {
     const result = fmt('June 2019');
     expect(result).toBe('Jun 1–Jun 30');
     expect(result).not.toBe('—');

--- a/lib/sailing/__tests__/date-parsing.test.ts
+++ b/lib/sailing/__tests__/date-parsing.test.ts
@@ -177,8 +177,14 @@ describe('parseLaycan — fuzzy windows (founder 2026-06-02: no single-day colla
     expect(r.start.toISOString().slice(0, 10)).toBe('2026-06-16');
     expect(r.end.toISOString().slice(0, 10)).toBe('2026-06-30');
   });
-  it('bare month "June 2019" → whole-month window at refYear, not single day', () => {
+  it('bare month "June 2019" → whole-month window honouring the stated year, not refYear', () => {
     const r = parseLaycan('June 2019', 2026)!;
+    expect(r.start.toISOString().slice(0, 10)).toBe('2019-06-01');
+    expect(r.end.toISOString().slice(0, 10)).toBe('2019-06-30');
+    expect(r.start.getTime()).not.toBe(r.end.getTime());
+  });
+  it('bare month "June" with NO year → whole-month window falls back to refYear', () => {
+    const r = parseLaycan('June', 2026)!;
     expect(r.start.toISOString().slice(0, 10)).toBe('2026-06-01');
     expect(r.end.toISOString().slice(0, 10)).toBe('2026-06-30');
     expect(r.start.getTime()).not.toBe(r.end.getTime());

--- a/lib/sailing/date-parsing.ts
+++ b/lib/sailing/date-parsing.ts
@@ -291,12 +291,16 @@ export function parseLaycan(
 
   // Bare "<Month>" or "<Month> <year>" (no day) → whole-month window, not a
   // single day. Guards against month-only laycans ("June 2019") collapsing.
-  const monthOnly = s.match(new RegExp(`^\\s*${MONTH_RE.source}(?:[\\s,]+\\d{4})?\\s*$`, 'i'));
+  // When the year is explicitly stated, honour it (mirrors the slash/dash range
+  // branches above which respect a captured year); fall back to refYear only
+  // when no year is present.
+  const monthOnly = s.match(new RegExp(`^\\s*${MONTH_RE.source}(?:[\\s,]+(\\d{4}))?\\s*$`, 'i'));
   if (monthOnly) {
     const mi = monthIdx(monthOnly[1]);
     if (mi != null) {
-      const lastDay = new Date(Date.UTC(refYear, mi + 1, 0)).getUTCDate();
-      return { start: mkUtc(refYear, mi, 1), end: mkUtc(refYear, mi, lastDay) };
+      const yr = monthOnly[2] ? Number(monthOnly[2]) : refYear;
+      const lastDay = new Date(Date.UTC(yr, mi + 1, 0)).getUTCDate();
+      return { start: mkUtc(yr, mi, 1), end: mkUtc(yr, mi, lastDay) };
     }
   }
 


### PR DESCRIPTION
## Audit finding #10 — month-only laycan discards stated year

### Problem
`parseLaycan` in `lib/sailing/date-parsing.ts` (~L294) matched bare
`"<Month> <year>"` laycans but **threw away the captured year** and substituted
`refYear`. So `parseLaycan('June 2019', 2026)` returned **June 2026**, not
June 2019. The adjacent slash/dash range branches (`15/09–25/09 2019`,
`15-20/06/2019`) already honour a captured year — the month-only branch was the
odd one out.

### Fix
Added a `(\d{4})` capture group to the month-only regex and read it:
- year present → use it (`June 2019` → 2019-06-01 .. 2019-06-30)
- no year → fall back to `refYear` as before (`June` → refYear whole month)

Parser-only change; the whole-month window semantics (never a single day) are
preserved.

### Tests
- `date-parsing.test.ts`: `June 2019` honours 2019; new `June` (no year) →
  refYear fallback case.
- `cargo-laycan-render.test.ts`: render still `Jun 1–Jun 30` (display omits the
  year, so the rendered string is unchanged).

### Verification
- `tsc --noEmit` → clean (heap-bumped; full-project tsc OOMs at default heap on VPS)
- `jest --findRelatedTests lib/sailing/date-parsing.ts` → **1414 passed, 1 skipped** (130 suites)
- target files → **57 passed**

### ⚠️ Follow-up needed (out of scope for this PR)
This is a **parser-only** fix. Laycans already stored in `parsed_results`
(e.g. existing demo data) were parsed with the old behaviour and still hold the
wrong year. **Regen does NOT re-parse** raw text → a **separate re-parse pass**
is required to correct stored rows. Not done here.
