### PR TITLE
Harden 4 demo parse prompts (FM-06/14/13/10/03) — Claude idiom

### DIFF
--- a/app/api/ai/classify/__tests__/route.test.ts
+++ b/app/api/ai/classify/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * PI2 behavioral test: a body longer than the old 3000 ceiling now reaches the
+ * classifier untruncated (FM-03). Drives the real classify route handler with a
+ * mocked LLM. The classify route reads emails from the SESSION (not the request
+ * body), so the session/csrf are mocked the same way as the parse-cargo route test.
+ */
+import { NextRequest } from 'next/dist/server/web/spec-extension/request';
+
+// Capture the user prompt the handler sends to the LLM.
+const captured: { userPrompt?: string } = {};
+
+jest.mock('@/lib/ai-provider', () => ({
+  callAiJson: jest.fn(async (_scope: string, _system: string, user: string) => {
+    captured.userPrompt = user;
+    return { classifications: [{ id: '1', category: 'OTHER', urgency: 'low', confidence: 0.5 }] };
+  }),
+}));
+
+jest.mock('@/lib/openai', () => ({
+  LLMTimeoutError: class LLMTimeoutError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'LLMTimeoutError';
+    }
+  },
+}));
+
+// Force live-LLM path (not the demo/cached short-circuit).
+jest.mock('@/lib/demo-mode', () => ({
+  isDemoMode: () => false,
+}));
+
+// CSRF always valid in the test harness.
+jest.mock('@/lib/csrf', () => ({
+  validateCsrf: () => true,
+}));
+
+jest.mock('@/lib/session', () => {
+  const getSession = jest.fn();
+  const updateSession = jest.fn();
+  return {
+    getSession,
+    updateSession,
+    requireSession: (request: { cookies: { get: (n: string) => { value: string } | undefined } }) => {
+      const sessionId = request.cookies.get('session_id')?.value;
+      const session = getSession(sessionId);
+      return { session, sessionId };
+    },
+  };
+});
+
+import { POST } from '@/app/api/ai/classify/route';
+import { getSession } from '@/lib/session';
+
+const mockGetSession = getSession as jest.MockedFunction<typeof getSession>;
+
+function makeEmail(id: string, body: string) {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    from: 'broker@example.com',
+    fromName: 'Broker',
+    fromEmail: 'broker@example.com',
+    to: 'me@example.com',
+    subject: 'Position list',
+    date: '2026-06-22',
+    body,
+    snippet: body.slice(0, 50),
+    labelIds: [],
+  };
+}
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/ai/classify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', origin: 'http://localhost:3000', Cookie: 'session_id=sess-1' },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  captured.userPrompt = undefined;
+});
+
+describe('classify route — FM-03 body no longer truncated at 3000 (PI2 behavioral)', () => {
+  it('sends a 5000-char body to the LLM without cutting it at 3000', async () => {
+    const longBody = 'MV TEST open Rotterdam. ' + 'x'.repeat(5000);
+    mockGetSession.mockReturnValue({
+      id: 'sess-1',
+      accessToken: 'token',
+      createdAt: new Date(),
+      emails: [makeEmail('1', longBody)],
+      classifications: [],
+      processedEmails: [],
+      parsedCargos: [],
+      parsedVessels: [],
+      parsedFixtureRecaps: [],
+      matches: [],
+      recaps: [],
+      commissionSummary: null,
+      counterparties: [],
+    } as never);
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(captured.userPrompt).toBeDefined();
+    // Old behavior truncated to ~3000; new ceiling (8000) keeps the full 5000-char body.
+    expect(captured.userPrompt!.length).toBeGreaterThan(3500);
+  });
+});

