### PR TITLE
fix(classification): NEEDS_ACTION at 48h SLA, not ~2h (units double-error)

### DIFF
--- a/lib/__tests__/classification-service.test.ts
+++ b/lib/__tests__/classification-service.test.ts
@@ -96,14 +96,17 @@ describe('deriveEmailStatus', () => {
     expect(deriveEmailStatus({ requiresReply: true, isUnanswered: false, hoursWithout: 0 })).toBe('RESPONDED');
   });
 
-  it('returns NEEDS_ACTION when hoursWithout >= UNANSWERED_THRESHOLD_HOURS / 24', () => {
-    // UNANSWERED_THRESHOLD_HOURS = 48, so threshold = 2 days = 48h/24 = 2
-    // hoursWithout >= 2 means NEEDS_ACTION (comparison is hours >= threshold_in_days)
-    expect(deriveEmailStatus({ requiresReply: true, isUnanswered: true, hoursWithout: 3 })).toBe('NEEDS_ACTION');
+  it('returns NEEDS_ACTION when hoursWithout >= UNANSWERED_THRESHOLD_HOURS (48h SLA)', () => {
+    // UNANSWERED_THRESHOLD_HOURS = 48 — comparison is in hours, not days.
+    // A deal unanswered >= 48h breaches SLA → NEEDS_ACTION.
+    expect(deriveEmailStatus({ requiresReply: true, isUnanswered: true, hoursWithout: 48 })).toBe('NEEDS_ACTION');
+    expect(deriveEmailStatus({ requiresReply: true, isUnanswered: true, hoursWithout: 72 })).toBe('NEEDS_ACTION');
   });
 
-  it('returns PENDING when requiresReply, isUnanswered, but below threshold', () => {
-    expect(deriveEmailStatus({ requiresReply: true, isUnanswered: true, hoursWithout: 1 })).toBe('PENDING');
+  it('returns PENDING for a 1-day-unanswered deal (24h, below 48h SLA)', () => {
+    // 1 day unanswered = 24h = below the 48h threshold → still PENDING, not NEEDS_ACTION.
+    expect(deriveEmailStatus({ requiresReply: true, isUnanswered: true, hoursWithout: 24 })).toBe('PENDING');
+    expect(deriveEmailStatus({ requiresReply: true, isUnanswered: true, hoursWithout: 47 })).toBe('PENDING');
   });
 });
 

--- a/lib/classification-service.ts
+++ b/lib/classification-service.ts
@@ -62,7 +62,7 @@ export function deriveEmailStatus(params: {
   const { requiresReply, isUnanswered, hoursWithout } = params;
   if (!requiresReply) return 'INFO_ONLY';
   if (!isUnanswered) return 'RESPONDED';
-  if (hoursWithout >= UNANSWERED_THRESHOLD_HOURS / 24) return 'NEEDS_ACTION';
+  if (hoursWithout >= UNANSWERED_THRESHOLD_HOURS) return 'NEEDS_ACTION';
   return 'PENDING';
 }
 


### PR DESCRIPTION
## Audit fix (wave-2)

NEEDS_ACTION fired at ~2h instead of the intended 48h SLA — a units double-error.

### Root cause (`lib/classification-service.ts`)
- L65 compared `hoursWithout` to `UNANSWERED_THRESHOLD_HOURS / 24` (48/24 = **2**)
- L90 computes `hoursWithout = daysWithoutReply * 24`

So `days*24 >= 2` made **any** deal unanswered >=1 day flip to `NEEDS_ACTION`, and the 24–48h `PENDING` window was unreachable.

### Fix
Compare in consistent **hours** — drop the `/24`:
```diff
-  if (hoursWithout >= UNANSWERED_THRESHOLD_HOURS / 24) return 'NEEDS_ACTION';
+  if (hoursWithout >= UNANSWERED_THRESHOLD_HOURS) return 'NEEDS_ACTION';
```

### Test
The test that **encoded** the bug now asserts the correct SLA:
- 24h / 47h → `PENDING`
- 48h / 72h → `NEEDS_ACTION`

### Propagation
Status recomputes per demo-hydration from persisted `daysWithoutReply` — fix propagates **without a regen**.

Tests: 15/15 green · `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)