### PR TITLE
perf(demo): scope hydrate live economics recompute to bucket rows only (audit-1 LOW 8 followup)

### DIFF
--- a/lib/demo-mode/__tests__/hydrate-demo-session-bucket-tce-parity.test.ts
+++ b/lib/demo-mode/__tests__/hydrate-demo-session-bucket-tce-parity.test.ts
@@ -74,6 +74,9 @@ function makeSeedDb(): Database.Database {
   // Realism-bucket sentinel row carrying a STALE seed TCE.
   db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured, tce_usd_per_day, freight_rate_usd_per_mt, freight_rate_source)
     VALUES ('c1','v1',50,'review bucket','potential','__demo_review__',0,0,NULL,?,NULL,NULL)`).run(SEED_SENTINEL_TCE);
+  // Main shortlist sentinel row (user_id IS NULL) — same resolvable ports, STALE seed TCE.
+  db.prepare(`INSERT INTO matches (cargo_id, vessel_id, score, reason, status, user_id, created_at, updated_at, reason_structured, tce_usd_per_day, freight_rate_usd_per_mt, freight_rate_source)
+    VALUES ('c1','v1',80,'shortlist',NULL,NULL,0,0,NULL,?,NULL,NULL)`).run(SEED_SENTINEL_TCE);
   return db;
 }
 
@@ -110,5 +113,25 @@ describe('buildDemoSessionBlob bucket economics == live board TCE (audit-1 LOW 8
     // Bucket TCE matches the board's live recompute, NOT the stale seed column.
     expect(tce).toBe(expectedLive);
     expect(tce).not.toBe(SEED_SENTINEL_TCE);
+  });
+
+  it('does NOT live-recompute main shortlist economics at hydrate (perf: persist-session-matches owns it)', () => {
+    // audit-1 LOW 8 perf follow-up: the live recompute is scoped to bucket rows
+    // only. Main matchRows (user_id IS NULL) carry the cheap seed economics — they
+    // are recomputed later by persist-session-matches, so a live recompute here is
+    // redundant O(N_main) work on every demo login. Proof: the main row keeps the
+    // seed-sentinel TCE (which a live Rotterdam→Santos recompute would never yield),
+    // while the bucket row in the test above DID get live-recomputed.
+    const db = makeSeedDb();
+    const expectedLive = liveBoardTce(db);
+    const blob = buildDemoSessionBlob(db);
+    db.close();
+
+    expect(expectedLive).not.toBe(SEED_SENTINEL_TCE);
+    expect(blob.matches).toHaveLength(1);
+    const mainTce = blob.matches[0].economics!.tceUsdPerDay;
+    // Main row kept the seed column — NOT live-recomputed.
+    expect(mainTce).toBe(SEED_SENTINEL_TCE);
+    expect(mainTce).not.toBe(expectedLive);
   });
 });

--- a/lib/demo-mode/hydrate-demo-session.ts
+++ b/lib/demo-mode/hydrate-demo-session.ts
@@ -190,7 +190,15 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
   const cargoByKey = new Map(dedupedCargos.map((c) => [`${c.emailId}|${c.itemIndex}`, c]));
   const vesselByKey = new Map(dedupedVessels.map((v) => [`${v.emailId}|${v.itemIndex}`, v]));
 
-  function rowsToMatches(rows: MatchRow[]): Match[] {
+  // liveRecompute: run the expensive resolveRecommendedBunkerPort +
+  // computeStoredMatchEconomics ONLY for the realism-bucket rows whose economics
+  // is read by session-buckets.ts (toBucketRows reads m.economics.tceUsdPerDay).
+  // The main shortlist (matchRows) is handed to persist-session-matches.ts, which
+  // ALWAYS recomputes economics itself (ignores m.economics) — so recomputing it
+  // here too would be O(N_main) wasted work on every demo login (audit-1 LOW 8
+  // perf follow-up to #1079). Main rows keep the cheap seedEconomics; correctness
+  // is unchanged because persist-session-matches overwrites it deterministically.
+  function rowsToMatches(rows: MatchRow[], liveRecompute: boolean): Match[] {
     return rows.map((r) => {
       const tce = r.tce_usd_per_day;
       // #883: compute demo war-risk from seeded ports + dwt, mirroring the live
@@ -239,7 +247,7 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
       const cargo = cargoByKey.get(`${r.cargo_id}|${r.cargo_item_index ?? 0}`);
       const vessel = vesselByKey.get(`${r.vessel_id}|${r.vessel_item_index ?? 0}`);
       let economics = seedEconomics;
-      if (cargo && vessel) {
+      if (liveRecompute && cargo && vessel) {
         const loadPort = cfValue(cargo.originPort);
         const dischargePort = cfValue(cargo.destinationPort);
         const distance = loadPort && dischargePort ? getPortDistance(loadPort, dischargePort) : null;
@@ -271,9 +279,11 @@ export function buildDemoSessionBlob(db: Database.Database): DemoBlob {
     });
   }
 
-  const matches = rowsToMatches(matchRows);
-  const lowConfidenceMatches = rowsToMatches(reviewRows);
-  const insufficientData = rowsToMatches(insufficientRows);
+  // Main shortlist: persist-session-matches recomputes economics — skip live recompute here.
+  const matches = rowsToMatches(matchRows, false);
+  // Bucket rows: session-buckets reads m.economics — recompute live for board parity.
+  const lowConfidenceMatches = rowsToMatches(reviewRows, true);
+  const insufficientData = rowsToMatches(insufficientRows, true);
 
   const processedEmails = buildProcessedEmails(emails, classifications, dedupedCargos, dedupedVessels);
 


### PR DESCRIPTION
## Что

PERF follow-up to merged #1079 (audit-1 LOW 8 bucket-TCE). #1079 added a live
economics recompute (`resolveRecommendedBunkerPort` + `computeStoredMatchEconomics`)
inside `rowsToMatches` in `lib/demo-mode/hydrate-demo-session.ts`. That recompute
ran for **all** match types — including the main shortlist `matchRows`.

But `lib/matching/persist-session-matches.ts` **always** recomputes main-shortlist
economics again afterward (it ignores `m.economics`), so the main-match recompute
at hydrate was redundant `O(N_main)` wasted work on every demo login.

## Fix

Scope the live recompute to **only** the review/insufficient bucket rows (whose
economics is read by `session-buckets.ts` `toBucketRows`). Main `matchRows` keep
the cheap `seedEconomics`.

Correctness unchanged — `persist-session-matches` overwrites main-row economics
deterministically regardless. Perf only.

- `rowsToMatches` gains a `liveRecompute` flag: `false` for `matchRows`, `true` for buckets.
- #1079 bucket-vs-board parity test stays green.
- New test asserts main `matchRows` are NOT live-recomputed at hydrate (keeps the seed sentinel TCE).

## Tests

- `hydrate-demo-session-bucket-tce-parity.test.ts` — 2/2 green (parity + perf-scope)
- `session-buckets-economics`, all `hydrate-demo-session*` suites — green
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)