### PR TITLE
fix(ports): reconcile port_da codes to port-master + CI gate (audit headline)

### DIFF
--- a/__tests__/ports/port-da-reconciliation.test.ts
+++ b/__tests__/ports/port-da-reconciliation.test.ts
@@ -1,0 +1,47 @@
+/**
+ * CI-gate: port-da ⇄ port-master reconciliation.
+ *
+ * Every port_code in scripts/seed-data/port-da-base.json MUST be resolvable
+ * back to itself by name through resolvePort(). If a DA tariff exists for a
+ * port but resolvePort(port_name) returns null or a *different* portCode, then
+ * getPortDa() silently returns 0 (wrong/missing port charges) — exactly the
+ * regression class this gate prevents.
+ *
+ * Failure-first: written before the data fix (8 missing ports + Jebel Ali /
+ * Port Rashid identity). Red before, green after.
+ *
+ * See CONTEXT.md (port_da, discharge_port) and the audit headline rec.
+ */
+
+import { resolvePort } from '@/lib/ports/resolve';
+import PORT_DA_BASE from '@/scripts/seed-data/port-da-base.json';
+
+interface PortDaEntry {
+  port_code: string;
+  port_name: string;
+  brackets: unknown[];
+}
+
+const DA_ENTRIES = PORT_DA_BASE as PortDaEntry[];
+
+describe('port-da ⇄ port-master reconciliation (CI gate)', () => {
+  it('has at least the full known DA set (sanity: file loaded)', () => {
+    expect(DA_ENTRIES.length).toBeGreaterThanOrEqual(54);
+  });
+
+  it.each(DA_ENTRIES.map((e) => [e.port_code, e.port_name] as const))(
+    'resolvePort(%s name=%s) resolves back to its own port_code',
+    (portCode, portName) => {
+      const resolved = resolvePort(portName);
+      expect(resolved).not.toBeNull();
+      expect(resolved!.portCode).toBe(portCode);
+    },
+  );
+
+  it('every DA port_code is present in port-master (LOCODE lookup)', () => {
+    const unresolvable = DA_ENTRIES.filter((e) => resolvePort(e.port_code) === null).map(
+      (e) => e.port_code,
+    );
+    expect(unresolvable).toEqual([]);
+  });
+});

--- a/data/ports/port-master.json
+++ b/data/ports/port-master.json
@@ -1427,7 +1427,10 @@
     "sourceNote": "Port de Barcelona",
     "craneSWL": 50,
     "craneType": "gantry",
