### PR TITLE
fix(demo): bucket-tab TCE recomputes live to match the board (audit-1 LOW 8)

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session-bucket-tce-parity.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session-bucket-tce-parity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * audit-1 LOW item 8 — bucket-TCE vs board divergence.
+ *
+ * The board/shortlist path (lib/matching/persist-session-matches.ts) recomputes
+ * economics LIVE on every render via resolveRecommendedBunkerPort +
+ * computeStoredMatchEconomics. The realism-bucket path read m.economics.tceUsdPerDay
+ * straight from the SEEDED matches.tce_usd_per_day column (a regen-time snapshot),
+ * so when bunker prices drift the SAME cargo/vessel pair showed a STALE TCE in the
+ * bucket tabs and a LIVE TCE on the board.
+ *
+ * Fix: buildDemoSessionBlob.rowsToMatches recomputes bucket-row economics with the
+ * SAME helper + inputs as the board when the seeded cargo/vessel carry resolvable
+ * ports — so bucket economics.tceUsdPerDay == the board's live value, not the seed
+ * column. Falls back to the seed column only when ports are unresolvable.
+ */
+import Database from 'better-sqlite3';
+import { buildDemoSessionBlob } from '../hydrate-demo-session';
+import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
+import { resolveRecommendedBunkerPort } from '@/lib/economics/bunker-routing';
+import { estimateVoyageDays } from '@/lib/economics/voyage-days';
+import { parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
+import { getPortDistance } from '@/lib/sailing/port-distances';
+import { cfValue } from '@/lib/types';
+import type { ParsedCargo, ParsedVessel } from '@/lib/types';
+
+// A cargo whose ports resolve a real distance (Rotterdam → Santos), so the live
+// economics recompute can actually fire. Mirrors the session-buckets-economics
+// fixture shape (cfValue reads `.value`).
+const CARGO = {
+  emailId: 'c1', itemIndex: 0,
+  originPort: { value: 'Rotterdam', confidence: 'confirmed', source_text: 'Rotterdam' },
+  destinationPort: { value: 'Santos', confidence: 'confirmed', source_text: 'Santos' },
+  cargoType: { value: 'GRAIN', confidence: 'confirmed', source_text: 'grain' },
+  weightMt: { value: 50000, confidence: 'confirmed', source_text: '50000' },
+} as unknown as ParsedCargo;
+const VESSEL = {
+  emailId: 'v1', itemIndex: 0,
+  dwtSummer: { value: 55000, confidence: 'confirmed', source_text: '55000' },
+  speedLaden: '14',
+  consumption: '28',
+} as unknown as ParsedVessel;
+
+// A TCE no Rotterdam→Santos recompute would ever produce — proves the blob did
+// NOT carry the raw seed column.
+const SEED_SENTINEL_TCE = 999_999;
+
+function makeSeedDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE emails (
+      account_id TEXT, gmail_message_id TEXT, thread_id TEXT, from_addr TEXT,
+      from_name TEXT, from_email TEXT, to_addr TEXT, subject TEXT, date TEXT,
+      body TEXT, snippet TEXT, label_ids TEXT, fetched_at INTEGER
+    );
+    CREATE TABLE parsed_results (
+      account_id TEXT, gmail_message_id TEXT, parse_type TEXT, parser_version TEXT,
+      result_json TEXT, parsed_at INTEGER
+    );
+    CREATE TABLE matches (
+      id INTEGER PRIMARY KEY, cargo_id TEXT, vessel_id TEXT, score INTEGER,
+      reason TEXT, status TEXT, user_id TEXT, created_at INTEGER, updated_at INTEGER,
+      reason_structured TEXT,
+      tce_usd_per_day REAL, freight_rate_usd_per_mt REAL, freight_rate_source TEXT
+    );
+  `);
+  db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+    VALUES ('demo','c1','t1','a@demo.local','me@demo.local','Cargo','2026-05-20','b','s','[]',0)`).run();
+  db.prepare(`INSERT INTO emails (account_id, gmail_message_id, thread_id, from_addr, to_addr, subject, date, body, snippet, label_ids, fetched_at)
+    VALUES ('demo','v1','t2','b@demo.local','me@demo.local','Vessel','2026-05-21','b','s','[]',0)`).run();
+  db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+    VALUES ('demo','c1','cargo','v1',?,0)`).run(JSON.stringify([CARGO]));
+  db.prepare(`INSERT INTO parsed_results (account_id, gmail_message_id, parse_type, parser_version, result_json, parsed_at)
+    VALUES ('demo','v1','vessel','v1',?,0)`).run(JSON.stringify([VESSEL]));
+  // Realism-bucket sentinel row carrying a STALE seed TCE.
+  db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured, tce_usd_per_day, freight_rate_usd_per_mt, freight_rate_source)
+    VALUES ('c1','v1',50,'review bucket','potential','__demo_review__',0,0,NULL,?,NULL,NULL)`).run(SEED_SENTINEL_TCE);
+  return db;
+}
+
+/** Replicate the board's live recompute (persist-session-matches.ts 86-98). */
+function liveBoardTce(db: Database.Database): number | null {
+  const loadPort = cfValue(CARGO.originPort);
+  const dischargePort = cfValue(CARGO.destinationPort);
+  const distance = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+  const recoSpeed = parseLeadingNumber(VESSEL.speedLaden) || 0;
+  const reco = resolveRecommendedBunkerPort(db, loadPort, dischargePort, 'VLSFO', {
+    dwt: cfValue(VESSEL.dwtSummer) ?? 0,
+    speedKn: recoSpeed,
+    consMtPerDay: parseConsumption(VESSEL.consumption, 0),
+    voyageDays: estimateVoyageDays(distance?.nm ?? null, recoSpeed),
+  });
+  return computeStoredMatchEconomics({ cargo: CARGO, vessel: VESSEL, db, bunkerPriceUsdPerMt: reco.priceUsdPerMt })
+    .tce_usd_per_day;
+}
+
+describe('buildDemoSessionBlob bucket economics == live board TCE (audit-1 LOW 8)', () => {
+  it('recomputes bucket-row economics.tceUsdPerDay live (not the stale seed column) when ports resolve', () => {
+    const db = makeSeedDb();
+    const expectedLive = liveBoardTce(db);
+    const blob = buildDemoSessionBlob(db);
+    db.close();
+
+    // The live recompute must actually produce a number for this fixture, else
+    // the assertion below is vacuous.
+    expect(expectedLive).not.toBeNull();
+    expect(expectedLive).not.toBe(SEED_SENTINEL_TCE);
+
+    expect(blob.lowConfidenceMatches).toHaveLength(1);
+    const tce = blob.lowConfidenceMatches![0].economics!.tceUsdPerDay;
+    // Bucket TCE matches the board's live recompute, NOT the stale seed column.
+    expect(tce).toBe(expectedLive);
+    expect(tce).not.toBe(SEED_SENTINEL_TCE);
+  });
+});

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -9,6 +9,12 @@ import { calculateWarRiskPremium } from '@/lib/economics/war-risk';
 import { estimateVesselValueUsd } from '@/lib/economics/vessel-value';
 import { normalizeVesselCapacityToCbm } from '@/lib/parsing/vessel-capacity-units';
 import { summarizeCommissions } from '@/lib/commission';
