### PR TITLE
fix(economics): EU ETS phase-in year from app clock (audit #6)

### DIFF
--- a/lib/economics/__tests__/compute-tce-ets-clock.test.ts
+++ b/lib/economics/__tests__/compute-tce-ets-clock.test.ts
@@ -1,0 +1,64 @@
+/**
+ * EU ETS phase-in must be anchored to the app clock (lib/clock `now`), NOT the
+ * raw wall-clock — audit finding #6.
+ *
+ * Before the fix, computeTce called calculateEuEts without a year, so the pure
+ * calc fell back to `new Date().getFullYear()`. That made a "deterministic"
+ * voyage P&L depend on when it ran: the same match computed in Dec 2025 vs
+ * Jan 2026 produced different ETS (phase-in 0.7 → 1.0, +43%), and demo-mode's
+ * frozen clock was ignored.
+ *
+ * These tests mock `@/lib/clock` so the phase-in year is fully injected.
+ */
+
+jest.mock('@/lib/clock', () => ({ now: jest.fn() }));
+
+import { now } from '@/lib/clock';
+import { computeTce } from '../compute-tce';
+import type { TceInputs } from '../compute-tce';
+
+const mockNow = now as jest.MockedFunction<typeof now>;
+
+// Intra-EU voyage with a real EUA price so ETS is non-zero and phase-in matters.
+const BASE: TceInputs = {
+  dwt: 15_000,
+  valueUsd: 8_000_000,
+  speedKts: 12,
+  consumptionMtPerDay: 50,
+  distanceNm: 1_000,
+  quantityMt: 9_750,
+  freightRateUsdPerMt: 15,
+  bunkerPriceUsdPerMt: 600,
+  euaPriceEur: 80,
+  canalUsd: 0,
+  daUsd: 0,
+  overrideDurationDays: 20,
+  euLegPercent: 1.0,
+  originEu: true,
+  destEu: true,
+};
+
+describe('computeTce EU ETS — clock-anchored phase-in (audit #6)', () => {
+  it('phase-in tracks the injected clock year, not the wall-clock', () => {
+    mockNow.mockReturnValue(new Date('2025-06-15T00:00:00.000Z'));
+    const ets2025 = computeTce(BASE).breakdown.ets_eur;
+
+    mockNow.mockReturnValue(new Date('2027-06-15T00:00:00.000Z'));
+    const ets2027 = computeTce(BASE).breakdown.ets_eur;
+
+    // phaseIn 2025 = 0.7, 2027 = 1.0 → 2025 is exactly 70% of fully-phased.
+    expect(ets2025).toBeGreaterThan(0);
+    expect(ets2025).toBeLessThan(ets2027);
+    expect(ets2025).toBeCloseTo(ets2027 * 0.7, 2);
+  });
+
+  it('same inputs + same frozen year → identical ETS regardless of month (Dec vs Jan)', () => {
+    mockNow.mockReturnValue(new Date('2025-12-31T00:00:00.000Z'));
+    const december = computeTce(BASE).breakdown.ets_eur;
+
+    mockNow.mockReturnValue(new Date('2025-01-01T00:00:00.000Z'));
+    const january = computeTce(BASE).breakdown.ets_eur;
+
+    expect(december).toBe(january);
+  });
+});

--- a/lib/economics/compute-tce.ts
+++ b/lib/economics/compute-tce.ts
@@ -26,6 +26,7 @@ import type { EcaZone } from '@/lib/knowledge/eca/parser';
 import type { ResolvedPort } from '@/lib/ports/resolve';
 import type { DataQuality } from '@/lib/data-quality/types';
 import { EUR_USD_FALLBACK } from './fx-rate';
+import { now } from '@/lib/clock';
 
 const ESTIMATED_DAYS_FALLBACK = 1;
 
@@ -231,6 +232,10 @@ export function computeTce(inputs: TceInputs): TceResult {
     euLegPercent,
     vlsfoBurnMt,
     euaPrice,
+    // Phase-in year anchored to the app clock: demo-frozen date under demo-mode,
+    // real year otherwise. UTC to avoid tz boundary flips. Keeps TCE deterministic
+    // — same match no longer drifts across a calendar year boundary. (audit #6)
+    year: now().getUTCFullYear(),
     originEu: inputs.originEu,
     destEu: inputs.destEu,
   });

--- a/lib/economics/ets.ts
+++ b/lib/economics/ets.ts
@@ -35,7 +35,11 @@ export interface EuEtsInput {
   euaPrice: number; // EUR/tCO2
   /** Fuel type for CO₂ factor lookup. Default 'VLSFO' → Cf=3.151. */
   fuelType?: string;
-  /** Calendar year for MRV phase-in. Default = current year (2026+ → 1.0). */
+  /**
+   * Calendar year for MRV phase-in. Omitted → fully-phased steady-state (1.0);
+   * the function never reads the wall-clock. Pass an explicit clock-anchored
+   * year for time-correct phase-in. (audit #6)
+   */
   year?: number;
   /**
    * EU ETS coverage factor — derived from whether voyage endpoints are in EU/EEA.
@@ -72,7 +76,11 @@ export function calculateEuEts(input: EuEtsInput): EuEtsResult {
   if (coverageFactor === 0) return { amountEur: 0, applicable: false };
 
   const cf = cfForFuel(fuelType ?? 'VLSFO');
-  const phase = phaseIn(year ?? new Date().getFullYear());
+  // Pure function: never read the wall-clock here (audit #6). When `year` is
+  // omitted, default to the 2026+ fully-phased steady-state (1.0). Production
+  // callers MUST pass an explicit clock-anchored year (demo-frozen via lib/clock)
+  // so the calc is deterministic and identical regardless of when it runs.
+  const phase = year === undefined ? 1.0 : phaseIn(year);
   const amount = vlsfoBurnMt * cf * euLegPercent * phase * euaPrice * coverageFactor;
   return {
     amountEur: Math.round(amount * 100) / 100,


### PR DESCRIPTION
## What

`calculateEuEts` is now a **pure function** — it no longer reads the wall-clock. When `year` is omitted it defaults to the 2026+ fully-phased steady-state (`phase = 1.0`). `computeTce` passes an explicit clock-anchored year via `lib/clock` `now().getUTCFullYear()` (demo-frozen under demo-mode, real year otherwise; UTC to avoid tz boundary flips).

## Why

Before, `computeTce` called `calculateEuEts` without a `year`, so the calc fell back to `new Date().getFullYear()`. That made a "deterministic" voyage P&L depend on **when it ran**: the same match computed Dec 2025 vs Jan 2026 produced different ETS (phase-in 0.7 → 1.0, +43%), and demo-mode's frozen clock was ignored.

## Notes

- **Pure-fn, no wall-clock**: phase-in year is now fully injected by the caller; the ETS calc is deterministic regardless of when it runs.
- **DATA-PATH**: stored worksheet ETS reflects the year at compute time → already-persisted worksheets need a **prod regen** to re-anchor to the app clock.

## Test
- New `lib/economics/__tests__/compute-tce-ets-clock.test.ts`: phase-in tracks injected clock year (not wall-clock); same frozen year → identical ETS across Dec/Jan.
- `npx jest lib/economics`: 229/229 green.
- `findRelatedTests` on changed files: 1080 passed, 3 skipped, 128 suites.
- `tsc --noEmit`: clean.

(Audit finding #6 — internal numbering, not GitHub issue #6.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)