### PR TITLE
fix(eua-cron): fall through to ICAP/TE when EEX returns null (audit wave-2)

### DIFF
--- a/__tests__/scripts/knowledge/cron/refresh-eua.test.ts
+++ b/__tests__/scripts/knowledge/cron/refresh-eua.test.ts
@@ -108,6 +108,39 @@ describe('refresh-eua cron — orchestration logic', () => {
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 
+  it('EEX null result (XLSX structure changed) → ICAP called as fallback → exit 0', async () => {
+    // Regression: refreshEex returning null is the normal "structure changed"
+    // signal; it must fall through to ICAP/TE, not freeze the carbon price.
+    (refreshEex as jest.Mock).mockResolvedValue(null);
+    (refreshIcap as jest.Mock).mockResolvedValue({
+      rowsChanged: 1,
+      priceDate: '2026-05-08',
+      price: 71.30,
+    });
+
+    const { main } = await import('@/scripts/knowledge/cron/refresh-eua');
+    await main();
+
+    expect(refreshIcap).toHaveBeenCalledTimes(1);
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  it('EEX null and ICAP null → TE called as tertiary fallback → exit 0', async () => {
+    (refreshEex as jest.Mock).mockResolvedValue(null);
+    (refreshIcap as jest.Mock).mockResolvedValue(null);
+    (refreshTradingEconomics as jest.Mock).mockResolvedValue({
+      rowsChanged: 1,
+      priceDate: '2026-06-01',
+      price: 65.50,
+    });
+
+    const { main } = await import('@/scripts/knowledge/cron/refresh-eua');
+    await main();
+
+    expect(refreshTradingEconomics).toHaveBeenCalledTimes(1);
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
   it('EEX success but stale price (>3 days ago) → ICAP called as fallback → exit 0', async () => {
     (refreshEex as jest.Mock).mockResolvedValue({
       rowsChanged: 1,

--- a/scripts/knowledge/cron/refresh-eua.ts
+++ b/scripts/knowledge/cron/refresh-eua.ts
@@ -46,11 +46,18 @@ export async function main(): Promise<void> {
   try {
     console.log('[EEX] Fetching auction results from EEX hub...');
     const r = await refreshEex(db);
-    if (!r) { reportSyncFailure(db, eexId, new Error('EEX XLSX parse failed — null result')); console.warn('[EEX] ✗ Null result — structure changed'); return; }
-    eexPriceDate = r.priceDate;
-    reportSyncSuccess(db, eexId, { rowsChanged: r.rowsChanged });
-    eexOk = true;
-    console.log(`[EEX] ✓ Done: price=${r.price} date=${r.priceDate}`);
+    if (!r) {
+      // Null is EEX's normal "XLSX structure changed" signal — NOT a hard stop.
+      // Leave eexOk=false and fall through to the ICAP/TE fallback chain so the
+      // carbon price doesn't freeze. (Returning here skipped both fallbacks.)
+      reportSyncFailure(db, eexId, new Error('EEX XLSX parse failed — null result'));
+      console.warn('[EEX] ✗ Null result — structure changed; falling through to fallbacks');
+    } else {
+      eexPriceDate = r.priceDate;
+      reportSyncSuccess(db, eexId, { rowsChanged: r.rowsChanged });
+      eexOk = true;
+      console.log(`[EEX] ✓ Done: price=${r.price} date=${r.priceDate}`);
+    }
   } catch (e) {
     reportSyncFailure(db, eexId, e as Error);
     console.error('[EEX] ✗ Failed:', e);


### PR DESCRIPTION
## Problem (audit wave-2 finding)

The EUA carbon-price cron silently skipped its ICAP/TradingEconomics fallbacks when EEX returned `null` — which is EEX's **normal** 'XLSX structure changed' signal. Result: the carbon price froze whenever the EEX sheet layout shifted.

## Root

`scripts/knowledge/cron/refresh-eua.ts` (~line 49): when `refreshEex()` returned `null`, `main()` did `reportSyncFailure(...)` then `return` — exiting entirely. ICAP/TE fallbacks were only reached when `refreshEex` **threw**, never on `null`.

## Fix

Drop the early `return`. On null, leave `eexOk=false` and fall through to the `needFallback` path (ICAP → TradingEconomics). Refactored the success path into an `else` branch.

## Tests (TDD)

- RED first: added `null → ICAP` and `null+null → TE` regression tests; both failed on buggy code (ICAP/TE never called).
- GREEN after fix: 10/10 pass.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)