+import { cfValue } from '@/lib/types';
+import { computeStoredMatchEconomics } from '@/lib/matching/stored-match-economics';
+import { resolveRecommendedBunkerPort } from '@/lib/economics/bunker-routing';
+import { estimateVoyageDays } from '@/lib/economics/voyage-days';
+import { parseLeadingNumber, parseConsumption } from '@/lib/matching/tce-calculator';
+import { getPortDistance } from '@/lib/sailing/port-distances';
 import type {
   Email, Classification, ParsedCargo, ParsedVessel, ParsedFixtureRecap, Match, ScoreBreakdown, SessionData,
 } from '@/lib/types';
@@ -179,6 +185,11 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
     `SELECT ${selectCols} FROM matches WHERE user_id = '__demo_insufficient__'`,
   ).all() as MatchRow[];
 
+  // Keyed by emailId|itemIndex so a bucket row can find its seeded cargo/vessel
+  // and recompute economics the same way the board does (see below).
+  const cargoByKey = new Map(dedupedCargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
+  const vesselByKey = new Map(dedupedVessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
+
   function rowsToMatches(rows: MatchRow[]): Match[] {
     return rows.map((r) => {
       const tce = r.tce_usd_per_day;
@@ -197,7 +208,7 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
       // Also carry the seed freight pair (QA FINDING-002): toBucketRows reads
       // the economics triple, so a tce-only object would render canonical TCE
       // with a NULL rate/source → "≈ Estimate" badge over a canonical value.
-      const economics: import('@/lib/types').EconomicsResult | undefined =
+      const seedEconomics: import('@/lib/types').EconomicsResult | undefined =
         tce != null && Number.isFinite(tce)
           ? {
               breakdown: {
@@ -216,6 +227,32 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
               freightRateSource: r.freight_rate_source ?? undefined,
             }
           : undefined;
+      // audit-1 LOW 8: the bucket tabs render m.economics.tceUsdPerDay (via
+      // toBucketRows), but the seed column is a regen-time snapshot. The board /
+      // shortlist path recomputes economics LIVE on every render
+      // (persist-session-matches.ts 86-98: resolveRecommendedBunkerPort +
+      // computeStoredMatchEconomics), so the SAME pair drifts to a different TCE
+      // across tabs when bunker prices move. Recompute here with the SAME helper +
+      // inputs so bucket TCE == board TCE. Falls back to seedEconomics when the
+      // seeded cargo/vessel lacks resolvable ports (e.g. ports only on the match
+      // row — the #883 war-risk path), keeping that behaviour intact.
+      const cargo = cargoByKey.get(`${r.cargo_id}|${r.cargo_item_index ?? 0}`);
+      const vessel = vesselByKey.get(`${r.vessel_id}|${r.vessel_item_index ?? 0}`);
+      let economics = seedEconomics;
+      if (cargo && vessel) {
+        const loadPort = cfValue(cargo.originPort);
+        const dischargePort = cfValue(cargo.destinationPort);
+        const distance = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
+        const recoSpeed = parseLeadingNumber(vessel.speedLaden) || 0;
+        const reco = resolveRecommendedBunkerPort(db, loadPort, dischargePort, 'VLSFO', {
+          dwt: cfValue(vessel.dwtSummer) ?? 0,
+          speedKn: recoSpeed,
+          consMtPerDay: parseConsumption(vessel.consumption, 0),
+          voyageDays: estimateVoyageDays(distance?.nm ?? null, recoSpeed),
+        });
+        const live = computeStoredMatchEconomics({ cargo, vessel, db, bunkerPriceUsdPerMt: reco.priceUsdPerMt });
+        if (live.economics) economics = live.economics;
+      }
       return {
         cargoEmailId: r.cargo_id,
         cargoItemIndex: r.cargo_item_index ?? 0,

--- a/lib/matching/session-buckets.ts
+++ b/lib/matching/session-buckets.ts
@@ -52,13 +52,15 @@ export function toBucketRows(
     const speedKts = vessel ? parseLeadingNumber(vessel.speedLaden) : 0;
     const consumptionMt = vessel ? parseConsumption(vessel.consumption) : 0;
 
-    // Canonical engine economics (#819 Phase B(b)): pair-analyzer attaches
-    // m.economics (computeStoredMatchEconomics — live bunker, port-DA, canal,
-    // war-risk-excluded convention) to every pair with a resolvable distance
-    // before bucket partition, so bucket matches already carry the same
-    // one-truth TCE the shortlist stores. Read it here (same economics-first
-    // read as regenerate-matches.ts writeBucket) so bucket tabs and the main
-    // board agree numerically.
+    // Canonical engine economics (#819 Phase B(b)): both producers of m.economics
+    // attach the LIVE computeStoredMatchEconomics value (live bunker, port-DA,
+    // canal, war-risk-excluded convention) before bucket partition —
+    // pair-analyzer on the live create-demo-session path, and
+    // hydrate-demo-session.rowsToMatches on the demo-seed path (audit-1 LOW 8:
+    // it used to read the stale regen-time tce_usd_per_day seed column, so bucket
+    // tabs diverged from the live board when bunker prices drifted). Reading
+    // m.economics here therefore agrees numerically with the main board on both
+    // paths. Same economics-first read as regenerate-matches.ts writeBucket.
     let tce_usd_per_day: number | null = m.economics?.tceUsdPerDay ?? null;
     let freight_rate_usd_per_mt: number | null = m.economics?.freightRateUsdPerMt ?? null;
     let freight_rate_source: string | null = m.economics?.freightRateSource ?? null;


### PR DESCRIPTION
## Problem (audit-1 LOW item 8 — bucket-TCE vs board divergence)

The realism-bucket tabs (`/matches` Review / Insufficient) rendered
`economics.tceUsdPerDay` straight from the **seeded** `matches.tce_usd_per_day`
column — a regen-time snapshot.

The board / shortlist path (`lib/matching/persist-session-matches.ts:86-98`)
recomputes economics **live** on every render via `resolveRecommendedBunkerPort`
+ `computeStoredMatchEconomics`. So the **same cargo–vessel pair** showed a
STALE seed TCE in the bucket tabs and a LIVE TCE on the main Matches board once
bunker prices drifted away from the seed snapshot.

Root cause: `lib/demo-mode/hydrate-demo-session.ts` `rowsToMatches` built
bucket-row economics from `r.tce_usd_per_day`; `lib/matching/session-buckets.ts`
`toBucketRows` then read that seed value verbatim.

## Fix

`rowsToMatches` now recomputes bucket-row economics with the **same helper +
inputs as the board** (`resolveRecommendedBunkerPort` → route-aware bunker price
→ `computeStoredMatchEconomics`) when the seeded cargo/vessel carry resolvable
ports. Falls back to the seed column only when ports are unresolvable — e.g.
when ports live only on the match row (the `#883` war-risk path), so that
behaviour is preserved.

Updated the now-stale parity comment in `session-buckets.ts` to reflect that
both producers of `m.economics` (live `pair-analyzer` path and demo-seed
`hydrate-demo-session` path) attach the live value.

## ⚠️ Value-bearing

**Bucket-tab TCE numbers will shift** to match the main Matches board (they were
showing a stale seed snapshot before). The board values are unchanged.

## Tests (TDD)

- NEW failing-first test `hydrate-demo-session-bucket-tce-parity.test.ts`:
  asserts `blob.lowConfidenceMatches[0].economics.tceUsdPerDay` equals the
  live-recomputed board value (11588), not the stale seed sentinel (999999).
- Affected suites green: 6 suites / 16 tests (all `hydrate-demo-session*` +
  `session-buckets-economics`).
- CI-excluded `tests/regression/bucket-hydrate-freight-provenance.test.ts`
  (FINDING-002, 4 tests) still green — empty `parsed_results` → seed-fallback
  path preserved.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)