-    "craneDataAsOf": "WPI-2025"
+    "craneDataAsOf": "WPI-2025",
+    "aliases": [
+      "Port of Barcelona"
+    ]
   },
   {
     "unlocode": "ESTAR",
@@ -2216,7 +2219,11 @@
     "sourceNote": "Port authority web",
     "craneSWL": 25,
     "craneType": "mobile",
-    "craneDataAsOf": "WPI-2025"
+    "craneDataAsOf": "WPI-2025",
+    "aliases": [
+      "Malta Marsaxlokk",
+      "Malta Freeport"
+    ]
   },
   {
     "unlocode": "SIKOP",
@@ -2832,7 +2839,11 @@
     "tidal": false,
     "icePort": false,
     "dataConfidence": "medium",
-    "sourceNote": "Lloyd's Port Handbk"
+    "sourceNote": "Lloyd's Port Handbk",
+    "aliases": [
+      "Port of Misurata",
+      "Misrata"
+    ]
   },
   {
     "unlocode": "DZALG",
@@ -4008,7 +4019,7 @@
   },
   {
     "unlocode": "AEDXB",
-    "name": "Jebel Ali",
+    "name": "Port Rashid",
     "country": "AE",
     "lat": 25.25,
     "lon": 55.267,
@@ -4026,8 +4037,9 @@
     "tidal": false,
     "icePort": false,
     "dataConfidence": "high",
-    "sourceNote": "DP World Jebel Ali",
+    "sourceNote": "Port Rashid, Dubai (AEDXB) — distinct port from Jebel Ali (AEJEA). port_da/port-master reconciliation.",
     "aliases": [
+      "Port Rashid Dubai",
       "Dubai",
       "Dubai Port",
       "Port of Dubai"
@@ -10858,5 +10870,192 @@
     ],
     "dataConfidence": "low",
     "sourceNote": "public port handbook / approximate coords \u2014 backfill follow-up (#fix-port-names)"
+  },
+  {
+    "unlocode": "AEJEA",
+    "name": "Jebel Ali",
+    "country": "AE",
+    "lat": 25.0046,
+    "lon": 55.0626,
+    "maxDraftM": 17,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 400,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general",
+      "RORO",
+      "tanker"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "high",
+    "sourceNote": "DP World Jebel Ali (AEJEA) \u2014 distinct from Port Rashid (AEDXB).. port_da/port-master reconciliation",
+    "aliases": [
+      "Jebel Ali Port"
+    ]
+  },
+  {
+    "unlocode": "AEKHL",
+    "name": "Khalifa Port",
+    "country": "AE",
+    "lat": 24.833,
+    "lon": 54.667,
+    "maxDraftM": 18,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 400,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "medium",
+    "sourceNote": "Abu Dhabi Ports / Khalifa Port (AEKHL).. port_da/port-master reconciliation",
+    "aliases": [
+      "Khalifa Port Abu Dhabi"
+    ]
+  },
+  {
+    "unlocode": "CGPNR",
+    "name": "Pointe-Noire",
+    "country": "CG",
+    "lat": -4.786,
+    "lon": 11.833,
+    "maxDraftM": 15,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 300,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "medium",
+    "sourceNote": "Port Autonome de Pointe-Noire (CGPNR).. port_da/port-master reconciliation",
+    "aliases": [
+      "Port of Pointe-Noire"
+    ]
+  },
+  {
+    "unlocode": "JOAQJ",
+    "name": "Aqaba",
+    "country": "JO",
+    "lat": 29.5167,
+    "lon": 35.0,
+    "maxDraftM": 13,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 300,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "medium",
+    "sourceNote": "Aqaba Container Terminal / Port of Aqaba (JOAQJ).. port_da/port-master reconciliation",
+    "aliases": [
+      "Port of Aqaba"
+    ]
+  },
+  {
+    "unlocode": "JOAQB",
+    "name": "Aqaba (alt code)",
+    "country": "JO",
+    "lat": 29.5167,
+    "lon": 35.0,
+    "maxDraftM": 13,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 300,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "low",
+    "sourceNote": "Alternate UN/LOCODE for Aqaba, Jordan (canonical JOAQJ). Kept for. port_da/port-master reconciliation"
+  },
+  {
+    "unlocode": "NAWVB",
+    "name": "Walvis Bay",
+    "country": "NA",
+    "lat": -22.94,
+    "lon": 14.502,
+    "maxDraftM": 14,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 300,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "medium",
+    "sourceNote": "Namport / Port of Walvis Bay (NAWVB).. port_da/port-master reconciliation",
+    "aliases": [
+      "Port of Walvis Bay"
+    ]
+  },
+  {
+    "unlocode": "NGTIN",
+    "name": "Tin Can Island",
+    "country": "NG",
+    "lat": 6.433,
+    "lon": 3.35,
+    "maxDraftM": 12,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 250,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general",
+      "RORO"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "medium",
+    "sourceNote": "Nigerian Ports Authority / Tincan Island Port Complex (NGTIN).. port_da/port-master reconciliation",
+    "aliases": [
+      "Tincan Island",
+      "Tin Can Island Port"
+    ]
+  },
+  {
+    "unlocode": "SADAM",
+    "name": "King Abdul Aziz Port Dammam",
+    "country": "SA",
+    "lat": 26.489,
+    "lon": 50.201,
+    "maxDraftM": 16,
+    "hasShoreCranes": true,
+    "berthType": "deep-sea",
+    "maxLOA": 366,
+    "cargoBerthTypes": [
+      "container",
+      "bulk",
+      "general"
+    ],
+    "tidal": false,
+    "icePort": false,
+    "dataConfidence": "medium",
+    "sourceNote": "Saudi Ports Authority (Mawani) / King Abdulaziz Port, Dammam (SADAM).. port_da/port-master reconciliation",
+    "aliases": [
+      "Dammam",
+      "King Abdulaziz Port",
+      "Dammam Port"
+    ]
   }
 ]

