### PR TITLE
fix(draft-quote): validate matchId ownership before enqueue (IDOR)

### DIFF
--- a/app/api/ai/__tests__/draft-quote.test.ts
+++ b/app/api/ai/__tests__/draft-quote.test.ts
@@ -52,11 +52,18 @@ jest.mock('@/lib/session-store', () => ({
   })),
 }));
 
+// Mock matches-repository — getMatch is used to enforce matchId ownership.
+jest.mock('@/lib/matching/matches-repository', () => ({
+  getMatch: jest.fn(),
+}));
+
 import { enqueueQuoteJob } from '@/lib/quote-jobs/store';
 import { getSession } from '@/lib/session';
+import { getMatch } from '@/lib/matching/matches-repository';
 
 const mockEnqueueQuoteJob = enqueueQuoteJob as jest.MockedFunction<typeof enqueueQuoteJob>;
 const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+const mockGetMatch = getMatch as jest.MockedFunction<typeof getMatch>;
 
 function makeRequest(body: unknown, sessionId?: string): NextRequest {
   const headers: Record<string, string> = {
@@ -192,6 +199,8 @@ describe('POST /api/ai/draft-quote', () => {
 
   it('forwards matchId from the body into the enqueued job', async () => {
     mockGetSession.mockReturnValue(baseSession);
+    // Match owned by the requesting session — passes ownership guard.
+    mockGetMatch.mockReturnValue({ id: 54332, user_id: 'session-1' } as ReturnType<typeof getMatch>);
     const req = makeRequest({ emailId: 'email-1', matchId: '54332' }, 'session-1');
     const res = await POST(req);
     expect(res.status).toBe(202);
@@ -199,5 +208,35 @@ describe('POST /api/ai/draft-quote', () => {
       expect.anything(),
       expect.objectContaining({ emailId: 'email-1', matchId: '54332' }),
     );
+  });
+
+  // ── IDOR guard: matchId ownership ─────────────────────────────────────────
+
+  it('returns 404 and does NOT enqueue when matchId belongs to another session', async () => {
+    mockGetSession.mockReturnValue(baseSession);
+    // Match exists but is owned by a different session (IDOR attempt).
+    mockGetMatch.mockReturnValue({ id: 99999, user_id: 'other-session' } as ReturnType<typeof getMatch>);
+    const req = makeRequest({ emailId: 'email-1', matchId: '99999' }, 'session-1');
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    expect(mockEnqueueQuoteJob).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 and does NOT enqueue when matchId does not exist', async () => {
+    mockGetSession.mockReturnValue(baseSession);
+    mockGetMatch.mockReturnValue(null);
+    const req = makeRequest({ emailId: 'email-1', matchId: '12345' }, 'session-1');
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    expect(mockEnqueueQuoteJob).not.toHaveBeenCalled();
+  });
+
+  it('enqueues with no ownership check when matchId is omitted', async () => {
+    mockGetSession.mockReturnValue(baseSession);
+    const req = makeRequest({ emailId: 'email-1' }, 'session-1');
+    const res = await POST(req);
+    expect(res.status).toBe(202);
+    expect(mockGetMatch).not.toHaveBeenCalled();
+    expect(mockEnqueueQuoteJob).toHaveBeenCalled();
   });
 });

--- a/app/api/ai/draft-quote/route.ts
+++ b/app/api/ai/draft-quote/route.ts
@@ -3,6 +3,7 @@ import { validateCsrf } from '@/lib/csrf';
 import { requireSession } from '@/lib/session';
 import { DraftQuoteBodySchema } from '@/lib/api-schemas';
 import { getStore } from '@/lib/session-store';
+import { getMatch } from '@/lib/matching/matches-repository';
 import { enqueueQuoteJob, QueueFullError } from '@/lib/quote-jobs/store';
 import { ensureWorker } from '@/lib/quote-jobs/ensure-worker';
 
@@ -21,8 +22,22 @@ export async function POST(request: NextRequest) {
   const parsedCargo = session.parsedCargos.find(r => r.emailId === emailId);
   if (!parsedCargo) return NextResponse.json({ error: 'Parsed request not found' }, { status: 404 });
 
+  const db = getStore().getDb();
+
+  // IDOR guard: a matchId is opaque to the worker (getMatch has no user_id
+  // filter), so verify ownership here before enqueue. Mirror matches/[id] —
+  // return 404 for both missing matches and matches owned by another session,
+  // so we never leak the existence of another session's match.
+  if (matchId !== undefined) {
+    const numId = Number(matchId);
+    const m = Number.isInteger(numId) && numId >= 1 ? getMatch(db, numId) : null;
+    if (!m || m.user_id !== sessionId) {
+      return NextResponse.json({ error: `Match not found: ${matchId}` }, { status: 404 });
+    }
+  }
+
   try {
-    const job = enqueueQuoteJob(getStore().getDb(), { sessionId, emailId, matchId });
+    const job = enqueueQuoteJob(db, { sessionId, emailId, matchId });
     ensureWorker();
     return NextResponse.json({ jobId: job.id, status: job.status }, { status: 202 });
   } catch (err) {


### PR DESCRIPTION
## Wave-2 security finding — IDOR in async quote worker

### Root
`app/api/ai/draft-quote/route.ts` validated `emailId` against the session
(`session.parsedCargos.find`) but passed `matchId` straight to
`enqueueQuoteJob` with **no ownership check**. The worker's
`getMatch(db, matchId)` (`lib/quote-jobs/match-context.ts`,
`scripts/quote-workshop/worker.ts`) has no `user_id` guard, so a client
could POST another session's `matchId` and receive that match's
vessel / route / rate / TCE inside their own quote — a classic IDOR.

Every other match route already guards `match.user_id === sessionId`
(see `app/api/matches/[id]/route.ts:152` and `:193`).

### Fix
When `matchId` is present, load it and require `m.user_id === sessionId`
**before** enqueue, returning `404` otherwise. Mirrors `matches/[id]` —
`404` for both missing and foreign matches so the existence of another
session's match is never leaked. Route-level fail-fast; the worker is
untouched. `matchId` stays optional (no guard when omitted).

### Tests (TDD)
- RED: foreign `matchId` and nonexistent `matchId` previously enqueued
  (got 202) — added 3 IDOR tests covering foreign → 404, missing → 404,
  omitted → 202-no-guard.
- Updated `forwards matchId` to mock an owned match (still 202).
- `app/api/ai/__tests__/draft-quote.test.ts`: **10/10 green**.
- `tsc --noEmit` clean; `findRelatedTests` 22 passed / 6 skipped / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)