### PR TITLE
fix(adapters,sanctions): defensive guards — IG-club alias matching + price sanity ranges

### DIFF
--- a/__tests__/lib/knowledge/bunker/shipandbunker-adapter.test.ts
+++ b/__tests__/lib/knowledge/bunker/shipandbunker-adapter.test.ts
@@ -213,6 +213,26 @@ describe('shipandbunker-adapter', () => {
       expect(fetchCount).toBe(1);
     });
 
+    it('skips out-of-range price, still writes in-range prices', async () => {
+      // Two rows: Rotterdam absurdly high (>2500), Singapore normal (in range).
+      const html = `<table><tbody>
+        <tr><th id="row-nl-rtm-VLSFO" class="port"><a href="#">Rotterdam</a></th>
+          <td headers="price-VLSFO">9999.00<span></span></td></tr>
+        <tr><th id="row-sg-sin-VLSFO" class="port"><a href="#">Singapore</a></th>
+          <td headers="price-VLSFO">812.00<span></span></td></tr>
+      </tbody></table>`;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await refreshShipAndBunker(db, async () => html);
+
+      expect(result.rowsChanged).toBe(1); // only Singapore
+      const rtm = db.prepare("SELECT * FROM bunker_prices WHERE port_unlocode='NLRTM' AND source='shipandbunker'").get();
+      expect(rtm).toBeUndefined();
+      const sgsin = db.prepare("SELECT * FROM bunker_prices WHERE port_unlocode='SGSIN' AND source='shipandbunker'").get() as any;
+      expect(sgsin.price_usd_per_mt).toBeCloseTo(812.0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('out of range'));
+      warnSpy.mockRestore();
+    });
+
     it('writes cache after successful fetch', async () => {
       const fetcher = async () => fixtureHtml;
       await refreshShipAndBunker(db, fetcher);

--- a/__tests__/lib/knowledge/bunker/usda-adapter.test.ts
+++ b/__tests__/lib/knowledge/bunker/usda-adapter.test.ts
@@ -141,6 +141,23 @@ describe('usda-adapter', () => {
       expect(result.rowsChanged).toBe(0);
     });
 
+    it('skips out-of-range price, still writes in-range prices', async () => {
+      const fetcher = async (): Promise<UsdaRecord[]> => [
+        { location: 'Rotterdam', fuel_type: 'IFO380', price_per_mt: '9999.00', report_date: '2026-05-08T00:00:00.000' },
+        { location: 'Singapore', fuel_type: 'IFO380', price_per_mt: '812.00', report_date: '2026-05-08T00:00:00.000' },
+      ];
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await refreshUsdaBunker(db, fetcher);
+
+      expect(result.rowsChanged).toBe(1); // only Singapore
+      const rtm = db.prepare("SELECT * FROM bunker_prices WHERE port_unlocode='NLRTM' AND source='usda'").get();
+      expect(rtm).toBeUndefined();
+      const sgsin = db.prepare("SELECT * FROM bunker_prices WHERE port_unlocode='SGSIN' AND source='usda'").get() as any;
+      expect(sgsin.price_usd_per_mt).toBeCloseTo(812.0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('out of range'));
+      warnSpy.mockRestore();
+    });
+
     it('upstreamVersion reflects latest report_date', async () => {
       const fetcher = async (): Promise<UsdaRecord[]> => [
         { location: 'Rotterdam', fuel_type: 'IFO380', price_per_mt: '789.50', report_date: '2026-05-07T00:00:00.000' },

--- a/__tests__/lib/knowledge/eua/eex-adapter.test.ts
+++ b/__tests__/lib/knowledge/eua/eex-adapter.test.ts
@@ -19,6 +19,65 @@ function loadFixture(name: string): Buffer {
   return readFileSync(join(FIXTURES_DIR, name));
 }
 
+// Build a minimal "stored" (uncompressed) ZIP with the two entries parseEexXlsx
+// reads, so range-guard behaviour can be exercised with an arbitrary price.
+function storedZip(entries: { name: string; data: Buffer }[]): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const e of entries) {
+    const nameBuf = Buffer.from(e.name, 'utf8');
+    const lh = Buffer.alloc(30);
+    lh.writeUInt32LE(0x04034b50, 0);
+    lh.writeUInt16LE(20, 4);
+    lh.writeUInt16LE(0, 8); // stored
+    lh.writeUInt32LE(0, 14); // crc (ignored for stored by parser)
+    lh.writeUInt32LE(e.data.length, 18);
+    lh.writeUInt32LE(e.data.length, 22);
+    lh.writeUInt16LE(nameBuf.length, 26);
+    const local = Buffer.concat([lh, nameBuf, e.data]);
+
+    const ch = Buffer.alloc(46);
+    ch.writeUInt32LE(0x02014b50, 0);
+    ch.writeUInt16LE(20, 6);
+    ch.writeUInt16LE(0, 10); // stored
+    ch.writeUInt32LE(0, 16); // crc
+    ch.writeUInt32LE(e.data.length, 20);
+    ch.writeUInt32LE(e.data.length, 24);
+    ch.writeUInt16LE(nameBuf.length, 28);
+    ch.writeUInt32LE(offset, 42);
+    centrals.push(Buffer.concat([ch, nameBuf]));
+
+    locals.push(local);
+    offset += local.length;
+  }
+  const cd = Buffer.concat(centrals);
+  const cdOffset = offset;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cd.length, 12);
+  eocd.writeUInt32LE(cdOffset, 16);
+  return Buffer.concat([...locals, cd, eocd]);
+}
+
+// XLSX with a single EU CAP3 auction row at `price` on serial 46030 (2026-01-08).
+function makeEexXlsx(price: number): Buffer {
+  const ss =
+    '<sst><si><t>Date</t></si><si><t>Auction Name</t></si>' +
+    '<si><t>Auction Price</t></si><si><t>CAP3 EU Auction</t></si></sst>';
+  const sheet =
+    '<worksheet><sheetData>' +
+    '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c></row>' +
+    `<row r="2"><c r="A2"><v>46030</v></c><c r="B2" t="s"><v>3</v></c><c r="C2"><v>${price}</v></c></row>` +
+    '</sheetData></worksheet>';
+  return storedZip([
+    { name: 'xl/worksheets/sheet1.xml', data: Buffer.from(sheet, 'utf8') },
+    { name: 'xl/sharedStrings.xml', data: Buffer.from(ss, 'utf8') },
+  ]);
+}
+
 function makeDb(): Database.Database {
   const db = new Database(':memory:');
   db.pragma('foreign_keys = ON');
@@ -176,6 +235,34 @@ describe('eex-adapter — refreshEex', () => {
     const result = await refreshEex(db, fetcher);
     expect(result).toBeNull();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[EEX]'), expect.any(String));
+    warnSpy.mockRestore();
+  });
+
+  it('sanity-check: hand-built XLSX parses (in-range price written)', async () => {
+    const fetcher = jest.fn().mockResolvedValue(makeEexXlsx(72));
+    const result = await refreshEex(db, fetcher);
+    expect(result).not.toBeNull();
+    expect(result!.price).toBe(72);
+    const row = db.prepare("SELECT * FROM eua_prices WHERE source='eex-auction'").get() as any;
+    expect(row.price_eur_per_tco2).toBeCloseTo(72, 2);
+  });
+
+  it('returns null + warns on out-of-range high price, writes nothing', async () => {
+    const fetcher = jest.fn().mockResolvedValue(makeEexXlsx(9999));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await refreshEex(db, fetcher);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('out of range'));
+    const row = db.prepare("SELECT * FROM eua_prices WHERE source='eex-auction'").get();
+    expect(row).toBeUndefined();
+    warnSpy.mockRestore();
+  });
+
+  it('returns null on out-of-range low price', async () => {
+    const fetcher = jest.fn().mockResolvedValue(makeEexXlsx(3));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await refreshEex(db, fetcher);
+    expect(result).toBeNull();
     warnSpy.mockRestore();
   });
 

--- a/lib/knowledge/bunker/shipandbunker-adapter.ts
+++ b/lib/knowledge/bunker/shipandbunker-adapter.ts
@@ -1,7 +1,11 @@
 import type Database from 'better-sqlite3';
 import * as fs from 'fs';
 import * as path from 'path';
-import { upsertBunkerPrice } from '@/lib/market/bunker-repository';
+import { upsertBunkerPrice, getLatestBunkerPrice } from '@/lib/market/bunker-repository';
+
+// Bunker sanity range (USD/mt). Mirrors oilmonster-adapter — reject implausible
+// scrapes (decimal-shift, header-as-price) instead of writing them to the DB.
+const RANGE_VLSFO = { min: 200, max: 2500 } as const;
 
 const SNB_URL = 'https://shipandbunker.com/prices';
 const DEFAULT_CACHE_PATH = '/var/cache/quantika/shipandbunker.html';
@@ -166,7 +170,16 @@ export async function refreshShipAndBunker(
   let rowsChanged = 0;
 
   const upsert = db.transaction(() => {
-    for (const [, { vlsfo, unlocode }] of parsed) {
+    for (const [portName, { vlsfo, unlocode }] of parsed) {
+      if (vlsfo < RANGE_VLSFO.min || vlsfo > RANGE_VLSFO.max) {
+        const last = getLatestBunkerPrice(db, unlocode, 'VLSFO');
+        console.warn(
+          `[ShipAndBunker] ${portName} VLSFO ${vlsfo} out of range ` +
+          `[${RANGE_VLSFO.min}–${RANGE_VLSFO.max}] — keeping last-good ` +
+          `(${last?.price_usd_per_mt ?? 'none'})`,
+        );
+        continue;
+      }
       upsertBunkerPrice(db, {
         port_unlocode: unlocode,
         fuel_grade: 'VLSFO',

--- a/lib/knowledge/bunker/usda-adapter.ts
+++ b/lib/knowledge/bunker/usda-adapter.ts
@@ -1,5 +1,9 @@
 import type Database from 'better-sqlite3';
-import { upsertBunkerPrice } from '@/lib/market/bunker-repository';
+import { upsertBunkerPrice, getLatestBunkerPrice } from '@/lib/market/bunker-repository';
+
+// Bunker sanity range (USD/mt). Mirrors oilmonster-adapter — reject implausible
+// values instead of writing them to the DB.
+const RANGE = { min: 200, max: 2500 } as const;
 
 const USDA_URL = 'https://agtransport.usda.gov/resource/y4ft-fdwn.json?$limit=1000';
 
@@ -57,6 +61,16 @@ export async function refreshUsdaBunker(
 
       const priceValue = parseFloat(rec.price_per_mt);
       if (!Number.isFinite(priceValue)) continue;
+
+      if (priceValue < RANGE.min || priceValue > RANGE.max) {
+        const last = getLatestBunkerPrice(db, portUnlocode, fuelGrade);
+        console.warn(
+          `[USDA] ${rec.location} ${fuelGrade} ${priceValue} out of range ` +
+          `[${RANGE.min}–${RANGE.max}] — keeping last-good ` +
+          `(${last?.price_usd_per_mt ?? 'none'})`,
+        );
+        continue;
+      }
 
       const priceDate = rec.report_date.slice(0, 10);
 

--- a/lib/knowledge/eua/eex-adapter.ts
+++ b/lib/knowledge/eua/eex-adapter.ts
@@ -1,6 +1,12 @@
 import type Database from 'better-sqlite3';
 import { inflateRawSync } from 'node:zlib';
-import { upsertEuaPrice } from '@/lib/market/eua-repository';
+import { upsertEuaPrice, getLatestEuaPrice } from '@/lib/market/eua-repository';
+
+// EUA sanity range (EUR/tCO₂). Wider than tradingeconomics-adapter [20–200] —
+// EEX is the primary auction source, so tolerate a broader plausible band but
+// still reject obviously-corrupt parses (e.g. a stray date serial or 0).
+const PRICE_MIN_EUR = 10;
+const PRICE_MAX_EUR = 250;
 
 export class EexNoAuctionFoundError extends Error {
   constructor(message: string) {
@@ -240,6 +246,16 @@ export async function refreshEex(
   }
 
   const { price, priceDate } = parsed;
+
+  if (price < PRICE_MIN_EUR || price > PRICE_MAX_EUR) {
+    const existing = getLatestEuaPrice(db, 'spot', { maxAgeDays: Infinity });
+    console.warn(
+      `[EEX] Price ${price} EUR out of range [${PRICE_MIN_EUR}–${PRICE_MAX_EUR}] — ` +
+      `keeping last-good (${existing?.price_eur_per_tco2 ?? 'none'} on ${existing?.price_date ?? 'n/a'})`,
+    );
+    return null;
+  }
+
   upsertEuaPrice(db, {
     price_date: priceDate,
     price_eur_per_tco2: price,

--- a/lib/sanctions/__tests__/pi-ig-clubs.test.ts
+++ b/lib/sanctions/__tests__/pi-ig-clubs.test.ts
@@ -35,4 +35,24 @@ describe('isIgClub', () => {
     expect(isIgClub('')).toBe(false);
     expect(isIgClub('Some Maritime Club')).toBe(false);
   });
+
+  it('matches IG club name variants with a leading "The "', () => {
+    // Real-world false-negative: "The North of England" is a legit IG club
+    // name variant but startsWith('north') never fires because of the prefix.
+    expect(isIgClub('The North of England')).toBe(true);
+    expect(isIgClub('The North of England P&I')).toBe(true);
+    expect(isIgClub('The Standard Club')).toBe(true);
+    expect(isIgClub('The West of England')).toBe(true);
+    expect(isIgClub('The Swedish Club')).toBe(true);
+    expect(isIgClub('The Britannia')).toBe(true);
+  });
+
+  it('does NOT match non-IG names that merely share a prefix (no false-positives)', () => {
+    // startsWith over-matched these: "standard"→Standard, "north"→North, "west"→West.
+    expect(isIgClub('Standard Chartered Bank')).toBe(false);
+    expect(isIgClub('Northern Trust')).toBe(false);
+    expect(isIgClub('Western Union')).toBe(false);
+    expect(isIgClub('London Stock Exchange')).toBe(false);
+    expect(isIgClub('American Express')).toBe(false);
+  });
 });

--- a/lib/sanctions/pi-ig-clubs.ts
+++ b/lib/sanctions/pi-ig-clubs.ts
@@ -4,8 +4,53 @@ export const PI_IG_CLUBS = [
 ] as const;
 export type IgClub = typeof PI_IG_CLUBS[number];
 
+// Name variants → canonical club. Mirrors the exact-name + alias approach in
+// lib/sanctions/iacs-members.ts. Keys are already normalized (lowercase, with
+// the leading "the " and trailing P&I/Club suffixes stripped) — see normalize().
+const ALIASES: Record<string, IgClub> = {
+  'north of england': 'North',
+  'north standard': 'North',
+  'west of england': 'West',
+};
+
+// Stripped before matching so "The North of England P&I Club" → "north of england".
+// NOT including "mutual" — "Steamship Mutual" is a canonical club name.
+const SUFFIXES = [
+  ' protection and indemnity',
+  ' p&i club',
+  ' p & i club',
+  ' p&i',
+  ' p & i',
+  ' club',
+];
+
+function normalize(name: string): string {
+  let s = name.toLowerCase().trim();
+  if (s.startsWith('the ')) s = s.slice(4).trim();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const suf of SUFFIXES) {
+      if (s.endsWith(suf)) {
+        s = s.slice(0, -suf.length).trim();
+        changed = true;
+      }
+    }
+  }
+  return s;
+}
+
+/**
+ * True when `clubName` is (a variant of) an International Group P&I club.
+ *
+ * Exact-name + alias matching (not prefix startsWith): startsWith over-matched
+ * non-IG names sharing a prefix ("Standard Chartered" → Standard) AND missed
+ * legit variants behind a "The " prefix ("The North of England"). Both fixed here.
+ */
 export function isIgClub(clubName: string): boolean {
   if (!clubName) return false;
-  const lower = clubName.toLowerCase().trim();
-  return PI_IG_CLUBS.some(club => lower.startsWith(club.toLowerCase()));
+  const norm = normalize(clubName);
+  if (!norm) return false;
+  if (PI_IG_CLUBS.some(club => club.toLowerCase() === norm)) return true;
+  return norm in ALIASES;
 }


### PR DESCRIPTION
## Summary
Two small founder-approved defensive fixes (disputed audit items), one PR. Both purely defensive — **no current value change**.

### PART 1 — `isIgClub` false-negatives (lib/sanctions/pi-ig-clubs.ts)
Old impl used `startsWith` on short prefixes, which both **over-matched** non-IG names sharing a prefix (`Standard Chartered` → Standard) and **missed** legit IG club variants behind a `The ` prefix (`The North of England`).
Now: exact-name + alias-set matching (mirrors `lib/sanctions/iacs-members.ts`), with `The ` prefix and `P&I`/`Club` suffix normalization. No new false-positives.

### PART 2 — price sanity-range guards (EEX / Ship&Bunker / USDA adapters)
These three only checked `Number.isFinite`. Added domain-range guards mirroring the existing `tradingeconomics-adapter` and `oilmonster-adapter` patterns:
- EEX EUA: reject if <10 or >250 EUR/tCO₂
- Ship&Bunker + USDA bunker: reject if <200 or >2500 USD/mt

Out-of-range values → `console.warn` + skip the write (keep last-good); in-range values still written.

## Tests (TDD — failing first)
- `isIgClub` matches a `The `-prefixed IG club and rejects non-IG lookalikes
- each adapter returns null/skips on an out-of-range price and still writes a valid in-range price (EEX uses a hand-built stored-ZIP XLSX fixture)
- All 54 affected + 36 caller (vessel-vetting, counterparty) tests green; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)