--- a/lib/__tests__/max-email-body-chars.test.ts
+++ b/lib/__tests__/max-email-body-chars.test.ts
@@ -1,0 +1,21 @@
+/**
+ * FM-03: classify body-preview ceiling. Real import of the source constant
+ * (not a mock) + classify-prompt truncation-awareness wiring.
+ */
+import { MAX_EMAIL_BODY_CHARS } from '@/lib/constants';
+import { CLASSIFICATION_SYSTEM_PROMPT } from '@/lib/prompts/classify';
+
+describe('FM-03 — MAX_EMAIL_BODY_CHARS classify ceiling', () => {
+  it('is raised to at least 8000 chars', () => {
+    expect(MAX_EMAIL_BODY_CHARS).toBeGreaterThanOrEqual(8000);
+  });
+
+  it('classify prompt has a truncation-awareness block', () => {
+    expect(CLASSIFICATION_SYSTEM_PROMPT).toMatch(/<truncation_awareness>/);
+    expect(CLASSIFICATION_SYSTEM_PROMPT).toMatch(/\[truncated\]/);
+  });
+
+  it('truncation block tells the model not to default to OTHER', () => {
+    expect(CLASSIFICATION_SYSTEM_PROMPT).toMatch(/do not default to OTHER/i);
+  });
+});

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -65,7 +65,7 @@ export const DEMO_SESSION_TTL_MS =
   parseInt(process.env.DEMO_SESSION_TTL_MS ?? '', 10) || 30 * 24 * 60 * 60 * 1000;
 export const EMAIL_FETCH_COUNT = 50;
 export const MIN_THREAD_LENGTH_FOR_RECAP = 5;
-export const MAX_EMAIL_BODY_CHARS = 3000;
+export const MAX_EMAIL_BODY_CHARS = 8000;
 export const UNANSWERED_THRESHOLD_HOURS = 48;
 
 export const MINUTES_SAVED_PER_RATE_REQUEST = 15;

--- a/lib/prompts/__tests__/parse-cargo-market-circular.test.ts
+++ b/lib/prompts/__tests__/parse-cargo-market-circular.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Wiring guard for the FM-14 market-circular multi-item block.
+ * Protects the WIRING of the block-separator recognition + worked example.
+ */
+import { CARGO_INQUIRY_PARSER_PROMPT } from '../parse-cargo';
+
+describe('CARGO_INQUIRY_PARSER_PROMPT — market-circular multi-item (FM-14)', () => {
+  it('wraps the new rule in an XML tag', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/<market_circular_multi_item>/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/<\/market_circular_multi_item>/);
+  });
+
+  it('names the ++++ / ==== / ---- block separators', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/\+\+\+\+/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/====/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/----/);
+  });
+
+  it('includes the 3-cargo worked example (urea / clinker / salt)', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/urea/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/clinker/);
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/salt/);
+  });
+
+  it('adds a missing_info breadcrumb when one item is returned despite a separator', () => {
+    expect(CARGO_INQUIRY_PARSER_PROMPT).toMatch(/verify this is not a multi-cargo market circular/);
+  });
+
+  it('avoids shouty all-caps imperatives in the new block', () => {
+    const block = CARGO_INQUIRY_PARSER_PROMPT
+      .split('<market_circular_multi_item>')[1]
+      .split('</market_circular_multi_item>')[0];
+    expect(block).not.toMatch(/\bMUST\b|\bMANDATORY\b|\bCRITICAL\b/);
+  });
+});

--- a/lib/prompts/__tests__/parse-recap-hardening.test.ts
+++ b/lib/prompts/__tests__/parse-recap-hardening.test.ts
@@ -33,3 +33,28 @@ describe('FIXTURE_RECAP_PARSER_PROMPT — role-noun guard (FM-13)', () => {
     expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/ACCOUNT vs CHARTERERS vs BROKER/);
   });
 });
+
+describe('FIXTURE_RECAP_PARSER_PROMPT — European-decimal all-fields (FM-10)', () => {
+  it('wraps the European-decimal rule in an XML tag', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/<european_decimal_rule>/);
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/<\/european_decimal_rule>/);
+  });
+
+  it('applies the rule to freight_rate, demurrage_rate, and cargo quantities (not just vessel_dwt)', () => {
+    const block = FIXTURE_RECAP_PARSER_PROMPT
+      .split('<european_decimal_rule>')[1]
+      .split('</european_decimal_rule>')[0];
+    expect(block).toMatch(/freight_rate/);
+    expect(block).toMatch(/demurrage_rate/);
+    expect(block).toMatch(/cargo_quantity_min/);
+  });
+
+  it('includes the 3.858 -> 3858 and 22.500 -> 22500 worked examples', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/3\.858.*3858/s);
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/22\.500.*22500/s);
+  });
+
+  it('keeps the existing vessel_dwt-scoped European-decimal note intact', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/vessel_dwt = 3858/);
+  });
+});

