### PR TITLE
fix(smoke): t60 systemd-run drops HOME — summary-t60.json vanishes

### DIFF
--- a/scripts/post-deploy-smoke/__tests__/schedule-t60.bats
+++ b/scripts/post-deploy-smoke/__tests__/schedule-t60.bats
@@ -35,3 +35,8 @@ teardown() { rm -rf "$TMP"; }
   grep -q "unit=quantika-t60-smoke" "$CALLS"
   grep -q "run-t60.sh 42 ABC123" "$CALLS"
 }
+
+@test "passes HOME through to the transient unit (systemd-run does not inherit it)" {
+  run bash "$SCRIPT" 42 ABC123
+  grep -q "setenv=HOME=$TMP" "$CALLS"
+}

--- a/scripts/post-deploy-smoke/schedule-t60.sh
+++ b/scripts/post-deploy-smoke/schedule-t60.sh
@@ -36,10 +36,15 @@ systemctl reset-failed "$UNIT.service" 2>/dev/null || true
 
 # Schedule the delayed run. --on-active=60min => fire 60 min from now, on dev-vps,
 # runner exits immediately (no Actions minutes burned on the wait).
+# systemd-run's transient unit does NOT inherit HOME from this shell (only PATH/USER
+# are set by default) — run-t60.sh derives its output dir from $HOME, so without this
+# --setenv it silently writes summary-t60.json under "/" instead of "$HOME/...",
+# where nothing ever looks for it.
 systemd-run \
   --unit="$UNIT" \
   --collect \
   --on-active=60min \
+  --setenv="HOME=$HOME" \
   --description="quantika-demo post-deploy t60 bake window (PR #$PR, $SHA)" \
   /root/post-deploy-smoke/run-t60.sh "$PR" "$SHA" "$BASE"
 


### PR DESCRIPTION
## Root cause

`systemd-run` transient units do not inherit `HOME` from the calling shell (confirmed live: only `PATH`/`USER` survive by default). `run-t60.sh` derives its output dir from `$HOME`:

```
ROOT="$HOME/orchestrator-state/quantika-demo/post-deploy-checks"
```

With `HOME` unset, this silently resolves to `/orchestrator-state/...` (filesystem root) instead of `/root/orchestrator-state/...`. No error, no crash — the run completes with `overall=PASS`, logs look clean in `journalctl`, but `summary-t60.json` lands in a directory nothing reads from.

Confirmed on PR #1100's real first bake-window run: journal shows `overall=PASS scheduled_sha=9854345...` at 07:31 UTC, but the file was written to `/orchestrator-state/quantika-demo/post-deploy-checks/1100/summary-t60.json` (root-owned path), not `~/orchestrator-state/...` where the orchestrator looks.

## Repro (before/after, live on dev-vps)

Used a scratch PR # and a 10s `systemd-run --on-active` timer (`--timer-property=AccuracySec=100ms` to keep it deterministic) instead of 60min:

- **Before fix**: `~/orchestrator-state/.../<PR>/` only had `t60-scheduled-sha` (written by `schedule-t60.sh`, which does have `$HOME`). `summary-t60.json` appeared under `/orchestrator-state/.../<PR>/` instead.
- **After fix**: `summary-t60.json` appears at the correct `~/orchestrator-state/.../<PR>/summary-t60.json`, and no file is created under the root-level path.

All scratch state cleaned up afterward; the global `.deployed-sha` marker was restored to its original value.

## Fix

`schedule-t60.sh` now passes `--setenv="HOME=$HOME"` to `systemd-run`, so the transient unit's environment matches the scheduling shell's — matching the existing pattern where every path in both scripts is already `$HOME`-relative.

## Tests

- Added a bats test asserting the `systemd-run` invocation includes `--setenv=HOME=...`.
- All 5 `schedule-t60.bats` + `run-t60.bats` tests pass.
- Regression suite (`test_t60_path_traversal.bats`, `test_t60_kill_midflight_stale_summary.bats`, `test_t60_command_injection.sh`) unaffected, all green.

## Not in scope / left for orchestrator

- `/root/post-deploy-smoke/schedule-t60.sh` on dev-vps is self-updated by the deploy pipeline from merged PRs (per CLAUDE.md) — not hand-patched here.
- Real PR #1100's `summary-t60.json` still sits at the wrong path (`/orchestrator-state/quantika-demo/post-deploy-checks/1100/summary-t60.json`, `overall=PASS`); moving it into place was blocked as out-of-scope production-state mutation. Data is intact and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)