### PR TITLE
chore(context): scope rules with paths, drop the redundant rule index

### DIFF
--- a/.claude/rules/admin-api.md
+++ b/.claude/rules/admin-api.md
@@ -1,21 +1,36 @@
+---
+paths:
+  - app/api/admin/**
+  - middleware.ts
+  - lib/auth/admin.ts
+  - __tests__/middleware-auth.test.ts
+---
+
 # Rules: app/api/admin/\*\* + middleware.ts
 
 ## Invariants
 
-- Каждый `/api/admin/*` handler обязан начинаться с `requireAdmin(req)` из `lib/auth/admin.ts`. Если `ADMIN_TOKEN` не задан → `500`. Если заголовок `X-Admin-Token` отсутствует/неверен → `401`.
+- Каждый `/api/admin/*` handler обязан проверять auth до обработки входа.
+  По умолчанию используй `requireAdmin(req)` из `lib/auth/admin.ts`: без
+  `ADMIN_TOKEN` он возвращает `500`, а без корректного `X-Admin-Token` — `401`.
+  Route с явно выделенным механизмом auth может быть исключением; например,
+  `/api/admin/cron-heartbeat` проверяет `X-Cron-Secret`.
 - Пути, у которых есть своя auth (cron, market, knowledge, whatsapp, pipedrive), **обязаны** быть в `AUTH_BYPASS_PATHS` в `middleware.ts`. Иначе middleware перехватит запрос и переадресует на `/login` до того, как handler проверит свой токен.
 - `AUTH_BYPASS_PATHS` — точные пути (`Set.has`), не префиксы. Добавление нового пути должно быть точным строковым совпадением.
 - `AUTH_BYPASS_PREFIXES` — только для Next.js статики (`/_next/*`). Не добавлять туда API-пути.
 
 ## Anti-patterns (история регрессий)
 
-- **Новый admin endpoint без bypass**: если добавить `/api/admin/X` с `requireAdmin`, но не добавить путь в `AUTH_BYPASS_PATHS` → middleware редиректит на `/login` → handler никогда не вызывается → silent 302 вместо 401/200. (ref: memory feedback_middleware_admin_whitelist.md)
-- **Bypass без requireAdmin**: убрать `requireAdmin` из handler, оставив путь в bypass → endpoint становится публичным без auth. Оба шага обязательны вместе.
+- **Новый admin endpoint без bypass**: handler со своим token/secret auth не
+  выполняется, если middleware раньше редиректит запрос на `/login`.
+- **Bypass без route auth**: путь в bypass становится публичным, если handler не
+  проверяет `requireAdmin` или другой явно выбранный credential/signature.
 - **Тест bypass без проверки middleware-auth.test.ts**: при добавлении нового bypass-пути — добавить его в `bypassPaths` массив теста `__tests__/middleware-auth.test.ts`.
 
 ## Checklist перед commit'ом
 
-- [ ] Новый `/api/admin/*` → `requireAdmin(req)` первой строкой в handler
+- [ ] Новый `/api/admin/*` → явный auth до обработки входа; по умолчанию
+      `requireAdmin(req)`, отдельный механизм только как документированное исключение
 - [ ] Путь добавлен в `AUTH_BYPASS_PATHS` в `middleware.ts`
 - [ ] Путь добавлен в `bypassPaths` в `__tests__/middleware-auth.test.ts`
 - [ ] `ADMIN_TOKEN` env var задокументирован в `.env.local.example` (если есть)

--- a/.claude/rules/ai-provider.md
+++ b/.claude/rules/ai-provider.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - lib/ai-provider.ts
+---
+
 # Rules: lib/ai-provider.ts
 
 ## Invariants

--- a/.claude/rules/retriever.md
+++ b/.claude/rules/retriever.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - lib/knowledge/embeddings/retriever*.ts
+---
+
 # Rules: lib/knowledge/embeddings/retriever\*
 
 ## Invariants

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,95 +1,32 @@
-# Claude Code — quantika-demo
+# Claude Code — Quantika Demo
 
-## Общий язык домена (читай ПЕРЕД задачей)
+Current code, `package.json`, and repository documentation are authoritative.
 
-- Перед задачей читай [`CONTEXT.md`](CONTEXT.md) — канонический глоссарий домена
-  фрахта (TCE, voyage P&L, RAG scope, bunker/discharge port, demotion reason,
-  match bucket, demo-mode и т.д.).
-- Имена переменных, тестов и функций = **каноничные термины оттуда**
-  (`tce`, не `timeCharterEq`; `discharge_port`, не `destinationPort`).
-  Новый доменный термин → допиши в `CONTEXT.md` в том же PR.
-- Новое архитектурное решение (новый провайдер, БД, движок, что трудно
-  откатить) → заведи ADR в [`docs/adr/`](docs/adr/) по шаблону из
-  [`docs/adr/README.md`](docs/adr/README.md).
+## Domain language
 
-## VPS Deploy Notes
+- Read [`CONTEXT.md`](CONTEXT.md) before domain work. It is the canonical freight
+  glossary for TCE, voyage P&L, RAG scope, ports, demotion reasons, match buckets,
+  and demo mode.
+- Use the canonical terms from `CONTEXT.md` in variables, functions, and tests.
+  Add a new durable term there in the same change that introduces it.
+- Record a hard-to-reverse architecture decision under [`docs/adr/`](docs/adr/)
+  using [`docs/adr/README.md`](docs/adr/README.md).
 
-- Прод (outreach-vps 185.249.225.169) — **systemd unit `quantika-demo`**
-  (`systemctl restart/status quantika-demo`, `journalctl -u quantika-demo`).
-  pm2 на проде НЕТ; legacy `scripts/deploy-vps.sh` (pm2) — не прод-путь.
-- Деплой: GH workflow `deploy.yml` → `/root/deploy-quantika-demo.sh` —
-  self-updating копия канонического `ops/scripts/deploy-quantika-demo.sh`
-  (staged build в `/root/quantika-demo-build` + атомный swap; см. #940).
-  Менять только через PR — ручные правки на VPS затираются self-update'ом.
-- `NEXT_PUBLIC_*` переменные запекаются в бандл при `npm run build`.
-  Изменение `.env.local` без rebuild не обновит клиентские флаги.
-- После изменения `.env.local` на проде: `systemctl restart quantika-demo`
-  (EnvironmentFile перечитывается на старте сервиса).
-- Новые страницы дают «client reference manifest does not exist» до полного `npm run build`.
+## Deployment facts
 
-## Доступные скиллы (quantika-specific)
+- Production uses the `quantika-demo` systemd unit. The legacy pm2 script
+  `scripts/deploy-vps.sh` is not the production path.
+- The `deploy.yml` workflow invokes `/root/deploy-quantika-demo.sh`, which updates
+  itself from the canonical `ops/scripts/deploy-quantika-demo.sh`. Manual VPS code
+  edits are overwritten by that flow.
+- `NEXT_PUBLIC_*` values are embedded during `npm run build`; changing runtime
+  configuration alone does not update client-side flags.
+- A new route requires a complete build before its client reference manifest exists.
 
-- `/next-best-practices` — ambient скилл для Next.js: RSC boundaries, async patterns, route handlers,
-  image/font optimization, hydration errors, bundling. Применяется при любой работе с app/ или pages/.
-- `/next-cache-components` — точечно при работе с PPR (Partial Pre-rendering), `'use cache'`,
-  ISR или Server Component кешированием.
-- `/taste-skill` — minimalist editorial preset. **Использовать ТОЛЬКО для marketing / landing страниц** (/about, /pricing). Для data-dense pages (matches, compare-routes, dashboard) использовать `/frontend-design`. Подробнее: SKILL.md «Scope Override».
+## Version-sensitive APIs
 
-## Свежие доки вместо памяти модели (анти-«устаревший API»)
+For Next.js, React, and shadcn APIs, verify the installed version in the repository
+and use current official documentation rather than model memory.
 
-Проект на **Next.js 16 + React 19** — новее катоффа знаний модели. Память модели
-про Next.js 14/15 здесь не источник истины.
-
-Перед написанием кода, который трогает нестабильные/новые API — **сверься со свежей
-документацией через WebFetch** (не пиши по памяти):
-
-- App Router, route handlers, server actions, middleware → `https://nextjs.org/docs/app`
-- `'use cache'`, PPR, ISR, кеширование → `https://nextjs.org/docs/app/building-your-application/caching`
-- React 19 (use, Actions, ref-as-prop) → `https://react.dev/reference/react`
-- shadcn/ui компоненты → `https://ui.shadcn.com/docs/components/<component>`
-
-Правило срабатывания: если API появился/менялся в Next 15+ или React 19, или есть
-малейшее сомнение в сигнатуре — сначала WebFetch нужной страницы доков, потом код.
-Для стабильных API (fs, fetch, обычный JSX) — не нужно, не трать контекст.
-
-Субагентам в планах (writing-plans / subagent-driven-development) включать строку:
-«Before using Next.js/React APIs introduced or changed after v14 — WebFetch the
-relevant nextjs.org/react.dev docs page first».
-
-## RTK — токен-компрессия вывода команд (trial)
-
-<!-- rtk-instructions v2 (condensed) -->
-
-Установлен `rtk` (Rust Token Killer): префиксуй им шумные команды — он сжимает
-вывод на 60–90% до попадания в контекст. Без фильтра — прозрачный passthrough,
-всегда безопасен. В цепочках `&&` префиксуй каждую команду.
-
-Где обязательно (самый шумный вывод):
-
-```bash
-rtk jest / rtk vitest      # только failures (-99%)
-rtk next build             # route metrics (-87%)
-rtk tsc / rtk lint         # ошибки, сгруппированы по файлам (-83%)
-rtk git diff / show        # компактный diff (-80%)
-rtk git status / log / add / commit / push
-rtk gh pr view / checks / run list (-80%)
-rtk npm run <script> / rtk npx <cmd>
-rtk curl <url>             # компактный HTTP (-70%)
-```
-
-Где НЕ нужно: команды с коротким выводом и когда нужен точный сырой вывод
-(парсинг SHA, json для скриптов — или используй `rtk proxy <cmd>`).
-⚠️ Финальная диагностика warnings/ошибок для отчёта — СЫРОЙ вывод (`rtk proxy`
-или без rtk): компрессия скрывает file:line детали (A/B 2026-06-11: rtk-агент
-отрапортовал «проблем нет» там, где без rtk нашлось 5 реальных stale-директив).
-Статистика экономии: `rtk gain`.
-
-<!-- /rtk-instructions -->
-
-## Path-scoped rules
-
-Перед редактированием модулей с историей регрессий — прочитать соответствующий файл:
-
-- `lib/ai-provider.ts` → `.claude/rules/ai-provider.md`
-- `lib/knowledge/embeddings/retriever*` → `.claude/rules/retriever.md`
-- `app/api/admin/**` + `middleware.ts` → `.claude/rules/admin-api.md`
+Subsystem rules live in `.claude/rules/` and load themselves when you touch the files
+they are scoped to.


### PR DESCRIPTION
Rules without `paths:` frontmatter load into every session unconditionally.
`admin-api.md`, `ai-provider.md` and `retriever.md` now declare the files they
cover, so they load only when those files are touched.

`CLAUDE.md` also carried a "Path-scoped rules" section listing which rule maps to which path. The rules announce their own scope through frontmatter, so that index was a second copy of the same fact — the kind that silently drifts out of sync. Replaced with one line saying rules load themselves.

Reference: [path-specific rules](https://code.claude.com/docs/en/memory#path-specific-rules).

Part of a wider pass across the workspace and allegro-lister that cut measured
startup context from 57,716 to 29,069 tokens on the first request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)