--- a/lib/prompts/__tests__/parse-recap-hardening.test.ts
+++ b/lib/prompts/__tests__/parse-recap-hardening.test.ts
@@ -50,8 +50,8 @@ describe('FIXTURE_RECAP_PARSER_PROMPT — European-decimal all-fields (FM-10)', 
   });
 
   it('includes the 3.858 -> 3858 and 22.500 -> 22500 worked examples', () => {
-    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/3\.858.*3858/s);
-    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/22\.500.*22500/s);
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/3\.858.*3858/);
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/22\.500.*22500/);
   });
 
   it('keeps the existing vessel_dwt-scoped European-decimal note intact', () => {

--- a/lib/prompts/__tests__/parse-recap-hardening.test.ts
+++ b/lib/prompts/__tests__/parse-recap-hardening.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Wiring guard for FM-13 (role-noun guard) and FM-10 (European-decimal, all fields).
+ * Protects the WIRING of the new blocks into FIXTURE_RECAP_PARSER_PROMPT.
+ */
+import { FIXTURE_RECAP_PARSER_PROMPT } from '../parse-recap';
+
+describe('FIXTURE_RECAP_PARSER_PROMPT — role-noun guard (FM-13)', () => {
+  it('wraps the role-noun guard in an XML tag', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/<role_noun_guard>/);
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/<\/role_noun_guard>/);
+  });
+
+  it('generalizes the rule across charterers / owners / broker', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/charterers \/ owners \/ broker/);
+  });
+
+  it('requires the charterers source_text to contain the "Charterers:" label', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/source_text .* contain the "Charterers:" label/);
+  });
+
+  it('includes a role-noun worked example that resolves to null', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/charterers = null/);
+  });
+
+  it('avoids shouty all-caps imperatives in the role-noun block', () => {
+    const block = FIXTURE_RECAP_PARSER_PROMPT
+      .split('<role_noun_guard>')[1]
+      .split('</role_noun_guard>')[0];
+    expect(block).not.toMatch(/\bMUST\b|\bMANDATORY\b|\bCRITICAL\b/);
+  });
+
+  it('preserves the existing ACCOUNT vs CHARTERERS vs BROKER section', () => {
+    expect(FIXTURE_RECAP_PARSER_PROMPT).toMatch(/ACCOUNT vs CHARTERERS vs BROKER/);
+  });
+});

--- a/lib/prompts/__tests__/parse-vessel-fleet-circular.test.ts
+++ b/lib/prompts/__tests__/parse-vessel-fleet-circular.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Wiring guard for the FM-06 fleet-circular completeness block.
+ * Protects the WIRING of the count-first rule + 3-vessel example into the prompt.
+ * LLM accuracy is covered by the live progonq corpus re-parse, not here.
+ */
+import { VESSEL_POSITION_PARSER_PROMPT } from '../parse-vessel';
+
+describe('VESSEL_POSITION_PARSER_PROMPT — fleet-circular completeness (FM-06)', () => {
+  it('wraps the new rule in an XML tag', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/<fleet_circular_completeness>/);
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/<\/fleet_circular_completeness>/);
+  });
+
+  it('instructs count-first before extracting any single vessel', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/count the vessel sections/i);
+  });
+
+  it('includes the 3-vessel worked example (ALPHA / BETA / GAMMA)', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/MV ALPHA/);
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/MV BETA/);
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/MV GAMMA/);
+  });
+
+  it('grounds each vessel via its own spec-block source_text', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/source_text from that vessel's own spec block/);
+  });
+
+  it('avoids shouty all-caps imperatives in the new block', () => {
+    const block = VESSEL_POSITION_PARSER_PROMPT
+      .split('<fleet_circular_completeness>')[1]
+      .split('</fleet_circular_completeness>')[0];
+    expect(block).not.toMatch(/\bMUST\b|\bMANDATORY\b|\bCRITICAL\b/);
+  });
+
+  it('preserves the existing FLEET COMPLETENESS section', () => {
+    expect(VESSEL_POSITION_PARSER_PROMPT).toMatch(/FLEET COMPLETENESS/);
+  });
+});

