### PR TITLE
fix(bunker): exclude stale on-route prices from ranking, not log-only (audit-1 #15)

### DIFF
--- a/__tests__/api/bunker-routeaware-parity.test.ts
+++ b/__tests__/api/bunker-routeaware-parity.test.ts
@@ -28,6 +28,17 @@ import { estimateVoyageDays } from '@/lib/economics/voyage-days';
 import { getPortDistance } from '@/lib/sailing/port-distances';
 import type { ParsedCargo, ParsedVessel } from '@/lib/types';
 
+/**
+ * Fresh seed date (2 days old) so prices pass the BUNKER_STALE_DAYS=7 freshness
+ * gate (FIX #15). A hard-coded calendar date would silently age past 7 days and
+ * get excluded, collapsing every on-route candidate to the fallback (cf. #1075).
+ */
+const SEED_DATE = (() => {
+  const d = new Date();
+  d.setDate(d.getDate() - 2);
+  return d.toISOString().slice(0, 10);
+})();
+
 /** DB with bunker_prices (Med hubs cheaper than NLRTM), eua + port_da for economics. */
 function makeDb(): Database.Database {
   const db = new Database(':memory:');
@@ -42,15 +53,15 @@ function makeDb(): Database.Database {
       UNIQUE(port_unlocode, fuel_grade, price_date)
     );
     -- Med + Black Sea hubs (on-route for Black-Sea → UK), all CHEAPER than NLRTM
-    INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 720, '2026-06-10', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 745, '2026-06-10', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('ESALG', 'VLSFO', 748, '2026-06-10', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('GRPIR', 'VLSFO', 760, '2026-06-10', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('ROCND', 'VLSFO', 770, '2026-06-10', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('ITAUG', 'VLSFO', 758, '2026-06-10', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 720, '${SEED_DATE}', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 745, '${SEED_DATE}', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ESALG', 'VLSFO', 748, '${SEED_DATE}', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GRPIR', 'VLSFO', 760, '${SEED_DATE}', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ROCND', 'VLSFO', 770, '${SEED_DATE}', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ITAUG', 'VLSFO', 758, '${SEED_DATE}', 'seed', datetime('now'));
     -- NW Europe hubs
-    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 800, '2026-06-10', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('BEANR', 'VLSFO', 815, '2026-06-10', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 800, '${SEED_DATE}', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('BEANR', 'VLSFO', 815, '${SEED_DATE}', 'seed', datetime('now'));
 
     CREATE TABLE eua_prices (
       contract_type     TEXT,
@@ -58,7 +69,7 @@ function makeDb(): Database.Database {
       price_date        TEXT,
       source            TEXT DEFAULT 'test'
     );
-    INSERT INTO eua_prices (contract_type, price_eur_per_tco2, price_date) VALUES ('spot', 77, '2026-06-10');
+    INSERT INTO eua_prices (contract_type, price_eur_per_tco2, price_date) VALUES ('spot', 77, '${SEED_DATE}');
 
     CREATE TABLE port_da_estimates (
       port_code TEXT, vessel_dwt_min INTEGER, vessel_dwt_max INTEGER,

--- a/__tests__/api/voyage/bunker-reco-adversarial.test.ts
+++ b/__tests__/api/voyage/bunker-reco-adversarial.test.ts
@@ -30,16 +30,16 @@ function createDb(): Database.Database {
       fetched_at       TEXT NOT NULL,
       UNIQUE(port_unlocode, fuel_grade, price_date)
     );
-    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('AEFJR', 'VLSFO', 880, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('USHOU', 'VLSFO', 806, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('NLRTM', 'MGO',  1192, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('GIGIB', 'MGO',  1172, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('SGSIN', 'MGO',  1144, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('AEFJR', 'MGO',  1482, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('USHOU', 'MGO',  1170, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('AEFJR', 'VLSFO', 880, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USHOU', 'VLSFO', 806, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'MGO',  1192, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'MGO',  1172, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'MGO',  1144, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('AEFJR', 'MGO',  1482, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USHOU', 'MGO',  1170, date('now','-2 day'), 'seed', datetime('now'));
   `);
   return d;
 }

--- a/__tests__/api/voyage/bunker-recommendation-basin-filter.test.ts
+++ b/__tests__/api/voyage/bunker-recommendation-basin-filter.test.ts
@@ -26,16 +26,16 @@ beforeAll(() => {
       UNIQUE(port_unlocode, fuel_grade, price_date)
     );
     -- Med + Black Sea hubs (must appear for Med voyages)
-    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('GRPIR', 'VLSFO', 760, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('ROCND', 'VLSFO', 740, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('ITAUG', 'VLSFO', 755, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, '2026-06-02', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GRPIR', 'VLSFO', 760, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ROCND', 'VLSFO', 740, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ITAUG', 'VLSFO', 755, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, date('now','-2 day'), 'seed', datetime('now'));
     -- Far-away hubs — basin filter must EXCLUDE for Med voyages
-    INSERT INTO bunker_prices VALUES ('USLAX', 'VLSFO', 950, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('BRSSZ', 'VLSFO', 720, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('ZADUR', 'VLSFO', 700, '2026-06-02', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USLAX', 'VLSFO', 950, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('BRSSZ', 'VLSFO', 720, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ZADUR', 'VLSFO', 700, date('now','-2 day'), 'seed', datetime('now'));
   `);
 });
 

--- a/__tests__/api/voyage/bunker-recommendation-candidates.test.ts
+++ b/__tests__/api/voyage/bunker-recommendation-candidates.test.ts
@@ -28,9 +28,9 @@ beforeAll(() => {
       UNIQUE(port_unlocode, fuel_grade, price_date)
     );
     -- Three on-route hubs priced; 20 others have no price → automatically excluded
-    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, '2026-06-02', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, '2026-06-02', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, date('now','-2 day'), 'seed', datetime('now'));
   `);
 });
 

--- a/__tests__/api/voyage/bunker-recommendation-eff-split.test.ts
+++ b/__tests__/api/voyage/bunker-recommendation-eff-split.test.ts
@@ -38,9 +38,9 @@ beforeAll(() => {
       fetched_at         TEXT NOT NULL
     );
     -- CYLMS: cheapest raw price but EU ETS carbon cost applies (CY prefix = Cyprus = EU)
-    INSERT INTO bunker_prices VALUES ('CYLMS', 'VLSFO', 595, '2026-06-02', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('CYLMS', 'VLSFO', 595, date('now','-2 day'), 'seed', datetime('now'));
     -- ESCEU: higher raw price but NON_EU_ETS_OVERRIDE → no carbon → lower effective $/MT
-    INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 609, '2026-06-02', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 609, date('now','-2 day'), 'seed', datetime('now'));
     -- EUA at 70 EUR/tCO2 — carbon surcharge on CYLMS ≈ 70*1.08*3.151*500/500 ≈ 238 USD/MT.
     -- date('now') keeps it within the 7-day freshness gate (#1069); a hardcoded
     -- past date would go stale vs the CI clock and null the lookup → no carbon.

--- a/__tests__/api/voyage/bunker-recommendation.test.ts
+++ b/__tests__/api/voyage/bunker-recommendation.test.ts
@@ -29,11 +29,11 @@ beforeAll(() => {
       UNIQUE(port_unlocode, fuel_grade, price_date)
     );
     -- Seed all 5 standard bunker hubs
-    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('AEFJR', 'VLSFO', 880, '2026-05-09', 'seed', datetime('now'));
-    INSERT INTO bunker_prices VALUES ('USHOU', 'VLSFO', 806, '2026-05-09', 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('NLRTM', 'VLSFO', 791, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 771, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('SGSIN', 'VLSFO', 801, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('AEFJR', 'VLSFO', 880, date('now','-2 day'), 'seed', datetime('now'));
+    INSERT INTO bunker_prices VALUES ('USHOU', 'VLSFO', 806, date('now','-2 day'), 'seed', datetime('now'));
   `);
 });
 

--- a/__tests__/api/voyage/bunker-stale-exclusion.test.ts
+++ b/__tests__/api/voyage/bunker-stale-exclusion.test.ts
@@ -1,0 +1,114 @@
+/**
+ * FIX #15: stale on-route bunker prices are EXCLUDED from the candidate set
+ * (audit-1 LOW, founder decision = enable filtering), not merely logged.
+ *
+ * A stale price (price_date older than BUNKER_STALE_DAYS) must never enter
+ * onRouteWithPrices, so it cannot feed the effective-$/MT ranking nor TCE.
+ *
+ * Critical invariant: when EVERY on-route candidate is stale, the NLRTM/default
+ * fallback path must still yield a bunker port — a match must never be left with
+ * no bunker port.
+ *
+ * Tests call the helpers directly (PI2 behavioral: real getLatestBunkerPrice +
+ * real ranking, not a string match).
+ */
+
+import Database from 'better-sqlite3';
+import {
+  resolveOnRouteBunkerCandidates,
+  resolveRecommendedBunkerPort,
+  BUNKER_STALE_DAYS,
+} from '@/lib/economics/bunker-routing';
+
+const STALE_DATE = (() => {
+  const d = new Date();
+  d.setDate(d.getDate() - (BUNKER_STALE_DAYS + 23));
+  return d.toISOString().slice(0, 10);
+})();
+const FRESH_DATE = (() => {
+  const d = new Date();
+  d.setDate(d.getDate() - 2);
+  return d.toISOString().slice(0, 10);
+})();
+
+// Basin filter: allow only the two Strait-of-Gibraltar hubs for this route.
+jest.mock('@/lib/sailing/voyage-basin', () => ({
+  isCandidateInVoyageBasins: jest.fn(
+    (candidate: string) => candidate === 'GIGIB' || candidate === 'ESCEU',
+  ),
+}));
+
+// Both GIGIB and ESCEU sit on the TRMAR → MXVER route.
+const DISTS: Record<string, number> = {
+  'TRMAR|MXVER': 7000, 'MXVER|TRMAR': 7000,
+  'TRMAR|GIGIB': 1300, 'GIGIB|TRMAR': 1300,
+  'GIGIB|MXVER': 5800, 'MXVER|GIGIB': 5800,
+  'TRMAR|ESCEU': 1320, 'ESCEU|TRMAR': 1320,
+  'ESCEU|MXVER': 5790, 'MXVER|ESCEU': 5790,
+};
+jest.mock('@/lib/sailing/port-distances', () => ({
+  getPortDistance: jest.fn((from: string, to: string) => {
+    const nm = DISTS[`${from}|${to}`];
+    return nm != null ? { nm, exact: true } : null;
+  }),
+}));
+
+let db: Database.Database;
+
+function seedDb(): Database.Database {
+  const d = new Database(':memory:');
+  d.exec(`
+    CREATE TABLE bunker_prices (
+      port_unlocode TEXT NOT NULL, fuel_grade TEXT NOT NULL,
+      price_usd_per_mt REAL NOT NULL, price_date TEXT NOT NULL,
+      source TEXT NOT NULL, fetched_at TEXT NOT NULL,
+      UNIQUE(port_unlocode, fuel_grade, price_date)
+    );
+    CREATE TABLE eua_prices (
+      price_date TEXT, price_eur_per_tco2 REAL, contract_type TEXT,
+      source TEXT, fetched_at TEXT
+    );
+  `);
+  return d;
+}
+
+afterEach(() => {
+  db?.close();
+});
+
+describe('FIX #15 stale bunker exclusion', () => {
+  it('EXCLUDES a stale on-route candidate, letting the fresh one win', () => {
+    db = seedDb();
+    // GIGIB stale + cheaper; ESCEU fresh + dearer. Stale must be dropped so the
+    // fresh ESCEU wins despite its higher price.
+    db.exec(`
+      INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 600, '${STALE_DATE}', 'oilmonster', datetime('now'));
+      INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 747, '${FRESH_DATE}', 'oilmonster', datetime('now'));
+    `);
+
+    const result = resolveOnRouteBunkerCandidates(db, 'TRMAR', 'MXVER', 'VLSFO');
+
+    const ports = result.candidates.map((c) => c.port);
+    expect(ports).not.toContain('GIGIB'); // stale → excluded
+    expect(ports).toContain('ESCEU'); // fresh → kept
+    expect(result.fallback).toBe(false);
+  });
+
+  it('falls back to a bunker port when ALL on-route candidates are stale', () => {
+    db = seedDb();
+    // Both on-route hubs stale → zero live candidates → NLRTM/default fallback.
+    db.exec(`
+      INSERT INTO bunker_prices VALUES ('GIGIB', 'VLSFO', 600, '${STALE_DATE}', 'oilmonster', datetime('now'));
+      INSERT INTO bunker_prices VALUES ('ESCEU', 'VLSFO', 747, '${STALE_DATE}', 'oilmonster', datetime('now'));
+    `);
+
+    const onRoute = resolveOnRouteBunkerCandidates(db, 'TRMAR', 'MXVER', 'VLSFO');
+    expect(onRoute.candidates).toHaveLength(0);
+    expect(onRoute.fallback).toBe(true);
+
+    const recommended = resolveRecommendedBunkerPort(db, 'TRMAR', 'MXVER', 'VLSFO');
+    expect(recommended.port).toBeTruthy(); // never left without a bunker port
+    expect(recommended.fallback).toBe(true);
+    expect(recommended.priceUsdPerMt).toBeGreaterThan(0);
+  });
+});

--- a/lib/economics/bunker-routing.ts
+++ b/lib/economics/bunker-routing.ts
@@ -54,7 +54,7 @@ export const BUNKER_CANDIDATES = [
 export const DETOUR_RATIO = 0.15;
 export const DETOUR_ABS_CAP_NM = 200;
 
-/** Log a warning if any on-route candidate's price is older than this many days. */
+/** Exclude any on-route candidate whose price is older than this many days. */
 export const BUNKER_STALE_DAYS = 7;
 
 /** Vessel defaults for per-port effective $/MT math (Supramax representative). */
@@ -138,9 +138,14 @@ export function resolveOnRouteBunkerCandidates(
     const priceRow = getLatestBunkerPrice(db, candidate, grade);
     if (!priceRow) continue;
 
-    // Freshness watchdog — log stale price, no DB write, no exclusion.
+    // Freshness gate — EXCLUDE stale prices (price_date older than
+    // BUNKER_STALE_DAYS) so they never feed the effective-$/MT ranking or TCE
+    // (FIX #15, founder decision = enable filtering). Keep the warn for
+    // visibility. If this empties the on-route set, the NLRTM/default fallback
+    // below still yields a bunker port.
     if (priceRow.price_date < staleThresholdStr) {
-      console.warn(`[bunker-rec] bunker_price_stale: ${candidate} last=${priceRow.price_date}`);
+      console.warn(`[bunker-rec] bunker_price_stale: ${candidate} last=${priceRow.price_date} (excluded)`);
+      continue;
     }
 
     let deviationNm = 0;


### PR DESCRIPTION
## What

`resolveOnRouteBunkerCandidates` (`lib/economics/bunker-routing.ts`) computed `staleThreshold`/`BUNKER_STALE_DAYS` but the stale check was **log-only** — a candidate whose `price_date` was older than 7 days was still pushed to `onRouteWithPrices` and ranked normally, feeding a stale bunker price into the effective-$/MT comparison and into the stored TCE.

Per founder decision (audit-1 LOW #15 = **enable filtering**), the watchdog is now a real gate: a stale candidate is `continue`d past so it never enters the ranking. The `console.warn` is kept (tagged `(excluded)`) for visibility.

## Fallback invariant (critical)

When exclusion empties the on-route set, `resolveOnRouteBunkerCandidates` returns `{ fallback: true, candidates: [] }` and `resolveRecommendedBunkerPort` still returns a bunker port via the existing NLRTM/default path. **A match is never left without a bunker port** — covered by a dedicated test.

## Value-bearing scope

Changes effective bunker cost (and therefore **TCE**) on any voyage whose winning or contending on-route hub carried a price older than `BUNKER_STALE_DAYS` (7). Routes with fresh on-route prices are unaffected. Routes that previously won on a stale price now either pick the cheapest *fresh* on-route hub or fall back to NLRTM.

## Tests

- **NEW** `__tests__/api/voyage/bunker-stale-exclusion.test.ts` (TDD, RED→GREEN):
  1. a candidate older than `BUNKER_STALE_DAYS` is **excluded**; the fresh candidate wins despite a higher price.
  2. when **all** on-route candidates are stale → fallback still yields a bunker port (`fallback: true`, `priceUsdPerMt > 0`).
- Existing `bunker-freshness-watchdog.test.ts` still green (warn token `bunker_price_stale` preserved).
- Refreshed hard-coded seed dates (`2026-06-02` / `2026-05-09`, now >7d stale vs the app clock) → `date('now','-2 day')` in 5 route-aware suites + the parity suite, mirroring the established `#1069`/`#1075` freshness-gate fixture convention. **No test expectations changed** (PI3) — only fixture as-of dates refreshed so they represent fresh prices as originally intended.

Affected suites — all green (65 tests):
`bunker-stale-exclusion`, `bunker-freshness-watchdog`, `bunker-routeaware-parity`, `bunker-recommendation`, `bunker-recommendation-candidates`, `bunker-recommendation-consumption-dwt`, `bunker-recommendation-basin-filter`, `bunker-recommendation-eff-split`, `bunker-reco-adversarial`.

`tsc --noEmit` clean.

> Note: not `Closes #15` — GitHub issue #15 is an unrelated Dependabot bump. `#15` here is the audit-1 LOW finding number, matching the repo's `(audit-1 #N)` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)