### PR TITLE
fix(ai-provider): getModel claude-cli 4-7 to 4-8

### DIFF
--- a/__tests__/lib/ai-provider-claude-cli.test.ts
+++ b/__tests__/lib/ai-provider-claude-cli.test.ts
@@ -12,7 +12,7 @@ jest.mock('child_process', () => ({
 // Import after mock registration so the inline require() in callClaudeCliRaw
 // gets the mocked module from Jest's module registry.
 const childProcess = require('child_process') as { spawnSync: jest.Mock };
-const { callClaudeCliRaw } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
+const { callClaudeCliRaw, getModel } = require('@/lib/ai-provider') as typeof import('@/lib/ai-provider');
 
 const OK_RESPONSE = (result: string) => ({
   status: 0,
@@ -22,6 +22,20 @@ const OK_RESPONSE = (result: string) => ({
   output: [null, '', ''],
   signal: null,
   error: undefined,
+});
+
+describe('getModel — claude-cli provider', () => {
+  const originalProvider = process.env.AI_PROVIDER;
+
+  afterEach(() => {
+    if (originalProvider === undefined) delete process.env.AI_PROVIDER;
+    else process.env.AI_PROVIDER = originalProvider;
+  });
+
+  it('returns claude-opus-4-8 when AI_PROVIDER=claude-cli', () => {
+    process.env.AI_PROVIDER = 'claude-cli';
+    expect(getModel('judge')).toBe('claude-opus-4-8');
+  });
 });
 
 describe('callClaudeCliRaw', () => {

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -508,7 +508,7 @@ export function getModel(scope: string): string {
     case 'bedrock':
       return process.env.BEDROCK_MODEL_ID ?? 'anthropic.claude-opus-4-7';
     case 'claude-cli':
-      return 'claude-opus-4-7';
+      return 'claude-opus-4-8';
     case 'openai':
     default:
       return process.env.AI_MODEL_HEAVY ?? 'gpt-5.5';


### PR DESCRIPTION
## Summary

- `getModel()` for `claude-cli` provider hardcoded `claude-opus-4-7`; updated to `claude-opus-4-8` (latest Opus per CLAUDE.md model list)
- Added behavioral test: `getModel('judge')` returns `'claude-opus-4-8'` when `AI_PROVIDER=claude-cli`
- Scope: single string change in `lib/ai-provider.ts:511`; no behavior change beyond the model ID

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `jest --findRelatedTests lib/ai-provider.ts` — 1150 passed, 0 failed
- [x] New behavioral test: `getModel — claude-cli provider` → `claude-opus-4-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)