--- a/lib/prompts/classify.ts
+++ b/lib/prompts/classify.ts
@@ -99,6 +99,15 @@ Also determine:
 
 SUBJECT/BODY DATE CONFLICT CHECK: If the email subject line contains a year (e.g. "8-12 JUN 2025" or "LAY 20-30 MAY 2025") and the email body contains a different year for the same date field (e.g. body says "LAYCAN DELIVERY: 20/30 May 2026"), this is a potential typo or stale subject. Lower confidence to reflect this ambiguity (e.g. 0.85 instead of 0.98). Note: category classification itself is usually unaffected by a year typo, but urgency calculation must use the BODY DATE as authoritative since the body contains the operator's intent.
 
+<truncation_awareness>
+The body_preview may end with "[truncated]" when the original email was longer than
+the preview budget. When you see "[truncated]":
+  - Classify from the visible content; do not default to OTHER because text is missing.
+  - If the visible content already identifies a category (vessel specs, cargo
+    tonnage, recap terms), use that category and lower confidence by about 0.05.
+  - Do not lower urgency on account of truncation alone.
+</truncation_awareness>
+
 You will receive an array of emails. Return a JSON object.
 
 Input format per email: { id, subject, from, date, body_preview }

--- a/lib/prompts/parse-cargo.ts
+++ b/lib/prompts/parse-cargo.ts
@@ -376,6 +376,35 @@ TERMS TEMPLATE WARNING: A subject line ending in "// [PORT] TERMS" or "[PORT] TE
 FIXTURE TERMS GUARD: Return empty items array if the email is a charter party acceptance message — when the body contains phrases like "chrtrs full terms a/e as fllws for X mins", "charterers' terms as follows for X hours", "please find attached charterers' full terms for X minutes". These are fixture terms documents offered for time-limited acceptance, NOT cargo inquiries.
 
 VESSEL POSITION GUARD: Also return empty items array if the email is a vessel availability/tonnage circular where a shipowner or operator is offering their vessel for employment. Identifies: (1) vessel capacity specs (DWCC, DWT) combined with vessel type descriptors (SID = single-deck, BOX = box-hold, GLESS = gearless, OHG = open-hatch) — these describe the ship, not the cargo; (2) "open [PORT] [date]/onw" or "open [PORT] ppt" — describes where the vessel is currently available; (3) "=> [REGION]" or "looking for employment in [REGION]" — describes preferred trading area, not a discharge port for specific cargo; (4) "line up [tonnage] DWCC" or "please line up [X/Y] dwcc [date] [location]" without a named commodity — this is a request to provide a vessel of that capacity, not a cargo movement. These emails read as "we have a ship available at X, seeking cargo toward Y" — NOT as a shipper seeking transportation for a specific cargo. Return empty items[] and set missing_info: ["This appears to be a vessel availability/tonnage circular, not a cargo inquiry"].
+<market_circular_multi_item>
+A market circular is one email containing several independent cargo offers, usually
+sent by a broker to a distribution list. Offers are commonly divided by block
+separators such as:
+  ++++    ====    ----    ***    ~~~
+  "Cargo N:"   "Inquiry N:"   "REF: [code]"
+  a blank line followed by a fresh commodity/route on a new line
+
+When two or more blocks are separated this way, each block is a separate cargo
+inquiry — emit one item per block.
+
+Worked example — three blocks become three items:
+Input:
+  8000mt urea, Sohar -> Mombasa, laycan Jul ++++
+  12000mt clinker, El Arish -> POC, spot ++++
+  5500mt salt, Constanta -> Lagos, Aug/Sep
+Output:
+  { "items": [
+    { "origin_port": { "value": "Sohar" }, "destination_port": { "value": "Mombasa" }, "weight_mt": { "value": 8000 } },
+    { "origin_port": { "value": "El Arish" }, "destination_port": { "value": "Egypt (port unspecified)" }, "weight_mt": { "value": 12000 } },
+    { "origin_port": { "value": "Constanta" }, "destination_port": { "value": "Lagos" }, "weight_mt": { "value": 5500 } }
+  ] }
+
+If you return a single item while the body still contains a ++++ (or ==== / ----)
+separator between distinct cargo/route/quantity combinations, add a missing_info
+entry: "Body contains ++++ separator —
+verify this is not a multi-cargo market circular." That keeps the omission
+visible instead of silently dropping cargoes.
+</market_circular_multi_item>
 IMPORTANT negative examples — these ARE cargo inquiries (do NOT trigger the guard):
 - "pls propose [suitable] vessels for our [cargo]" = shipper asking broker to find tonnage for specific cargo → PARSE as cargo inquiry
 - "pls propose described ladies for our firm cargo" = same — "ladies" is informal for ships — still a cargo inquiry

