### PR TITLE
fix(ports): context-aware homonym disambiguation (audit-1 LOW #5)

### DIFF
--- a/__tests__/ports/resolve.test.ts
+++ b/__tests__/ports/resolve.test.ts
@@ -286,6 +286,83 @@ describe('wave-2 ports — alias resolution', () => {
   });
 });
 
+// ── Homonym disambiguation (audit-1 LOW #5) ──────────────────────────────────
+// Two ports share a folded name with a different LOCODE/country:
+//   Cartagena → ESCAR (ES, Mediterranean, first-wins) vs COCTG (CO)
+//   Tripoli   → LBKYE (LB, Eastern Med, first-wins)   vs LYTIP (LY)
+// An OPTIONAL context hint (counterpart port coords/country, or explicit country)
+// breaks the tie. With NO hint the behavior MUST stay exactly first-wins.
+describe('resolvePort — homonym disambiguation via context hint', () => {
+  it('Cartagena with NO hint → unchanged first-wins (ESCAR / Spain)', () => {
+    const r = resolvePort('Cartagena');
+    expect(r).not.toBeNull();
+    expect(r!.portCode).toBe('ESCAR');
+    expect(r!.country).toBe('ES');
+  });
+
+  it('Cartagena with a South-American counterpart → COCTG (Colombia)', () => {
+    // Santos, Brazil (-23.96, -46.30) — Colombian Cartagena is far nearer.
+    const r = resolvePort('Cartagena', { counterpart: { lat: -23.96, lon: -46.3 } });
+    expect(r).not.toBeNull();
+    expect(r!.portCode).toBe('COCTG');
+    expect(r!.country).toBe('CO');
+  });
+
+  it('Cartagena with a Mediterranean counterpart → ESCAR (Spain)', () => {
+    // Genoa, Italy (44.4, 8.9) — Spanish Cartagena is far nearer.
+    const r = resolvePort('Cartagena', { counterpart: { lat: 44.4, lon: 8.9 } });
+    expect(r).not.toBeNull();
+    expect(r!.portCode).toBe('ESCAR');
+    expect(r!.country).toBe('ES');
+  });
+
+  it('Cartagena with an explicit country hint {country:"CO"} → COCTG', () => {
+    const r = resolvePort('Cartagena', { country: 'CO' });
+    expect(r).not.toBeNull();
+    expect(r!.portCode).toBe('COCTG');
+  });
+
+  it('Cartagena with a resolved counterpart port object → uses its coords', () => {
+    const santos = resolvePort('Santos');
+    expect(santos).not.toBeNull();
+    const r = resolvePort('Cartagena', { counterpart: santos });
+    expect(r!.portCode).toBe('COCTG');
+  });
+
+  it('Tripoli with a Lebanon-side counterpart → LBKYE (Lebanon)', () => {
+    // Near Beirut (33.9, 35.5).
+    const r = resolvePort('Tripoli', { counterpart: { lat: 33.9, lon: 35.5 } });
+    expect(r).not.toBeNull();
+    expect(r!.portCode).toBe('LBKYE');
+    expect(r!.country).toBe('LB');
+  });
+
+  it('Tripoli with a Libya-side counterpart → LYTIP (Libya)', () => {
+    // Central/western Med, near Tunisia (37.0, 10.0).
+    const r = resolvePort('Tripoli', { counterpart: { lat: 37.0, lon: 10.0 } });
+    expect(r).not.toBeNull();
+    expect(r!.portCode).toBe('LYTIP');
+    expect(r!.country).toBe('LY');
+  });
+
+  it('Tripoli with NO hint → unchanged first-wins (LBKYE / Lebanon)', () => {
+    const r = resolvePort('Tripoli');
+    expect(r!.portCode).toBe('LBKYE');
+  });
+
+  it('non-homonym port (Rotterdam) is unaffected by a context hint', () => {
+    const withCtx = resolvePort('Rotterdam', { counterpart: { lat: -23.96, lon: -46.3 } });
+    const without = resolvePort('Rotterdam');
+    expect(withCtx!.portCode).toBe(without!.portCode);
+    expect(withCtx!.portCode).toBe('NLRTM');
+  });
+
+  it('homonym with an empty/uninformative context falls back to first-wins', () => {
+    const r = resolvePort('Cartagena', { counterpart: { lat: null, lon: null } });
+    expect(r!.portCode).toBe('ESCAR');
+  });
+});
+
 describe('resolvePort — diacritic folding (Gate5 #4: re-parsed ports carry native diacritics)', () => {
   // Re-parsed demo ports arrive with native diacritics ("Constanța", "Aliağa")
   // that the ASCII port-master entries ("Constanta", "Aliaga") never matched →

--- a/app/api/voyage/compare-routes/route.ts
+++ b/app/api/voyage/compare-routes/route.ts
@@ -79,9 +79,14 @@ export async function POST(req: NextRequest) {
   // W1-1: the resolver receives a free-text port name (body.origin/destination),
   // but port_da_estimates is keyed by 5-char UN/LOCODE — resolve name→LOCODE
   // first, else the lookup never matches and DA is silently 0.
+  // Pre-resolve both legs (no context) so each can act as the other's homonym
+  // counterpart inside the per-port resolver below.
+  const originRaw = body.origin ? resolvePort(body.origin) : null;
+  const destRaw = body.destination ? resolvePort(body.destination) : null;
   const daResolver: DaResolver = (portCode, vesselDwt) => {
     try {
-      const resolved = resolvePort(portCode);
+      const counterpart = portCode === body.origin ? destRaw : originRaw;
+      const resolved = resolvePort(portCode, counterpart ? { counterpart } : undefined);
       if (!resolved) return 0;
       const da = getPortDa({ portCode: resolved.portCode, vesselDwt });
       return da?.totalFixedUsd ?? 0;

--- a/app/api/voyage/tce/route.ts
+++ b/app/api/voyage/tce/route.ts
@@ -44,8 +44,12 @@ const DEFAULT_COMMISSION_PCT_TTL = 3.75;
  *   port_not_found; UI shows an amber "approximate port" note.
  * - Genuinely-unknown free-text names → null (caller should return 400).
  */
-function resolvePortOrPassthrough(input: string): { port: ResolvedPort; approximate: boolean } | null {
-  const resolved = resolvePort(input);
+function resolvePortOrPassthrough(
+  input: string,
+  counterpart?: ResolvedPort | null,
+): { port: ResolvedPort; approximate: boolean } | null {
+  // Counterpart (the other voyage leg) disambiguates bare homonym names.
+  const resolved = resolvePort(input, counterpart ? { counterpart } : undefined);
   if (resolved) return { port: resolved, approximate: false };
   // BC: allow unknown 5-char LOCODE-format strings through as synthetic port
   if (LOCODE_RE.test(input)) {
@@ -236,7 +240,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const data = parsed.data;
 
   // Resolve ports at API entry — single source of truth for downstream
-  const originR = resolvePortOrPassthrough(data.route.originPort);
+  // Seed each leg with the other as a homonym counterpart (originSeed has no
+  // context; destination then disambiguates against it; origin re-resolves against
+  // the now-known destination). For unambiguous names this is a no-op.
+  const originSeed = resolvePortOrPassthrough(data.route.originPort);
+  const destinationR = resolvePortOrPassthrough(data.route.destinationPort, originSeed?.port ?? null);
+  const originR = resolvePortOrPassthrough(data.route.originPort, destinationR?.port ?? null);
   if (!originR) {
     return NextResponse.json(
       { error: 'port_not_found', input: 'originPort', value: data.route.originPort },
@@ -244,7 +253,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
   const originResolved = originR.port;
-  const destinationR = resolvePortOrPassthrough(data.route.destinationPort);
   if (!destinationR) {
     return NextResponse.json(
       { error: 'port_not_found', input: 'destinationPort', value: data.route.destinationPort },
@@ -279,7 +287,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Guard on a resolvable ballast distance > 0 and dwt > 0, mirroring buildMatchEconomics.
     const openPosition = data.vessel.openPosition;
     if (openPosition && data.vessel.dwt > 0) {
-      const openR = resolvePortOrPassthrough(openPosition);
+      const openR = resolvePortOrPassthrough(openPosition, originResolved);
       const openName = openR?.port.portName ?? openPosition;
       const ballastLeg = getPortDistance(openName, originResolved.portName);
       if (ballastLeg && ballastLeg.nm > 0) {

--- a/docs/superpowers/plans/2026-06-20-low5-ports-namesake-disambiguation.md
+++ b/docs/superpowers/plans/2026-06-20-low5-ports-namesake-disambiguation.md
@@ -1,0 +1,81 @@
+# Plan — FIX #5 (audit-1 LOW): context-aware homonym port disambiguation
+
+**Date:** 2026-06-20
+**Branch:** `fix-low5-ports`
+**Tier:** M (founder = FULL M fix)
+**Issue ref:** audit-1 LOW item #5 (NOT GitHub issue #5 — that is the unrelated Wave-5 follow-up)
+
+## Problem
+
+`lib/ports/resolve.ts` `buildIndex()` populates `byName` first-wins (line ~85).
+Two ports in the 488-port dataset share a folded name with a different
+LOCODE/country:
+
+| Name      | First-wins (current) | Other          |
+|-----------|----------------------|----------------|
+| Cartagena | `ESCAR` (ES, Med)    | `COCTG` (CO)   |
+| Tripoli   | `LBKYE` (LB, E-Med)  | `LYTIP` (LY)   |
+
+A bare name (`"Cartagena"`) always resolves to the arbitrary first-loaded port
+regardless of route context → wrong distance, wrong bunker port, wrong TCE for
+prod users who type bare names. Demo data uses LOCODEs / unambiguous strings, so
+demo TCE is **not** currently affected.
+
+## Design (surgical, backward-compatible)
+
+Add an **optional** `context` param to `resolvePort` / `resolvePortStrict`. Used
+ONLY to break homonym ties. When NO context is given, behavior stays EXACTLY
+first-wins → zero regression on the 488-port dataset.
+
+```ts
+export interface ResolveContext {
+  /** Counterpart voyage port — its coords/country break homonym ties */
+  counterpart?: { lat?: number | null; lon?: number | null; country?: string | null } | null;
+  /** Explicit ISO alpha-2 country hint (highest priority) */
+  country?: string | null;
+}
+export function resolvePort(input: string, context?: ResolveContext): ResolvedPort | null;
+```
+
+- Index: add `byNameAll: Map<string, PortEntry[]>` keeping ALL same-name entries
+  reachable. `byName` (first-wins) stays for the no-context path.
+- Tie-break runs ONLY when `context` supplied AND `byNameAll` has >1 candidate.
+  Priority: explicit `country` hint (unique match) → counterpart coords
+  (nearest by haversine) → counterpart country match → else fall through to
+  first-wins.
+- LOCODE path unchanged (LOCODE is unique → homonym-immune).
+
+## Wiring (call-sites that already have the counterpart port)
+
+| File | Site | Action |
+|------|------|--------|
+| `lib/matching/tce-calculator.ts` | `deriveEtsCoverage` (load+disch) | pass counterpart |
+| `lib/port-da/match-da.ts` | `sumMatchPortDaUsd` (port siblings) | pass counterpart |
+| `lib/sailing/fit-breakdown.ts` | `isEuropeanDischarge(disch)` (+ `cargo.originPort`) | add optional counterpart param, wire caller |
+| `app/api/voyage/tce/route.ts` | `resolvePortOrPassthrough` (origin↔dest) | add optional counterpart param, thread |
+| `app/api/voyage/compare-routes/route.ts` | `daResolver` closure (body.origin/destination) | pass counterpart |
+| `lib/knowledge/distances/lookup.ts` | `resolvePortStrict(LOCODE)` | **SKIP** — LOCODE-only, homonym-immune (documented) |
+
+Where no counterpart is available, the call stays unchanged.
+
+## TDD
+
+Failing tests first (`__tests__/ports/resolve.test.ts`, append-only — PI3):
+1. Cartagena + South-American counterpart coords → `COCTG`
+2. Cartagena + Mediterranean counterpart coords → `ESCAR`
+3. Cartagena + NO hint → unchanged first-wins (`ESCAR`)
+4. Cartagena + explicit `{country:'CO'}` → `COCTG`
+5. Tripoli + Lebanon-side counterpart → `LBKYE`; + Libya-side counterpart → `LYTIP`
+6. Non-homonym (`Rotterdam`) + context → identical to no-context (no effect)
+
+## Out of scope
+
+- No new region/basin field in port-master.json (tie-break uses existing lat/lon).
+- No change to vague-region resolution (`resolve-vague.ts`).
+- `lookup.ts` LOCODE path not wired (homonym-immune by construction).
+
+## Verification
+
+- `npx tsc --noEmit`
+- `npx jest __tests__/ports/resolve.test.ts lib/port-da/__tests__/match-da.test.ts lib/sailing/__tests__/fit-breakdown.test.ts --runInBand --forceExit`
+- Demo TCE unchanged (zero bare homonym strings in demo data).

--- a/lib/matching/tce-calculator.ts
+++ b/lib/matching/tce-calculator.ts
@@ -246,8 +246,11 @@ export const quoteSuezSafe = _quoteSuezSafe;
 /** Derive EU-ETS coverage flags from port names. Used by both the stored match path
  *  and the detail route to guarantee identical euLegPercent/originEu/destEu. */
 export function deriveEtsCoverage(loadPort?: string | null, dischargePort?: string | null) {
-  const rl = loadPort ? (resolvePort(loadPort) ?? resolveVaguePort(loadPort)) : null;
-  const rd = dischargePort ? (resolvePort(dischargePort) ?? resolveVaguePort(dischargePort)) : null;
+  // Pass the counterpart voyage port so a bare homonym name (Cartagena, Tripoli)
+  // resolves to the correct basin instead of the arbitrary first-wins entry.
+  const rdRaw = dischargePort ? resolvePort(dischargePort) : null;
+  const rl = loadPort ? (resolvePort(loadPort, { counterpart: rdRaw }) ?? resolveVaguePort(loadPort)) : null;
+  const rd = dischargePort ? (resolvePort(dischargePort, { counterpart: rl }) ?? resolveVaguePort(dischargePort)) : null;
   const originEu = isEuCountry(rl?.country ?? null);
   const destEu = isEuCountry(rd?.country ?? null);
   return { originEu, destEu, euLegPercent: (originEu || destEu) ? 1.0 : 0 };

--- a/lib/port-da/match-da.ts
+++ b/lib/port-da/match-da.ts
@@ -53,13 +53,18 @@ export function sumMatchPortDaUsd(
   let total = 0;
   let confidence: PortDaBreakdown['confidence'] = 'verified';
   let anyResolved = false;
-  for (const name of portNames) {
+  // Pre-resolve each name (no context) so a sibling can act as the homonym
+  // counterpart — a bare "Cartagena" then resolves to the basin of the other leg.
+  const rawResolved = portNames.map((n) => (n ? resolvePort(n) : null));
+  for (let i = 0; i < portNames.length; i++) {
+    const name = portNames[i];
     if (!name) continue;
     try {
+      const counterpart = rawResolved.find((r, j) => j !== i && r) ?? null;
       // Exact match first; fall back to vague-descriptor resolution (ARA, "European
       // Continent", etc.) exactly as resolvePortOrPassthrough does in the detail route,
       // so the LIST path no longer silently drops discharge DA for range descriptors.
-      const resolved = resolvePort(name) ?? resolveVaguePort(name);
+      const resolved = resolvePort(name, { counterpart }) ?? resolveVaguePort(name);
       if (!resolved) continue;
       // Pass cargoType=undefined → getPortDa resolves to 'general' (the only seed
       // cargo type).  This mirrors resolveDaUsd in the detail route and guarantees

--- a/lib/ports/resolve.ts
+++ b/lib/ports/resolve.ts
@@ -35,6 +35,19 @@ export interface ResolvedPort {
   master?: PortMaster;
 }
 
+/**
+ * Optional disambiguation hint. Used ONLY to break homonym ties (ports that
+ * share a folded name but have a different LOCODE/country — e.g. Cartagena
+ * ESCAR/ES vs COCTG/CO, Tripoli LBKYE/LB vs LYTIP/LY). When omitted, resolution
+ * stays exactly first-wins so there is zero regression on unambiguous names.
+ */
+export interface ResolveContext {
+  /** Counterpart voyage port — its coords/country break the tie (nearest wins). */
+  counterpart?: { lat?: number | null; lon?: number | null; country?: string | null } | null;
+  /** Explicit ISO-3166 alpha-2 country hint (highest priority). */
+  country?: string | null;
+}
+
 export class PortNotFoundError extends Error {
   constructor(input: string) {
     super(`Port not found: "${input}"`);
@@ -59,8 +72,9 @@ interface PortEntry {
 
 type PortIndex = {
   byLocode: Map<string, PortEntry>;
-  byName: Map<string, PortEntry>;   // lowercase canonical name → entry
-  byAlias: Map<string, PortEntry>;  // lowercase alias → entry
+  byName: Map<string, PortEntry>;        // lowercase canonical name → first-wins entry
+  byNameAll: Map<string, PortEntry[]>;   // lowercase canonical name → ALL same-name entries (homonyms)
+  byAlias: Map<string, PortEntry>;       // lowercase alias → entry
   entries: PortEntry[];
 };
 
@@ -72,6 +86,7 @@ function buildIndex(): PortIndex {
   const ports = PORTS_JSON as PortEntry[];
   const byLocode = new Map<string, PortEntry>();
   const byName = new Map<string, PortEntry>();
+  const byNameAll = new Map<string, PortEntry[]>();
   const byAlias = new Map<string, PortEntry>();
 
   for (const port of ports) {
@@ -85,6 +100,11 @@ function buildIndex(): PortIndex {
     if (!byName.has(nameLower)) {
       byName.set(nameLower, port);
     }
+    // Keep EVERY same-name entry reachable for homonym tie-breaking. Insertion
+    // order is preserved, so byNameAll.get(name)[0] === byName.get(name).
+    const bucket = byNameAll.get(nameLower);
+    if (bucket) bucket.push(port);
+    else byNameAll.set(nameLower, [port]);
 
     for (const alias of port.aliases ?? []) {
       const aliasLower = foldDiacritics(alias.toLowerCase());
@@ -94,7 +114,7 @@ function buildIndex(): PortIndex {
     }
   }
 
-  _index = { byLocode, byName, byAlias, entries: ports };
+  _index = { byLocode, byName, byNameAll, byAlias, entries: ports };
   return _index;
 }
 
@@ -111,6 +131,61 @@ const LOCODE_RE = /^[A-Za-z]{5}$/;
  */
 function foldDiacritics(s: string): string {
   return s.normalize('NFKD').replace(/\p{Diacritic}/gu, '');
+}
+
+/** Great-circle distance (km) — only a relative ordering is needed for tie-break. */
+function haversineKm(aLat: number, aLon: number, bLat: number, bLon: number): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(bLat - aLat);
+  const dLon = toRad(bLon - aLon);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(aLat)) * Math.cos(toRad(bLat)) * Math.sin(dLon / 2) ** 2;
+  return 2 * 6371 * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Break a homonym tie among `candidates` using the supplied context. Returns the
+ * chosen entry, or null when the context carries no usable signal (caller then
+ * falls back to first-wins). Priority:
+ *   1. explicit `context.country` (unique case-insensitive match)
+ *   2. counterpart coordinates → nearest candidate by great-circle distance
+ *   3. counterpart country → unique case-insensitive match
+ */
+function pickHomonym(candidates: PortEntry[], context: ResolveContext): PortEntry | null {
+  const byCountry = (iso: string | null | undefined): PortEntry | null => {
+    if (!iso) return null;
+    const want = iso.trim().toUpperCase();
+    const hits = candidates.filter((c) => (c.country ?? '').toUpperCase() === want);
+    return hits.length === 1 ? hits[0] : null;
+  };
+
+  // 1. Explicit country hint.
+  const explicit = byCountry(context.country);
+  if (explicit) return explicit;
+
+  const cp = context.counterpart;
+  if (cp) {
+    // 2. Nearest to counterpart coordinates.
+    if (typeof cp.lat === 'number' && typeof cp.lon === 'number') {
+      let best: PortEntry | null = null;
+      let bestKm = Infinity;
+      for (const c of candidates) {
+        if (typeof c.lat !== 'number' || typeof c.lon !== 'number') continue;
+        const km = haversineKm(cp.lat, cp.lon, c.lat, c.lon);
+        if (km < bestKm) {
+          bestKm = km;
+          best = c;
+        }
+      }
+      if (best) return best;
+    }
+    // 3. Counterpart country match.
+    const sameCountry = byCountry(cp.country);
+    if (sameCountry) return sameCountry;
+  }
+
+  return null;
 }
 
 function toResolvedPort(entry: PortEntry): ResolvedPort {
@@ -131,13 +206,14 @@ function toResolvedPort(entry: PortEntry): ResolvedPort {
  * Resolve a port from any format: LOCODE ("BEANR") or name/alias ("Antwerp",
  * "Antwerpen", "Rotterdam"). Returns null when the port cannot be found.
  */
-export function resolvePort(input: string): ResolvedPort | null {
+export function resolvePort(input: string, context?: ResolveContext): ResolvedPort | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
 
   const idx = buildIndex();
 
   // ── LOCODE path ─────────────────────────────────────────────────────────
+  // A LOCODE is unique, so it is inherently homonym-free — context is ignored.
   if (LOCODE_RE.test(trimmed)) {
     const locode = trimmed.toUpperCase();
     const entry = idx.byLocode.get(locode);
@@ -146,6 +222,17 @@ export function resolvePort(input: string): ResolvedPort | null {
   }
 
   const lower = foldDiacritics(trimmed.toLowerCase());
+
+  // ── Homonym tie-break ───────────────────────────────────────────────────
+  // Only when a context hint is supplied AND the folded name collides across
+  // multiple ports. No hint → skip entirely and keep exact first-wins below.
+  if (context) {
+    const candidates = idx.byNameAll.get(lower);
+    if (candidates && candidates.length > 1) {
+      const picked = pickHomonym(candidates, context);
+      if (picked) return toResolvedPort(picked);
+    }
+  }
 
   // ── Exact name match ────────────────────────────────────────────────────
   const byName = idx.byName.get(lower);
@@ -186,8 +273,8 @@ export function resolvePort(input: string): ResolvedPort | null {
  * Like resolvePort() but throws PortNotFoundError instead of returning null.
  * Useful in strict contexts where a missing port is a programming error.
  */
-export function resolvePortStrict(input: string): ResolvedPort {
-  const result = resolvePort(input);
+export function resolvePortStrict(input: string, context?: ResolveContext): ResolvedPort {
+  const result = resolvePort(input, context);
   if (!result) throw new PortNotFoundError(input);
   return result;
 }

--- a/lib/sailing/fit-breakdown.ts
+++ b/lib/sailing/fit-breakdown.ts
@@ -601,14 +601,20 @@ const VAGUE_DESCRIPTOR_RX =
  * mis-flagged. Isolated from regionMatchesPort so widening detection here does
  * NOT affect the hard voyage-restriction gate (its other consumer).
  */
-function isEuropeanDischarge(port: string | null | undefined): boolean {
+function isEuropeanDischarge(
+  port: string | null | undefined,
+  counterpart?: string | null,
+): boolean {
   if (!port) return false;
   // Primary: a concrete port → EU iff its RESOLVED country is EU/EEA. This catches
   // named EU ports the region map omits (Monfalcone/IT, Gijón/ES, Catania/IT,
   // Thisvi/GR — founder Gate5 2026-06-03) AND correctly rejects non-EU Mediterranean
   // ports (Bejaia/DZ, Alexandria/EG) that the 'europe' region map wrongly swept in
   // via the Mediterranean basin. resolvePort folds diacritics (Constanța→Constanta).
-  const resolved = resolvePort(port);
+  // The load port (counterpart) disambiguates homonyms: Spanish Cartagena (EU)
+  // vs Colombian Cartagena (non-EU) by basin proximity.
+  const ctx = counterpart ? resolvePort(counterpart) : null;
+  const resolved = resolvePort(port, ctx ? { counterpart: ctx } : undefined);
   if (resolved) return isEuCountry(resolved.country);
   // Fallback: vague AREA descriptor (no concrete port resolves) that names an EU
   // country ("East Coast Greece port (unspecified)"). Double-gated so a non-EU
@@ -697,7 +703,7 @@ export function computeFitBreakdown(input: FitBreakdownInput): FitBreakdown {
   if (
     euDischargeAge != null &&
     euDischargeAge >= 25 &&
-    isEuropeanDischarge(cfValue(cargo.destinationPort))
+    isEuropeanDischarge(cfValue(cargo.destinationPort), cfValue(cargo.originPort))
   ) {
     caps.push({
       reason: `vessel ${euDischargeAge}yr + EU discharge — PSC/charterer age risk`,


### PR DESCRIPTION
## Problem
audit-1 LOW item **#5** (NOT GitHub issue #5 — that's an unrelated Wave-5 follow-up).

`lib/ports/resolve.ts` `buildIndex()` populates `byName` first-wins. Two ports share a folded name with a different LOCODE/country:

| Name | first-wins (current) | other |
|------|----------------------|-------|
| Cartagena | `ESCAR` (ES, Med) | `COCTG` (CO) |
| Tripoli | `LBKYE` (LB, E-Med) | `LYTIP` (LY) |

A bare name resolved to the arbitrary first-loaded port regardless of route context → wrong distance, wrong bunker port, wrong TCE for prod users typing bare names.

## Fix (surgical, backward-compatible)
- `resolvePort` / `resolvePortStrict` gain an **optional** `context` param (`{ counterpart?, country? }`) used ONLY to break homonym ties.
- With **no hint** the path is byte-identical first-wins → **zero regression** on the 488-port dataset.
- `buildIndex` keeps every same-name entry reachable (`byNameAll`); tie-break priority: explicit country → counterpart coords (haversine nearest) → counterpart country.
- LOCODE path unchanged (LOCODE is unique → homonym-immune).

## Wiring (call-sites that already have the counterpart voyage port)
`lib/matching/tce-calculator.ts` (deriveEtsCoverage) · `lib/port-da/match-da.ts` (sumMatchPortDaUsd) · `lib/sailing/fit-breakdown.ts` (isEuropeanDischarge) · `app/api/voyage/tce/route.ts` · `app/api/voyage/compare-routes/route.ts`.
`lib/knowledge/distances/lookup.ts` is LOCODE-only (homonym-immune) → left unchanged.

## Demo impact
Demo data has **zero bare homonym strings** → demo TCE unchanged. Fix protects prod users typing bare names.

## Test plan
- TDD: failing homonym tests written first (`__tests__/ports/resolve.test.ts`), then implemented.
- `npx tsc --noEmit` → clean (heap raised on VPS).
- `npx jest __tests__/ports/resolve.test.ts lib/port-da/__tests__/match-da.test.ts lib/sailing/__tests__/fit-breakdown.test.ts __tests__/economics/compare-routes-da.test.ts` → **203/203**.
- voyage/tce route + tce-calculator suites → **71/71**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)