### PR TITLE
docs(ops): Cloudflare Tunnel setup + internal TLS for Caddy

### DIFF
--- a/docs/RUNBOOK-CADDY-DOMAINS.md
+++ b/docs/RUNBOOK-CADDY-DOMAINS.md
@@ -1,44 +1,113 @@
-# Runbook — Adding a Domain to Caddy on VPS
+# Runbook — Publishing a Domain (Cloudflare Tunnel + Caddy)
 
-Active Caddyfile: `/etc/caddy/Caddyfile` on `root@185.249.225.169`.
-Per-domain blocks live in repo at `ops/Caddyfile.<domain>` and must be **manually
-appended** to `/etc/caddy/Caddyfile` on the VPS — Caddy does NOT auto-import
-these.
+**Traffic path (since 2026-08-14):**
 
-## Steps to add a new domain
+```
+visitor → Cloudflare edge → cloudflared (tunnel "quantika-prod")
+        → Caddy on localhost:443 → app (localhost:3000 demo, localhost:8100 allegro)
+```
+
+The origin `185.249.225.169` accepts **no inbound web traffic**: `ufw` allows
+port 22 only. Ports 80/443 are closed, so the site is reachable exclusively
+through the tunnel. Direct-to-IP access (the old Cloudflare bypass) is gone.
+
+Key files on the VPS:
+
+| Path                                  | Purpose                                                |
+| ------------------------------------- | ------------------------------------------------------ |
+| `/etc/cloudflared/config.yml`         | Tunnel id, credentials file, ingress rules             |
+| `/root/.cloudflared/<tunnel-id>.json` | Tunnel credentials (secret, never commit)              |
+| `/etc/caddy/Caddyfile`                | `allegro.quantika.org` block + `import Caddyfile.demo` |
+| `/etc/caddy/Caddyfile.demo`           | `demo.quantika.org` block                              |
+
+Tunnel: `quantika-prod`, id `9f780626-d43c-4969-90fc-af94bffd67c6`.
+
+## TLS
+
+Caddy serves **`tls internal`** (Caddy's local CA) on both hosts and cloudflared
+connects with `noTLSVerify: true`. Let's Encrypt is no longer used and cannot be
+used: HTTP-01/TLS-ALPN validation needs inbound 80/443, which are closed. Never
+remove `tls internal` from a site block — Caddy would start failing ACME renewals.
+
+Public certificates are Cloudflare's (edge), so visitors are unaffected.
+
+## Steps to publish a new domain
 
 ```bash
 ssh root@185.249.225.169
 cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.bak.$(date +%Y%m%d-%H%M%S)
-cat /root/quantika-demo/ops/Caddyfile.<domain> >> /etc/caddy/Caddyfile
-systemctl reload caddy
-systemctl is-active caddy   # must be 'active'
 ```
 
-Wait ~30s for Let's Encrypt provisioning, then verify:
+1. Add a Caddy site block — `tls internal` is mandatory:
 
-```bash
-curl -sI https://<domain>/api/health   # expect HTTP/2 200
-```
+   ```caddyfile
+   <domain> {
+       tls internal
+       reverse_proxy localhost:<port>
+   }
+   ```
 
-## Cloudflare prerequisites
+   ```bash
+   systemctl reload caddy && systemctl is-active caddy
+   ```
 
-- Cloudflare SSL mode must be **Full** (not Flexible, not Full-strict).
-  Caddy auto-provisions a Let's Encrypt cert; CF "Full-strict" rejects only
-  self-signed, so LE works either way — but **Full** is the documented setting.
-- DNS A record points `<domain>` → VPS public IP `185.249.225.169`.
+2. Add an ingress rule to `/etc/cloudflared/config.yml`, **above** the catch-all
+   `- service: http_status:404`:
+
+   ```yaml
+   - hostname: <domain>
+     service: https://localhost:443
+     originRequest:
+       originServerName: <domain>
+   ```
+
+   ```bash
+   cloudflared tunnel ingress validate   # must print OK
+   ```
+
+3. Point DNS at the tunnel (creates a proxied CNAME to
+   `<tunnel-id>.cfargotunnel.com`; add `--overwrite-dns` to replace an existing
+   A/CNAME record):
+
+   ```bash
+   cloudflared tunnel route dns quantika-prod <domain>
+   ```
+
+4. Apply and verify:
+
+   ```bash
+   systemctl restart cloudflared && systemctl is-active cloudflared
+   curl -sI https://<domain>/   # expect HTTP/2 200
+   ```
+
+## Cloudflare zone settings (already applied)
+
+| Setting                 | Value                                                                                     |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| SSL/TLS encryption mode | Full (strict)                                                                             |
+| Always Use HTTPS        | On                                                                                        |
+| HSTS                    | On, max-age 6 months, no includeSubDomains, no preload                                    |
+| Managed transforms      | "Add security headers", "Remove X-Powered-By"                                             |
+| Rate limiting rule      | `login-brute-force` — 10 POSTs / 10s per IP on `demo.quantika.org/api/auth/login` → Block |
+| Zero Trust Access       | `allegro.quantika.org` — policy `two-emails`, one-time PIN login                          |
+
+`includeSubDomains` is deliberately off: a subdomain without HTTPS would become
+unreachable for the whole max-age window.
 
 ## Rollback
 
 ```bash
 cp /etc/caddy/Caddyfile.bak.<timestamp> /etc/caddy/Caddyfile
 systemctl reload caddy
+# tunnel-level rollback: restore the previous ingress block, then
+systemctl restart cloudflared
 ```
 
-## Why blocks aren't auto-imported
+Reopening the origin to the internet (`ufw allow 80,443/tcp`) is **not** a
+rollback — it re-creates the bypass this setup removed.
 
-The active `/etc/caddy/Caddyfile` is hand-curated (e.g., `allegro.quantika.org`
-includes `basic_auth` with env-var credentials that depend on
-`/etc/systemd/system/caddy.service.d/auth.conf`). Auto-importing every
-`ops/Caddyfile.*` would require unifying all secrets in systemd drop-ins.
-Until that is done, this runbook is the source of truth.
+## Prerequisites for the tunnel to work
+
+- Outbound TCP/UDP to `*.argotunnel.com:7844` must stay open (checked on setup).
+- `cloudflared.service` must be enabled; if it dies, both hosts go down —
+  `systemctl status cloudflared` is the first thing to check on an outage.

--- a/docs/RUNBOOK-CADDY-DOMAINS.md
+++ b/docs/RUNBOOK-CADDY-DOMAINS.md
@@ -22,6 +22,14 @@ Key files on the VPS:
 
 Tunnel: `quantika-prod`, id `9f780626-d43c-4969-90fc-af94bffd67c6`.
 
+**The VPS is the source of truth, not this repo.** Verified 2026-08-14: the live
+`demo.quantika.org` block is `tls internal` + `encode gzip zstd` +
+`header /api/* Cache-Control "no-store"` + a plain `reverse_proxy localhost:3000`.
+Two repo files describe the same host — `ops/Caddyfile.demo.quantika.org` and
+`ops/caddy/Caddyfile.demo` — and neither matches it: the latter also carries the
+SSE fixes (compression exclusion, `flush_interval -1`) that were never applied on
+the VPS. Copying either file over the live one changes behaviour; diff first.
+
 ## TLS
 
 Caddy serves **`tls internal`** (Caddy's local CA) on both hosts and cloudflared

--- a/ops/Caddyfile.demo.quantika.org
+++ b/ops/Caddyfile.demo.quantika.org
@@ -1,3 +1,6 @@
 demo.quantika.org {
+    # Caddy local CA: the origin has no inbound 80/443, so ACME cannot run.
+    # cloudflared connects with noTLSVerify — see docs/RUNBOOK-CADDY-DOMAINS.md
+    tls internal
     reverse_proxy localhost:3000
 }

--- a/ops/caddy/Caddyfile.demo
+++ b/ops/caddy/Caddyfile.demo
@@ -1,4 +1,7 @@
 demo.quantika.org {
+    # Caddy local CA: the origin has no inbound 80/443 (traffic arrives through
+    # Cloudflare Tunnel), so ACME cannot run. See docs/RUNBOOK-CADDY-DOMAINS.md
+    tls internal
     # Exclude SSE path from compression — gzip/zstd buffers the infinite stream
     # before flushing, causing a proxy timeout → HTTP 503. (#626)
     @compressible {

--- a/ops/cloudflared/config.yml
+++ b/ops/cloudflared/config.yml
@@ -1,0 +1,21 @@
+# Reference copy of /etc/cloudflared/config.yml on 185.249.225.169.
+# Edit the live file on the VPS, then mirror the change here.
+# The credentials file it points at is a secret and is NOT in this repo.
+# See docs/RUNBOOK-CADDY-DOMAINS.md for the publish/rollback procedure.
+
+tunnel: 9f780626-d43c-4969-90fc-af94bffd67c6
+credentials-file: /root/.cloudflared/9f780626-d43c-4969-90fc-af94bffd67c6.json
+originRequest:
+  noTLSVerify: true
+  connectTimeout: 30s
+
+ingress:
+  - hostname: demo.quantika.org
+    service: https://localhost:443
+    originRequest:
+      originServerName: demo.quantika.org
+  - hostname: allegro.quantika.org
+    service: https://localhost:443
+    originRequest:
+      originServerName: allegro.quantika.org
+  - service: http_status:404


### PR DESCRIPTION
## What changed on prod (already live)

The origin (`185.249.225.169`) no longer accepts inbound web traffic. Public
traffic now reaches it only through the `quantika-prod` Cloudflare Tunnel:

```
visitor → Cloudflare edge → cloudflared → Caddy (localhost:443) → app
```

`ufw` allows port 22 only; the direct-to-IP Cloudflare bypass is gone. Because
ACME can no longer validate, both Caddy site blocks serve `tls internal` and
cloudflared connects with `noTLSVerify`.

## This PR

Docs and ops files catching up with that change — no application code touched.

- `docs/RUNBOOK-CADDY-DOMAINS.md` rewritten around the tunnel path, with the
  live zone settings (Full strict, HSTS, managed transforms, login rate limit,
  Access on `allegro.quantika.org`) and a rollback section
- `tls internal` added to both `ops/` copies of the demo site block, so a deploy
  from the repo cannot silently re-break TLS
- `ops/cloudflared/config.yml` — reference copy of the live ingress config
  (credentials file is a secret and stays out of the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)