### PR TITLE
fix(backfill-815): roll back partial writes on strict abort (audit-1 LOW #13)

### DIFF
--- a/scripts/demo-seed/__tests__/backfill-815-weights.test.ts
+++ b/scripts/demo-seed/__tests__/backfill-815-weights.test.ts
@@ -202,6 +202,39 @@ describe('backfill-815-weights', () => {
     expect(output).toMatch(/MISSING_ROW/);
   });
 
+  it('MIXED strict abort: updatable Marmara row is rolled back (no partial writes)', () => {
+    // Seed full DB (Marmara stale → WOULD update), then delete one OTHER fixture
+    // row to force a MISSING_ROW. Strict mode must abort AND roll back the
+    // Marmara write, so "no writes performed" is literally true.
+    const otherIds = getAllFixtureEmailIds().filter((id) => id !== MARMARA_EMAIL_ID);
+    const missingId = otherIds[0];
+
+    const setup = new Database(dbPath);
+    setup
+      .prepare(`DELETE FROM parsed_results WHERE gmail_message_id=? AND parse_type='cargo'`)
+      .run(missingId);
+    setup.close();
+
+    const { stdout, stderr, exitCode } = runBackfill(dbPath);
+    const output = stdout + stderr;
+
+    expect(exitCode).not.toBe(0);
+    expect(output).toMatch(/MISSING_ROW/);
+    expect(output).toMatch(/no writes performed/);
+
+    // Marmara item 0 MUST remain stale (rolled back) — NOT 186
+    const db = new Database(dbPath, { readonly: true });
+    const row = db
+      .prepare(`SELECT result_json FROM parsed_results WHERE gmail_message_id=? AND parse_type='cargo'`)
+      .get(MARMARA_EMAIL_ID) as { result_json: string };
+    db.close();
+
+    const item0 = JSON.parse(row.result_json)[0];
+    expect(item0.weightMtMax).toBeNull();
+    expect(item0.weightMtMin).toBeNull();
+    expect(item0.weightMt).toMatchObject({ value: null });
+  });
+
   it('idempotent: second run produces 0 updates', () => {
     const r1 = runBackfill(dbPath);
     expect(r1.exitCode).toBe(0);

--- a/scripts/demo-seed/backfill-815-weights.ts
+++ b/scripts/demo-seed/backfill-815-weights.ts
@@ -112,6 +112,14 @@ async function main() {
     byEmail.set(c.emailId, arr);
   }
 
+  // Sentinel thrown at the end of the batch when strict-mode hits a
+  // MISSING_ROW/AMBIGUOUS_MATCH. Thrown INSIDE the better-sqlite3 transaction
+  // so the whole batch rolls back — making "no writes performed" literally true
+  // (previously updateRow.run() flushed each row immediately under WAL, so the
+  // abort message was a false claim while partial writes were already committed).
+  class AbortMissingRows extends Error {}
+
+  const runBatch = () => {
   for (const [emailId, cargoes] of byEmail) {
     const row = selectRow.get(emailId) as { result_json: string } | undefined;
     if (!row) {
@@ -178,12 +186,29 @@ async function main() {
     }
   }
 
-  console.log(`[backfill-815] done — updated=${updates} skipped-already-correct=${skipped} skipped-missing=${skippedMissing} skipped-ambiguous=${skippedAmbiguous}`);
+  // Trigger rollback of every write above when strict mode saw a missing row.
+  if (missingRows > 0) throw new AbortMissingRows();
+  };
 
-  if (missingRows > 0) {
-    console.error(`[backfill-815] ABORT — ${missingRows} MISSING_ROW or AMBIGUOUS_MATCH; no writes performed`);
-    process.exit(1);
+  try {
+    // Wrap writes in a single transaction so a strict-mode abort rolls back
+    // the whole batch atomically. DRY mode opens the db read-only — no
+    // transaction needed (and none would be writable).
+    if (!DRY && updateRow) {
+      db.transaction(runBatch)();
+    } else {
+      runBatch();
+    }
+  } catch (err) {
+    if (err instanceof AbortMissingRows) {
+      console.log(`[backfill-815] done — updated=${updates} skipped-already-correct=${skipped} skipped-missing=${skippedMissing} skipped-ambiguous=${skippedAmbiguous}`);
+      console.error(`[backfill-815] ABORT — ${missingRows} MISSING_ROW or AMBIGUOUS_MATCH; no writes performed`);
+      process.exit(1);
+    }
+    throw err;
   }
+
+  console.log(`[backfill-815] done — updated=${updates} skipped-already-correct=${skipped} skipped-missing=${skippedMissing} skipped-ambiguous=${skippedAmbiguous}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Problem (audit-1 LOW item 13)

`scripts/demo-seed/backfill-815-weights.ts` ran `updateRow.run()` per-row **inside** the loop with no enclosing transaction. Under better-sqlite3 WAL each `run()` flushes immediately. Then *after* the loop, if `missingRows > 0`, it printed:

```
[backfill-815] ABORT — N MISSING_ROW or AMBIGUOUS_MATCH; no writes performed
```

and `exit 1` — but partial writes were **already committed**. The "no writes performed" claim was false.

## Fix

- Wrap the per-row write loop in `db.transaction(runBatch)()`.
- Throw an `AbortMissingRows` sentinel at the end of the batch when `missingRows > 0` — thrown *inside* the transaction so the whole batch **rolls back atomically**.
- Catch outside the transaction → print summary + ABORT, `exit 1`. Now "no writes performed" is literally true.
- Clean all-correct path and DRY (read-only) path preserved.

## TDD

- **RED first:** new MIXED-case test seeds the stale Marmara row (would-update) + a sibling `MISSING_ROW`. Asserts the Marmara row stays **stale (rolled back)** after the strict abort. Failed with `Received: 186` on old code (partial write committed).
- **GREEN:** after fix the row remains `null`.
- Existing all-missing test stays green.

## Tests

```
Tests: 11 passed, 11 total
```
tsc clean (`--noEmit`, heap-bumped for VPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)