--- a/docs/superpowers/plans/2026-06-20-port-da-master-reconciliation.md
+++ b/docs/superpowers/plans/2026-06-20-port-da-master-reconciliation.md
@@ -1,0 +1,42 @@
+# Plan: port_da ⇄ port-master reconciliation + CI gate
+
+**Date:** 2026-06-20
+**Branch:** fix-portmaster-cigate
+**Tier:** M (disputed audit headline rec, founder-approved)
+
+## Problem
+
+`scripts/seed-data/port-da-base.json` carries DA tariffs for 54 `port_code`s, but
+`resolvePort(port_name)` could not reconcile all of them back to `data/ports/port-master.json`:
+
+1. **8 port_codes absent from port-master** — `AEJEA AEKHL CGPNR JOAQB JOAQJ NAWVB NGTIN SADAM`.
+   `resolvePort` returns `null` → `getPortDa` silently returns 0 (no port charges → wrong TCE).
+2. **Jebel Ali / Port Rashid identity collision** — port-master mapped `AEDXB` to name
+   `"Jebel Ali"`, while port-da-base has a *separate* `AEJEA` row for Jebel Ali (cheaper
+   tariff than `AEDXB` "Port Rashid Dubai"). Name lookup picked the wrong DA.
+3. **3 fuzzy-mismatch names** (code present, name resolves to a *different* port via the
+   substring fallback): `ESBCN` "Port of Barcelona" → MEBAR/Bar, `MTMAR` "Malta Marsaxlokk"
+   → MTMLA/Malta, `LYMRA` "Port of Misurata" → OMOFC/Sur.
+
+## Fix
+
+### Part 1 — Data (`data/ports/port-master.json`)
+- Add 8 missing ports with authoritative UNLOCODE / name / country / lat-lon
+  (coords cross-checked via web search — Wilhelmsen/Wikipedia/Namport/NPA/Mawani/MagicPort).
+- Rename `AEDXB` `"Jebel Ali"` → `"Port Rashid"`, add alias `"Port Rashid Dubai"`
+  (the DA name) so `AEDXB` resolves to its own tariff; add new `AEJEA` "Jebel Ali" entry
+  at its real coords (25.0046, 55.0626) so `resolvePort("Jebel Ali")` → AEJEA.
+- Add exact aliases to ESBCN / MTMAR / LYMRA so their DA names resolve before the fuzzy
+  substring fallback fires.
+
+### Part 2 — CI gate (`__tests__/ports/port-da-reconciliation.test.ts`)
+- Walk every `port_code` in port-da-base and assert
+  `resolvePort(port_name).portCode === port_code`, plus every code is LOCODE-resolvable.
+- TDD: this test is the failing-first test — RED before the data fix (12 fail), GREEN after.
+
+## Invariants preserved
+- **Demo TCE/DA unchanged**: 0/146 demo matches route through any of these ports
+  (verified: no references in `scripts/demo-seed/` or demo cargo data). The distance
+  namespace `'jebel ali' → 'Dubai'` in `lib/sailing/port-distances.ts` is independent of
+  port-master and untouched.
+- No source-code logic changed — data + new test only.


### PR DESCRIPTION
## Problem
`scripts/seed-data/port-da-base.json` has DA tariffs for 54 `port_code`s, but `resolvePort(port_name)` could not reconcile all of them to `data/ports/port-master.json`:

1. **8 codes absent from port-master** — `AEJEA AEKHL CGPNR JOAQB JOAQJ NAWVB NGTIN SADAM`. `resolvePort` → `null` → `getPortDa` silently returns **0** (missing port charges → wrong voyage TCE).
2. **Jebel Ali / Port Rashid identity** — port-master mapped `AEDXB` → name `"Jebel Ali"`, but port-da-base has a *separate* `AEJEA` row for Jebel Ali (cheaper tariff than AEDXB "Port Rashid Dubai"). Name lookup picked the wrong DA.
3. **3 fuzzy-mismatch names** — code present but DA name resolved to a *different* port via the substring fallback: `ESBCN` "Port of Barcelona"→Bar, `MTMAR` "Malta Marsaxlokk"→Malta, `LYMRA` "Port of Misurata"→Sur.

## Fix
**Part 1 — Data** (`data/ports/port-master.json`)
- Added the 8 missing ports with authoritative UNLOCODE / name / country / lat-lon (coords cross-checked via web search: Wilhelmsen, Wikipedia, Namport, Nigerian Ports Authority, Saudi Ports/Mawani, MagicPort).
- Renamed `AEDXB` `"Jebel Ali"` → `"Port Rashid"` (+alias `"Port Rashid Dubai"`); added new `AEJEA` "Jebel Ali" at its real coords (25.0046, 55.0626).
- Added exact aliases to ESBCN / MTMAR / LYMRA so DA names resolve before the fuzzy fallback.

**Part 2 — CI gate** (`__tests__/ports/port-da-reconciliation.test.ts`)
- Walks every `port_code` and asserts `resolvePort(port_name).portCode === port_code` + LOCODE-resolvable. TDD red (12 fail) → green (56 pass).

## Invariants
- **Demo TCE/DA unchanged**: 0/146 demo matches route through these ports (no refs in `scripts/demo-seed/` or demo cargo data).
- Distance namespace `'jebel ali'→'Dubai'` in `port-distances.ts` is independent and untouched.
- No source-code logic changed — data + new test only.

## Verification
- `__tests__/ports/port-da-reconciliation.test.ts` — 56 passed
- resolve / port-da-large-vessels / generate-route-map / port-distances / compare-routes-da — 375 passed
- AEDXB voyage/seed tests (tce-auto-bunker, tce-missing-bunker-port, war-risk-unlocode, unlocode-seed, port-master-wave-a) — 60 passed
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)