### PR TITLE
fix(laytime): FHEX/FHINC exclude Fridays not Sundays (audit, founder-approved)

### DIFF
--- a/app/laytime/page.tsx
+++ b/app/laytime/page.tsx
@@ -210,8 +210,8 @@ export default function LaytimePage() {
                   >
                     <option value="SHINC">SHINC (Sundays/Holidays Included)</option>
                     <option value="SHEX">SHEX (Sundays/Holidays Excluded)</option>
-                    <option value="FHINC">FHINC (First Half Included)</option>
-                    <option value="FHEX">FHEX (First Half Excluded)</option>
+                    <option value="FHINC">FHINC (Fridays/Holidays Included)</option>
+                    <option value="FHEX">FHEX (Fridays/Holidays Excluded)</option>
                   </select>
                 </div>
 

--- a/lib/__tests__/laytime-calculator.test.ts
+++ b/lib/__tests__/laytime-calculator.test.ts
@@ -1,4 +1,4 @@
-import { calculateLaytime, isSunday, isHoliday, isExcluded } from '../laytime/calculator';
+import { calculateLaytime, isSunday, isFriday, isHoliday, isExcluded } from '../laytime/calculator';
 import type { LaytimeInput } from '../types';
 
 // ── Helper function tests ──
@@ -35,6 +35,29 @@ describe('isSunday', () => {
 
   test('returns false for Saturday 2026-05-09', () => {
     expect(isSunday('2026-05-09')).toBe(false);
+  });
+});
+
+describe('isFriday', () => {
+  test('throws TypeError on empty string', () => {
+    expect(() => isFriday('')).toThrow(TypeError);
+  });
+
+  test('throws TypeError on invalid date string', () => {
+    expect(() => isFriday('not-a-date')).toThrow(TypeError);
+  });
+
+  // 2026-05-15 is a Friday (Sun 05-10 + 5 days)
+  test('returns true for Friday 2026-05-15', () => {
+    expect(isFriday('2026-05-15')).toBe(true);
+  });
+
+  test('returns false for Sunday 2026-05-10', () => {
+    expect(isFriday('2026-05-10')).toBe(false);
+  });
+
+  test('returns false for Saturday 2026-05-16', () => {
+    expect(isFriday('2026-05-16')).toBe(false);
   });
 });
 
@@ -124,8 +147,21 @@ describe('isExcluded', () => {
     expect(isExcluded('2026-05-12', 'SHEX', ['2026-05-12'])).toBe(true);
   });
 
-  test('FHEX excludes Sunday', () => {
-    expect(isExcluded('2026-05-10', 'FHEX', [])).toBe(true); // Sunday
+  // FHEX = Fridays and Holidays Excluded (glossary.ts). FH = Fridays, NOT Sundays.
+  test('FHEX excludes Friday', () => {
+    expect(isExcluded('2026-05-15', 'FHEX', [])).toBe(true); // Friday
+  });
+
+  test('FHEX does NOT exclude Sunday', () => {
+    expect(isExcluded('2026-05-10', 'FHEX', [])).toBe(false); // Sunday counts in FHEX
+  });
+
+  test('FHEX excludes holiday', () => {
+    expect(isExcluded('2026-05-12', 'FHEX', ['2026-05-12'])).toBe(true);
+  });
+
+  test('FHINC does not exclude Friday', () => {
+    expect(isExcluded('2026-05-15', 'FHINC', [])).toBe(false); // Friday
   });
 
   test('FHINC does not exclude Sunday', () => {
@@ -448,16 +484,33 @@ describe('calculateLaytime SHEX mode', () => {
 // ── Additional mode coverage ──
 
 describe('calculateLaytime FHEX and FHINC modes', () => {
-  test('FHEX: behaves like SHEX (simplified)', () => {
+  // FHEX = Fridays and Holidays Excluded. Friday is the weekend day, NOT Sunday.
+  test('FHEX: excludes Friday and holiday, counts Sunday', () => {
+    // Range Tue 2026-05-12 → Mon 2026-05-18 (full week). Friday = 05-15.
     const input: LaytimeInput = {
       allowedLaytimeDays: 5,
       mode: 'FHEX',
       commencedAt: '2026-05-12T00:00:00Z',
-      completedAt: '2026-05-17T00:00:00Z',
+      completedAt: '2026-05-18T00:00:00Z',
       portHolidays: ['2026-05-13'],
     };
     const result = calculateLaytime(input);
-    // Should exclude holiday like SHEX
+
+    // Friday 05-15 excluded with reason 'friday'
+    const fri = result.breakdown.find((e) => e.date === '2026-05-15');
+    expect(fri?.excluded).toBe(true);
+    expect(fri?.reason).toBe('friday');
+
+    // Sunday 05-17 must be COUNTED under FHEX (not excluded)
+    const sun = result.breakdown.find((e) => e.date === '2026-05-17');
+    expect(sun?.excluded).toBe(false);
+
+    // Holiday 05-13 excluded with reason 'holiday'
+    const hol = result.breakdown.find((e) => e.date === '2026-05-13');
+    expect(hol?.excluded).toBe(true);
+    expect(hol?.reason).toBe('holiday');
+
+    // Full days 12,14,16,17 counted (13 holiday, 15 Friday excluded; 18 ~0min) = 4*24
     expect(result.usedLaytimeHours).toBeCloseTo(4 * 24, 1);
   });
 

--- a/lib/laytime/calculator.ts
+++ b/lib/laytime/calculator.ts
@@ -13,6 +13,17 @@ export function isSunday(dateStr: string): boolean {
   return date.getUTCDay() === 0;
 }
 
+export function isFriday(dateStr: string): boolean {
+  if (!dateStr || typeof dateStr !== 'string') {
+    throw new TypeError('dateStr must be a non-empty string');
+  }
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) {
+    throw new TypeError(`Invalid date string: ${dateStr}`);
+  }
+  return date.getUTCDay() === 5;
+}
+
 export function isHoliday(dateStr: string, holidays: string[]): boolean {
   if (!dateStr || typeof dateStr !== 'string') {
     throw new TypeError('dateStr must be a non-empty string');
@@ -48,11 +59,31 @@ export function isExcluded(dateStr: string, mode: LaytimeMode, holidays: string[
     return false;
   }
 
-  if (mode === 'SHEX' || mode === 'FHEX') {
+  // SHEX = Sundays and Holidays Excluded.
+  if (mode === 'SHEX') {
     return isSunday(dateStr) || isHoliday(dateStr, holidays);
   }
 
+  // FHEX = Fridays and Holidays Excluded (glossary.ts) — common in
+  // Middle East/North Africa trades where Friday is the weekly holiday.
+  // FH = Fridays, NOT Sundays.
+  if (mode === 'FHEX') {
+    return isFriday(dateStr) || isHoliday(dateStr, holidays);
+  }
+
   return false;
+}
+
+// Resolves the exclusion reason label for the daily breakdown given the
+// mode-specific weekend day. SHEX → 'sunday', FHEX → 'friday', else 'holiday'.
+export function excludedReason(dateStr: string, mode: LaytimeMode): 'sunday' | 'friday' | 'holiday' {
+  if (mode === 'SHEX' && isSunday(dateStr)) {
+    return 'sunday';
+  }
+  if (mode === 'FHEX' && isFriday(dateStr)) {
+    return 'friday';
+  }
+  return 'holiday';
 }
 
 export function calculateLaytime(input: LaytimeInput): LaytimeResult {
@@ -99,11 +130,7 @@ export function calculateLaytime(input: LaytimeInput): LaytimeResult {
     const minutesInDay = calculateMinutesInDay(currentDate, commencedDate, completedDate);
 
     const excluded = isExcluded(dateStr, mode, portHolidays);
-    const reason = excluded
-      ? isSunday(dateStr)
-        ? 'sunday'
-        : 'holiday'
-      : undefined;
+    const reason = excluded ? excludedReason(dateStr, mode) : undefined;
 
     const hoursInDay = minutesInDay / 60;
 


### PR DESCRIPTION
## Problem
FHEX/FHINC modes excluded **Sundays** instead of **Fridays**. Per the canonical glossary (`lib/prompts/glossary.ts:94`):

> FHEX = Fridays and Holidays Excluded (common in Middle East/North Africa trades where Friday is a holiday)

`isExcluded()`'s FHEX branch called `isSunday()`, so the wrong day was dropped from laytime counting — **shifting demurrage / used-laytime money** on every FHEX/FHINC calculation. Disputed audit item, founder-approved.

LIVE on prod (`LAYTIME_ENGINE_ENABLED=true`).

## Fix
- `isFriday()` helper (`getUTCDay() === 5`)
- `isExcluded()`: split `SHEX` (Sundays) from `FHEX` (Fridays); FHEX now excludes Fridays + holidays. SHEX/SHINC/FHINC unchanged.
- `excludedReason()`: mode-aware breakdown label — `SHEX→'sunday'`, `FHEX→'friday'`, else `'holiday'`
- `app/laytime/page.tsx`: relabel FH options "First Half" → "Fridays/Holidays" (matched glossary; "First Half" was also wrong)

## ⚠️ VALUE-BEARING
Changes `demurrageOrDespatch` / `usedLaytimeHours` on FHEX/FHINC calcs. SHEX/SHINC outputs are byte-identical.

## TDD
RED first: FHEX-over-a-Friday test asserted Friday excluded + Sunday counted (failed on old impl). Then GREEN.

## Tests
`laytime-calculator` + 5 related laytime suites: **98/98 green**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)