### PR TITLE
fix(commission): compute commissionSummary on demo/prod hydrate path

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session.test.ts
@@ -192,6 +192,21 @@ describe('buildDemoSessionBlob', () => {
     db.close();
   });
 
+  it('computes commissionSummary from seeded recap clauses (demo/prod hydrate path)', () => {
+    const db = makeSeedDb();
+    // A fixture recap carrying a commission clause, as the seed holds (~EUR 315k + ~USD 11k live).
+    db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+      VALUES ('demo','e1','recap','v1','[{"emailId":"e1","itemIndex":0,"vesselName":"MV Demo","loadPort":"Rotterdam","dischPort":"Hamburg","commissionPercent":2.5,"commissionAmount":5000,"commissionCurrency":"EUR"}]',0)`).run();
+
+    const blob = buildDemoSessionBlob(db);
+
+    expect(blob.parsedFixtureRecaps).toHaveLength(1);
+    expect(blob.commissionSummary).not.toBeNull();
+    expect(blob.commissionSummary!.details).toHaveLength(1);
+    expect(blob.commissionSummary!.totalByCurrency).toEqual([{ currency: 'EUR', amount: 5000 }]);
+    db.close();
+  });
+
   it('skips a malformed result_json row but keeps the valid rows (and warns)', () => {
     const db = makeSeedDb();
     db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -8,6 +8,7 @@ import { logger } from '@/lib/logger';
 import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import { normalizeVesselCapacityToCbm } from '@/lib/parsing/vessel-capacity-units';
+import { summarizeCommissions } from '@/lib/commission';
 import type {
   Email, Classification, ParsedCargo, ParsedVessel, ParsedFixtureRecap, Match, ScoreBreakdown, SessionData,
 } from '@/lib/types';
@@ -16,7 +17,7 @@ type DemoBlob = Pick<
   SessionData,
   'emails' | 'classifications' | 'parsedCargos' | 'parsedVessels'
   | 'parsedFixtureRecaps' | 'processedEmails' | 'matches' | 'isSampleData' | 'accountId'
-  | 'lowConfidenceMatches' | 'insufficientData'
+  | 'lowConfidenceMatches' | 'insufficientData' | 'commissionSummary'
 >;
 
 interface EmailRow {
@@ -239,12 +240,18 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
 
   const processedEmails = buildProcessedEmails(emails, classifications, dedupedCargos, dedupedVessels);
 
+  // Commission summary: the live LLM path computes this in app/api/ai/parse-recap/route.ts,
+  // but the demo/prod hydrate path never did — /commission and /summary showed 0 despite
+  // recaps carrying commission clauses (#1060). Mirror parse-recap: summarize the recaps here.
+  const commissionSummary = summarizeCommissions(parsedFixtureRecaps);
+
   return {
     emails,
     classifications,
     parsedCargos: dedupedCargos,
     parsedVessels: dedupedVessels,
     parsedFixtureRecaps,
+    commissionSummary,
     processedEmails,
     matches,
     lowConfidenceMatches,


### PR DESCRIPTION
## Problem (wave-2 audit finding)

`/commission` and `/summary` showed **0** on the live demo. `summarizeCommissions()` ran **only** in the live LLM path (`app/api/ai/parse-recap/route.ts`). Demo/prod builds the session via `buildDemoSessionBlob` (`lib/demo-mode/hydrate-demo-session.ts`), which filled `parsedFixtureRecaps` but left `commissionSummary = null` — so the seeded commission clauses (~EUR 315k + ~USD 11k) never surfaced.

## Fix

Mirror the parse-recap route: call `summarizeCommissions(parsedFixtureRecaps)` in `buildDemoSessionBlob` and set `commissionSummary`. Uses the **current post-#1060** summarizer (structural-pct code preserved, not reverted).

`commissionSummary` is computed at hydrate (per-session blob) and propagates on rehydrate/login — **no demo-seed regen needed**; existing live sessions refresh on re-hydration.

## Tests (TDD)

- RED: blob `commissionSummary` undefined/null with seeded recap commission clauses.
- GREEN: populated — `details` length 1, `totalByCurrency = [{EUR, 5000}]`.
- `hydrate-demo-session.test.ts`: 6/6 · `--findRelatedTests`: 58/58 · `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)