--- a/lib/prompts/parse-recap.ts
+++ b/lib/prompts/parse-recap.ts
@@ -24,6 +24,21 @@ NULL FIELD RULE: When information is absent, set the field to null (plain JSON n
 vessel_yob NULL RULE: vessel_yob must be null (not 0) when the build year is not stated in the recap. 0 is not a valid year-of-build.
   ✗ vessel_yob: 0
   ✓ vessel_yob: null
+<european_decimal_rule>
+This applies to every numeric field: vessel_dwt, cargo_quantity_min,
+cargo_quantity_max, freight_rate, demurrage_rate, despatch_rate, loading_rate,
+discharging_rate, and any other numeric value.
+
+When a number uses a dot as a thousands separator followed by exactly three digits
+(pattern X.YYY or X.YYY.ZZZ), the dot is a thousands separator, not a decimal point:
+  "3.858 TON"    -> 3858      (not 3.858)
+  "22.500 USD"   -> 22500     (not 22.5)
+  "1.500.000 kg" -> 1500000
+A comma is the decimal mark in this notation ("3,5" -> 3.5).
+
+The vessel_dwt note in the field definitions below is one instance of this rule;
+this general version takes precedence and covers all numeric fields.
+</european_decimal_rule>
 
 freight_payment ANTI-FABRICATION: extract freight_payment ONLY from verbatim text in the email. NEVER fabricate percentage splits, payment schedules, or split-payment structures that are not written in the email.
   ✗ freight_payment = "90% on signing B/L, 10% on delivery" (not in email) → correct: null or verbatim text

--- a/lib/prompts/parse-recap.ts
+++ b/lib/prompts/parse-recap.ts
@@ -102,6 +102,29 @@ ACCOUNT vs CHARTERERS vs BROKER:
   ACCOUNT NULL RULE: account=null when NONE of these signals are present: "ACCT:", "for account of", "Account [Company]" in header. Purpose phrases are NOT account signals:
   ✗ account = "owners" from "Pls kindly find below recap of agreed terms for owners final confirmation" → WRONG (this is the PURPOSE of the email, not an account designation — "owners" here is a role, not a company)
   ✓ account = null when no explicit account label is present
+<role_noun_guard>
+The words "Charterers", "Owners", "Master", "Broker" appearing inside a clause
+body are roles — the grammatical subject of an obligation — not party names. A CP
+contains many such clauses, so matching a few example phrases is not enough; the
+test is structural.
+
+Worked example — a role-noun resolves to null:
+  Body: "...DEMURRAGE TO BE PAID BY CHARTERERS WITHIN 10 BANKING DAYS..."
+        (no "Charterers:" label anywhere in the body)
+  -> charterers = null   (the word is a role inside a clause, not a disclosed party)
+
+A role-noun (do not use as a party name):
+  "FOR CHARTERERS ACCOUNT"   "AT OWNERS RISK"   "MASTER TO SIGN B/L"
+A party name (safe to use):
+  "Charterers: Acme Shipping Ltd"   "Owners: Varan Ltd"
+
+Set charterers / owners / broker only from a line where the role label is directly
+followed by a company name, e.g. "Charterers: [Company]". For charterers, the
+source_text should contain the "Charterers:" label together with the company name;
+if your only candidate is a clause sentence such as "FOR CHARTERERS ACCOUNT",
+that is a role-noun, so set the field to null. When no labeled line exists, the
+field is null.
+</role_noun_guard>
 - charterers: the party who contracted the vessel charter. Source: explicit "Charterers:" label in the recap body ONLY. Do NOT populate charterers from the "ACCT:" field — that maps to account.
   ✗ charterers = "ETMS" from the email FROM: line (ETMS is the forwarding broker, not the contracting charterer)
   ✓ charterers extracted from explicit "Charterers:" label in the recap body only

--- a/lib/prompts/parse-vessel.ts
+++ b/lib/prompts/parse-vessel.ts
@@ -341,6 +341,29 @@ FLEET COMPLETENESS — SUMMARY TABLE + SPEC BLOCKS:
 FORMATTING MARKERS:
 - Rows of asterisks (** ... **) or (*** *** ***) are section delimiters, NOT empty signals.
 - A vessel section wrapped in asterisks or star separators is real data — extract it normally.
+<fleet_circular_completeness>
+A fleet position circular is one email offering several vessels — a fleet list,
+numbered entries, or consecutive spec blocks each with its own "open [PORT]".
+Each vessel is a separate item.
+
+Worked example — three vessel sections become three items:
+Input:
+  *** MV ALPHA, 8500 DWT, open Rotterdam 15 May ***
+  *** MV BETA, 11000 DWT, open Hamburg 20 May ***
+  *** MV GAMMA, 15000 DWT, open Antwerp 25 May ***
+Output:
+  { "items": [
+    { "vessel_name": { "value": "MV ALPHA", "confidence": "confirmed", "source_text": "MV ALPHA, 8500 DWT, open Rotterdam 15 May" } },
+    { "vessel_name": { "value": "MV BETA",  "confidence": "confirmed", "source_text": "MV BETA, 11000 DWT, open Hamburg 20 May" } },
+    { "vessel_name": { "value": "MV GAMMA", "confidence": "confirmed", "source_text": "MV GAMMA, 15000 DWT, open Antwerp 25 May" } }
+  ] }
+
+Before extracting any single vessel, count the vessel sections in the email, then
+return one item per section — eight sections give eight items. Copy each
+vessel_name.source_text from that vessel's own spec block, so every vessel is
+read individually. Returning fewer items than sections drops vessels that cannot
+be recovered later, so the item count and the section count should match.
+</fleet_circular_completeness>
 - Example: "**********\n\nMV SEA MAJESTY\n\nDWCC 8600 MTS ... OPEN @ TRIPOLI\n**********" → extract vessel SEA MAJESTY with DWCC 8600.
 
 Extract per vessel:


### PR DESCRIPTION
## Summary
Five surgical, audit-derived fixes to the demo email-parse prompts (`docs/audits/2026-06-22-parser-real-email-audit.md`). All new rule blocks use Claude idiom (XML-wrapped, example-first, calm imperatives — no all-caps) per `docs/research/claude-migration-research-2026-06-22.md` §4.

- **FM-06** parse-vessel: fleet-circular completeness (count-first + 3-vessel example)
- **FM-14** parse-cargo: market-circular multi-item (++++/====/---- separators + example)
- **FM-13** parse-recap: general role-noun guard + charterers source_text grounding
- **FM-10** parse-recap: European-decimal promoted to top-level all-numeric-fields rule
- **FM-03** classify: MAX_EMAIL_BODY_CHARS 3000→8000 + truncation-awareness note

## Coverage note
Prompt edits cover BOTH the live `app/api/ai/*` routes and the offline `scripts/demo-seed` path — both import the same `lib/prompts/*` constants (verified). One edit per fix, no duplication.

## Side-effect
`app/api/emails/fetch` raw-body cap (`MAX_EMAIL_BODY_CHARS * 2`) goes 6000→16000 — benign.

## Implementer notes (deviations from plan, both minimal & contract-preserving)
- FM-14 breadcrumb phrase rewrapped onto one line so the plan's own wiring regex (`/verify this is not a multi-cargo market circular/`) matches; prompt content identical.
- FM-10 wiring test dropped the `/s` (dotAll) regex flag — repo tsc target predates es2018 (TS1501); the matched examples are single-line so the assertion is unchanged.

## Out of scope / follow-ups
- Live progonq corpus re-parse (audit P0 diagnostic) validates real LLM accuracy — separate task.
- R4 classify prompt parity for the truncation block (only if R4 is promoted to default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)