### PR TITLE
feat(dd-i18n): Due Diligence panel fully in English

### DIFF
--- a/__tests__/components/match/DDCheckRow.test.tsx
+++ b/__tests__/components/match/DDCheckRow.test.tsx
@@ -17,15 +17,15 @@ describe('DDCheckRow', () => {
       <DDCheckRow
         label="TCE vs breakeven"
         state="pass"
-        evidence="TCE $9,600/day — $1,400/day выше breakeven"
-        detail={'TCE — дневная доходность.\nРасчёт: TCE $9,600/сут − breakeven $8,200/сут = +$1,400/сут → выше breakeven.\nWar-risk показан в breakdown отдельно.'}
-        source="Расчёт TCE"
+        evidence="TCE $9,600/day — $1,400/day above breakeven"
+        detail={'TCE — daily voyage return.\nCalc: TCE $9,600/day − breakeven $8,200/day = +$1,400/day → above breakeven.\nWar-risk shown separately in the breakdown.'}
+        source="TCE calculation"
       />,
     );
 
     // label + evidence visible immediately
     expect(screen.getByText('TCE vs breakeven')).toBeInTheDocument();
-    expect(screen.getByText(/выше breakeven/)).toBeInTheDocument();
+    expect(screen.getByText(/above breakeven/)).toBeInTheDocument();
     // detail body NOT in DOM before toggle
     expect(screen.queryByTestId('dd-check-detail')).not.toBeInTheDocument();
 
@@ -33,8 +33,8 @@ describe('DDCheckRow', () => {
     await user.click(screen.getByTestId('dd-check-toggle'));
     const body = screen.getByTestId('dd-check-detail');
     expect(body).toBeInTheDocument();
-    expect(body).toHaveTextContent('Расчёт: TCE $9,600/сут');
-    expect(body).toHaveTextContent('Источник: Расчёт TCE');
+    expect(body).toHaveTextContent('Calc: TCE $9,600/day');
+    expect(body).toHaveTextContent('Source: TCE calculation');
 
     // toggle label flips and collapses
     await user.click(screen.getByTestId('dd-check-toggle'));
@@ -43,7 +43,7 @@ describe('DDCheckRow', () => {
 
   it('no detail → no toggle button (gap rows stay flat, never fake-disclose)', () => {
     render(
-      <DDCheckRow label="RightShip score" state="inactive" evidence="не подключено" detail={null} source={null} />,
+      <DDCheckRow label="RightShip score" state="inactive" evidence="not connected" detail={null} source={null} />,
     );
     expect(screen.getByText('RightShip score')).toBeInTheDocument();
     expect(screen.queryByTestId('dd-check-toggle')).not.toBeInTheDocument();
@@ -54,28 +54,28 @@ describe('DDCheckRow', () => {
     const user = userEvent.setup();
     render(
       <DDCheckRow
-        label="Осадка — порт погрузки"
+        label="Laden draft — load port"
         state="pass"
-        evidence="Осадка в грузу ~9.2m vs лимит причала 10.5m"
+        evidence="Laden draft ~9.2m vs berth draft limit 10.5m"
         detail="base explanation"
-        source="Исходное письмо + port-master.json"
+        source="Circular + port-master.json"
         derivation={{ dwt: 35000, cargoTons: 30000, laden: 9.2, portLimit: 10.5, pass: true }}
       />,
     );
     await user.click(screen.getByTestId('dd-check-toggle'));
     const der = screen.getByTestId('dd-draft-derivation');
     expect(der).toHaveTextContent('DWT 35,000 mt');
-    expect(der).toHaveTextContent('загрузка 86%'); // 30000/35000
+    expect(der).toHaveTextContent('load factor 86%'); // 30000/35000
     expect(der).toHaveTextContent('0.4991 × 35,000^0.2991');
-    expect(der).toHaveTextContent('округление вверх = 9.2 m');
-    expect(der).toHaveTextContent(/запас .*1\.3 m/); // 10.5 − 9.2
+    expect(der).toHaveTextContent('round up = 9.2 m');
+    expect(der).toHaveTextContent(/margin .*1\.3 m/); // 10.5 − 9.2
   });
 
   it('draft derivation: null portLimit → registry-gap line, no margin', async () => {
     const user = userEvent.setup();
     render(
       <DDCheckRow
-        label="Осадка — порт выгрузки"
+        label="Laden draft — discharge port"
         state="pass"
         evidence="e"
         detail="d"
@@ -84,7 +84,7 @@ describe('DDCheckRow', () => {
       />,
     );
     await user.click(screen.getByTestId('dd-check-toggle'));
-    expect(screen.getByTestId('dd-draft-derivation')).toHaveTextContent('не задан');
+    expect(screen.getByTestId('dd-draft-derivation')).toHaveTextContent('not in port directory');
   });
 
   it('no derivation → no steps block; plain detail still toggles', async () => {
@@ -102,6 +102,6 @@ describe('DDCheckRow', () => {
     );
     await user.click(screen.getByTestId('dd-check-toggle'));
     expect(screen.getByTestId('dd-check-detail')).toHaveTextContent('just an explanation');
-    expect(screen.queryByText(/Источник:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Source:/)).not.toBeInTheDocument();
   });
 });

--- a/components/match/DDCheckRow.tsx
+++ b/components/match/DDCheckRow.tsx
@@ -4,7 +4,7 @@
  * Due-Diligence check row — THIN 'use client' leaf (hybrid disclosure).
  *
  * Renders one pre-built DDCheck: state icon + label + evidence (always visible),
- * plus a «Подробнее» chevron that reveals the server-built `detail` (worked-calc /
+ * plus a "Details" chevron that reveals the server-built `detail` (worked-calc /
  * plain-language explanation) and a `source` badge.
  *
  * RSC boundary (recon Q3): this is the ONLY interactive piece. It MUST NOT import
@@ -35,7 +35,7 @@ export interface DDCheckRowProps {
   evidence: string | null;
   detail?: string | null;
   source?: string | null;
-  /** Draft rows: numeric inputs → full laden-draft formula rendered in «Подробнее». */
+  /** Draft rows: numeric inputs → full laden-draft formula rendered in "Details". */
   derivation?: DraftDerivation | null;
 }
 
@@ -56,18 +56,18 @@ function DraftDerivationSteps({ d }: { d: DraftDerivation }) {
   return (
     <div className="text-xs text-ds-text-muted space-y-0.5" data-testid="dd-draft-derivation">
       <div>
-        DWT {fmt(d.dwt)} mt · груз {fmt(d.cargoTons)} mt (верхн. граница) · загрузка {loadPct}%
+        DWT {fmt(d.dwt)} mt · cargo {fmt(d.cargoTons)} mt (upper bound) · load factor {loadPct}%
       </div>
-      <div className="font-mono">→ 1) осадка полная: 0.4991 × {fmt(d.dwt)}^0.2991 = {fullLoad.toFixed(2)} m</div>
+      <div className="font-mono">→ 1) full-load draft: 0.4991 × {fmt(d.dwt)}^0.2991 = {fullLoad.toFixed(2)} m</div>
       <div className="font-mono">→ 2) × ({fmt(d.cargoTons)}&thinsp;/&thinsp;{fmt(d.dwt)})^0.3 = {raw.toFixed(2)} m</div>
-      <div className="font-mono text-ds-text">→ 3) округление вверх = {d.laden.toFixed(1)} m</div>
+      <div className="font-mono text-ds-text">→ 3) round up = {d.laden.toFixed(1)} m</div>
       {margin != null ? (
         <div className={`font-mono ${d.pass ? 'text-emerald-600' : 'text-red-500'}`}>
-          → vs лимит причала {d.portLimit!.toFixed(1)} m · запас {margin >= 0 ? '+' : '−'}{Math.abs(margin).toFixed(1)} m {d.pass ? '✓' : '✗'}
+          → vs berth limit {d.portLimit!.toFixed(1)} m · margin {margin >= 0 ? '+' : '−'}{Math.abs(margin).toFixed(1)} m {d.pass ? '✓' : '✗'}
         </div>
       ) : (
         <div className="text-ds-text-muted">
-          → лимит причала не задан в реестре портов{d.pass ? ' · проходит (нет данных)' : ''}
+          → berth limit not in port directory{d.pass ? ' · passes (no data)' : ''}
         </div>
       )}
     </div>
@@ -100,7 +100,7 @@ export function DDCheckRow({ label, state, evidence, detail, source, derivation 
             data-testid="dd-check-toggle"
           >
             {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-            {open ? 'Свернуть' : 'Подробнее'}
+            {open ? 'Collapse' : 'Details'}
           </button>
         )}
 
@@ -117,7 +117,7 @@ export function DDCheckRow({ label, state, evidence, detail, source, derivation 
             {derivation && <DraftDerivationSteps d={derivation} />}
             {source && (
               <span className="inline-block text-xs text-ds-text-subtle bg-ds-surface-subtle border border-ds-border/60 px-1.5 py-0.5 rounded">
-                Источник: {source}
+                Source: {source}
               </span>
             )}
           </div>

--- a/components/match/DueDiligencePanel.tsx
+++ b/components/match/DueDiligencePanel.tsx
@@ -24,7 +24,7 @@ const CATEGORY_ICONS: Record<string, LucideIcon> = {
 
 export function DueDiligencePanel({ model }: { model: DDModel }) {
   const { counter, fitPercent } = model;
-  const criticalText = counter.flagsCritical === 0 ? 'нет' : String(counter.flagsCritical);
+  const criticalText = counter.flagsCritical === 0 ? 'none' : String(counter.flagsCritical);
 
   return (
     <section
@@ -39,9 +39,9 @@ export function DueDiligencePanel({ model }: { model: DDModel }) {
             Due Diligence
           </h2>
           <p className="text-sm text-ds-text mt-1">
-            Прогнали <span className="font-semibold">{counter.ran}</span> проверок
+            Ran <span className="font-semibold">{counter.ran}</span> checks
             <span className="text-ds-text-muted">
-              {' · '}{counter.pass} ✓ · {counter.caution} ⚠{counter.info > 0 && <> · <Info className="inline h-3.5 w-3.5 align-text-bottom text-sky-600" aria-hidden /> {counter.info}</>} · критичных стопов {criticalText}
+              {' · '}{counter.pass} ✓ · {counter.caution} ⚠{counter.info > 0 && <> · <Info className="inline h-3.5 w-3.5 align-text-bottom text-sky-600" aria-hidden /> {counter.info}</>} · critical stops {criticalText}
             </span>
           </p>
         </div>

--- a/docs/research/recon-dd-i18n-2026-06-19.md
+++ b/docs/research/recon-dd-i18n-2026-06-19.md
@@ -1,0 +1,380 @@
+# DD Panel i18n Recon — 2026-06-19
+
+**Branch:** `dd-i18n-recon`
+**Scope:** Map every Russian user-visible string in the Due Diligence panel surface so
+the copy can be fully translated to English without missing anything or breaking CI.
+
+---
+
+## 1. String Surface — Complete Table
+
+All Russian strings enumerated by source file. Strings that already are English are
+noted as **[EN — no change]**. Interpolated tokens that must survive translation are
+shown in `{braces}`.
+
+### 1.1 `lib/matching/due-diligence.ts`
+
+#### SRC const (source badges shown in «Источник:» row)
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 163 | `'Исходное письмо + port-master.json'` | source | `'Circular + port-master.json'` | Shown for draft/LOA rows |
+| 164 | `'Исходное письмо + port-master.json'` | source | `'Circular + port-master.json'` | SRC.loa = same as SRC.draft |
+| 165 | `'Исходное письмо'` | source | `'Vessel circular'` | SRC.letter |
+| 166 | `'L5C-матрица'` | source | `'L5C matrix'` | SRC.l5c |
+| 167 | `'IMSBC-Code'` | source | **[EN — no change]** | |
+| 168 | `'Расчёт TCE'` | source | `'TCE calculation'` | SRC.tce — **asserted in test** |
+| 169 | `'Baltic-сид / исходное письмо'` | source | `'Baltic index / vessel circular'` | SRC.freight |
+| 170 | `'Расчёт фит-%'` | source | `'Fit-% model'` | SRC.fit |
+| 171 | `'Paris MoU'` | source | **[EN — no change]** | |
+| 172 | `'Реестр IACS'` | source | `'IACS register'` | SRC.iacs |
+| 173 | `'Equasis'` | source | **[EN — no change]** | |
+| 174 | `'IG P&I clubs'` | source | **[EN — no change]** | |
+| 175 | `'OFAC/EU'` | source | **[EN — no change]** | |
+| 176 | `'JWC Area Lists'` | source | **[EN — no change]** | |
+
+#### Category labels (`DDCategory.label`)
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 451 | `'Судно ↔ порт'` | header | `'Vessel ↔ port'` | Category key: vessel-port |
+| 529 | `'Груз ↔ трюмы'` | header | `'Cargo ↔ holds'` | Category key: cargo-holds |
+| 605 | `'Экономика рейса'` | header | `'Voyage economics'` | Category key: economics |
+| 719 | `'Ветинг судна'` | header | `'Vessel vetting'` | Category key: vetting |
+| 755 | `'Комплаенс / риск'` | header | `'Compliance / risk'` | Category key: compliance |
+
+#### Check labels (`DDCheck.label`)
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 454 | `'Осадка — порт погрузки'` | label | `'Laden draft — load port'` | **Asserted in test byLabel** |
+| 455 | `'Осадка — порт выгрузки'` | label | `'Laden draft — discharge port'` | **Asserted in test byLabel** |
+| 457 | `'Краны / грузовое оборудование'` | label | `'Cranes / cargo gear'` | |
+| 244 | `'LOA под причал'` | label | `'LOA vs berth'` | Mixed RU/EN; **asserted in test byLabel** |
+| 466 | `'Воздушный габарит'` | label | `'Air draught clearance'` | Gap row; **asserted in test** |
+| 531 | `'Объём груза под трюмы'` | label | `'Cargo volume vs holds'` | **Asserted in test byLabel** |
+| 540 | `'Тип груза ↔ тип судна'` | label | `'Cargo type ↔ vessel type'` | |
+| 480 | `'Чистота трюмов / прошлый груз'` | label | `'Hold cleanliness / prior cargo'` | **Asserted in test byLabel** |
+| 515 | `'IMSBC группа'` | label | `'IMSBC group'` | |
+| 563 | `'TCE vs breakeven'` | label | **[EN — no change]** | |
+| 612 | `'Экономика рейса (фит)'` | label | `'Voyage economics (fit)'` | **Asserted in test byLabel** |
+| 621 | `'Утилизация DWT'` | label | `'DWT utilisation'` | **Asserted in test byLabel** |
+| 630 | `'Балласт-переход'` | label | `'Ballast leg'` | |
+| 586 | `'Фрахт vs Baltic'` | label | `'Freight vs Baltic'` | |
+| 671 | `'Ветинг судна (сводно)'` | label | `'Vessel vetting (summary)'` | **Asserted in test byLabel** |
+| 688 | `'Готовность / тайминг'` | label | `'Readiness / timing'` | (×3 locations) |
+| 706 | `'Класс судна (фит)'` | label | `'Vessel class (fit)'` | |
+| 717 | `'RightShip score'` | label | **[EN — no change]** | |
+| 730 | `'Санкции судна (OFAC/EU)'` | label | `'Vessel sanctions (OFAC/EU)'` | **Asserted in test byLabel** |
+| 752 | `'War-risk / JWC'` | label | **[EN — no change]** | |
+| 761 | `'KYC чартерера'` | label | `'Charterer KYC'` | Gap row; **asserted in test** |
+
+#### INACTIVE evidence strings (2nd arg to `INACTIVE()`)
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 466 | `'нет данных'` | evidence | `'no data'` | Воздушный габарит |
+| 522 | `'нет данных'` | evidence | `'no data'` | IMSBC when absent |
+| 561 | `'нет данных'` | evidence | `'no data'` | TCE when null |
+| 586 | `'нет данных'` | evidence | `'no data'` | Freight when null |
+| 703 | `'нет данных'` | evidence | `'no data'` | Timing fallback |
+| 717 | `'не подключено'` | evidence | `'not connected'` | RightShip |
+| 761 | `'не подключено'` | evidence | `'not connected'` | KYC |
+
+#### Evidence strings (interpolated)
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 249 | `'LOA судна нет в исходном письме — нужно уточнить'` | evidence | `'Vessel LOA missing from circular — needs confirmation'` | **Test asserts /письм/i** |
+| 262 | `` `LOA судна ${v}m; нет данных по причалу — нужно уточнить` `` | evidence | `` `Vessel LOA ${v}m; no berth data — needs confirmation` `` | **Test asserts /причал/i** |
+| 269 | `` `погрузка max ${loadLimit}m` `` | evidence fragment | `` `load max ${loadLimit}m` `` | Joined with ' / ' |
+| 270 | `` `выгрузка max ${dischLimit}m` `` | evidence fragment | `` `disch max ${dischLimit}m` `` | Joined with ' / ' |
+| 283 | `` `LOA судна ${v}m превышает лимит обоих причалов` `` | evidence | `` `Vessel LOA ${v}m exceeds both berth limits` `` | Fallback when no reason |
+| 285 | `` `LOA судна ${v}m превышает лимит причала` `` | evidence | `` `Vessel LOA ${v}m exceeds berth limit` `` | Single-port fallback |
+| 299 | `` `LOA судна ${v}m vs лимит причала (${limitStr})` `` | evidence | `` `Vessel LOA ${v}m vs berth limit (${limitStr})` `` | Pass evidence |
+| 424 | `` `Осадка в грузу ~${estM}m vs лимит причала ${limM}m` `` | evidence | `` `Laden draft ~${estM}m vs berth draft limit ${limM}m` `` | |
+| 505 | `` `несовместимый прошлый груз` `` | evidence | `'incompatible prior cargo'` | Hold cleanliness caution |
+| 506 | `` `Прошлый груз: ${prev} — требуется доп. зачистка` `` | evidence | `` `Prior cargo: ${prev} — extra cleaning required` `` | |
+| 508 | `` `Прошлый груз: ${prev} — совместимо` `` | evidence | `` `Prior cargo: ${prev} — compatible` `` | |
+| 576 | `` `TCE .../day — .../day ${diff >= 0 ? 'выше' : 'ниже'} breakeven` `` | evidence | `` `... ${diff >= 0 ? 'above' : 'below'} breakeven` `` | **Test asserts 'ниже breakeven'** |
+| 589 | `` `Ставка фрахта: ${src}${estimated ? ' (оценка)' : ''}${note}` `` | evidence | `` `Freight rate: ${src}${estimated ? ' (estimate)' : ''}${note}` `` | **Test asserts 'оценка'** |
+| 589 | `' · расход оценён'` | evidence suffix | `' · consumption estimated'` | **Test asserts 'расход оценён'** |
+| 655 | `'нет данных по судну'` | evidence | `'no vessel data'` | Vetting inactive per factor |
+| 699 | `` `Готовность: ${verdict}` `` | evidence | `` `Readiness: ${verdict}` `` | |
+
+#### Hold cleanliness special inactive row
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 484 | `'Данных нет в исходном письме — нужно уточнить'` | evidence | `'Not in circular — confirm with owner/broker'` | **Test asserts 'уточнить'** |
+| 484–488 | `'Прошлый груз не указан в письме-циркуляре судна (типично для ~96% циркуляров). При наличии данных мы сверяем совместимость с текущим грузом по L5C-матрице (риск перекрёстного загрязнения, требования к зачистке трюмов). Здесь — требуется уточнить у судовладельца/брокера.'` | detail | `'Prior cargo not listed in the vessel circular (typical for ~96% of circulars). When available, we check compatibility with the current cargo via the L5C matrix (cross-contamination risk, hold-cleaning requirements). Action: confirm with owner/broker.'` | **Test asserts 'L5C'** |
+| 488 | `'Смотрим последние грузы судна и проверяем совместимость с текущим грузом по L5C-матрице (риск перекрёстного загрязнения, требования к зачистке трюмов). Источник — поле прошлых грузов из письма судна.'` | detail | `'Checking vessel\'s last cargoes for compatibility with the current cargo via the L5C matrix (cross-contamination risk, hold-cleaning requirements). Source: prior-cargo field from vessel circular.'` | |
+
+#### `draftDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 188 | `'Проверяем, войдёт ли судно под причал: расчётную осадку судна в грузу сравниваем с допустимым лимитом причала из реестра портов.'` | detail | `'Checking whether the vessel fits the berth: estimated laden draft is compared against the berth draft limit from the port directory.'` | |
+| 190 | `'Оценка осадки по DWT и загрузке (скрининг), считается от верхней границы груза — не точный расчёт осадки.'` | caveat | `'Draft estimate derived from DWT and load factor (screening); computed from the upper cargo range bound — not a precision draft calculation.'` | **Test asserts 'скрининг'** |
+| 193 | `` `Расчёт: осадка в грузу ~${e}m vs лимит причала ${l}m → запас ${margin}m.` `` | detail calc | `` `Calc: laden draft ~${e}m vs berth limit ${l}m → margin ${margin}m.` `` | **Test asserts '9.2' and '10.5'** |
+| 196 | `` `Расчёт: осадка в грузу ~${e}m; лимит причала не задан в реестре портов.` `` | detail calc | `` `Calc: laden draft ~${e}m; no berth limit in port directory.` `` | |
+| 199 | `'Нет данных DWT/груза для расчёта осадки в грузу — проверка по заявленной статической осадке судна.'` | detail | `'No DWT/cargo data for laden-draft estimate — check uses vessel\'s stated max draft.'` | **Test asserts 'нет данных'** |
+
+#### `loaDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 226 | `'Проверяем, влезет ли судно по длине (LOA) под причал: длину судна сравниваем с максимальной длиной у причала из реестра портов.'` | detail | `'Checking whether the vessel fits the berth by length (LOA): vessel LOA is compared against the berth\'s maximum LOA from the port directory.'` | |
+| 228 | `'Лимит LOA причала — из реестра портов (есть не у всех портов; черноморские внутренние порты пока без данных). Не учитывает индивидуальные ограничения конкретного терминала.'` | caveat | `'Berth LOA limit sourced from port directory (not available for all ports; some Black Sea inland ports currently without data). Does not account for individual terminal restrictions.'` | |
+| 230 | `` `Расчёт: LOA судна ${v}m vs лимит причала ${lim}.` `` | detail calc | `` `Calc: vessel LOA ${v}m vs berth limit ${lim}.` `` | |
+
+#### `utilDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 306 | `'Утилизация — какую долю грузоподъёмности судна занимает груз.'` | detail | `'DWT utilisation — what share of the vessel\'s carrying capacity the cargo occupies.'` | |
+| 308 | `'Вместимость = DWCC (полезная грузоподъёмность), если задана, иначе DWT. Вес груза — номинал из письма; осадка и объём считаются от верхней границы диапазона.'` | caveat | `'Capacity = DWCC (deadweight cargo capacity) when specified, otherwise DWT. Cargo weight is the nominal figure from the circular; draft and volume are computed from the upper bound of the range.'` | **Test asserts 'номинал'** |
+| 315 | `` `Расчёт: груз ${cargo} mt ÷ вместимость ${cap} mt = ${pct}% → ${rationale}` `` | detail calc | `` `Calc: cargo ${cargo} mt ÷ capacity ${cap} mt = ${pct}% → ${rationale}` `` | `{rationale}` stays EN (from fitBreakdown) |
+
+#### `volumeDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 323 | `'Проверяем, поместится ли груз по ОБЪЁМУ: вес × удельный погрузочный объём (stowage factor) сравниваем с зерновой вместимостью трюмов.'` | detail | `'Checking whether the cargo fits by VOLUME: weight × stowage factor compared against grain capacity of the holds.'` | `stowage factor` / `grain capacity` are maritime terms |
+| 326 | `'Stowage factor берётся из письма; если не указан — оценка по типу груза.'` | caveat | `'Stowage factor taken from the circular; if absent, estimated by cargo type.'` | |
+| 329 | `` `Расчёт: груз занимает ~${m[1]}% объёма трюмов (зерновая вместимость).` `` | detail calc | `` `Calc: cargo occupies ~${m[1]}% of hold volume (grain capacity).` `` | |
+
+#### `ballastDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 340 | `'Балластный переход — расстояние от текущей позиции судна до порта погрузки (судно идёт без груза).'` | detail | `'Ballast leg — distance from the vessel\'s current position to the load port (vessel sailing without cargo).'` | |
+| 342 | `'Бункер балластного перехода учтён в строке TCE, отдельно здесь не показан. Дистанция — lookup по таблице портов, приблизительно.'` | caveat | `'Ballast-leg bunker is included in the TCE figure and not shown separately here. Distance is a port-table lookup — approximate.'` | |
+| 347 | `` `Расчёт: переход ~${nm} nm vs радиус класса ~${r} nm (${cls}) → ${rationale}` `` | detail calc | `` `Calc: ballast leg ~${nm} nm vs class radius ~${r} nm (${cls}) → ${rationale}` `` | `{cls}` and `{rationale}` stay EN |
+
+#### `tceDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 354 | `'TCE (Time Charter Equivalent) — дневная доходность рейса за вычетом портовых сборов и бункера. Сравниваем с точкой безубыточности судовладельца: выше → рейс прибыльный, ниже → убыток.'` | detail | `'TCE (Time Charter Equivalent) — daily voyage return net of port costs and bunker. Compared against the owner\'s breakeven: above → voyage profitable, below → loss-making.'` | |
+| 357 | `'War-risk показан в breakdown отдельной строкой — в это число он НЕ входит. '` | caveat | `'War-risk premium is shown separately in the breakdown — it is NOT included in this figure. '` | **Test asserts 'war-risk' (case-insensitive)** |
+| 358 | `'Комиссия (адрес + брокераж, ставка из письма либо 3.75% TTL по умолчанию) ВЫЧТЕНА из фрахта — TCE здесь net-of-commission.'` | caveat | `'Commission (address + brokerage, rate from circular or 3.75% TTL default) has been DEDUCTED from freight — TCE shown here is net-of-commission.'` | |
+| 362 | `'выше breakeven'` | verdict | `'above breakeven'` | **Test asserts** |
+| 362 | `'ниже breakeven'` | verdict | `'below breakeven'` | **Test asserts 'ниже breakeven'** |
+| 363 | `` `Расчёт: TCE ${usd(tce)}/сут − breakeven ${usd(be)}/сут = ${sign}${usd(diff)}/сут → ${verdict}.` `` | detail calc | `` `Calc: TCE ${usd(tce)}/day − breakeven ${usd(be)}/day = ${sign}${usd(diff)}/day → ${verdict}.` `` | **Test asserts '9,600', '8,200', '1,400'** |
+
+#### `ageDetail()` helper
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 370 | `'Возраст судна: год отсчёта минус год постройки. До 15 лет — современное, 15–22 — зрелое (выше риск обслуживания), свыше 22 — повышенный риск задержаний и off-hire.'` | detail | `'Vessel age: reference year minus build year. Under 15 years — modern; 15–22 — mature (higher maintenance risk); over 22 — elevated detention and off-hire risk.'` | |
+| 373 | `` `Расчёт: ${refYear} − ${built} = ${refYear - built} лет → ${rationale}` `` | detail calc | `` `Calc: ${refYear} − ${built} = ${refYear - built} years → ${rationale}` `` | **Test asserts '2026', '2015', '11'** |
+
+#### `VETTING_LOOKUP` details
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 382–384 | `'Флаг судна сверяется со списком Paris MoU (межгосударственный меморандум по портовому контролю). Серый/чёрный список флага = повышенный риск задержаний судна в портах.'` | detail | `'Vessel flag is checked against the Paris MoU list (inter-governmental Memorandum of Understanding on Port State Control). Grey/black-listed flag = elevated risk of port detentions.'` | |
+| 388–390 | `'Классификационное общество судна проверяется на членство в IACS (ассоциация ведущих классов). Класс вне IACS — повышенный технический риск.'` | detail | `'Classification society is checked for IACS membership (International Association of Classification Societies). Non-IACS class = elevated technical risk.'` | |
+| 393–395 | `'Страховщик ответственности (P&I) судна проверяется на членство в International Group — пуле ведущих клубов с надёжным покрытием.'` | detail | `'P&I insurer is checked for membership in the International Group — the pool of leading clubs with robust coverage.'` | |
+| 397–399 | `'История задержаний судна портовым контролем (PSC) по базе Equasis. Свежие задержания = повышенный риск инспекций.'` | detail | `'Vessel\'s port-state-control (PSC) detention history from Equasis. Recent detentions = elevated inspection risk.'` | |
+| 401–403 | `'Рейтинг углеродной интенсивности (CII, A–E) из Equasis. A/B/C — в норме, D — внимание, E — повышенный риск эксплуатационных ограничений.'` | detail | `'Carbon Intensity Indicator (CII, A–E) from Equasis. A/B/C — within norms; D — attention; E — elevated risk of operational restrictions.'` | |
+
+#### Vetting summary row + timing
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 674–676 | `'Сводная оценка ветинга судна (флаг, класс, возраст, P&I, PSC, CII) — детализация по судну недоступна в этом снэпшоте.'` | detail | `'Rolled-up vessel vetting assessment (flag, class, age, P&I, PSC, CII) — per-factor breakdown not available for this snapshot.'` | |
+| 683 | `'Готовность судна к laycan: сопоставляем дату освобождения и переход до порта погрузки с окном laycan груза. Данные — из письма.'` | detail | `'Vessel readiness for laycan: we compare the open date and ballast passage to the load port against the cargo\'s laycan window. Source: vessel circular.'` | `laycan` is an industry term |
+
+#### Cargo-type check detail
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 543–545 | `'Сверяем тип груза с типом и конструкцией судна (балкер/твиндекер и т.п.) на принципиальную совместимость. Данные — из письма.'` | detail | `'Checking cargo type compatibility with vessel type and design (bulker/tweendecker etc.). Source: vessel circular.'` | |
+
+#### IMSBC check detail
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 518–520 | `'Сверяем груз с Кодексом IMSBC (морская перевозка навалочных грузов): группа A/B/C, требования к перевозке и ограничения судна.'` | detail | `'Checking cargo against the IMSBC Code (International Maritime Solid Bulk Cargoes): Group A/B/C classification, carriage requirements, and vessel restrictions.'` | |
+
+#### Cranes check detail
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 461–463 | `'Проверяем, есть ли у судна собственные краны/деррики на случай порта без береговой перегрузочной техники. Данные — из письма-циркуляра судна.'` | detail | `'Checking whether the vessel has its own cranes/derricks for ports without shore gear. Source: vessel circular.'` | |
+
+#### Economics check details
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 614–616 | `'Доля экономики рейса в итоговом фит-%: насколько рейс выгоден относительно альтернатив для этого класса судна.'` | detail | `'Voyage economics contribution to the overall fit-%: how profitable this voyage is relative to alternatives for this vessel class.'` | |
+| 594–596 | `'Откуда взята ставка фрахта: вручную из письма (manual/parsed) или оценка по индексу Baltic / сиду. Оценочная ставка → число приблизительное, помечается «оценка».'` | detail | `'Freight rate source: manually entered from the circular (manual/parsed) or estimated from the Baltic index / seed. Estimated rate → approximate figure, flagged as "(estimate)".'` | |
+
+#### Compliance check details
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 734–736 | `'Проверяем судно, его владельца и управляющую компанию по санкционным спискам OFAC (США) и ЕС. Красный флаг блокирует рейс. Данные — из санкционного слоя системы на момент матчинга.'` | detail | `'Checking vessel, owner, and manager against OFAC (US) and EU sanctions lists. A blocking flag prevents the voyage. Data from the sanctions layer as of the matching timestamp.'` | |
+| 748–750 | `'Проверяем, проходит ли позиция судна или рейс через зоны военного риска по спискам JWC (Joint War Committee). Попадание в зону = надбавка war-risk и повышенный риск. Стоимость war-risk показана в breakdown TCE отдельно.'` | detail | `'Checking whether the vessel position or voyage passes through JWC (Joint War Committee) war-risk zones. Entry into a zone = war-risk surcharge and elevated risk. War-risk cost is shown separately in the TCE breakdown.'` | |
+
+#### Class fit detail
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 710–712 | `'Насколько класс судна (handysize/supramax/panamax/capesize) подходит под параметры груза и рейса — вклад в итоговый фит-%.'` | detail | `'How well the vessel class (handysize/supramax/panamax/capesize) matches cargo and voyage parameters — its contribution to the overall fit-%.'` | |
+
+---
+
+### 1.2 `components/match/DueDiligencePanel.tsx`
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 27 | `'нет'` (criticalText when 0) | label | `'none'` | Inline ternary |
+| 42–44 | `'Прогнали '` + `' проверок'` | hero counter | `'Ran '` + `' checks'` | Wraps `{counter.ran}` |
+| 44 | `'· критичных стопов '` | hero counter | `'· critical stops '` | Wraps `{criticalText}` |
+
+### 1.3 `components/match/DDCheckRow.tsx`
+
+| file:line | Current RU string | Type | EN proposal | Notes |
+|---|---|---|---|---|
+| 103 | `'Свернуть'` | button | `'Collapse'` | **Test clicks button by testid, not text** |
+| 103 | `'Подробнее'` | button | `'Details'` | **Test clicks button by testid, not text** |
+| 119 | `'Источник: {source}'` | source badge prefix | `'Source: {source}'` | **Test asserts `/Источник:/`** |
+| 59 | `` `DWT {fmt(d.dwt)} mt · груз {fmt(d.cargoTons)} mt (верхн. граница) · загрузка {loadPct}%` `` | formula step | `` `DWT {fmt(d.dwt)} mt · cargo {fmt(d.cargoTons)} mt (upper bound) · load factor {loadPct}%` `` | **Test asserts 'загрузка 86%'** |
+| 61 | `'→ 1) осадка полная: 0.4991 × ...'` | formula step | `'→ 1) full-load draft: 0.4991 × ...'` | |
+| 62 | `'→ 2) × ...'` | formula step | **[EN — no change]** | Already EN formula |
+| 63 | `'→ 3) округление вверх = ...'` | formula step | `'→ 3) round up = ...'` | **Test asserts 'округление вверх = 9.2 m'** |
+| 66 | `'→ vs лимит причала ... · запас ...'` | formula step | `'→ vs berth limit ... · margin ...'` | **Test asserts /запас .*1\.3 m/** |
+| 70 | `'→ лимит причала не задан в реестре портов'` | formula step | `'→ berth limit not in port directory'` | **Test asserts 'не задан'** |
+
+### 1.4 `components/match/DraftCalcBreakdown.tsx`
+
+All user-visible strings in this component are **already in English** — no changes needed here.
+
+---
+
+## 2. Tests Asserting Russian Substrings — Will Break on Translation
+
+These test assertions will need updating when copy is translated.
+
+### 2.1 `lib/matching/__tests__/due-diligence.test.ts`
+
+| file:line | Assertion | Breaks on | Fix strategy |
+|---|---|---|---|
+| 105 | `byLabel(m, 'Осадка — порт погрузки')` | label rename | Update byLabel arg to EN label |
+| 106 | `byLabel(m, 'Объём груза под трюмы')` | label rename | Update byLabel arg |
+| 117 | `.not.toContain('Чистота трюмов / прошлый груз')` | label rename | Update to EN label |
+| 122 | `byLabel(m, 'Чистота трюмов / прошлый груз')` | label rename | Update byLabel arg |
+| 127 | `byLabel(m, 'Чистота трюмов / прошлый груз')` | label rename | Update byLabel arg |
+| 134 | `byLabel(m, 'Объём груза под трюмы')` | label rename | Update byLabel arg |
+| 135 | `byLabel(m, 'Экономика рейса (фит)')` | label rename | Update byLabel arg |
+| 136 | `byLabel(m, 'Утилизация DWT')` | label rename | Update byLabel arg |
+| 142 | `byLabel(m, 'Воздушный габарит')` | label rename | Update byLabel arg |
+| 145 | `byLabel(m, 'KYC чартерера')` | label rename | Update byLabel arg |
+| 172 | `byLabel(m, 'Утилизация DWT')` | label rename | Update byLabel arg |
+| 196 | `byLabel(m, 'Ветинг судна (сводно)')` | label rename | Update byLabel arg |
+| 210 | `byLabel(m, 'Санкции судна (OFAC/EU)')` | label rename | Update byLabel arg |
+| 218 | `.toContain('ниже breakeven')` | evidence string | Update to `'below breakeven'` |
+| 230 | `.toContain('оценка')` | evidence string | Update to `'estimate'` |
+| 231 | `.toContain('расход оценён')` | evidence string | Update to `'consumption estimated'` |
+| 267 | `.toMatch(/письм/i)` | evidence string | Update regex to `/circular/i` |
+| 278 | `.toMatch(/причал/i)` | evidence string | Update regex to `/berth/i` |
+| 304 | `byLabel(m, 'Воздушный габарит')` | label rename | Update |
+| 304 | `byLabel(m, 'KYC чартерера')` | label rename | Update |
+| 310 | `byLabel(m, 'Воздушный габарит')` | label rename | Update |
+| 310 | `byLabel(m, 'KYC чартерера')` | label rename | Update |
+| 321 | `byLabel(m, 'Чистота трюмов / прошлый груз')` | label rename | Update |
+| 324 | `.toContain('уточнить')` | evidence string | Update to `'confirm'` |
+| 338 | `.toBe('Расчёт TCE')` | source badge | Update to `'TCE calculation'` |
+| 350 | `.toContain('номинал')` | detail string | Update to `'nominal'` |
+| 355 | `byLabel(m, 'Осадка — порт погрузки')` | label rename | Update |
+| 358 | `.toLowerCase().toContain('скрининг')` | detail string | Update to `'screening'` |
+| 363 | `byLabel(m, 'Осадка — порт погрузки')` | label rename | Update |
+| 377 | `byLabel(m, 'Осадка — порт погрузки')` | label rename | Update |
+| 385 | `byLabel(m, 'Осадка — порт выгрузки')` | label rename | Update |
+| 394 | `byLabel(m, 'Осадка — порт погрузки')` | label rename | Update |
+| 398 | `.toLowerCase().toContain('нет данных')` | detail string | Update to `'no dwt/cargo'` or `/no data/i` |
+
+### 2.2 `__tests__/components/match/DDCheckRow.test.tsx`
+
+| file:line | Assertion | Breaks on | Fix strategy |
+|---|---|---|---|
+| 20 | `evidence="... выше breakeven"` | prop value passed as Russian | Update prop to EN |
+| 21 | `detail='TCE — дневная доходность...'` | prop value passed as Russian | Update prop to EN |
+| 22 | `source="Расчёт TCE"` | source badge value | Update to `'TCE calculation'` |
+| 28 | `.getByText(/выше breakeven/)` | evidence text | Update regex to `/above breakeven/` |
+| 36 | `.toHaveTextContent('Расчёт: TCE $9,600/сут')` | detail text | Update to EN |
+| 37 | `.toHaveTextContent('Источник: Расчёт TCE')` | badge prefix + source | Update both |
+| 46 | `evidence="не подключено"` | prop value | Update to `'not connected'` |
+| 57 | `label="Осадка — порт погрузки"` | prop value | Update to EN label |
+| 59 | `evidence="Осадка в грузу ~9.2m vs лимит причала 10.5m"` | prop value | Update to EN |
+| 61 | `source="Исходное письмо + port-master.json"` | source badge | Update to `'Circular + port-master.json'` |
+| 68 | `.toHaveTextContent('загрузка 86%')` | formula step | Update to `'load factor 86%'` |
+| 70 | `.toHaveTextContent('округление вверх = 9.2 m')` | formula step | Update to `'round up = 9.2 m'` |
+| 71 | `.toHaveTextContent(/запас .*1\.3 m/)` | formula step | Update to `/margin .*1\.3 m/` |
+| 78 | `label="Осадка — порт выгрузки"` | prop value | Update to EN label |
+| 87 | `.toHaveTextContent('не задан')` | formula step | Update to `'not in port directory'` |
+| 105 | `.queryByText(/Источник:/)` | badge prefix | Update to `/Source:/` |
+
+### 2.3 Tests that are **safe** (no Russian assertion, but use Russian labels to select rows)
+
+The `byLabel()` helper in `due-diligence.test.ts` looks up checks by `label` field — all tests
+that call `byLabel(m, 'Осадка ...')` etc. will break since labels change. These are ALL listed
+in section 2.1 above. No hidden safe zone.
+
+---
+
+## 3. Interpolated Numbers / Units — Must Stay Intact
+
+These tokens appear inside translated strings and must not be altered:
+
+| Token pattern | Context | Keep as-is |
+|---|---|---|
+| `${h.estimatedLadenDraftM}m` | Draft detail | Yes — numeric, `m` is unit |
+| `${h.portLimitM}m` | Draft detail | Yes |
+| `${margin}m` | Draft detail | Yes |
+| `${vesselLoaM}m` | LOA detail/evidence | Yes |
+| `${limitStr}` | LOA evidence (e.g. `load max 180m / disch max 180m`) | Yes — sub-fragments also translated above |
+| `${num(cargo)} mt` | Util detail | Yes — `mt` = metric tons |
+| `${num(cap)} mt` | Util detail | Yes |
+| `${pct}%` | Util/volume detail | Yes |
+| `~${m[1]}%` | Volume detail | Yes |
+| `~${m[1]} nm` | Ballast detail | Yes — `nm` = nautical miles |
+| `~${num(r)} nm` | Ballast detail | Yes |
+| `${usd(tce)}/day` | TCE evidence/detail | Yes — `$` and `/day` preserved |
+| `${usd(breakeven)}/day` | TCE detail | Yes |
+| `${sign}${usd(diff)}/day` | TCE detail | Yes |
+| `${refYear} − ${built}` | Age detail | Yes — arithmetic |
+| `${refYear - built} years` | Age detail | `years` needs EN — currently `лет` (translate) |
+| `${c!.rationale}` | Various calc lines | Yes — already EN from fitBreakdown |
+| `${cls}` | Ballast detail | Yes — handysize/supramax etc. |
+| `${src}` | Freight evidence | Yes — 'baltic', 'parsed' etc. |
+| `${args.worksheet.readiness.verdict}` | Timing evidence | Yes — 'ideal', 'ready' etc. |
+| `${prev.join(', ')}` | Hold evidence | Yes — cargo names |
+
+---
+
+## 4. RSC Boundary Analysis
+
+**Confirmed unaffected.** All string changes are pure copy swaps within:
+- `lib/matching/due-diligence.ts` — server-only builder (no `'use client'`)
+- `components/match/DueDiligencePanel.tsx` — server component (no `'use client'`)
+- `components/match/DDCheckRow.tsx` — already `'use client'`; only string literals change, no new imports needed
+- `components/match/DraftCalcBreakdown.tsx` — already `'use client'`; no changes needed
+
+No new client imports are introduced by any of the translation changes. The RSC boundary
+between DueDiligencePanel (server) → DDCheckRow (client leaf) remains unchanged — strings
+arrive as props, not imported constants. **No bundle impact.**
+
+---
+
+## 5. Risk Summary
+
+**Low risk overall.** The translation is a pure string-swap with zero logic change. The
+main CI risk is **41 test assertions** (33 in `due-diligence.test.ts`, 14 in
+`DDCheckRow.test.tsx`) that assert Russian substrings — these MUST be updated in the same
+PR that translates the source strings. Several assertions use `byLabel()` to look up checks
+by Russian label; all are enumerated in Section 2. The `DraftCalcBreakdown.tsx` component
+is already entirely in English and requires no changes.

--- a/docs/superpowers/plans/2026-06-19-dd-i18n-plan.md
+++ b/docs/superpowers/plans/2026-06-19-dd-i18n-plan.md
@@ -1,0 +1,55 @@
+# Implementation Plan — Due Diligence panel → full English 2026-06-19
+
+> Recon (THE SPEC): `docs/research/recon-dd-i18n-2026-06-19.md` — every RU string with
+> file:line + approved EN proposal (§1) and every RU-asserting test with fix (§2).
+> Tier M · Opus 4.8 :high · branch from `dd-i18n-recon` (carries recon + this plan).
+> Origin: founder 2026-06-19 — "сделай Due Diligence полностью на английском".
+> Presentation-only copy swap. ZERO engine/data/scoring change. NO regen (strings live in code).
+
+## Goal
+Translate every user-visible Russian string in the Due Diligence panel surface to the
+professional maritime-broker English already proposed in the recon table — and update the
+47 tests that assert Russian substrings — in ONE PR, CI green.
+
+## Files (edit EXACTLY per recon §1 — do not re-translate creatively, use the approved column)
+1. `lib/matching/due-diligence.ts` — SRC const, category labels, check labels, INACTIVE
+   evidence, interpolated evidence, detail helpers (draftDetail/loaDetail/utilDetail/
+   volumeDetail/ballastDetail/tceDetail/ageDetail), VETTING_LOOKUP details, vetting-summary,
+   timing, cargo-type/IMSBC/cranes/economics/compliance/class details. ~70 strings.
+2. `components/match/DueDiligencePanel.tsx` — hero counter "Прогнали N проверок · критичных
+   стопов M" → "Ran N checks · critical stops M"; criticalText "нет" → "none".
+3. `components/match/DDCheckRow.tsx` — "Свернуть"/"Подробнее" → "Collapse"/"Details";
+   "Источник:" → "Source:"; draft formula steps (lines 59–70) per recon.
+4. `components/match/DraftCalcBreakdown.tsx` — NO CHANGE (already English; verify only).
+
+## Tests (SAME PR — recon §2, all 47 enumerated)
+- `lib/matching/__tests__/due-diligence.test.ts` — 33 assertions (byLabel args + toContain/
+  toMatch substrings). Update byLabel args to the new EN labels; update RU substrings to the
+  EN equivalents from recon. Several are regex (/письм/i→/circular/i, /причал/i→/berth/i).
+- `__tests__/components/match/DDCheckRow.test.tsx` — 14 assertions (props passed as RU +
+  getByText/toHaveTextContent on RU). Update prop values AND expectations to EN.
+
+## Hard rules
+- Interpolation tokens stay intact (recon §3): braces, mt, m3, nm, %, $, /day, arithmetic,
+  rationale/cls/src (already EN). Translate prose around them. Special: "лет" → "years".
+- No logic/state/counter/fitPercent change. detail/source/evidence/label are presentation
+  strings. Honesty invariant intact: null-source → inactive, never fake-pass.
+- RSC boundary unchanged (recon §4): no new client imports; strings arrive as props.
+- Apostrophes inside EN strings → escape or use double-quotes to avoid breaking JS.
+
+## Verification (executor emits markers)
+- `NODE_OPTIONS=--max-old-space-size=4096 npx tsc --noEmit` — clean.
+- `npx jest lib/matching/__tests__/due-diligence.test.ts __tests__/components/match/DDCheckRow.test.tsx`
+  — all green. RUN SYNCHRONOUSLY, one blocking bash command — NOT background/Monitor.
+- `npm run build` — succeeds; confirm /match/[id] bundle NOT bloated (no port-master in client).
+- Grep the 4 source files for any remaining Cyrillic — expect ZERO (catch missed strings).
+- Open PR; emit PR_URL and EXIT_STATUS markers. COMMIT before exit (do not leave WIP).
+
+## Acceptance
+- Zero Cyrillic in the 4 DD source files (grep clean).
+- tsc + jest (both test files) + build green.
+- Counter/fitPercent/honesty unchanged; bundle flat.
+
+## Non-goals (YAGNI)
+No engine/seed/regen. No translation of the rest of the app. No new strings/sources. No
+restructuring of the panel. Do not touch DraftCalcBreakdown (already EN).

--- a/lib/matching/__tests__/due-diligence.test.ts
+++ b/lib/matching/__tests__/due-diligence.test.ts
@@ -102,44 +102,44 @@ describe('buildDueDiligence', () => {
       'vessel-port', 'cargo-holds', 'economics', 'vetting', 'compliance',
     ]);
     expect(m.counter.ran).toBeGreaterThan(0);
-    expect(byLabel(m, 'Осадка — порт погрузки')?.state).toBe('pass');
-    expect(byLabel(m, 'Объём груза под трюмы')?.state).toBe('pass');
+    expect(byLabel(m, 'Laden draft — load port')?.state).toBe('pass');
+    expect(byLabel(m, 'Cargo volume vs holds')?.state).toBe('pass');
   });
 
   it('honesty: null lastCargoes → hold-cleanliness inactive, NOT pass, excluded from counter', () => {
     const vessel = { ...fullVessel(), lastCargoes: null };
     const m = buildDueDiligence(fullArgs({ vessel }));
-    const hold = byLabel(m, 'Чистота трюмов / прошлый груз');
+    const hold = byLabel(m, 'Hold cleanliness / prior cargo');
     expect(hold?.state).toBe('inactive');
     expect(hold?.state).not.toBe('pass');
     // inactive must not be counted as a run check
     const ranLabels = flat(m).filter((c) => c.state !== 'inactive').map((c) => c.label);
-    expect(ranLabels).not.toContain('Чистота трюмов / прошлый груз');
+    expect(ranLabels).not.toContain('Hold cleanliness / prior cargo');
   });
 
   it('honesty: null cargoDescription → hold-cleanliness inactive', () => {
     const m = buildDueDiligence(fullArgs({ cargoDescription: null }));
-    expect(byLabel(m, 'Чистота трюмов / прошлый груз')?.state).toBe('inactive');
+    expect(byLabel(m, 'Hold cleanliness / prior cargo')?.state).toBe('inactive');
   });
 
   it('honesty: compatible last cargo → pass with living evidence', () => {
     const m = buildDueDiligence(fullArgs());
-    const hold = byLabel(m, 'Чистота трюмов / прошлый груз');
+    const hold = byLabel(m, 'Hold cleanliness / prior cargo');
     expect(hold?.state).toBe('pass');
     expect(hold?.evidence).toContain('wheat');
   });
 
   it('honesty: missing fitBreakdown → fb-dependent rows inactive, no crash', () => {
     const m = buildDueDiligence(fullArgs({ fitBreakdown: null }));
-    expect(byLabel(m, 'Объём груза под трюмы')?.state).toBe('inactive');
-    expect(byLabel(m, 'Экономика рейса (фит)')?.state).toBe('inactive');
-    expect(byLabel(m, 'Утилизация DWT')?.state).toBe('inactive');
+    expect(byLabel(m, 'Cargo volume vs holds')?.state).toBe('inactive');
+    expect(byLabel(m, 'Voyage economics (fit)')?.state).toBe('inactive');
+    expect(byLabel(m, 'DWT utilisation')?.state).toBe('inactive');
     expect(m.categories).toHaveLength(5);
   });
 
   it('honesty: Воздушный габарит / RightShip / KYC are permanent gap rows — always inactive', () => {
     const m = buildDueDiligence(fullArgs());
-    for (const label of ['Воздушный габарит', 'RightShip score', 'KYC чартерера']) {
+    for (const label of ['Air draught clearance', 'RightShip score', 'Charterer KYC']) {
       const row = byLabel(m, label);
       expect(row).toBeDefined();
       expect(row?.state).toBe('inactive');
@@ -169,7 +169,7 @@ describe('buildDueDiligence', () => {
     zeroWeightComp.weight = 0;
     zeroWeightComp.score = 0;
     const m = buildDueDiligence(fullArgs({ fitBreakdown: fb }));
-    expect(byLabel(m, 'Утилизация DWT')?.state).toBe('inactive');
+    expect(byLabel(m, 'DWT utilisation')?.state).toBe('inactive');
   });
 
   it('parity: fitPercent echoes the passed value, never recomputes from fitBreakdown', () => {
@@ -193,13 +193,13 @@ describe('buildDueDiligence', () => {
 
   it('vetting: no vessel → rolled-up summary row + sub-factors absent', () => {
     const m = buildDueDiligence(fullArgs({ vessel: null }));
-    expect(byLabel(m, 'Ветинг судна (сводно)')?.state).toBe('pass');
+    expect(byLabel(m, 'Vessel vetting (summary)')?.state).toBe('pass');
     expect(byLabel(m, 'Vessel age')).toBeUndefined();
   });
 
   it('sanctions blocking → compliance flag + flagsCritical = 1', () => {
     const m = buildDueDiligence(fullArgs({ sanctions: { risk: 'HIGH', reason: 'OFAC listed', blocking: true } }));
-    const s = byLabel(m, 'Санкции судна (OFAC/EU)');
+    const s = byLabel(m, 'Vessel sanctions (OFAC/EU)');
     expect(s?.state).toBe('caution');
     expect(s?.evidence).toContain('OFAC');
     expect(m.counter.flagsCritical).toBe(1);
@@ -207,7 +207,7 @@ describe('buildDueDiligence', () => {
 
   it('sanctions clean → pass, flagsCritical = 0', () => {
     const m = buildDueDiligence(fullArgs());
-    expect(byLabel(m, 'Санкции судна (OFAC/EU)')?.state).toBe('pass');
+    expect(byLabel(m, 'Vessel sanctions (OFAC/EU)')?.state).toBe('pass');
     expect(m.counter.flagsCritical).toBe(0);
   });
 
@@ -215,7 +215,7 @@ describe('buildDueDiligence', () => {
     const m = buildDueDiligence(fullArgs({ tceUsdPerDay: 7000, breakevenTce: 8200 }));
     const tce = byLabel(m, 'TCE vs breakeven');
     expect(tce?.state).toBe('caution');
-    expect(tce?.evidence).toContain('ниже breakeven');
+    expect(tce?.evidence).toContain('below breakeven');
   });
 
   it('TCE null → inactive', () => {
@@ -225,10 +225,10 @@ describe('buildDueDiligence', () => {
 
   it('freight estimate source → caution «оценка»', () => {
     const m = buildDueDiligence(fullArgs({ freightRateSource: 'baltic', consumptionEstimated: true }));
-    const fr = byLabel(m, 'Фрахт vs Baltic');
+    const fr = byLabel(m, 'Freight vs Baltic');
     expect(fr?.state).toBe('caution');
-    expect(fr?.evidence).toContain('оценка');
-    expect(fr?.evidence).toContain('расход оценён');
+    expect(fr?.evidence).toContain('estimate');
+    expect(fr?.evidence).toContain('consumption estimated');
   });
 });
 
@@ -241,7 +241,7 @@ describe('buildDueDiligence — LOA berth row', () => {
     ws.vessel.loa = 150;
     ws.cargo = { ...ws.cargo, loadPort: 'Sfax', dischargePort: 'Sfax' };
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    const row = byLabel(m, 'LOA под причал');
+    const row = byLabel(m, 'LOA vs berth');
     expect(row?.state).toBe('pass');
     expect(row?.evidence).toContain('150');
     expect(row?.detail).toBeTruthy();
@@ -253,7 +253,7 @@ describe('buildDueDiligence — LOA berth row', () => {
     ws.vessel.loa = 200; // > Sfax 180
     ws.cargo = { ...ws.cargo, loadPort: 'Sfax', dischargePort: 'Sfax' };
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    const row = byLabel(m, 'LOA под причал');
+    const row = byLabel(m, 'LOA vs berth');
     expect(row?.state).toBe('caution');
     expect(row?.evidence).toMatch(/LOA/i);
   });
@@ -262,9 +262,9 @@ describe('buildDueDiligence — LOA berth row', () => {
     const ws = fullWorksheet(); // no loa on fixture vessel
     ws.cargo = { ...ws.cargo, loadPort: 'Sfax', dischargePort: 'Sfax' };
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    const row = byLabel(m, 'LOA под причал');
+    const row = byLabel(m, 'LOA vs berth');
     expect(row?.state).toBe('inactive');
-    expect(row?.evidence).toMatch(/письм/i);
+    expect(row?.evidence).toMatch(/circular/i);
   });
 
   it('honesty: vessel LOA present but no berth data on the ports → inactive «нет данных по причалу»', () => {
@@ -273,9 +273,9 @@ describe('buildDueDiligence — LOA berth row', () => {
     // Odesa has no maxLOA (backfill pending); Alexandria likewise.
     ws.cargo = { ...ws.cargo, loadPort: 'Odesa', dischargePort: 'Alexandria' };
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    const row = byLabel(m, 'LOA под причал');
+    const row = byLabel(m, 'LOA vs berth');
     expect(row?.state).toBe('inactive');
-    expect(row?.evidence).toMatch(/причал/i);
+    expect(row?.evidence).toMatch(/berth/i);
   });
 
   it('DISCH-LOA both ports fail: evidence shows both reasons, not just load', () => {
@@ -284,7 +284,7 @@ describe('buildDueDiligence — LOA berth row', () => {
     ws.vessel.loa = 200;
     ws.cargo = { ...ws.cargo, loadPort: 'Sfax', dischargePort: 'Sfax' };
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    const row = byLabel(m, 'LOA под причал');
+    const row = byLabel(m, 'LOA vs berth');
     expect(row?.state).toBe('caution');
     // Both port failures must appear in evidence — verified by presence of separator
     // (single-port failure uses the reason directly without ' / ').
@@ -307,7 +307,7 @@ describe('buildDueDiligence — detail + source disclosure', () => {
 
   it('permanent gap rows (Воздушный габарит / RightShip / KYC) → detail null AND source null', () => {
     const m = buildDueDiligence(fullArgs());
-    for (const label of ['Воздушный габарит', 'RightShip score', 'KYC чартерера']) {
+    for (const label of ['Air draught clearance', 'RightShip score', 'Charterer KYC']) {
       const row = byLabel(m, label);
       expect(row?.state).toBe('inactive');
       expect(row?.detail ?? null).toBeNull();
@@ -318,10 +318,10 @@ describe('buildDueDiligence — detail + source disclosure', () => {
   it('founder honesty: null lastCargoes → hold-cleanliness inactive BUT keeps detail + «уточнить» evidence (never fake-pass)', () => {
     const vessel = { ...fullVessel(), lastCargoes: null };
     const m = buildDueDiligence(fullArgs({ vessel }));
-    const hold = byLabel(m, 'Чистота трюмов / прошлый груз');
+    const hold = byLabel(m, 'Hold cleanliness / prior cargo');
     expect(hold?.state).toBe('inactive');
     expect(hold?.state).not.toBe('pass');
-    expect(hold?.evidence).toContain('уточнить');
+    expect(hold?.evidence).toContain('confirm');
     // honesty disclosure: this special inactive row DOES explain itself
     expect(hold?.detail).toBeTruthy();
     expect(hold?.detail).toContain('L5C');
@@ -335,7 +335,7 @@ describe('buildDueDiligence — detail + source disclosure', () => {
     expect(tce?.detail).toContain('8,200');
     expect(tce?.detail).toContain('1,400'); // diff
     expect(tce?.detail?.toLowerCase()).toContain('war-risk');
-    expect(tce?.source).toBe('Расчёт TCE');
+    expect(tce?.source).toBe('TCE calculation');
   });
 
   it('worked-calc utilisation: detail reconciles with stored bracketData numbers', () => {
@@ -343,24 +343,24 @@ describe('buildDueDiligence — detail + source disclosure', () => {
     const util = fb.components.find((c) => c.factor === 'utilisation')!;
     util.bracketData = '24,000 / 27,000 mt';
     const m = buildDueDiligence(fullArgs({ fitBreakdown: fb }));
-    const row = byLabel(m, 'Утилизация DWT');
+    const row = byLabel(m, 'DWT utilisation');
     expect(row?.detail).toContain('24,000');
     expect(row?.detail).toContain('27,000');
     expect(row?.detail).toContain('89%'); // 24000/27000
-    expect(row?.detail).toContain('номинал'); // honesty caveat (nominal weight)
+    expect(row?.detail).toContain('nominal'); // honesty caveat (nominal weight)
   });
 
   it('worked-calc draft: detail shows laden vs limit + screening honesty caveat', () => {
     const m = buildDueDiligence(fullArgs());
-    const row = byLabel(m, 'Осадка — порт погрузки');
+    const row = byLabel(m, 'Laden draft — load port');
     expect(row?.detail).toContain('9.2'); // estimatedLadenDraftM
     expect(row?.detail).toContain('10.5'); // portLimitM
-    expect(row?.detail?.toLowerCase()).toContain('скрининг');
+    expect(row?.detail?.toLowerCase()).toContain('screening');
   });
 
   it('draft derivation: load row carries {dwt, cargoTons, laden, portLimit, pass}; laden mirrors STORED estimate 1:1', () => {
     const m = buildDueDiligence(fullArgs());
-    const row = byLabel(m, 'Осадка — порт погрузки');
+    const row = byLabel(m, 'Laden draft — load port');
     expect(row?.derivation).toBeTruthy();
     expect(row?.derivation?.dwt).toBe(35000);
     expect(row?.derivation?.cargoTons).toBe(30000);
@@ -374,12 +374,12 @@ describe('buildDueDiligence — detail + source disclosure', () => {
     const ws = fullWorksheet();
     ws.cargo.weightMtEffective = 32000;
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    expect(byLabel(m, 'Осадка — порт погрузки')?.derivation?.cargoTons).toBe(32000);
+    expect(byLabel(m, 'Laden draft — load port')?.derivation?.cargoTons).toBe(32000);
   });
 
   it('draft derivation: discharge row recomputes laden from DWT+cargo when stored estimate absent (engine-parity ceil)', () => {
     const m = buildDueDiligence(fullArgs());
-    const row = byLabel(m, 'Осадка — порт выгрузки');
+    const row = byLabel(m, 'Laden draft — discharge port');
     const fullLoad = 0.4991 * Math.pow(35000, 0.2991);
     const ratio = Math.min(30000 / 35000, 1);
     const expected = Math.ceil(fullLoad * Math.pow(ratio, 0.3) * 10) / 10;
@@ -393,9 +393,9 @@ describe('buildDueDiligence — detail + source disclosure', () => {
     ws.vessel.dwtSummer = null;
     ws.hardFilters.draft = { pass: true }; // no stored estimate either
     const m = buildDueDiligence(fullArgs({ worksheet: ws }));
-    const row = byLabel(m, 'Осадка — порт погрузки');
+    const row = byLabel(m, 'Laden draft — load port');
     expect(row?.derivation == null).toBe(true);
-    expect(row?.detail?.toLowerCase()).toContain('нет данных');
+    expect(row?.detail?.toLowerCase()).toContain('no dwt/cargo');
   });
 
   it('draft derivation: never feeds counter (display-only parity)', () => {
@@ -429,7 +429,7 @@ describe('buildDueDiligence — detail + source disclosure', () => {
 
   it('inactive fb-dependent rows → detail/source null (no fake explanation)', () => {
     const m = buildDueDiligence(fullArgs({ fitBreakdown: null }));
-    const row = byLabel(m, 'Утилизация DWT');
+    const row = byLabel(m, 'DWT utilisation');
     expect(row?.state).toBe('inactive');
     expect(row?.detail ?? null).toBeNull();
     expect(row?.source ?? null).toBeNull();

--- a/lib/matching/due-diligence.ts
+++ b/lib/matching/due-diligence.ts
@@ -9,8 +9,8 @@
  * presentation re-derivations on the SAME stored vessel/cargo snapshot the page
  * already uses — allowed; they do not touch scoring / regen.
  *
- * Honesty invariant: any null / absent source → `inactive` («не подключено / нет
- * данных»), NEVER a fake `pass`. The hero counter counts active checks only
+ * Honesty invariant: any null / absent source → `inactive` ("not connected / no
+ * data"), NEVER a fake `pass`. The hero counter counts active checks only
  * (pass / caution / info) — inactive rows are excluded.
  */
 
@@ -29,9 +29,9 @@ import { portCanHandleLOA } from '@/lib/sailing/port-master';
 export type DDState = 'pass' | 'caution' | 'info' | 'inactive';
 
 /**
- * Numeric, JSON-serializable payload for the "Осадка в грузу" rows so the client
+ * Numeric, JSON-serializable payload for the "Laden draft" rows so the client
  * DDCheckRow can render the FULL laden-draft derivation (steps 1-3 + berth margin)
- * inside «Подробнее». Display-only: `pass` echoes the STORED hardFilters.draft.pass
+ * inside "Details". Display-only: `pass` echoes the STORED hardFilters.draft.pass
  * verdict, and `laden` mirrors the STORED estimatedLadenDraftM 1:1 when present
  * (recomputed with the engine formula only as a fallback). Intermediates
  * (fullLoadDraftM / ratio) are recomputed on the client from `dwt`/`cargoTons` —
@@ -56,7 +56,7 @@ export interface DDCheck {
   /** Living evidence — a real number / fact from the stored snapshot. Null when inactive. */
   evidence: string | null;
   /**
-   * Plain-language demo disclosure («Подробнее»): what the check is, what we found,
+   * Plain-language demo disclosure ("Details"): what the check is, what we found,
    * and — for quantitative checks (has_calc) — a worked-calc line (inputs → op →
    * result) built from STORED fields only. Honesty caveats are baked in where the
    * engine number is not a 1:1 literal (war-risk excluded from TCE; nominal vs max
@@ -64,11 +64,11 @@ export interface DDCheck {
    * never read by `counter` / `fitPercent` (parity invariant).
    */
   detail?: string | null;
-  /** Short source badge (Equasis / Paris MoU / Расчёт TCE / …). Null on gap rows. */
+  /** Short source badge (Equasis / Paris MoU / TCE calculation / …). Null on gap rows. */
   source?: string | null;
   /**
    * Draft rows only — numeric inputs so the client renders the full laden-draft
-   * formula in «Подробнее». Null when DWT/cargo are missing (no derivation possible)
+   * formula in "Details". Null when DWT/cargo are missing (no derivation possible)
    * or on non-draft rows. Purely presentational — never read by `counter` (parity).
    */
   derivation?: DraftDerivation | null;
@@ -157,16 +157,16 @@ function num(n: number): string {
 
 /** Source badges per check (recon Q2 map). */
 const SRC = {
-  draft: 'Исходное письмо + port-master.json',
-  loa: 'Исходное письмо + port-master.json',
-  letter: 'Исходное письмо',
-  l5c: 'L5C-матрица',
+  draft: 'Circular + port-master.json',
+  loa: 'Circular + port-master.json',
+  letter: 'Vessel circular',
+  l5c: 'L5C matrix',
   imsbc: 'IMSBC-Code',
-  tce: 'Расчёт TCE',
-  freight: 'Baltic-сид / исходное письмо',
-  fit: 'Расчёт фит-%',
+  tce: 'TCE calculation',
+  freight: 'Baltic index / vessel circular',
+  fit: 'Fit-% model',
   parisMou: 'Paris MoU',
-  iacs: 'Реестр IACS',
+  iacs: 'IACS register',
   equasis: 'Equasis',
   pandi: 'IG P&I clubs',
   sanctions: 'OFAC/EU',
@@ -180,23 +180,23 @@ const BALLAST_RADIUS_NM: Record<string, number> = {
   capesize: 4000,
 };
 
-/** "Осадка в грузу" worked-calc from stored hardFilters.draft / destDraft. */
+/** "Laden draft" worked-calc from stored hardFilters.draft / destDraft. */
 function draftDetail(
   h: { estimatedLadenDraftM?: number; portLimitM?: number } | undefined,
 ): string {
   const base =
-    'Проверяем, войдёт ли судно под причал: расчётную осадку судна в грузу сравниваем с допустимым лимитом причала из реестра портов.';
+    'Checking whether the vessel fits the berth: estimated laden draft is compared against the berth draft limit from the port directory.';
   const caveat =
-    'Оценка осадки по DWT и загрузке (скрининг), считается от верхней границы груза — не точный расчёт осадки.';
+    'Draft estimate derived from DWT and load factor (screening); computed from the upper cargo range bound — not a precision draft calculation.';
   if (h?.estimatedLadenDraftM != null && h?.portLimitM != null) {
     const margin = Math.round((h.portLimitM - h.estimatedLadenDraftM) * 10) / 10;
-    return `${base}\nРасчёт: осадка в грузу ~${h.estimatedLadenDraftM}m vs лимит причала ${h.portLimitM}m → запас ${margin}m.\n${caveat}`;
+    return `${base}\nCalc: laden draft ~${h.estimatedLadenDraftM}m vs berth limit ${h.portLimitM}m → margin ${margin}m.\n${caveat}`;
   }
   if (h?.estimatedLadenDraftM != null) {
-    return `${base}\nРасчёт: осадка в грузу ~${h.estimatedLadenDraftM}m; лимит причала не задан в реестре портов.\n${caveat}`;
+    return `${base}\nCalc: laden draft ~${h.estimatedLadenDraftM}m; no berth limit in port directory.\n${caveat}`;
   }
   // No laden estimate stored → screening could not compute draft-in-cargo.
-  return `${base}\nНет данных DWT/груза для расчёта осадки в грузу — проверка по заявленной статической осадке судна.\n${caveat}`;
+  return `${base}\nNo DWT/cargo data for laden-draft estimate — check uses vessel's stated max draft.\n${caveat}`;
 }
 
 /**
@@ -220,33 +220,33 @@ function buildDraftDerivation(
   return { dwt, cargoTons, laden, portLimit: h.portLimitM ?? null, pass: h.pass };
 }
 
-/** "LOA под причал" detail — what the gate is + screening caveat. */
+/** "LOA vs berth" detail — what the gate is + screening caveat. */
 function loaDetail(vesselLoaM: number, limitStr: string | null): string {
   const base =
-    'Проверяем, влезет ли судно по длине (LOA) под причал: длину судна сравниваем с максимальной длиной у причала из реестра портов.';
+    "Checking whether the vessel fits the berth by length (LOA): vessel LOA is compared against the berth's maximum LOA from the port directory.";
   const caveat =
-    'Лимит LOA причала — из реестра портов (есть не у всех портов; черноморские внутренние порты пока без данных). Не учитывает индивидуальные ограничения конкретного терминала.';
+    'Berth LOA limit sourced from port directory (not available for all ports; some Black Sea inland ports currently without data). Does not account for individual terminal restrictions.';
   if (limitStr) {
-    return `${base}\nРасчёт: LOA судна ${vesselLoaM}m vs лимит причала ${limitStr}.\n${caveat}`;
+    return `${base}\nCalc: vessel LOA ${vesselLoaM}m vs berth limit ${limitStr}.\n${caveat}`;
   }
   return `${base}\n${caveat}`;
 }
 
 /**
- * Task #8 — LOA-под-причал berth-gate row. Re-derives the check on the SAME stored
+ * Task #8 — LOA-vs-berth berth-gate row. Re-derives the check on the SAME stored
  * snapshot (worksheet.vessel.loa + port-master maxLOA), like checkCompatibility —
  * parity-safe and robust to pre-gate persisted matches. Honesty: any missing data
  * → inactive (never fake-pass). Graceful pass everywhere data is absent.
  */
 function buildLoaBerthRow(args: BuildDDArgs): DDCheck {
-  const LABEL = 'LOA под причал';
+  const LABEL = 'LOA vs berth';
   const vesselLoa = args.worksheet?.vessel?.loa ?? null;
   const loadPort = args.worksheet?.cargo?.loadPort ?? null;
   const dischPort = args.worksheet?.cargo?.dischargePort ?? null;
 
   // Honesty: vessel LOA not parsed from the circular → inactive, never fake-pass.
   if (vesselLoa == null) {
-    return { label: LABEL, state: 'inactive', evidence: 'LOA судна нет в исходном письме — нужно уточнить', detail: null, source: null };
+    return { label: LABEL, state: 'inactive', evidence: 'Vessel LOA missing from circular — needs confirmation', detail: null, source: null };
   }
 
   const loadResult = portCanHandleLOA(loadPort, vesselLoa);
@@ -259,15 +259,15 @@ function buildLoaBerthRow(args: BuildDDArgs): DDCheck {
     return {
       label: LABEL,
       state: 'inactive',
-      evidence: `LOA судна ${vesselLoa}m; нет данных по причалу — нужно уточнить`,
+      evidence: `Vessel LOA ${vesselLoa}m; no berth data — needs confirmation`,
       detail: null,
       source: null,
     };
   }
 
   const limitStr = [
-    loadLimit != null ? `погрузка max ${loadLimit}m` : null,
-    dischLimit != null ? `выгрузка max ${dischLimit}m` : null,
+    loadLimit != null ? `load max ${loadLimit}m` : null,
+    dischLimit != null ? `disch max ${dischLimit}m` : null,
   ].filter(Boolean).join(' / ');
 
   const loadFail = !loadResult.ok ? loadResult : null;
@@ -280,9 +280,9 @@ function buildLoaBerthRow(args: BuildDDArgs): DDCheck {
       const reasons = [loadFail.reason, dischFail.reason].filter(Boolean);
       evidence = reasons.length > 0
         ? reasons.join(' / ')
-        : `LOA судна ${vesselLoa}m превышает лимит обоих причалов`;
+        : `Vessel LOA ${vesselLoa}m exceeds both berth limits`;
     } else {
-      evidence = anyFail.reason ?? `LOA судна ${vesselLoa}m превышает лимит причала`;
+      evidence = anyFail.reason ?? `Vessel LOA ${vesselLoa}m exceeds berth limit`;
     }
     return {
       label: LABEL,
@@ -295,56 +295,56 @@ function buildLoaBerthRow(args: BuildDDArgs): DDCheck {
   return {
     label: LABEL,
     state: 'pass',
-    evidence: `LOA судна ${vesselLoa}m vs лимит причала (${limitStr})`,
+    evidence: `Vessel LOA ${vesselLoa}m vs berth limit (${limitStr})`,
     detail: loaDetail(vesselLoa, limitStr || null),
     source: SRC.loa,
   };
 }
 
-/** "Утилизация DWT" worked-calc from stored bracketData "X / Y mt". */
+/** "DWT utilisation" worked-calc from stored bracketData "X / Y mt". */
 function utilDetail(c: FitBreakdownComponent | undefined): string {
-  const base = 'Утилизация — какую долю грузоподъёмности судна занимает груз.';
+  const base = "DWT utilisation — what share of the vessel's carrying capacity the cargo occupies.";
   const caveat =
-    'Вместимость = DWCC (полезная грузоподъёмность), если задана, иначе DWT. Вес груза — номинал из письма; осадка и объём считаются от верхней границы диапазона.';
+    'Capacity = DWCC (deadweight cargo capacity) when specified, otherwise DWT. Cargo weight is the nominal figure from the circular; draft and volume are computed from the upper bound of the range.';
   const m = c?.bracketData?.match(/([\d,]+)\s*\/\s*([\d,]+)\s*mt/i);
   if (m) {
     const cargo = Number(m[1].replace(/,/g, ''));
     const cap = Number(m[2].replace(/,/g, ''));
     if (cargo > 0 && cap > 0) {
       const pct = Math.round((cargo / cap) * 100);
-      return `${base}\nРасчёт: груз ${num(cargo)} mt ÷ вместимость ${num(cap)} mt = ${pct}% → ${c!.rationale}\n${caveat}`;
+      return `${base}\nCalc: cargo ${num(cargo)} mt ÷ capacity ${num(cap)} mt = ${pct}% → ${c!.rationale}\n${caveat}`;
     }
   }
   return `${base}\n${caveat}`;
 }
 
-/** "Объём груза под трюмы" worked-calc from stored bracketData "N% of grain". */
+/** "Cargo volume vs holds" worked-calc from stored bracketData "N% of grain". */
 function volumeDetail(c: FitBreakdownComponent | undefined): string {
   const base =
-    'Проверяем, поместится ли груз по ОБЪЁМУ: вес × удельный погрузочный объём (stowage factor) сравниваем с зерновой вместимостью трюмов.';
+    'Checking whether the cargo fits by VOLUME: weight × stowage factor compared against grain capacity of the holds.';
   const caveat =
-    'Stowage factor берётся из письма; если не указан — оценка по типу груза.';
+    'Stowage factor taken from the circular; if absent, estimated by cargo type.';
   const m = c?.bracketData?.match(/([\d.]+)\s*%/);
   if (m) {
-    return `${base}\nРасчёт: груз занимает ~${m[1]}% объёма трюмов (зерновая вместимость).\n${caveat}`;
+    return `${base}\nCalc: cargo occupies ~${m[1]}% of hold volume (grain capacity).\n${caveat}`;
   }
   return `${base}\n${caveat}`;
 }
 
-/** "Балласт-переход" worked-calc from stored bracketData "~N nm" + vesselClass radius. */
+/** "Ballast leg" worked-calc from stored bracketData "~N nm" + vesselClass radius. */
 function ballastDetail(
   c: FitBreakdownComponent | undefined,
   vesselClass: string | undefined,
 ): string {
   const base =
-    'Балластный переход — расстояние от текущей позиции судна до порта погрузки (судно идёт без груза).';
+    "Ballast leg — distance from the vessel's current position to the load port (vessel sailing without cargo).";
   const caveat =
-    'Бункер балластного перехода учтён в строке TCE, отдельно здесь не показан. Дистанция — lookup по таблице портов, приблизительно.';
+    'Ballast-leg bunker is included in the TCE figure and not shown separately here. Distance is a port-table lookup — approximate.';
   const m = c?.bracketData?.match(/~?\s*([\d,]+)\s*nm/i);
   const cls = vesselClass?.toLowerCase();
   const r = cls ? BALLAST_RADIUS_NM[cls] : undefined;
   if (m && r) {
-    return `${base}\nРасчёт: переход ~${m[1]} nm vs радиус класса ~${num(r)} nm (${cls}) → ${c!.rationale}\n${caveat}`;
+    return `${base}\nCalc: ballast leg ~${m[1]} nm vs class radius ~${num(r)} nm (${cls}) → ${c!.rationale}\n${caveat}`;
   }
   return `${base}\n${caveat}`;
 }
@@ -352,15 +352,15 @@ function ballastDetail(
 /** "TCE vs breakeven" worked-calc from stored tce / breakeven columns. */
 function tceDetail(tce: number, breakeven: number | null): string {
   const base =
-    'TCE (Time Charter Equivalent) — дневная доходность рейса за вычетом портовых сборов и бункера. Сравниваем с точкой безубыточности судовладельца: выше → рейс прибыльный, ниже → убыток.';
+    "TCE (Time Charter Equivalent) — daily voyage return net of port costs and bunker. Compared against the owner's breakeven: above → voyage profitable, below → loss-making.";
   const caveat =
-    'War-risk показан в breakdown отдельной строкой — в это число он НЕ входит. ' +
-    'Комиссия (адрес + брокераж, ставка из письма либо 3.75% TTL по умолчанию) ВЫЧТЕНА из фрахта — TCE здесь net-of-commission.';
+    'War-risk premium is shown separately in the breakdown — it is NOT included in this figure. ' +
+    'Commission (address + brokerage, rate from circular or 3.75% TTL default) has been DEDUCTED from freight — TCE shown here is net-of-commission.';
   if (breakeven != null) {
     const diff = tce - breakeven;
     const sign = diff >= 0 ? '+' : '−';
-    const verdict = diff >= 0 ? 'выше breakeven' : 'ниже breakeven';
-    return `${base}\nРасчёт: TCE ${usd(tce)}/сут − breakeven ${usd(breakeven)}/сут = ${sign}${usd(Math.abs(diff))}/сут → ${verdict}.\n${caveat}`;
+    const verdict = diff >= 0 ? 'above breakeven' : 'below breakeven';
+    return `${base}\nCalc: TCE ${usd(tce)}/day − breakeven ${usd(breakeven)}/day = ${sign}${usd(Math.abs(diff))}/day → ${verdict}.\n${caveat}`;
   }
   return `${base}\n${caveat}`;
 }
@@ -368,9 +368,9 @@ function tceDetail(tce: number, breakeven: number | null): string {
 /** "Vessel age" worked-calc from stored vessel.built + refYear. */
 function ageDetail(built: number | null | undefined, refYear: number, rationale: string): string {
   const base =
-    'Возраст судна: год отсчёта минус год постройки. До 15 лет — современное, 15–22 — зрелое (выше риск обслуживания), свыше 22 — повышенный риск задержаний и off-hire.';
+    'Vessel age: reference year minus build year. Under 15 years — modern; 15–22 — mature (higher maintenance risk); over 22 — elevated detention and off-hire risk.';
   if (built != null) {
-    return `${base}\nРасчёт: ${refYear} − ${built} = ${refYear - built} лет → ${rationale}`;
+    return `${base}\nCalc: ${refYear} − ${built} = ${refYear - built} years → ${rationale}`;
   }
   return base;
 }
@@ -380,27 +380,27 @@ const VETTING_LOOKUP: Record<string, { detail: string; source: string }> = {
   flag: {
     source: SRC.parisMou,
     detail:
-      'Флаг судна сверяется со списком Paris MoU (межгосударственный меморандум по портовому контролю). Серый/чёрный список флага = повышенный риск задержаний судна в портах.',
+      'Vessel flag is checked against the Paris MoU list (inter-governmental Memorandum of Understanding on Port State Control). Grey/black-listed flag = elevated risk of port detentions.',
   },
   class: {
     source: SRC.iacs,
     detail:
-      'Классификационное общество судна проверяется на членство в IACS (ассоциация ведущих классов). Класс вне IACS — повышенный технический риск.',
+      'Classification society is checked for IACS membership (International Association of Classification Societies). Non-IACS class = elevated technical risk.',
   },
   pandi: {
     source: SRC.pandi,
     detail:
-      'Страховщик ответственности (P&I) судна проверяется на членство в International Group — пуле ведущих клубов с надёжным покрытием.',
+      'P&I insurer is checked for membership in the International Group — the pool of leading clubs with robust coverage.',
   },
   psc: {
     source: SRC.equasis,
     detail:
-      'История задержаний судна портовым контролем (PSC) по базе Equasis. Свежие задержания = повышенный риск инспекций.',
+      "Vessel's port-state-control (PSC) detention history from Equasis. Recent detentions = elevated inspection risk.",
   },
   cii: {
     source: SRC.equasis,
     detail:
-      'Рейтинг углеродной интенсивности (CII, A–E) из Equasis. A/B/C — в норме, D — внимание, E — повышенный риск эксплуатационных ограничений.',
+      'Carbon Intensity Indicator (CII, A–E) from Equasis. A/B/C — within norms; D — attention; E — elevated risk of operational restrictions.',
   },
 };
 
@@ -422,7 +422,7 @@ function buildVesselPort(args: BuildDDArgs): DDCategory {
   ): string | null => {
     if (!h) return null;
     if (h.estimatedLadenDraftM != null && h.portLimitM != null) {
-      return `Осадка в грузу ~${h.estimatedLadenDraftM}m vs лимит причала ${h.portLimitM}m`;
+      return `Laden draft ~${h.estimatedLadenDraftM}m vs berth draft limit ${h.portLimitM}m`;
     }
     return h.reason ?? componentEvidence(fbDraft);
   };
@@ -448,22 +448,22 @@ function buildVesselPort(args: BuildDDArgs): DDCategory {
 
   return {
     key: 'vessel-port',
-    label: 'Судно ↔ порт',
+    label: 'Vessel ↔ port',
     icon: 'ship',
     checks: [
-      draftRow('Осадка — порт погрузки', hf?.draft),
-      draftRow('Осадка — порт выгрузки', hf?.destDraft),
+      draftRow('Laden draft — load port', hf?.draft),
+      draftRow('Laden draft — discharge port', hf?.destDraft),
       {
-        label: 'Краны / грузовое оборудование',
+        label: 'Cranes / cargo gear',
         state: craneState,
         evidence: hf?.crane?.reason ?? componentEvidence(fbCranes),
         detail: craneActive
-          ? 'Проверяем, есть ли у судна собственные краны/деррики на случай порта без береговой перегрузочной техники. Данные — из письма-циркуляра судна.'
+          ? 'Checking whether the vessel has its own cranes/derricks for ports without shore gear. Source: vessel circular.'
           : null,
         source: craneActive ? SRC.letter : null,
       },
       buildLoaBerthRow(args),
-      INACTIVE('Воздушный габарит', 'нет данных'),
+      INACTIVE('Air draught clearance', 'no data'),
     ],
   };
 }
@@ -473,19 +473,19 @@ function buildCargoHolds(args: BuildDDArgs): DDCategory {
   const fbCargoType = findComponent(args.fitBreakdown, 'cargoType');
   const imsbc = args.worksheet?.hardFilters?.imsbc;
 
-  const HOLD_LABEL = 'Чистота трюмов / прошлый груз';
+  const HOLD_LABEL = 'Hold cleanliness / prior cargo';
   // Founder-locked honesty copy when the circular never carried last cargoes (~96%).
-  // The inactive row STILL explains itself — never a glued «нет данных», never fake-pass.
+  // The inactive row STILL explains itself — never a glued "no data", never fake-pass.
   const holdNoData: DDCheck = {
     label: HOLD_LABEL,
     state: 'inactive',
-    evidence: 'Данных нет в исходном письме — нужно уточнить',
+    evidence: 'Not in circular — confirm with owner/broker',
     detail:
-      'Прошлый груз не указан в письме-циркуляре судна (типично для ~96% циркуляров). При наличии данных мы сверяем совместимость с текущим грузом по L5C-матрице (риск перекрёстного загрязнения, требования к зачистке трюмов). Здесь — требуется уточнить у судовладельца/брокера.',
+      'Prior cargo not listed in the vessel circular (typical for ~96% of circulars). When available, we check compatibility with the current cargo via the L5C matrix (cross-contamination risk, hold-cleaning requirements). Action: confirm with owner/broker.',
     source: SRC.l5c,
   };
   const holdBase =
-    'Смотрим последние грузы судна и проверяем совместимость с текущим грузом по L5C-матрице (риск перекрёстного загрязнения, требования к зачистке трюмов). Источник — поле прошлых грузов из письма судна.';
+    "Checking vessel's last cargoes for compatibility with the current cargo via the L5C matrix (cross-contamination risk, hold-cleaning requirements). Source: prior-cargo field from vessel circular.";
 
   // Hold cleanliness — re-derived from the SAME stored vessel/cargo snapshot.
   // Honesty: missing last cargoes OR missing cargo description → inactive, never pass.
@@ -501,47 +501,47 @@ function buildCargoHolds(args: BuildDDArgs): DDCategory {
       const r = checkCompatibility(prev, args.cargoDescription);
       if (!r.compatible) {
         const reasons = r.blocking_pairs.map((b) => `${b.previous}: ${b.reason}`).join('; ');
-        holdCheck = { label: HOLD_LABEL, state: 'caution', evidence: reasons || 'несовместимый прошлый груз', detail: holdBase, source: SRC.l5c };
+        holdCheck = { label: HOLD_LABEL, state: 'caution', evidence: reasons || 'incompatible prior cargo', detail: holdBase, source: SRC.l5c };
       } else if (r.requires_extra_clean) {
-        holdCheck = { label: HOLD_LABEL, state: 'caution', evidence: `Прошлый груз: ${prev.join(', ')} — требуется доп. зачистка`, detail: holdBase, source: SRC.l5c };
+        holdCheck = { label: HOLD_LABEL, state: 'caution', evidence: `Prior cargo: ${prev.join(', ')} — extra cleaning required`, detail: holdBase, source: SRC.l5c };
       } else {
-        holdCheck = { label: HOLD_LABEL, state: 'pass', evidence: `Прошлый груз: ${prev.join(', ')} — совместимо`, detail: holdBase, source: SRC.l5c };
+        holdCheck = { label: HOLD_LABEL, state: 'pass', evidence: `Prior cargo: ${prev.join(', ')} — compatible`, detail: holdBase, source: SRC.l5c };
       }
     }
   }
 
   const imsbcCheck: DDCheck = imsbc
     ? {
-        label: 'IMSBC группа',
+        label: 'IMSBC group',
         state: imsbc.pass === false || imsbc.warning ? 'caution' : 'info',
         evidence: imsbc.reason ?? null,
         detail:
-          'Сверяем груз с Кодексом IMSBC (морская перевозка навалочных грузов): группа A/B/C, требования к перевозке и ограничения судна.',
+          'Checking cargo against the IMSBC Code (International Maritime Solid Bulk Cargoes): Group A/B/C classification, carriage requirements, and vessel restrictions.',
         source: SRC.imsbc,
       }
-    : INACTIVE('IMSBC группа', 'нет данных');
+    : INACTIVE('IMSBC group', 'no data');
 
   const volumeState = componentState(fbVolume);
   const cargoTypeState = componentState(fbCargoType);
 
   return {
     key: 'cargo-holds',
-    label: 'Груз ↔ трюмы',
+    label: 'Cargo ↔ holds',
     icon: 'package',
     checks: [
       {
-        label: 'Объём груза под трюмы',
+        label: 'Cargo volume vs holds',
         state: volumeState,
         evidence: componentEvidence(fbVolume),
         detail: volumeState !== 'inactive' ? volumeDetail(fbVolume) : null,
         source: volumeState !== 'inactive' ? SRC.letter : null,
       },
       {
-        label: 'Тип груза ↔ тип судна',
+        label: 'Cargo type ↔ vessel type',
         state: cargoTypeState,
         evidence: componentEvidence(fbCargoType),
         detail: cargoTypeState !== 'inactive'
-          ? 'Сверяем тип груза с типом и конструкцией судна (балкер/твиндекер и т.п.) на принципиальную совместимость. Данные — из письма.'
+          ? 'Checking cargo type compatibility with vessel type and design (bulker/tweendecker etc.). Source: vessel circular.'
           : null,
         source: cargoTypeState !== 'inactive' ? SRC.letter : null,
       },
@@ -559,7 +559,7 @@ function buildEconomics(args: BuildDDArgs): DDCategory {
   // TCE vs breakeven — stored single source (list==detail parity).
   let tceCheck: DDCheck;
   if (args.tceUsdPerDay == null) {
-    tceCheck = INACTIVE('TCE vs breakeven', 'нет данных');
+    tceCheck = INACTIVE('TCE vs breakeven', 'no data');
   } else if (args.breakevenTce == null) {
     tceCheck = {
       label: 'TCE vs breakeven',
@@ -573,7 +573,7 @@ function buildEconomics(args: BuildDDArgs): DDCategory {
     tceCheck = {
       label: 'TCE vs breakeven',
       state: diff >= 0 ? 'pass' : 'caution',
-      evidence: `TCE ${usd(args.tceUsdPerDay)}/day — ${usd(Math.abs(diff))}/day ${diff >= 0 ? 'выше' : 'ниже'} breakeven`,
+      evidence: `TCE ${usd(args.tceUsdPerDay)}/day — ${usd(Math.abs(diff))}/day ${diff >= 0 ? 'above' : 'below'} breakeven`,
       detail: tceDetail(args.tceUsdPerDay, args.breakevenTce),
       source: SRC.tce,
     };
@@ -583,16 +583,16 @@ function buildEconomics(args: BuildDDArgs): DDCategory {
   let freightCheck: DDCheck;
   const src = args.freightRateSource;
   if (!src) {
-    freightCheck = INACTIVE('Фрахт vs Baltic', 'нет данных');
+    freightCheck = INACTIVE('Freight vs Baltic', 'no data');
   } else {
     const estimated = src === 'baltic' || src === 'estimated';
-    const note = args.consumptionEstimated ? ' · расход оценён' : '';
+    const note = args.consumptionEstimated ? ' · consumption estimated' : '';
     freightCheck = {
-      label: 'Фрахт vs Baltic',
+      label: 'Freight vs Baltic',
       state: estimated ? 'caution' : 'info',
-      evidence: `Ставка фрахта: ${src}${estimated ? ' (оценка)' : ''}${note}`,
+      evidence: `Freight rate: ${src}${estimated ? ' (estimate)' : ''}${note}`,
       detail:
-        'Откуда взята ставка фрахта: вручную из письма (manual/parsed) или оценка по индексу Baltic / сиду. Оценочная ставка → число приблизительное, помечается «оценка».',
+        'Freight rate source: manually entered from the circular (manual/parsed) or estimated from the Baltic index / seed. Estimated rate → approximate figure, flagged as "(estimate)".',
       source: SRC.freight,
     };
   }
@@ -604,28 +604,28 @@ function buildEconomics(args: BuildDDArgs): DDCategory {
 
   return {
     key: 'economics',
-    label: 'Экономика рейса',
+    label: 'Voyage economics',
     icon: 'coin',
     checks: [
       tceCheck,
       {
-        label: 'Экономика рейса (фит)',
+        label: 'Voyage economics (fit)',
         state: fbEconState,
         evidence: componentEvidence(fbEconomics),
         detail: fbEconState !== 'inactive'
-          ? 'Доля экономики рейса в итоговом фит-%: насколько рейс выгоден относительно альтернатив для этого класса судна.'
+          ? 'Voyage economics contribution to the overall fit-%: how profitable this voyage is relative to alternatives for this vessel class.'
           : null,
         source: fbEconState !== 'inactive' ? SRC.tce : null,
       },
       {
-        label: 'Утилизация DWT',
+        label: 'DWT utilisation',
         state: fbUtilState,
         evidence: componentEvidence(fbUtil),
         detail: fbUtilState !== 'inactive' ? utilDetail(fbUtil) : null,
         source: fbUtilState !== 'inactive' ? SRC.tce : null,
       },
       {
-        label: 'Балласт-переход',
+        label: 'Ballast leg',
         state: fbBallastState,
         evidence: componentEvidence(fbBallast),
         detail: fbBallastState !== 'inactive' ? ballastDetail(fbBallast, vesselClass) : null,
@@ -652,7 +652,7 @@ function buildVetting(args: BuildDDArgs): DDCategory {
         : f.verdict === 'caution' || f.verdict === 'warn' ? 'caution'
         : 'inactive'; // unknown → honesty: no data on this vessel
       if (state === 'inactive') {
-        checks.push({ label: f.label, state, evidence: 'нет данных по судну', detail: null, source: null });
+        checks.push({ label: f.label, state, evidence: 'no vessel data', detail: null, source: null });
         continue;
       }
       // age is the one quantitative vetting factor (refYear − built); the rest are lookups.
@@ -668,11 +668,11 @@ function buildVetting(args: BuildDDArgs): DDCategory {
     // No live vessel snapshot — fall back to the rolled-up vetting component.
     const rollState = componentState(fbVetting);
     checks.push({
-      label: 'Ветинг судна (сводно)',
+      label: 'Vessel vetting (summary)',
       state: rollState,
       evidence: componentEvidence(fbVetting),
       detail: rollState !== 'inactive'
-        ? 'Сводная оценка ветинга судна (флаг, класс, возраст, P&I, PSC, CII) — детализация по судну недоступна в этом снэпшоте.'
+        ? 'Rolled-up vessel vetting assessment (flag, class, age, P&I, PSC, CII) — per-factor breakdown not available for this snapshot.'
         : null,
       source: rollState !== 'inactive' ? SRC.equasis : null,
     });
@@ -680,12 +680,12 @@ function buildVetting(args: BuildDDArgs): DDCategory {
 
   // Timing readiness — fb timing component, or readiness verdict as a fallback.
   const timingDetail =
-    'Готовность судна к laycan: сопоставляем дату освобождения и переход до порта погрузки с окном laycan груза. Данные — из письма.';
+    "Vessel readiness for laycan: we compare the open date and ballast passage to the load port against the cargo's laycan window. Source: vessel circular.";
   let timingCheck: DDCheck;
   if (fbTiming) {
     const ts = componentState(fbTiming);
     timingCheck = {
-      label: 'Готовность / тайминг',
+      label: 'Readiness / timing',
       state: ts,
       evidence: componentEvidence(fbTiming),
       detail: ts !== 'inactive' ? timingDetail : null,
@@ -693,30 +693,30 @@ function buildVetting(args: BuildDDArgs): DDCategory {
     };
   } else if (args.worksheet?.readiness?.verdict) {
     timingCheck = {
-      label: 'Готовность / тайминг',
+      label: 'Readiness / timing',
       state: 'info',
-      evidence: `Готовность: ${args.worksheet.readiness.verdict}`,
+      evidence: `Readiness: ${args.worksheet.readiness.verdict}`,
       detail: timingDetail,
       source: SRC.letter,
     };
   } else {
-    timingCheck = INACTIVE('Готовность / тайминг', 'нет данных');
+    timingCheck = INACTIVE('Readiness / timing', 'no data');
   }
 
   const classState = componentState(fbClass);
   checks.push({
-    label: 'Класс судна (фит)',
+    label: 'Vessel class (fit)',
     state: classState,
     evidence: componentEvidence(fbClass),
     detail: classState !== 'inactive'
-      ? 'Насколько класс судна (handysize/supramax/panamax/capesize) подходит под параметры груза и рейса — вклад в итоговый фит-%.'
+      ? 'How well the vessel class (handysize/supramax/panamax/capesize) matches cargo and voyage parameters — its contribution to the overall fit-%.'
       : null,
     source: classState !== 'inactive' ? SRC.fit : null,
   });
   checks.push(timingCheck);
-  checks.push(INACTIVE('RightShip score', 'не подключено'));
+  checks.push(INACTIVE('RightShip score', 'not connected'));
 
-  return { key: 'vetting', label: 'Ветинг судна', icon: 'shield-check', checks };
+  return { key: 'vetting', label: 'Vessel vetting', icon: 'shield-check', checks };
 }
 
 function buildCompliance(args: BuildDDArgs): DDCategory {
@@ -725,15 +725,15 @@ function buildCompliance(args: BuildDDArgs): DDCategory {
 
   let sanctionsCheck: DDCheck;
   if (!sanctions) {
-    sanctionsCheck = INACTIVE('Санкции судна (OFAC/EU)', 'нет данных');
+    sanctionsCheck = INACTIVE('Vessel sanctions (OFAC/EU)', 'no data');
   } else {
     const clean = sanctions.risk === 'NONE' || sanctions.risk === 'LOW';
     sanctionsCheck = {
-      label: 'Санкции судна (OFAC/EU)',
+      label: 'Vessel sanctions (OFAC/EU)',
       state: !clean || sanctions.blocking ? 'caution' : 'pass',
       evidence: sanctions.reason ?? `Sanctions risk: ${sanctions.risk}`,
       detail:
-        'Проверяем судно, его владельца и управляющую компанию по санкционным спискам OFAC (США) и ЕС. Красный флаг блокирует рейс. Данные — из санкционного слоя системы на момент матчинга.',
+        'Checking vessel, owner, and manager against OFAC (US) and EU sanctions lists. A blocking flag prevents the voyage. Data from the sanctions layer as of the matching timestamp.',
       source: SRC.sanctions,
     };
   }
@@ -745,20 +745,20 @@ function buildCompliance(args: BuildDDArgs): DDCategory {
         state: warState,
         evidence: war.reason ?? null,
         detail: warState !== 'inactive'
-          ? 'Проверяем, проходит ли позиция судна или рейс через зоны военного риска по спискам JWC (Joint War Committee). Попадание в зону = надбавка war-risk и повышенный риск. Стоимость war-risk показана в breakdown TCE отдельно.'
+          ? 'Checking whether the vessel position or voyage passes through JWC (Joint War Committee) war-risk zones. Entry into a zone = war-risk surcharge and elevated risk. War-risk cost is shown separately in the TCE breakdown.'
           : null,
         source: warState !== 'inactive' ? SRC.jwc : null,
       }
-    : INACTIVE('War-risk / JWC', 'нет данных');
+    : INACTIVE('War-risk / JWC', 'no data');
 
   return {
     key: 'compliance',
-    label: 'Комплаенс / риск',
+    label: 'Compliance / risk',
     icon: 'scale',
     checks: [
       sanctionsCheck,
       warCheck,
-      INACTIVE('KYC чартерера', 'не подключено'),
+      INACTIVE('Charterer KYC', 'not connected'),
     ],
   };
 }


### PR DESCRIPTION
## What

Translate every user-visible Russian string in the **Due Diligence panel** to professional maritime-broker English. Presentation-only copy swap — **zero engine/scoring/counter change**.

Applies the approved `EN proposal` column from `docs/research/recon-dd-i18n-2026-06-19.md` verbatim (no creative re-translation), per `docs/superpowers/plans/2026-06-19-dd-i18n-plan.md`.

## Changes

- **`lib/matching/due-diligence.ts`** (~70 strings): SRC source badges, category labels, check labels, INACTIVE evidence, interpolated evidence, detail helpers (`draftDetail`/`loaDetail`/`utilDetail`/`volumeDetail`/`ballastDetail`/`tceDetail`/`ageDetail`), `VETTING_LOOKUP`, vetting-summary, timing, cargo-type/IMSBC/cranes/economics/compliance/class details.
- **`components/match/DueDiligencePanel.tsx`**: hero counter (`Ran N checks · critical stops M`) + `criticalText` (`none`).
- **`components/match/DDCheckRow.tsx`**: `Collapse`/`Details`, `Source:`, draft formula steps.
- **`DraftCalcBreakdown.tsx`**: untouched (already English).
- **Tests**: 47 RU-asserting assertions updated to EN across `due-diligence.test.ts` (33) and `DDCheckRow.test.tsx` (14) — `byLabel` args, `toContain`/`toMatch` substrings, regex `письм→circular` / `причал→berth`.

## Invariants held

- Interpolation tokens (`${...}`, `mt`/`m3`/`nm`/`%`/`$`/`/day`, arithmetic, `rationale`/`cls`/`src`) kept intact; `лет → years`.
- Honesty invariant intact: null source → `inactive`, never fake-pass.
- RSC boundary unchanged — no new client imports.
- Zero Cyrillic in the 4 source files (grep clean).

## Verification

- `npx tsc --noEmit` — clean.
- `npx jest` (both DD test files) — **44 passed, 2 suites**.
- `npm run build` — blocked by the known worktree/Turbopack root-resolution limitation (node_modules in parent worktree); verified statically instead: diff is string-literal-only, no import/logic/`use client` changes, `DraftCalcBreakdown` untouched. Run a full build on a normal checkout before merge to confirm bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)