### PR TITLE
fix(test): seed fresh EUA dates so #1069 freshness gate passes (CI green)

### DIFF
--- a/__tests__/api/voyage/bunker-recommendation-eff-split.test.ts
+++ b/__tests__/api/voyage/bunker-recommendation-eff-split.test.ts
@@ -41,8 +41,10 @@ beforeAll(() => {
     INSERT INTO bunker_prices VALUES ('CYLMS', 'VLSFO', 595, '2026-06-02', 'seed', datetime('now'));
     -- ESCEU: higher raw price but NON_EU_ETS_OVERRIDE → no carbon → lower effective $/MT
     INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 609, '2026-06-02', 'seed', datetime('now'));
-    -- EUA at 70 EUR/tCO2 — carbon surcharge on CYLMS ≈ 70*1.08*3.151*500/500 ≈ 238 USD/MT
-    INSERT INTO eua_prices VALUES ('2026-06-02', 70, 'spot', 'seed', datetime('now'));
+    -- EUA at 70 EUR/tCO2 — carbon surcharge on CYLMS ≈ 70*1.08*3.151*500/500 ≈ 238 USD/MT.
+    -- date('now') keeps it within the 7-day freshness gate (#1069); a hardcoded
+    -- past date would go stale vs the CI clock and null the lookup → no carbon.
+    INSERT INTO eua_prices VALUES (date('now'), 70, 'spot', 'seed', datetime('now'));
   `);
 });
 

--- a/__tests__/api/voyage/tce-auto-eua.test.ts
+++ b/__tests__/api/voyage/tce-auto-eua.test.ts
@@ -37,7 +37,9 @@ beforeAll(() => {
       fetched_at         TEXT NOT NULL,
       UNIQUE(price_date, contract_type)
     );
-    INSERT INTO eua_prices VALUES ('2026-05-04', 72.65, 'spot', 'eex-auction-static-seed', datetime('now'));
+    -- date('now') keeps the seed within the 7-day freshness gate (#1069); a
+    -- hardcoded past date would go stale vs the CI clock and null the lookup.
+    INSERT INTO eua_prices VALUES (date('now'), 72.65, 'spot', 'eex-auction-static-seed', datetime('now'));
   `);
 });
 


### PR DESCRIPTION
## Problem
Main CI was RED. The 7-day EUA freshness gate from #1069 (`getLatestEuaPrice` nulls `eua_prices` rows older than `EUA_STALE_DAYS=7`) broke two tests that seeded `eua_prices` with **hardcoded past dates**:

- `__tests__/api/voyage/tce-auto-eua.test.ts` — seed `'2026-05-04'`, asserts `euaPriceSource.value === 72.65` (auto-lookup path).
- `__tests__/api/voyage/bunker-recommendation-eff-split.test.ts` — seed `'2026-06-02'`, asserts ESCEU wins on effective $/MT via the EUA carbon surcharge.

Once the CI clock (2026-06-20) drifted >7 days past those literals, the auto-lookup returned `null` → EUA value/carbon dropped → intended assertions failed. Hardcoded past seed dates are a **time-bomb** under the gate.

## Fix
Replace the two hardcoded seed dates with SQLite `date('now')` so the seed is always inside the freshness window. **No assertion weakened, gate not disabled, no `maxAgeDays: Infinity` mask** — production still nulls stale prices; only the test seed is made non-stale. Added a one-line comment at each seed explaining why.

## Suite-wide audit (other `INSERT INTO eua_prices` literal dates)
Grepped the whole suite. No other gate-affected, fresh-expecting EUA seed needs fixing:

| File | Seed | Verdict |
|------|------|---------|
| `tce-auto-eua.test.ts` | `'2026-05-04'` → `date('now')` | **FIXED** — auto-lookup, asserts 72.65 |
| `bunker-recommendation-eff-split.test.ts` | `'2026-06-02'` → `date('now')` | **FIXED** — carbon surcharge asserted |
| `tce-auto-bunker.test.ts` | `'2026-05-04'` | Left — `euaPriceEur:0` bypasses auto-lookup (gate never hit) |
| `tce-missing-bunker-port.test.ts` | `'2026-06-04'` | Left — `euaPriceEur:0` bypass |
| `tce-ets-autoderive.test.ts` | `'2026-05-09'` | Left — passes manual `euaPriceEur:72.65` |
| `bunker-routeaware-parity.test.ts` | `'2026-06-10'` | Left — parity assertion is value-agnostic (gate→fallback in both list+detail); GREEN |
| `market-eua-kpi.test.ts` | stale seed | Left — **intentionally** tests the gate (stale→FALLBACK+`stale:true`, #1069) |
| `market-indices.test.ts` | `'2026-05-10'` | Left — `getEuaHistory` has no freshness gate (only `<= date('now')`) |
| `eua-repository.test.ts`, `024-eua-prices-rewrite.test.ts` | various | Left — intentional gate/migration tests |

## Acceptance — #1069
#1069 is already MERGED; this is a follow-up that keeps the suite green under its new gate. The gate behaviour (warn + degrade to `FALLBACK_EUA_EUR_PER_TCO2`) is untouched.

## Verification
- `npx jest tce-auto-eua bunker-recommendation-eff-split --runInBand --forceExit` → **9 passed**
- `npx jest --findRelatedTests <both files> --maxWorkers=1` → **9 passed**
- `npx tsc --noEmit` → clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
